### PR TITLE
fix(backup): preserve SQL fidelity and recovery safety

### DIFF
--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -11,7 +11,8 @@ use rusqlite::types::ValueRef;
 use rusqlite::Connection;
 use std::fs;
 use std::path::{Path, PathBuf};
-use tempfile::NamedTempFile;
+use std::sync::{Mutex, MutexGuard};
+use tempfile::{Builder, NamedTempFile};
 
 const CC_SWITCH_SQL_EXPORT_HEADER: &str = "-- CC Switch SQLite 导出";
 
@@ -19,6 +20,17 @@ const CC_SWITCH_SQL_EXPORT_HEADER: &str = "-- CC Switch SQLite 导出";
 /// A row larger than this cap is emitted alone because it cannot be split.
 const INSERT_BATCH_MAX_ROWS: usize = 200;
 const INSERT_BATCH_MAX_BYTES: usize = 1024 * 1024;
+
+/// Serialize every operation that observes or mutates the database-backup
+/// directory. Always acquire this guard before `Database.conn`.
+static BACKUP_FILE_OPERATION_LOCK: Mutex<()> = Mutex::new(());
+type BackupFileOperationGuard = MutexGuard<'static, ()>;
+
+fn lock_backup_file_operations() -> Result<BackupFileOperationGuard, AppError> {
+    BACKUP_FILE_OPERATION_LOCK
+        .lock()
+        .map_err(|e| AppError::Database(format!("Backup file operation lock failed: {e}")))
+}
 
 /// `dump_sql` 会写出的 PRAGMA。其余 PRAGMA 一律拒绝——`temp_store_directory`
 /// 能把临时文件重定向到任意目录，`writable_schema` 能绕过 schema 完整性检查。
@@ -79,7 +91,7 @@ const SYNC_SKIP_TABLES: &[&str] = &[
     "usage_daily_rollups",
 ];
 
-/// Tables whose local data is preserved from the live database during WebDAV import.
+/// Tables whose local data is preserved (restored from a local snapshot) during WebDAV import.
 /// Excludes ephemeral tables like provider_health that can safely rebuild at runtime.
 const SYNC_PRESERVE_TABLES: &[&str] = &[
     "proxy_request_logs",
@@ -141,7 +153,7 @@ impl Database {
     }
 
     /// Import SQL generated for sync, then restore local-only tables from the
-    /// current live database before replacing it.
+    /// current device snapshot before replacing the main database.
     pub(crate) fn import_sql_string_for_sync(&self, sql_raw: &str) -> Result<String, AppError> {
         self.import_sql_string_inner(sql_raw, SYNC_PRESERVE_TABLES)
     }
@@ -204,9 +216,11 @@ impl Database {
             Self::restore_tables(local_snapshot, &temp_conn, preserve_tables)?;
         }
 
+        let backup_file_guard = lock_backup_file_operations()?;
         let backup_path = {
             let mut main_conn = lock_conn!(self.conn);
-            let backup_path = Self::backup_database_file_from_conn(&main_conn, &[])?;
+            let backup_path =
+                Self::backup_database_file_from_conn(&backup_file_guard, &main_conn, &[])?;
             let backup = Backup::new(&temp_conn, &mut main_conn)
                 .map_err(|e| AppError::Database(e.to_string()))?;
             Self::complete_backup(&backup, "替换主数据库")?;
@@ -385,9 +399,10 @@ impl Database {
     pub(crate) fn periodic_backup_if_needed(&self) -> Result<(), AppError> {
         let interval_hours = crate::settings::effective_backup_interval_hours();
         if interval_hours > 0 {
+            let backup_file_guard = lock_backup_file_operations()?;
             let backup_dir = get_app_config_dir().join("backups");
             if !backup_dir.exists() {
-                self.backup_database_file()?;
+                self.backup_database_file_locked(&backup_file_guard)?;
             } else {
                 let latest = fs::read_dir(&backup_dir).ok().and_then(|entries| {
                     entries
@@ -410,7 +425,7 @@ impl Database {
                     log::info!(
                         "Periodic backup: latest backup is older than {interval_hours} hours, creating new backup"
                     );
-                    self.backup_database_file()?;
+                    self.backup_database_file_locked(&backup_file_guard)?;
                 }
             }
         }
@@ -445,27 +460,41 @@ impl Database {
 
     /// 生成一致性快照备份，返回备份文件路径（不存在主库时返回 None）
     pub(crate) fn backup_database_file(&self) -> Result<Option<PathBuf>, AppError> {
-        let conn = lock_conn!(self.conn);
-        Self::backup_database_file_from_conn(&conn, &[])
+        let backup_file_guard = lock_backup_file_operations()?;
+        self.backup_database_file_locked(&backup_file_guard)
     }
 
-    /// Create a safety backup from a connection whose caller already owns the
-    /// appropriate database guard. This lets restore keep one guard across the
-    /// safety snapshot and the final live replacement.
+    fn backup_database_file_locked(
+        &self,
+        backup_file_guard: &BackupFileOperationGuard,
+    ) -> Result<Option<PathBuf>, AppError> {
+        let conn = lock_conn!(self.conn);
+        Self::backup_database_file_from_conn(backup_file_guard, &conn, &[])
+    }
+
+    /// Create a safety backup from a connection whose caller already owns both
+    /// the backup-file operation guard and the appropriate database guard.
     fn backup_database_file_from_conn(
+        backup_file_guard: &BackupFileOperationGuard,
         source_conn: &Connection,
         protected_paths: &[&Path],
     ) -> Result<Option<PathBuf>, AppError> {
-        Self::backup_database_file_from_conn_with_hook(source_conn, protected_paths, |_| Ok(()))
+        Self::backup_database_file_from_conn_with_hook(
+            backup_file_guard,
+            source_conn,
+            protected_paths,
+            |_, _| Ok(()),
+        )
     }
 
     fn backup_database_file_from_conn_with_hook<F>(
+        _backup_file_guard: &BackupFileOperationGuard,
         source_conn: &Connection,
         protected_paths: &[&Path],
         before_publish: F,
     ) -> Result<Option<PathBuf>, AppError>
     where
-        F: FnOnce(&Path) -> Result<(), AppError>,
+        F: FnOnce(&Path, &Path) -> Result<(), AppError>,
     {
         let db_path = get_app_config_dir().join("cc-switch.db");
         if !db_path.exists() {
@@ -480,19 +509,17 @@ impl Database {
         fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
 
         let base_id = format!("db_backup_{}", Local::now().format("%Y%m%d_%H%M%S"));
-        let mut backup_id = base_id.clone();
-        let mut backup_path = backup_dir.join(format!("{backup_id}.db"));
-        let mut counter = 1;
-        while backup_path.exists() {
-            backup_id = format!("{base_id}_{counter}");
-            backup_path = backup_dir.join(format!("{backup_id}.db"));
-            counter += 1;
-        }
+        let mut next_suffix = 0;
+        let mut backup_path =
+            Self::next_available_backup_path(&backup_dir, &base_id, &mut next_suffix);
 
         // Build and validate the backup under a non-.db temporary name. Backup
         // discovery and retention only see the final path after the complete
         // SQLite image has been atomically published.
-        let temp_path = NamedTempFile::new_in(&backup_dir)
+        let mut temp_path = Builder::new()
+            .prefix(".cc-switch-backup-")
+            .suffix(".tmp")
+            .tempfile_in(&backup_dir)
             .map_err(|e| AppError::io(&backup_dir, e))?
             .into_temp_path();
         let temp_db_path: &Path = temp_path.as_ref();
@@ -503,11 +530,22 @@ impl Database {
         Self::complete_backup(&backup, "创建数据库安全备份")?;
         drop(backup);
         Self::validate_sqlite_integrity(&dest_conn)?;
-        drop(dest_conn);
-        before_publish(temp_db_path)?;
-        temp_path
-            .persist_noclobber(&backup_path)
-            .map_err(|e| AppError::io(&backup_path, e.error))?;
+        dest_conn
+            .close()
+            .map_err(|(_, e)| AppError::Database(format!("关闭数据库安全备份失败: {e}")))?;
+        before_publish(temp_db_path, &backup_path)?;
+
+        loop {
+            match temp_path.persist_noclobber(&backup_path) {
+                Ok(()) => break,
+                Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    temp_path = error.path;
+                    backup_path =
+                        Self::next_available_backup_path(&backup_dir, &base_id, &mut next_suffix);
+                }
+                Err(error) => return Err(AppError::io(&backup_path, error.error)),
+            }
+        }
 
         // The newly created safety backup must never be the cleanup victim.
         // During restore, the selected source is protected as well. If the
@@ -518,6 +556,32 @@ impl Database {
         cleanup_protected.extend_from_slice(protected_paths);
         Self::cleanup_db_backups(&backup_dir, &cleanup_protected)?;
         Ok(Some(backup_path))
+    }
+
+    fn next_available_backup_path(
+        backup_dir: &Path,
+        base_id: &str,
+        next_suffix: &mut usize,
+    ) -> PathBuf {
+        loop {
+            let backup_id = if *next_suffix == 0 {
+                base_id.to_string()
+            } else {
+                format!("{base_id}_{}", *next_suffix)
+            };
+            *next_suffix += 1;
+            let backup_path = backup_dir.join(format!("{backup_id}.db"));
+            if !backup_path.exists() {
+                return backup_path;
+            }
+        }
+    }
+
+    fn same_existing_backup_path(left: &Path, right: &Path) -> bool {
+        match (fs::canonicalize(left), fs::canonicalize(right)) {
+            (Ok(left), Ok(right)) => left == right,
+            _ => left == right,
+        }
     }
 
     /// 清理旧的数据库备份，保留最新的 N 个
@@ -545,21 +609,19 @@ impl Database {
         let mut sorted = entries;
         sorted.sort_by_key(|entry| entry.metadata().and_then(|m| m.modified()).ok());
 
-        let protected_names = protected_paths
-            .iter()
-            .filter_map(|path| path.file_name())
-            .collect::<Vec<_>>();
         let mut removed = 0;
         for entry in sorted {
             if removed >= remove_count {
                 break;
             }
-            let file_name = entry.file_name();
-            if protected_names.contains(&file_name.as_os_str()) {
+            let path = entry.path();
+            if protected_paths
+                .iter()
+                .any(|protected| Self::same_existing_backup_path(&path, protected))
+            {
                 continue;
             }
 
-            let path = entry.path();
             if let Err(err) = fs::remove_file(&path) {
                 log::warn!("删除旧数据库备份失败 {}: {}", path.display(), err);
             } else {
@@ -887,6 +949,7 @@ impl Database {
 
     /// List all database backup files, sorted by creation time (newest first)
     pub fn list_backups() -> Result<Vec<BackupEntry>, AppError> {
+        let _backup_file_guard = lock_backup_file_operations()?;
         let backup_dir = get_app_config_dir().join("backups");
         if !backup_dir.exists() {
             return Ok(vec![]);
@@ -923,6 +986,17 @@ impl Database {
 
     /// Restore database from a backup file. Returns the safety backup ID.
     pub fn restore_from_backup(&self, filename: &str) -> Result<String, AppError> {
+        self.restore_from_backup_with_hook(filename, |_| Ok(()))
+    }
+
+    fn restore_from_backup_with_hook<F>(
+        &self,
+        filename: &str,
+        before_replace: F,
+    ) -> Result<String, AppError>
+    where
+        F: FnOnce(Option<&Path>) -> Result<(), AppError>,
+    {
         // Security: validate filename to prevent path traversal
         if filename.contains("..")
             || filename.contains('/')
@@ -934,6 +1008,7 @@ impl Database {
             ));
         }
 
+        let backup_file_guard = lock_backup_file_operations()?;
         let backup_dir = get_app_config_dir().join("backups");
         let backup_path = backup_dir.join(filename);
 
@@ -979,8 +1054,12 @@ impl Database {
         // the safety file exactly represents the state being replaced.
         let safety_backup = {
             let mut main_conn = lock_conn!(self.conn);
-            let safety_backup =
-                Self::backup_database_file_from_conn(&main_conn, &[backup_path.as_path()])?;
+            let safety_backup = Self::backup_database_file_from_conn(
+                &backup_file_guard,
+                &main_conn,
+                &[backup_path.as_path()],
+            )?;
+            before_replace(safety_backup.as_deref())?;
             let backup = Backup::new(&staging_conn, &mut main_conn)
                 .map_err(|e| AppError::Database(e.to_string()))?;
             Self::complete_backup(&backup, "恢复主数据库")?;
@@ -1036,6 +1115,7 @@ impl Database {
 
         let new_filename = format!("{name_part}.db");
 
+        let _backup_file_guard = lock_backup_file_operations()?;
         let backup_dir = get_app_config_dir().join("backups");
         let old_path = backup_dir.join(old_filename);
         let new_path = backup_dir.join(&new_filename);
@@ -1070,6 +1150,7 @@ impl Database {
             ));
         }
 
+        let _backup_file_guard = lock_backup_file_operations()?;
         let backup_path = get_app_config_dir().join("backups").join(filename);
         if !backup_path.exists() {
             return Err(AppError::InvalidInput(format!(
@@ -1085,7 +1166,7 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
-    use super::Database;
+    use super::{lock_backup_file_operations, Database};
     use crate::error::AppError;
     use crate::settings::{get_settings, update_settings, AppSettings};
     use rusqlite::Connection;
@@ -2200,19 +2281,26 @@ mod tests {
         visible_before.sort();
 
         let error = {
+            let backup_file_guard = lock_backup_file_operations()?;
             let conn = crate::database::lock_conn!(db.conn);
-            Database::backup_database_file_from_conn_with_hook(&conn, &[], |temp_path| {
-                assert!(
-                    temp_path.exists(),
-                    "completed backup should exist before publish"
-                );
-                assert_ne!(
-                    temp_path.extension().and_then(|ext| ext.to_str()),
-                    Some("db"),
-                    "staging files must stay invisible to backup discovery"
-                );
-                Err(AppError::Config("simulated publish failure".to_string()))
-            })
+            Database::backup_database_file_from_conn_with_hook(
+                &backup_file_guard,
+                &conn,
+                &[],
+                |temp_path, target_path| {
+                    assert!(
+                        temp_path.exists(),
+                        "completed backup should exist before publish"
+                    );
+                    assert_ne!(
+                        temp_path.extension().and_then(|ext| ext.to_str()),
+                        Some("db"),
+                        "staging files must stay invisible to backup discovery"
+                    );
+                    assert!(!target_path.exists());
+                    Err(AppError::Config("simulated publish failure".to_string()))
+                },
+            )
         }
         .expect_err("publish failure must be returned");
         assert!(error.to_string().contains("simulated publish failure"));
@@ -2232,6 +2320,136 @@ mod tests {
             files_after, files_before,
             "failed publish must not leave either a visible backup or a temporary file"
         );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn backup_publish_retries_a_noclobber_name_collision() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let _settings = SettingsGuard::with_backup_retain_count(10);
+        let db = Database::init()?;
+        let mut claimed_path = None;
+
+        let published_path = {
+            let backup_file_guard = lock_backup_file_operations()?;
+            let conn = crate::database::lock_conn!(db.conn);
+            Database::backup_database_file_from_conn_with_hook(
+                &backup_file_guard,
+                &conn,
+                &[],
+                |_, target_path| {
+                    claimed_path = Some(target_path.to_path_buf());
+                    std::fs::write(target_path, b"claimed by another process")
+                        .map_err(|e| AppError::io(target_path, e))?;
+                    Ok(())
+                },
+            )?
+            .expect("file-backed database should create a backup")
+        };
+
+        let claimed_path = claimed_path.expect("publish hook should receive the first target");
+        assert_ne!(published_path, claimed_path);
+        assert_eq!(
+            std::fs::read(&claimed_path).map_err(|e| AppError::io(&claimed_path, e))?,
+            b"claimed by another process"
+        );
+        let published_conn = Connection::open_with_flags(
+            &published_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )?;
+        Database::validate_sqlite_integrity(&published_conn)?;
+
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        let temporary_files = std::fs::read_dir(&backup_dir)
+            .map_err(|e| AppError::io(&backup_dir, e))?
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".cc-switch-backup-")
+            })
+            .count();
+        assert_eq!(
+            temporary_files, 0,
+            "publish retry must consume the temp file"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn concurrent_backup_renames_never_overwrite_the_shared_target() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let _settings = SettingsGuard::with_backup_retain_count(10);
+        let db = Database::init()?;
+        let mut source_filenames = Vec::new();
+        for provider_id in ["first-source", "second-source"] {
+            {
+                let conn = crate::database::lock_conn!(db.conn);
+                conn.execute("DELETE FROM providers", [])?;
+                conn.execute(
+                    "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                     VALUES (?1, 'claude', ?1, '{}', '{}')",
+                    [provider_id],
+                )?;
+            }
+            let source_path = db
+                .backup_database_file()?
+                .expect("file-backed database should create a backup");
+            source_filenames.push(
+                source_path
+                    .file_name()
+                    .expect("backup should have a filename")
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+        }
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let handles = source_filenames
+            .iter()
+            .cloned()
+            .map(|source_filename| {
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    Database::rename_backup(&source_filename, "shared-target")
+                        .map_err(|e| e.to_string())
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+        let results = handles
+            .into_iter()
+            .map(|handle| {
+                handle
+                    .join()
+                    .map_err(|_| AppError::Config("rename thread panicked".to_string()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(results.iter().filter(|result| result.is_err()).count(), 1);
+
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        let target_path = backup_dir.join("shared-target.db");
+        let remaining_source = source_filenames
+            .iter()
+            .map(|filename| backup_dir.join(filename))
+            .find(|path| path.exists())
+            .expect("the losing source must remain after the target collision");
+        let mut provider_ids = [&target_path, &remaining_source]
+            .into_iter()
+            .map(|path| -> Result<String, AppError> {
+                let conn =
+                    Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+                conn.query_row("SELECT id FROM providers", [], |row| row.get(0))
+                    .map_err(AppError::from)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        provider_ids.sort();
+        assert_eq!(provider_ids, vec!["first-source", "second-source"]);
         Ok(())
     }
 
@@ -2312,6 +2530,125 @@ mod tests {
             safety_provider, "live-before-restore",
             "safety backup must exactly represent the live state being replaced"
         );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[serial]
+    fn restore_protects_case_variant_source_path_from_retention() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let _settings = SettingsGuard::with_backup_retain_count(1);
+        let db = Database::init()?;
+        let source_path = db
+            .backup_database_file()?
+            .expect("file-backed database should create a backup");
+        let source_filename = source_path
+            .file_name()
+            .expect("backup should have a filename")
+            .to_string_lossy()
+            .into_owned();
+        let case_variant = format!(
+            "{}.db",
+            source_filename
+                .strip_suffix(".db")
+                .expect("generated backup should use a .db suffix")
+                .to_ascii_uppercase()
+        );
+
+        db.restore_from_backup(&case_variant)?;
+        assert!(
+            source_path.exists(),
+            "retention must recognize a case-variant path as the selected source"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn restore_blocks_backup_deletion_until_live_replacement_finishes() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let db = Database::init()?;
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.execute("DELETE FROM providers", [])?;
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('restore-source', 'claude', 'Restore Source', '{}', '{}')",
+                [],
+            )?;
+        }
+        let source_path = db
+            .backup_database_file()?
+            .expect("file-backed database should create a backup");
+        let source_filename = source_path
+            .file_name()
+            .expect("backup should have a filename")
+            .to_string_lossy()
+            .into_owned();
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.execute("DELETE FROM providers", [])?;
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('live-before-restore', 'claude', 'Live Before Restore', '{}', '{}')",
+                [],
+            )?;
+        }
+
+        let (attempt_tx, attempt_rx) = std::sync::mpsc::channel();
+        let (result_tx, result_rx) = std::sync::mpsc::channel();
+        let mut delete_handle = None;
+        let mut observed_safety_filename = None;
+        let safety_id = db.restore_from_backup_with_hook(&source_filename, |safety_path| {
+            let safety_path = safety_path.ok_or_else(|| {
+                AppError::Config("restore should create a safety backup".to_string())
+            })?;
+            let safety_filename = safety_path
+                .file_name()
+                .ok_or_else(|| AppError::Config("safety backup has no filename".to_string()))?
+                .to_string_lossy()
+                .into_owned();
+            observed_safety_filename = Some(safety_filename.clone());
+            delete_handle = Some(std::thread::spawn(move || {
+                let _ = attempt_tx.send(());
+                let result = Database::delete_backup(&safety_filename).map_err(|e| e.to_string());
+                let _ = result_tx.send(result);
+            }));
+
+            attempt_rx
+                .recv_timeout(std::time::Duration::from_secs(1))
+                .map_err(|e| AppError::Config(format!("delete thread did not start: {e}")))?;
+            match result_rx.recv_timeout(std::time::Duration::from_millis(150)) {
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Ok(()),
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => Err(AppError::Config(
+                    "delete thread disconnected before restore completed".to_string(),
+                )),
+                Ok(result) => Err(AppError::Config(format!(
+                    "backup deletion completed before live replacement: {result:?}"
+                ))),
+            }
+        })?;
+
+        let delete_result = result_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .map_err(|e| AppError::Config(format!("delete did not resume after restore: {e}")))?;
+        delete_result.map_err(AppError::Config)?;
+        delete_handle
+            .expect("delete thread should be created")
+            .join()
+            .map_err(|_| AppError::Config("delete thread panicked".to_string()))?;
+
+        let expected_safety_filename = format!("{safety_id}.db");
+        assert_eq!(
+            observed_safety_filename.as_deref(),
+            Some(expected_safety_filename.as_str())
+        );
+        let live_provider: String = {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.query_row("SELECT id FROM providers", [], |row| row.get(0))?
+        };
+        assert_eq!(live_provider, "restore-source");
         Ok(())
     }
 

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -6,7 +6,7 @@ use super::{lock_conn, Database};
 use crate::config::get_app_config_dir;
 use crate::error::AppError;
 use chrono::{Local, Utc};
-use rusqlite::backup::Backup;
+use rusqlite::backup::{Backup, StepResult};
 use rusqlite::types::ValueRef;
 use rusqlite::Connection;
 use std::fs;
@@ -154,9 +154,6 @@ impl Database {
         let sql_content = sql_raw.trim_start_matches('\u{feff}');
         Self::validate_cc_switch_sql_export(sql_content)?;
 
-        // 导入前备份现有数据库
-        let backup_path = self.backup_database_file()?;
-
         let local_snapshot = if preserve_tables.is_empty() {
             None
         } else {
@@ -187,6 +184,14 @@ impl Database {
             None::<fn(rusqlite::hooks::AuthContext<'_>) -> rusqlite::hooks::Authorization>,
         );
         batch_result.map_err(|e| AppError::Database(format!("执行 SQL 导入失败: {e}")))?;
+        if !temp_conn.is_autocommit() {
+            let _ = temp_conn.execute_batch("ROLLBACK;");
+            return Err(AppError::localized(
+                "backup.sql.incomplete_transaction",
+                "SQL 备份事务未完成，文件可能已截断。",
+                "The SQL backup transaction is incomplete; the file may be truncated.",
+            ));
+        }
 
         // Validate the schema produced by the input itself before migrations
         // can create missing tables and accidentally make a truncated file look valid.
@@ -199,15 +204,14 @@ impl Database {
             Self::restore_tables(local_snapshot, &temp_conn, preserve_tables)?;
         }
 
-        // 使用 Backup 将临时库原子写回主库
-        {
+        let backup_path = {
             let mut main_conn = lock_conn!(self.conn);
+            let backup_path = Self::backup_database_file_from_conn(&main_conn, &[])?;
             let backup = Backup::new(&temp_conn, &mut main_conn)
                 .map_err(|e| AppError::Database(e.to_string()))?;
-            backup
-                .step(-1)
-                .map_err(|e| AppError::Database(e.to_string()))?;
-        }
+            Self::complete_backup(&backup, "替换主数据库")?;
+            backup_path
+        };
 
         let backup_id = backup_path
             .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().to_string()))
@@ -225,12 +229,25 @@ impl Database {
         {
             let backup =
                 Backup::new(&conn, &mut snapshot).map_err(|e| AppError::Database(e.to_string()))?;
-            backup
-                .step(-1)
-                .map_err(|e| AppError::Database(e.to_string()))?;
+            Self::complete_backup(&backup, "创建内存数据库快照")?;
         }
 
         Ok(snapshot)
+    }
+
+    fn complete_backup(backup: &Backup<'_, '_>, context: &str) -> Result<(), AppError> {
+        let result = backup
+            .step(-1)
+            .map_err(|e| AppError::Database(format!("{context}失败: {e}")))?;
+        match result {
+            StepResult::Done => Ok(()),
+            StepResult::More | StepResult::Busy | StepResult::Locked => Err(AppError::Database(
+                format!("{context}未完成: SQLite Backup 返回 {result:?}"),
+            )),
+            _ => Err(AppError::Database(format!(
+                "{context}未完成: SQLite Backup 返回未知状态"
+            ))),
+        }
     }
 
     fn validate_cc_switch_sql_export(sql: &str) -> Result<(), AppError> {
@@ -428,6 +445,17 @@ impl Database {
 
     /// 生成一致性快照备份，返回备份文件路径（不存在主库时返回 None）
     pub(crate) fn backup_database_file(&self) -> Result<Option<PathBuf>, AppError> {
+        let conn = lock_conn!(self.conn);
+        Self::backup_database_file_from_conn(&conn, &[])
+    }
+
+    /// Create a safety backup from a connection whose caller already owns the
+    /// appropriate database guard. This lets restore keep one guard across the
+    /// safety snapshot and the final live replacement.
+    fn backup_database_file_from_conn(
+        source_conn: &Connection,
+        protected_paths: &[&Path],
+    ) -> Result<Option<PathBuf>, AppError> {
         let db_path = get_app_config_dir().join("cc-switch.db");
         if !db_path.exists() {
             return Ok(None);
@@ -450,23 +478,27 @@ impl Database {
             counter += 1;
         }
 
-        {
-            let conn = lock_conn!(self.conn);
-            let mut dest_conn =
-                Connection::open(&backup_path).map_err(|e| AppError::Database(e.to_string()))?;
-            let backup = Backup::new(&conn, &mut dest_conn)
-                .map_err(|e| AppError::Database(e.to_string()))?;
-            backup
-                .step(-1)
-                .map_err(|e| AppError::Database(e.to_string()))?;
-        }
+        let mut dest_conn =
+            Connection::open(&backup_path).map_err(|e| AppError::Database(e.to_string()))?;
+        let backup = Backup::new(source_conn, &mut dest_conn)
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        Self::complete_backup(&backup, "创建数据库安全备份")?;
+        drop(backup);
+        drop(dest_conn);
 
-        Self::cleanup_db_backups(&backup_dir)?;
+        // The newly created safety backup must never be the cleanup victim.
+        // During restore, the selected source is protected as well. If the
+        // configured retention is too small to keep both, temporarily exceed
+        // it instead of deleting either side of the recovery operation.
+        let mut cleanup_protected = Vec::with_capacity(protected_paths.len() + 1);
+        cleanup_protected.push(backup_path.as_path());
+        cleanup_protected.extend_from_slice(protected_paths);
+        Self::cleanup_db_backups(&backup_dir, &cleanup_protected)?;
         Ok(Some(backup_path))
     }
 
     /// 清理旧的数据库备份，保留最新的 N 个
-    fn cleanup_db_backups(dir: &Path) -> Result<(), AppError> {
+    fn cleanup_db_backups(dir: &Path, protected_paths: &[&Path]) -> Result<(), AppError> {
         let retain = crate::settings::effective_backup_retain_count();
         let entries = match fs::read_dir(dir) {
             Ok(iter) => iter
@@ -490,12 +522,52 @@ impl Database {
         let mut sorted = entries;
         sorted.sort_by_key(|entry| entry.metadata().and_then(|m| m.modified()).ok());
 
-        for entry in sorted.into_iter().take(remove_count) {
-            if let Err(err) = fs::remove_file(entry.path()) {
-                log::warn!("删除旧数据库备份失败 {}: {}", entry.path().display(), err);
+        let protected_names = protected_paths
+            .iter()
+            .filter_map(|path| path.file_name())
+            .collect::<Vec<_>>();
+        let mut removed = 0;
+        for entry in sorted {
+            if removed >= remove_count {
+                break;
+            }
+            let file_name = entry.file_name();
+            if protected_names.contains(&file_name.as_os_str()) {
+                continue;
+            }
+
+            let path = entry.path();
+            if let Err(err) = fs::remove_file(&path) {
+                log::warn!("删除旧数据库备份失败 {}: {}", path.display(), err);
+            } else {
+                removed += 1;
             }
         }
         Ok(())
+    }
+
+    fn validate_sqlite_integrity(conn: &Connection) -> Result<(), AppError> {
+        let mut stmt = conn
+            .prepare("PRAGMA quick_check;")
+            .map_err(|e| AppError::Database(format!("检查数据库完整性失败: {e}")))?;
+        let results = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| AppError::Database(format!("检查数据库完整性失败: {e}")))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| AppError::Database(format!("检查数据库完整性失败: {e}")))?;
+
+        if results.len() == 1 && results[0].eq_ignore_ascii_case("ok") {
+            return Ok(());
+        }
+
+        Err(AppError::localized(
+            "backup.db.integrity_failed",
+            format!("数据库备份完整性检查失败: {}", results.join("; ")),
+            format!(
+                "Database backup integrity check failed: {}",
+                results.join("; ")
+            ),
+        ))
     }
 
     /// Validate that the external SQL created a recognizable CC Switch schema.
@@ -848,29 +920,52 @@ impl Database {
             )));
         }
 
-        // Step 1: Create safety backup of current database
-        let safety_backup = self.backup_database_file()?;
+        // Open read-only before creating the safety backup. `Connection::open`
+        // would recreate a source removed by retention cleanup as an empty DB.
+        let source_conn = Connection::open_with_flags(
+            &backup_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Stage and fully validate the selected file before touching the live
+        // connection. A corrupt/future-schema backup or failed migration must
+        // leave the current database unchanged.
+        let temp_file = NamedTempFile::new().map_err(|e| AppError::IoContext {
+            context: "创建数据库恢复暂存文件失败".to_string(),
+            source: e,
+        })?;
+        let mut staging_conn =
+            Connection::open(temp_file.path()).map_err(|e| AppError::Database(e.to_string()))?;
+        {
+            let backup = Backup::new(&source_conn, &mut staging_conn)
+                .map_err(|e| AppError::Database(e.to_string()))?;
+            Self::complete_backup(&backup, "读取数据库备份")?;
+        }
+        drop(source_conn);
+
+        Self::validate_sqlite_integrity(&staging_conn)?;
+        Self::validate_imported_schema(&staging_conn)?;
+        Self::ensure_incremental_auto_vacuum_on_conn(&staging_conn)?;
+        Self::create_tables_on_conn(&staging_conn)?;
+        Self::apply_schema_migrations_on_conn(&staging_conn)?;
+        Self::ensure_model_pricing_seeded_on_conn(&staging_conn)?;
+        Self::validate_sqlite_integrity(&staging_conn)?;
+
+        // Keep one main-DB guard across the safety snapshot and final apply so
+        // the safety file exactly represents the state being replaced.
+        let safety_backup = {
+            let mut main_conn = lock_conn!(self.conn);
+            let safety_backup =
+                Self::backup_database_file_from_conn(&main_conn, &[backup_path.as_path()])?;
+            let backup = Backup::new(&staging_conn, &mut main_conn)
+                .map_err(|e| AppError::Database(e.to_string()))?;
+            Self::complete_backup(&backup, "恢复主数据库")?;
+            safety_backup
+        };
         let safety_id = safety_backup
             .and_then(|p| p.file_stem().map(|s| s.to_string_lossy().to_string()))
             .unwrap_or_default();
-
-        // Step 2: Open the backup file and restore it to the main database
-        let source_conn =
-            Connection::open(&backup_path).map_err(|e| AppError::Database(e.to_string()))?;
-
-        {
-            let mut main_conn = lock_conn!(self.conn);
-            let backup = Backup::new(&source_conn, &mut main_conn)
-                .map_err(|e| AppError::Database(e.to_string()))?;
-            backup
-                .step(-1)
-                .map_err(|e| AppError::Database(e.to_string()))?;
-        }
-
-        // Step 3: Run schema migrations (backup may be from an older version)
-        self.create_tables()?;
-        self.apply_schema_migrations()?;
-        self.ensure_model_pricing_seeded()?;
 
         log::info!("Database restored from backup: {filename}, safety backup: {safety_id}");
         Ok(safety_id)
@@ -969,7 +1064,7 @@ impl Database {
 mod tests {
     use super::Database;
     use crate::error::AppError;
-    use crate::settings::{update_settings, AppSettings};
+    use crate::settings::{get_settings, update_settings, AppSettings};
     use rusqlite::Connection;
     use serial_test::serial;
 
@@ -1014,6 +1109,26 @@ mod tests {
                 Some(previous) => std::env::set_var("CC_SWITCH_TEST_HOME", previous),
                 None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
             }
+        }
+    }
+
+    struct SettingsGuard {
+        previous: AppSettings,
+    }
+
+    impl SettingsGuard {
+        fn with_backup_retain_count(retain: u32) -> Self {
+            let previous = get_settings();
+            let mut next = previous.clone();
+            next.backup_retain_count = Some(retain);
+            update_settings(next).expect("set backup retention for test");
+            Self { previous }
+        }
+    }
+
+    impl Drop for SettingsGuard {
+        fn drop(&mut self) {
+            let _ = update_settings(self.previous.clone());
         }
     }
 
@@ -1290,6 +1405,53 @@ mod tests {
             |row| row.get(0),
         )?;
         assert!(!partial_exists, "失败导入的临时对象不得进入主库");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn import_rejects_truncated_open_transaction_and_keeps_live_database() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let source = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(source.conn);
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('remote-provider', 'claude', 'Remote Provider', '{}', '{}')",
+                [],
+            )?;
+        }
+        let exported = source.export_sql_string()?;
+        let truncated = exported
+            .strip_suffix("COMMIT;\nPRAGMA foreign_keys=ON;\n")
+            .expect("CC Switch export should end with a committed transaction");
+
+        let target = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(target.conn);
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('live-provider', 'claude', 'Live Provider', '{}', '{}')",
+                [],
+            )?;
+        }
+
+        let error = target
+            .import_sql_string(truncated)
+            .expect_err("an export truncated before COMMIT must be rejected");
+        assert!(
+            error.to_string().contains("incomplete")
+                || error.to_string().contains("未完成")
+                || error.to_string().contains("截断"),
+            "unexpected error: {error}"
+        );
+
+        let conn = crate::database::lock_conn!(target.conn);
+        let providers = conn
+            .prepare("SELECT id FROM providers ORDER BY id")?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(providers, vec!["live-provider"]);
         Ok(())
     }
 
@@ -1991,6 +2153,159 @@ mod tests {
         assert_eq!(
             provider_health_count, 0,
             "同步导入应清除可重建的本地 provider_health 状态"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn restore_with_retain_one_keeps_source_and_exact_safety_snapshot() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let _settings = SettingsGuard::with_backup_retain_count(1);
+        let db = Database::init()?;
+
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.execute("DELETE FROM providers", [])?;
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('restore-source', 'claude', 'Restore Source', '{}', '{}')",
+                [],
+            )?;
+        }
+        let source_path = db
+            .backup_database_file()?
+            .expect("file-backed database should create a backup");
+        let source_filename = source_path
+            .file_name()
+            .expect("backup should have a filename")
+            .to_string_lossy()
+            .into_owned();
+
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.execute("DELETE FROM providers", [])?;
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('live-before-restore', 'claude', 'Live Before Restore', '{}', '{}')",
+                [],
+            )?;
+        }
+
+        let safety_id = db.restore_from_backup(&source_filename)?;
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        let safety_path = backup_dir.join(format!("{safety_id}.db"));
+        assert!(
+            source_path.exists(),
+            "selected restore source must be retained"
+        );
+        assert!(
+            safety_path.exists(),
+            "pre-restore safety backup must be retained"
+        );
+
+        let backup_count = std::fs::read_dir(&backup_dir)
+            .map_err(|e| AppError::io(&backup_dir, e))?
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "db"))
+            .count();
+        assert_eq!(
+            backup_count, 2,
+            "retain=1 may be exceeded temporarily to protect both recovery endpoints"
+        );
+
+        let live_provider: String = {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.query_row("SELECT id FROM providers", [], |row| row.get(0))?
+        };
+        assert_eq!(live_provider, "restore-source");
+
+        let safety_conn =
+            Connection::open_with_flags(&safety_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+        let safety_provider: String =
+            safety_conn.query_row("SELECT id FROM providers", [], |row| row.get(0))?;
+        assert_eq!(
+            safety_provider, "live-before-restore",
+            "safety backup must exactly represent the live state being replaced"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn restore_rejects_future_schema_before_touching_live_database() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let db = Database::init()?;
+
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.execute("DELETE FROM providers", [])?;
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('future-source', 'claude', 'Future Source', '{}', '{}')",
+                [],
+            )?;
+        }
+        let source_path = db
+            .backup_database_file()?
+            .expect("file-backed database should create a backup");
+        let source_filename = source_path
+            .file_name()
+            .expect("backup should have a filename")
+            .to_string_lossy()
+            .into_owned();
+        {
+            let source_conn = Connection::open(&source_path)?;
+            source_conn.execute_batch(&format!(
+                "PRAGMA user_version = {};",
+                crate::database::SCHEMA_VERSION + 1
+            ))?;
+        }
+
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.execute("DELETE FROM providers", [])?;
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('live-provider', 'claude', 'Live Provider', '{}', '{}')",
+                [],
+            )?;
+        }
+
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        let backup_count_before = std::fs::read_dir(&backup_dir)
+            .map_err(|e| AppError::io(&backup_dir, e))?
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "db"))
+            .count();
+
+        let error = db
+            .restore_from_backup(&source_filename)
+            .expect_err("future-schema backup must be rejected");
+        assert!(
+            error.to_string().contains("newer")
+                || error.to_string().contains("过新")
+                || error.to_string().contains("版本"),
+            "unexpected error: {error}"
+        );
+
+        let live_provider: String = {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.query_row("SELECT id FROM providers", [], |row| row.get(0))?
+        };
+        assert_eq!(
+            live_provider, "live-provider",
+            "failed staging validation must not replace the live database"
+        );
+
+        let backup_count_after = std::fs::read_dir(&backup_dir)
+            .map_err(|e| AppError::io(&backup_dir, e))?
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "db"))
+            .count();
+        assert_eq!(
+            backup_count_after, backup_count_before,
+            "staging failure should occur before creating a redundant safety backup"
         );
         Ok(())
     }

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -171,6 +171,12 @@ impl Database {
         let temp_path = temp_file.path().to_path_buf();
         let temp_conn =
             Connection::open(&temp_path).map_err(|e| AppError::Database(e.to_string()))?;
+        // SQLite Backup copies the source database header into the destination.
+        // Configure the empty staging database before creating any tables so a
+        // SQL import cannot downgrade the main DB from incremental vacuum to NONE.
+        temp_conn
+            .execute("PRAGMA auto_vacuum = INCREMENTAL;", [])
+            .map_err(|e| AppError::Database(format!("设置暂存库 auto_vacuum 失败: {e}")))?;
 
         // authorizer 只覆盖外部 SQL，执行完立刻摘掉：紧随其后的
         // `create_tables_on_conn` / `apply_schema_migrations_on_conn` 是本程序自己的
@@ -937,6 +943,38 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(name, "Provider One");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn sql_import_preserves_incremental_auto_vacuum() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let source = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(source.conn);
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('vacuum-provider', 'claude', 'Vacuum Provider', '{}', '{}')",
+                [],
+            )?;
+        }
+        let sql = source.export_sql_string()?;
+
+        let target = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(target.conn);
+            assert_eq!(Database::get_auto_vacuum_mode(&conn)?, 2);
+        }
+
+        target.import_sql_string(&sql)?;
+
+        let conn = crate::database::lock_conn!(target.conn);
+        assert_eq!(
+            Database::get_auto_vacuum_mode(&conn)?,
+            2,
+            "SQL 导入不得把主库的 INCREMENTAL auto_vacuum 降级为 NONE"
+        );
         Ok(())
     }
 

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -28,7 +28,7 @@ const IMPORT_ALLOWED_PRAGMAS: &[&str] = &["foreign_keys", "user_version"];
 ///
 /// 头部校验（`validate_cc_switch_sql_export`）只比较一个注释前缀，任何人都能在
 /// 合法前缀后面接着写别的语句。`ATTACH DATABASE '/path/x.db'` 的副作用发生在
-/// `validate_basic_state` 之前，导入即使最终失败，文件也已经被创建；而 `settings`
+/// 暂存库的 schema 校验之前，导入即使最终失败，文件也已经被创建；而 `settings`
 /// 表不在 `SYNC_SKIP_TABLES` / `SYNC_PRESERVE_TABLES` 之列，WebDAV/S3 同步会走
 /// 同一条 `import_sql_string_inner`，所以这条路径的输入不可信。
 ///
@@ -79,7 +79,7 @@ const SYNC_SKIP_TABLES: &[&str] = &[
     "usage_daily_rollups",
 ];
 
-/// Tables whose local data is preserved (restored from local snapshot) during WebDAV import.
+/// Tables whose local data is preserved from the live database during WebDAV import.
 /// Excludes ephemeral tables like provider_health that can safely rebuild at runtime.
 const SYNC_PRESERVE_TABLES: &[&str] = &[
     "proxy_request_logs",
@@ -141,7 +141,7 @@ impl Database {
     }
 
     /// Import SQL generated for sync, then restore local-only tables from the
-    /// current device snapshot before replacing the main database.
+    /// current live database before replacing it.
     pub(crate) fn import_sql_string_for_sync(&self, sql_raw: &str) -> Result<String, AppError> {
         self.import_sql_string_inner(sql_raw, SYNC_PRESERVE_TABLES)
     }
@@ -456,6 +456,17 @@ impl Database {
         source_conn: &Connection,
         protected_paths: &[&Path],
     ) -> Result<Option<PathBuf>, AppError> {
+        Self::backup_database_file_from_conn_with_hook(source_conn, protected_paths, |_| Ok(()))
+    }
+
+    fn backup_database_file_from_conn_with_hook<F>(
+        source_conn: &Connection,
+        protected_paths: &[&Path],
+        before_publish: F,
+    ) -> Result<Option<PathBuf>, AppError>
+    where
+        F: FnOnce(&Path) -> Result<(), AppError>,
+    {
         let db_path = get_app_config_dir().join("cc-switch.db");
         if !db_path.exists() {
             return Ok(None);
@@ -478,13 +489,25 @@ impl Database {
             counter += 1;
         }
 
+        // Build and validate the backup under a non-.db temporary name. Backup
+        // discovery and retention only see the final path after the complete
+        // SQLite image has been atomically published.
+        let temp_path = NamedTempFile::new_in(&backup_dir)
+            .map_err(|e| AppError::io(&backup_dir, e))?
+            .into_temp_path();
+        let temp_db_path: &Path = temp_path.as_ref();
         let mut dest_conn =
-            Connection::open(&backup_path).map_err(|e| AppError::Database(e.to_string()))?;
+            Connection::open(temp_db_path).map_err(|e| AppError::Database(e.to_string()))?;
         let backup = Backup::new(source_conn, &mut dest_conn)
             .map_err(|e| AppError::Database(e.to_string()))?;
         Self::complete_backup(&backup, "创建数据库安全备份")?;
         drop(backup);
+        Self::validate_sqlite_integrity(&dest_conn)?;
         drop(dest_conn);
+        before_publish(temp_db_path)?;
+        temp_path
+            .persist_noclobber(&backup_path)
+            .map_err(|e| AppError::io(&backup_path, e.error))?;
 
         // The newly created safety backup must never be the cleanup victim.
         // During restore, the selected source is protected as well. If the
@@ -1164,7 +1187,7 @@ mod tests {
                 error.to_string().to_ascii_lowercase().contains("authoriz"),
                 "{label} 必须由 authorizer 拒绝，实际错误: {error}"
             );
-            // 光报错不够：文件创建发生在 prepare 之后、`validate_basic_state` 之前，
+            // 光报错不够：文件创建发生在 prepare 之后、暂存库 schema 校验之前，
             // 守卫若失效，即便导入整体失败，文件也已经躺在磁盘上了。
             assert!(
                 !target.exists(),
@@ -2159,6 +2182,61 @@ mod tests {
 
     #[test]
     #[serial]
+    fn failed_backup_publish_leaves_no_visible_or_temporary_file() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let db = Database::init()?;
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        std::fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        let mut files_before = std::fs::read_dir(&backup_dir)
+            .map_err(|e| AppError::io(&backup_dir, e))?
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect::<Vec<_>>();
+        files_before.sort();
+        let mut visible_before = Database::list_backups()?
+            .into_iter()
+            .map(|entry| entry.filename)
+            .collect::<Vec<_>>();
+        visible_before.sort();
+
+        let error = {
+            let conn = crate::database::lock_conn!(db.conn);
+            Database::backup_database_file_from_conn_with_hook(&conn, &[], |temp_path| {
+                assert!(
+                    temp_path.exists(),
+                    "completed backup should exist before publish"
+                );
+                assert_ne!(
+                    temp_path.extension().and_then(|ext| ext.to_str()),
+                    Some("db"),
+                    "staging files must stay invisible to backup discovery"
+                );
+                Err(AppError::Config("simulated publish failure".to_string()))
+            })
+        }
+        .expect_err("publish failure must be returned");
+        assert!(error.to_string().contains("simulated publish failure"));
+        let mut visible_after = Database::list_backups()?
+            .into_iter()
+            .map(|entry| entry.filename)
+            .collect::<Vec<_>>();
+        visible_after.sort();
+        assert_eq!(visible_after, visible_before);
+        let mut files_after = std::fs::read_dir(&backup_dir)
+            .map_err(|e| AppError::io(&backup_dir, e))?
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.file_name())
+            .collect::<Vec<_>>();
+        files_after.sort();
+        assert_eq!(
+            files_after, files_before,
+            "failed publish must not leave either a visible backup or a temporary file"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
     fn restore_with_retain_one_keeps_source_and_exact_safety_snapshot() -> Result<(), AppError> {
         let _test_home = TestHomeGuard::new();
         let _settings = SettingsGuard::with_backup_retain_count(1);
@@ -2181,6 +2259,9 @@ mod tests {
             .expect("backup should have a filename")
             .to_string_lossy()
             .into_owned();
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        let stale_path = backup_dir.join("stale-unprotected.db");
+        std::fs::write(&stale_path, b"stale").map_err(|e| AppError::io(&stale_path, e))?;
 
         {
             let conn = crate::database::lock_conn!(db.conn);
@@ -2193,7 +2274,6 @@ mod tests {
         }
 
         let safety_id = db.restore_from_backup(&source_filename)?;
-        let backup_dir = crate::config::get_app_config_dir().join("backups");
         let safety_path = backup_dir.join(format!("{safety_id}.db"));
         assert!(
             source_path.exists(),
@@ -2202,6 +2282,10 @@ mod tests {
         assert!(
             safety_path.exists(),
             "pre-restore safety backup must be retained"
+        );
+        assert!(
+            !stale_path.exists(),
+            "retention should still remove an unprotected stale backup"
         );
 
         let backup_count = std::fs::read_dir(&backup_dir)
@@ -2227,6 +2311,52 @@ mod tests {
         assert_eq!(
             safety_provider, "live-before-restore",
             "safety backup must exactly represent the live state being replaced"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn restore_rejects_corrupt_db_before_touching_live_database() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let db = Database::init()?;
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.execute("DELETE FROM providers", [])?;
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('live-provider', 'claude', 'Live Provider', '{}', '{}')",
+                [],
+            )?;
+        }
+
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        std::fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        let corrupt_path = backup_dir.join("corrupt.db");
+        std::fs::write(&corrupt_path, b"not a sqlite database")
+            .map_err(|e| AppError::io(&corrupt_path, e))?;
+        let mut backups_before = Database::list_backups()?
+            .into_iter()
+            .map(|entry| entry.filename)
+            .collect::<Vec<_>>();
+        backups_before.sort();
+
+        db.restore_from_backup("corrupt.db")
+            .expect_err("corrupt backup must be rejected");
+
+        let live_provider: String = {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.query_row("SELECT id FROM providers", [], |row| row.get(0))?
+        };
+        assert_eq!(live_provider, "live-provider");
+        let mut backups_after = Database::list_backups()?
+            .into_iter()
+            .map(|entry| entry.filename)
+            .collect::<Vec<_>>();
+        backups_after.sort();
+        assert_eq!(
+            backups_after, backups_before,
+            "failed staging must not create a safety backup"
         );
         Ok(())
     }

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -310,8 +310,54 @@ impl Database {
             }
         }
 
+        Self::restore_sqlite_sequences(source_conn, &tx, tables)?;
+
         tx.commit()
             .map_err(|e| AppError::Database(format!("提交恢复事务失败: {e}")))?;
+        Ok(())
+    }
+
+    fn restore_sqlite_sequences(
+        source_conn: &Connection,
+        target_conn: &Connection,
+        tables: &[&str],
+    ) -> Result<(), AppError> {
+        if !Self::table_exists(source_conn, "sqlite_sequence")?
+            || !Self::table_exists(target_conn, "sqlite_sequence")?
+        {
+            return Ok(());
+        }
+
+        let mut source_stmt = source_conn
+            .prepare(
+                "SELECT seq FROM sqlite_sequence
+                 WHERE name = ?1 ORDER BY rowid DESC LIMIT 1",
+            )
+            .map_err(|e| AppError::Database(format!("读取 AUTOINCREMENT 序列失败: {e}")))?;
+        for table in tables {
+            target_conn
+                .execute("DELETE FROM sqlite_sequence WHERE name = ?1", [*table])
+                .map_err(|e| {
+                    AppError::Database(format!("清理表 {table} 的 AUTOINCREMENT 序列失败: {e}"))
+                })?;
+
+            let mut rows = source_stmt
+                .query([*table])
+                .map_err(|e| AppError::Database(format!("查询表 {table} 序列失败: {e}")))?;
+            if let Some(row) = rows.next().map_err(|e| AppError::Database(e.to_string()))? {
+                let sequence = row
+                    .get::<_, rusqlite::types::Value>(0)
+                    .map_err(|e| AppError::Database(format!("解析表 {table} 序列失败: {e}")))?;
+                target_conn
+                    .execute(
+                        "INSERT INTO sqlite_sequence (name, seq) VALUES (?1, ?2)",
+                        rusqlite::params![table, sequence],
+                    )
+                    .map_err(|e| {
+                        AppError::Database(format!("恢复表 {table} 的 AUTOINCREMENT 序列失败: {e}"))
+                    })?;
+            }
+        }
         Ok(())
     }
 
@@ -590,6 +636,8 @@ impl Database {
             }
         }
 
+        Self::dump_sqlite_sequences(conn, skip_tables, &mut output)?;
+
         // Triggers must be created after loading table data so they cannot
         // change dump rows or abandon the remainder of a multi-row INSERT.
         for sql in triggers {
@@ -599,6 +647,51 @@ impl Database {
 
         output.push_str("COMMIT;\nPRAGMA foreign_keys=ON;\n");
         Ok(output)
+    }
+
+    fn dump_sqlite_sequences(
+        conn: &Connection,
+        skip_tables: &[&str],
+        output: &mut String,
+    ) -> Result<(), AppError> {
+        if !Self::table_exists(conn, "sqlite_sequence")? {
+            return Ok(());
+        }
+
+        let mut stmt = conn
+            .prepare("SELECT name, seq FROM sqlite_sequence ORDER BY name")
+            .map_err(|e| AppError::Database(format!("读取 AUTOINCREMENT 序列失败: {e}")))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| AppError::Database(format!("查询 AUTOINCREMENT 序列失败: {e}")))?;
+        let mut values = Vec::new();
+        while let Some(row) = rows.next().map_err(|e| AppError::Database(e.to_string()))? {
+            let table: String = row
+                .get(0)
+                .map_err(|e| AppError::Database(format!("解析 AUTOINCREMENT 表名失败: {e}")))?;
+            if skip_tables.iter().any(|skipped| *skipped == table) {
+                continue;
+            }
+            let sequence = row
+                .get_ref(1)
+                .map_err(|e| AppError::Database(format!("解析表 {table} 序列失败: {e}")))?;
+            values.push(format!(
+                "({}, {})",
+                Self::format_sql_value(ValueRef::Text(table.as_bytes()))?,
+                Self::format_sql_value(sequence)?
+            ));
+        }
+
+        // Data INSERTs update sqlite_sequence to MAX(rowid), which loses a
+        // deleted high-water mark. Replace those derived values with the exact
+        // source metadata after all user-table rows have been loaded.
+        output.push_str("DELETE FROM sqlite_sequence;\n");
+        if !values.is_empty() {
+            output.push_str("INSERT INTO sqlite_sequence (name, seq) VALUES ");
+            output.push_str(&values.join(","));
+            output.push_str(";\n");
+        }
+        Ok(())
     }
 
     fn quote_identifier(identifier: &str) -> String {
@@ -1336,6 +1429,74 @@ mod tests {
         let (storage_class, negative_infinity) = real_value("negative-infinity")?;
         assert_eq!(storage_class, "real");
         assert_eq!(negative_infinity, f64::NEG_INFINITY);
+        Ok(())
+    }
+
+    #[test]
+    fn dump_sql_preserves_autoincrement_high_water_marks() -> Result<(), AppError> {
+        let source = Connection::open_in_memory()?;
+        source.execute_batch(
+            "CREATE TABLE autoincrement_rows (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 value TEXT NOT NULL
+             );
+             INSERT INTO autoincrement_rows (value) VALUES ('one'), ('two'), ('deleted-high');
+             DELETE FROM autoincrement_rows WHERE id = 3;",
+        )?;
+
+        let sql = Database::dump_sql(&source, &[])?;
+        let target = Connection::open_in_memory()?;
+        target.execute_batch(&sql)?;
+
+        let sequence: i64 = target.query_row(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'autoincrement_rows'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(sequence, 3, "已删除的最高 ID 仍应保留在序列高水位中");
+        target.execute(
+            "INSERT INTO autoincrement_rows (value) VALUES ('after-restore')",
+            [],
+        )?;
+        assert_eq!(target.last_insert_rowid(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn sync_style_restore_preserves_local_autoincrement_high_water_marks() -> Result<(), AppError> {
+        let source = Connection::open_in_memory()?;
+        source.execute_batch(
+            "CREATE TABLE autoincrement_rows (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 value TEXT NOT NULL
+             );
+             INSERT INTO autoincrement_rows (value) VALUES ('one'), ('two'), ('deleted-high');
+             DELETE FROM autoincrement_rows WHERE id = 3;",
+        )?;
+
+        // A sync dump skips device-local rows and their sequence metadata.
+        let staged_sql = Database::dump_sql(&source, &["autoincrement_rows"])?;
+        let target = Connection::open_in_memory()?;
+        target.execute_batch(&staged_sql)?;
+        let staged_sequence_count: i64 = target.query_row(
+            "SELECT COUNT(*) FROM sqlite_sequence WHERE name = 'autoincrement_rows'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(staged_sequence_count, 0);
+
+        Database::restore_tables(&source, &target, &["autoincrement_rows"])?;
+        let restored_sequence: i64 = target.query_row(
+            "SELECT seq FROM sqlite_sequence WHERE name = 'autoincrement_rows'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(restored_sequence, 3);
+        target.execute(
+            "INSERT INTO autoincrement_rows (value) VALUES ('after-sync')",
+            [],
+        )?;
+        assert_eq!(target.last_insert_rowid(), 4);
         Ok(())
     }
 

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -627,23 +627,54 @@ impl Database {
         match value {
             ValueRef::Null => Ok("NULL".to_string()),
             ValueRef::Integer(i) => Ok(i.to_string()),
-            ValueRef::Real(f) => Ok(f.to_string()),
-            ValueRef::Text(t) => {
-                let text = std::str::from_utf8(t)
-                    .map_err(|e| AppError::Database(format!("文本字段不是有效的 UTF-8: {e}")))?;
-                let escaped = text.replace('\'', "''");
-                Ok(format!("'{escaped}'"))
-            }
-            ValueRef::Blob(bytes) => {
-                let mut s = String::from("X'");
-                for b in bytes {
-                    use std::fmt::Write;
-                    let _ = write!(&mut s, "{b:02X}");
+            ValueRef::Real(f) => Ok(Self::format_sql_real(f)),
+            ValueRef::Text(t) => match std::str::from_utf8(t) {
+                // SQLite's SQL parser treats NUL as the end of the statement.
+                // Keep readable literals for normal UTF-8, and use a hex cast
+                // whenever a TEXT value cannot safely appear in SQL source.
+                Ok(text) if !text.contains('\0') => {
+                    let escaped = text.replace('\'', "''");
+                    Ok(format!("'{escaped}'"))
                 }
-                s.push('\'');
-                Ok(s)
-            }
+                _ => Ok(format!("CAST({} AS TEXT)", Self::format_sql_blob(t))),
+            },
+            ValueRef::Blob(bytes) => Ok(Self::format_sql_blob(bytes)),
         }
+    }
+
+    fn format_sql_real(value: f64) -> String {
+        if value.is_nan() {
+            // SQLite normalizes bound NaN values to NULL as well.
+            return "NULL".to_string();
+        }
+        if value.is_infinite() {
+            return if value.is_sign_negative() {
+                "-9.0e999".to_string()
+            } else {
+                "9.0e999".to_string()
+            };
+        }
+        if value == 0.0 && value.is_sign_negative() {
+            return "-0.0".to_string();
+        }
+
+        let mut literal = value.to_string();
+        if !literal.contains(['.', 'e', 'E']) {
+            // Without a decimal point/exponent SQLite stores integer-valued
+            // REALs as INTEGER in columns without REAL affinity (e.g. STRICT ANY).
+            literal.push_str(".0");
+        }
+        literal
+    }
+
+    fn format_sql_blob(bytes: &[u8]) -> String {
+        let mut s = String::from("X'");
+        for b in bytes {
+            use std::fmt::Write;
+            let _ = write!(&mut s, "{b:02X}");
+        }
+        s.push('\'');
+        s
     }
 
     /// List all database backup files, sorted by creation time (newest first)
@@ -1237,6 +1268,74 @@ mod tests {
                 "ordinary-tail".to_string()
             )
         );
+        Ok(())
+    }
+
+    #[test]
+    fn dump_sql_preserves_text_bytes_and_real_storage_class() -> Result<(), AppError> {
+        let source = Connection::open_in_memory()?;
+        source.execute_batch(
+            "CREATE TABLE scalar_values (
+                 label TEXT PRIMARY KEY,
+                 value ANY
+             ) STRICT;
+             INSERT INTO scalar_values VALUES ('nul-text', CAST(X'610062' AS TEXT));
+             INSERT INTO scalar_values VALUES ('invalid-text', CAST(X'80FF' AS TEXT));",
+        )?;
+        for (label, value) in [
+            ("real-one", 1.0),
+            ("negative-zero", -0.0),
+            ("positive-infinity", f64::INFINITY),
+            ("negative-infinity", f64::NEG_INFINITY),
+        ] {
+            source.execute(
+                "INSERT INTO scalar_values (label, value) VALUES (?1, ?2)",
+                rusqlite::params![label, value],
+            )?;
+        }
+
+        let sql = Database::dump_sql(&source, &[])?;
+        assert!(
+            sql.contains("CAST(X'610062' AS TEXT)") && sql.contains("CAST(X'80FF' AS TEXT)"),
+            "含 NUL 或非法 UTF-8 的 TEXT 必须使用十六进制表达式"
+        );
+
+        let target = Connection::open_in_memory()?;
+        target.execute_batch(&sql)?;
+
+        for (label, expected_hex) in [("nul-text", "610062"), ("invalid-text", "80FF")] {
+            let (storage_class, bytes): (String, String) = target.query_row(
+                "SELECT typeof(value), hex(value) FROM scalar_values WHERE label = ?1",
+                [label],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )?;
+            assert_eq!(storage_class, "text");
+            assert_eq!(bytes, expected_hex);
+        }
+
+        let real_value = |label: &str| -> Result<(String, f64), rusqlite::Error> {
+            target.query_row(
+                "SELECT typeof(value), value FROM scalar_values WHERE label = ?1",
+                [label],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+        };
+        let (storage_class, one) = real_value("real-one")?;
+        assert_eq!(storage_class, "real");
+        assert_eq!(one, 1.0);
+
+        let (storage_class, negative_zero) = real_value("negative-zero")?;
+        assert_eq!(storage_class, "real");
+        assert_eq!(negative_zero, 0.0);
+        assert!(negative_zero.is_sign_negative());
+
+        let (storage_class, positive_infinity) = real_value("positive-infinity")?;
+        assert_eq!(storage_class, "real");
+        assert_eq!(positive_infinity, f64::INFINITY);
+
+        let (storage_class, negative_infinity) = real_value("negative-infinity")?;
+        assert_eq!(storage_class, "real");
+        assert_eq!(negative_infinity, f64::NEG_INFINITY);
         Ok(())
     }
 

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -188,10 +188,13 @@ impl Database {
         );
         batch_result.map_err(|e| AppError::Database(format!("执行 SQL 导入失败: {e}")))?;
 
-        // 补齐缺失表/索引并进行基础校验
+        // Validate the schema produced by the input itself before migrations
+        // can create missing tables and accidentally make a truncated file look valid.
+        Self::validate_imported_schema(&temp_conn)?;
+
+        // 补齐缺失表/索引并执行迁移
         Self::create_tables_on_conn(&temp_conn)?;
         Self::apply_schema_migrations_on_conn(&temp_conn)?;
-        Self::validate_basic_state(&temp_conn)?;
         if let Some(local_snapshot) = local_snapshot.as_ref() {
             Self::restore_tables(local_snapshot, &temp_conn, preserve_tables)?;
         }
@@ -495,18 +498,35 @@ impl Database {
         Ok(())
     }
 
-    /// 基础状态校验
-    fn validate_basic_state(conn: &Connection) -> Result<(), AppError> {
-        let provider_count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM providers", [], |row| row.get(0))
-            .map_err(|e| AppError::Database(e.to_string()))?;
-        let mcp_count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM mcp_servers", [], |row| row.get(0))
-            .map_err(|e| AppError::Database(e.to_string()))?;
+    /// Validate that the external SQL created a recognizable CC Switch schema.
+    ///
+    /// These tables all existed in the oldest supported SQL-export schema
+    /// (v3.8.x). Checking before migrations keeps header-only/truncated files
+    /// from being completed by `create_tables_on_conn`, while allowing a valid
+    /// backup whose user-owned configuration tables happen to contain no rows.
+    fn validate_imported_schema(conn: &Connection) -> Result<(), AppError> {
+        const REQUIRED_TABLES: &[&str] = &[
+            "providers",
+            "provider_endpoints",
+            "mcp_servers",
+            "prompts",
+            "skills",
+            "skill_repos",
+            "settings",
+        ];
 
-        if provider_count == 0 && mcp_count == 0 {
-            return Err(AppError::Config(
-                "导入的 SQL 未包含有效的供应商或 MCP 数据".to_string(),
+        let mut missing = Vec::new();
+        for table in REQUIRED_TABLES {
+            if !Self::table_exists(conn, table)? {
+                missing.push(*table);
+            }
+        }
+        if !missing.is_empty() {
+            let names = missing.join(", ");
+            return Err(AppError::localized(
+                "backup.sql.invalid_schema",
+                format!("导入的 SQL 缺少 CC Switch 必需表：{names}"),
+                format!("The imported SQL is missing required CC Switch tables: {names}"),
             ));
         }
         Ok(())
@@ -1067,6 +1087,94 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(name, "Provider One");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn import_accepts_genuine_export_without_provider_or_mcp_rows() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let source = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(source.conn);
+            let counts: (i64, i64) = conn.query_row(
+                "SELECT
+                    (SELECT COUNT(*) FROM providers),
+                    (SELECT COUNT(*) FROM mcp_servers)",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )?;
+            assert_eq!(counts, (0, 0));
+            conn.execute(
+                "INSERT INTO settings (key, value) VALUES ('empty-export-marker', 'kept')",
+                [],
+            )?;
+        }
+        let sql = source.export_sql_string()?;
+
+        let target = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(target.conn);
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('target-sentinel', 'claude', 'Must Be Cleared', '{}', '{}')",
+                [],
+            )?;
+        }
+        target.import_sql_string(&sql)?;
+
+        let conn = crate::database::lock_conn!(target.conn);
+        let counts: (i64, i64) = conn.query_row(
+            "SELECT
+                (SELECT COUNT(*) FROM providers),
+                (SELECT COUNT(*) FROM mcp_servers)",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(counts, (0, 0));
+        let marker: String = conn.query_row(
+            "SELECT value FROM settings WHERE key = 'empty-export-marker'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(marker, "kept");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn import_rejects_header_only_sql_and_keeps_existing_database() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let target = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(target.conn);
+            conn.execute(
+                "INSERT INTO providers (id, app_type, name, settings_config, meta)
+                 VALUES ('sentinel', 'claude', 'Existing Provider', '{}', '{}')",
+                [],
+            )?;
+        }
+
+        let header_only = format!(
+            "{}\nPRAGMA foreign_keys=OFF;\nBEGIN TRANSACTION;\nCOMMIT;\n",
+            super::CC_SWITCH_SQL_EXPORT_HEADER
+        );
+        let error = target
+            .import_sql_string(&header_only)
+            .expect_err("缺少原始 schema 的文件必须被拒绝");
+        assert!(
+            error.to_string().contains("required CC Switch tables")
+                || error.to_string().contains("CC Switch 必需表"),
+            "应由原始 schema 校验拒绝，实际错误: {error}"
+        );
+
+        let conn = crate::database::lock_conn!(target.conn);
+        let provider: (i64, String) = conn.query_row(
+            "SELECT COUNT(*), MIN(name) FROM providers WHERE id = 'sentinel'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(provider, (1, "Existing Provider".into()));
         Ok(())
     }
 

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -2923,7 +2923,7 @@ impl Database {
         Self::ensure_model_pricing_seeded_on_conn(&conn)
     }
 
-    fn ensure_model_pricing_seeded_on_conn(conn: &Connection) -> Result<(), AppError> {
+    pub(crate) fn ensure_model_pricing_seeded_on_conn(conn: &Connection) -> Result<(), AppError> {
         // 每次启动都执行 INSERT OR IGNORE，增量追加新模型；仅修复仍等于旧内置值的定价。
         Self::seed_model_pricing(conn)?;
         Self::repair_current_model_pricing(conn)


### PR DESCRIPTION
## Summary / 概述

This is the first layer of the follow-up audit after #6122.

- Preserve SQLite `auto_vacuum`, TEXT byte/storage semantics, REAL values, and `sqlite_sequence` AUTOINCREMENT high-water marks across SQL export/import.
- Accept genuine schema-complete empty exports while rejecting header-only, truncated-transaction, cross-file, and otherwise unsafe SQL without touching the live database.
- Publish database snapshots through hidden temporary files with no-clobber retry, keep restore source/safety snapshots protected during retention, reject corrupt/future-schema snapshots before replacement, and serialize backup-directory operations inside the process.
- Add focused regression coverage for legacy/current SQL formats, failure atomicity, filename collisions, retention, rename/delete races, and exact pre-restore safety snapshots.

Backup-directory coordination is process-local and relies on CC Switch's existing single-instance runtime invariant. Concurrent destructive operations from external tools or another process remain out of scope.

## Related Issue / 关联 Issue

Refs #6129

Follow-up to #6122. Dependent Draft: #6147.

## Screenshots / 截图

Not applicable — Rust backend and tests only.

## Verification / 验证

- `cargo fmt --check`
- `cargo clippy --lib -- -D warnings`
- `cargo test --lib database::backup::tests -- --test-threads=1` — 34 passed, 2 ignored performance harnesses
- `cargo test --test import_export_sync -- --test-threads=1` — 26 passed

## Checklist / 检查清单

- [x] `pnpm typecheck` not applicable (Rust-only diff)
- [x] `pnpm format:check` not applicable (Rust-only diff)
- [x] `cargo clippy` passes (Rust code changed)
- [x] No user-facing text or i18n changes