### PR TITLE
fix(skills): 区分 ZIP 导入冲突与无 Skill 错误

### DIFF
--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -9,7 +9,7 @@ use crate::error::format_skill_error;
 use crate::services::skill::{
     DiscoverableSkill, ImportSkillSelection, MigrationResult, Skill, SkillBackupEntry, SkillRepo,
     SkillService, SkillStorageLocation, SkillUninstallResult, SkillUpdateInfo,
-    SkillsShSearchResult,
+    SkillsShSearchResult, ZipSkillInstallResult,
 };
 use crate::store::AppState;
 use std::str::FromStr;
@@ -332,7 +332,7 @@ pub fn install_skills_from_zip(
     file_path: String,
     current_app: String,
     app_state: State<'_, AppState>,
-) -> Result<Vec<InstalledSkill>, String> {
+) -> Result<ZipSkillInstallResult, String> {
     let app_type = parse_app_type(&current_app)?;
     let path = std::path::Path::new(&file_path);
 

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -195,6 +195,39 @@ pub struct MigrationResult {
     pub errors: Vec<String>,
 }
 
+/// ZIP 安装时跳过 Skill 的原因。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ZipSkillSkipReason {
+    /// 同名目录已由 CC Switch 管理。
+    ManagedConflict,
+    /// 当前 SSOT 中存在未纳管的同名路径。
+    StorageConflict,
+    /// 当前应用的 Skills 目录中存在未纳管的同名路径。
+    AppDirectoryConflict,
+    /// ZIP 内多个 Skill 会安装到同一个目录。
+    DuplicateInArchive,
+}
+
+/// ZIP 安装时因冲突被跳过的 Skill。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZipSkillSkippedItem {
+    pub directory: String,
+    pub name: String,
+    pub reason: ZipSkillSkipReason,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub existing_skill_id: Option<String>,
+}
+
+/// ZIP 安装结果，区分实际安装项与因冲突跳过的项。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ZipSkillInstallResult {
+    pub installed: Vec<InstalledSkill>,
+    pub skipped: Vec<ZipSkillSkippedItem>,
+}
+
 // ========== skills.sh API 类型 ==========
 
 /// skills.sh API 原始响应
@@ -3053,7 +3086,7 @@ impl SkillService {
         db: &Arc<Database>,
         zip_path: &Path,
         current_app: &AppType,
-    ) -> Result<Vec<InstalledSkill>> {
+    ) -> Result<ZipSkillInstallResult> {
         // 解压到临时目录
         let temp_guard = Self::extract_local_zip(zip_path)?;
         let temp_dir = temp_guard.path();
@@ -3070,12 +3103,20 @@ impl SkillService {
         }
 
         let ssot_dir = Self::get_ssot_dir()?;
-        let mut installed = Vec::new();
         let existing_skills = db.get_all_installed_skills()?;
         let zip_stem = zip_path
             .file_stem()
             .and_then(|s| s.to_str())
             .map(|s| s.to_string());
+
+        struct ZipCandidate {
+            source: PathBuf,
+            directory: String,
+            name: String,
+            description: Option<String>,
+        }
+
+        let mut candidates = Vec::with_capacity(skill_dirs.len());
 
         for skill_dir in skill_dirs {
             // 解析元数据（提前解析，用于确定安装名）
@@ -3125,20 +3166,6 @@ impl SkillService {
                 }
             };
 
-            // 检查是否已有同名 directory 的 skill
-            let conflict = existing_skills
-                .values()
-                .find(|s| s.directory.eq_ignore_ascii_case(&install_name));
-
-            if let Some(existing) = conflict {
-                log::warn!(
-                    "Skill directory '{}' already exists (from {}), skipping",
-                    install_name,
-                    existing.id
-                );
-                continue;
-            }
-
             let (name, description) = match meta {
                 Some(m) => (
                     m.name.unwrap_or_else(|| install_name.clone()),
@@ -3147,22 +3174,144 @@ impl SkillService {
                 None => (install_name.clone(), None),
             };
 
-            // 复制到 SSOT
-            let dest = ssot_dir.join(&install_name);
-            if dest.exists() {
-                let _ = fs::remove_dir_all(&dest);
+            candidates.push(ZipCandidate {
+                source: skill_dir,
+                directory: install_name,
+                name,
+                description,
+            });
+        }
+
+        let mut directory_counts: HashMap<String, usize> = HashMap::new();
+        for candidate in &candidates {
+            *directory_counts
+                .entry(candidate.directory.to_lowercase())
+                .or_default() += 1;
+        }
+
+        let app_dir = if matches!(current_app, AppType::ClaudeDesktop) {
+            None
+        } else {
+            Some(Self::get_app_skills_dir(current_app)?)
+        };
+        let should_sync = app_dir
+            .as_ref()
+            .is_some_and(|directory| directory != &ssot_dir);
+
+        let mut installable = Vec::new();
+        let mut skipped = Vec::new();
+
+        for candidate in candidates {
+            let normalized = candidate.directory.to_lowercase();
+            let skip = if directory_counts.get(&normalized).copied().unwrap_or(0) > 1 {
+                Some((ZipSkillSkipReason::DuplicateInArchive, None))
+            } else if let Some(existing) = existing_skills.values().find(|skill| {
+                skill.directory.eq_ignore_ascii_case(&candidate.directory)
+                    || skill
+                        .id
+                        .eq_ignore_ascii_case(&format!("local:{}", candidate.directory))
+            }) {
+                Some((
+                    ZipSkillSkipReason::ManagedConflict,
+                    Some(existing.id.clone()),
+                ))
+            } else if Self::find_case_insensitive_entry(&ssot_dir, &candidate.directory)?.is_some()
+            {
+                Some((ZipSkillSkipReason::StorageConflict, None))
+            } else if should_sync
+                && Self::find_case_insensitive_entry(
+                    app_dir
+                        .as_ref()
+                        .expect("syncable app must have a directory"),
+                    &candidate.directory,
+                )?
+                .is_some()
+            {
+                Some((ZipSkillSkipReason::AppDirectoryConflict, None))
+            } else {
+                None
+            };
+
+            if let Some((reason, existing_skill_id)) = skip {
+                log::warn!(
+                    "Skipping ZIP Skill directory '{}' because of {:?}",
+                    candidate.directory,
+                    reason
+                );
+                skipped.push(ZipSkillSkippedItem {
+                    directory: candidate.directory,
+                    name: candidate.name,
+                    reason,
+                    existing_skill_id,
+                });
+            } else {
+                installable.push(candidate);
             }
-            Self::copy_dir_recursive(&skill_dir, &dest)?;
+        }
+
+        let mut installed = Vec::with_capacity(installable.len());
+
+        for candidate in installable {
+            let staging_prefix = format!(
+                ".{}.install-",
+                Self::sanitize_backup_segment(&candidate.directory)
+            );
+            let staging_guard = tempfile::Builder::new()
+                .prefix(&staging_prefix)
+                .tempdir_in(&ssot_dir)
+                .context("创建 ZIP Skill 临时安装目录失败")?;
+            let staging = staging_guard.path();
+            let dest = ssot_dir.join(&candidate.directory);
+
+            Self::copy_dir_recursive(&candidate.source, staging)?;
+
+            // 复制期间目录状态可能发生变化；落盘前再次检查，避免覆盖新出现的路径。
+            if Self::find_case_insensitive_entry(&ssot_dir, &candidate.directory)?.is_some() {
+                skipped.push(ZipSkillSkippedItem {
+                    directory: candidate.directory,
+                    name: candidate.name,
+                    reason: ZipSkillSkipReason::StorageConflict,
+                    existing_skill_id: None,
+                });
+                continue;
+            }
+
+            if should_sync
+                && Self::find_case_insensitive_entry(
+                    app_dir
+                        .as_ref()
+                        .expect("syncable app must have a directory"),
+                    &candidate.directory,
+                )?
+                .is_some()
+            {
+                skipped.push(ZipSkillSkippedItem {
+                    directory: candidate.directory,
+                    name: candidate.name,
+                    reason: ZipSkillSkipReason::AppDirectoryConflict,
+                    existing_skill_id: None,
+                });
+                continue;
+            }
+
+            fs::rename(staging, &dest).with_context(|| {
+                format!(
+                    "移动 ZIP Skill 到 SSOT 失败: {} -> {}",
+                    staging.display(),
+                    dest.display()
+                )
+            })?;
+            drop(staging_guard);
 
             // 计算内容哈希
             let content_hash = Self::compute_dir_hash(&dest).ok();
 
             // 创建 InstalledSkill 记录
             let skill = InstalledSkill {
-                id: format!("local:{install_name}"),
-                name,
-                description,
-                directory: install_name.clone(),
+                id: format!("local:{}", candidate.directory),
+                name: candidate.name,
+                description: candidate.description,
+                directory: candidate.directory.clone(),
                 repo_owner: None,
                 repo_name: None,
                 repo_branch: None,
@@ -3174,10 +3323,19 @@ impl SkillService {
             };
 
             // 保存到数据库
-            db.save_skill(&skill)?;
+            if let Err(err) = db.save_skill(&skill) {
+                let _ = Self::remove_path(&dest);
+                return Err(err.into());
+            }
 
             // 同步到当前应用目录
-            Self::sync_to_app_dir(&install_name, current_app)?;
+            if should_sync {
+                if let Err(err) = Self::sync_to_app_dir(&candidate.directory, current_app) {
+                    let _ = db.delete_skill(&skill.id);
+                    let _ = Self::remove_path(&dest);
+                    return Err(err);
+                }
+            }
 
             log::info!(
                 "Skill {} installed from ZIP, enabled for {:?}",
@@ -3187,7 +3345,27 @@ impl SkillService {
             installed.push(skill);
         }
 
-        Ok(installed)
+        Ok(ZipSkillInstallResult { installed, skipped })
+    }
+
+    /// 在目录下查找大小写不敏感的同名路径，同时覆盖文件、目录和失效 symlink。
+    fn find_case_insensitive_entry(parent: &Path, name: &str) -> Result<Option<PathBuf>> {
+        if !parent.exists() {
+            return Ok(None);
+        }
+
+        for entry in fs::read_dir(parent)? {
+            let entry = entry?;
+            if entry
+                .file_name()
+                .to_string_lossy()
+                .eq_ignore_ascii_case(name)
+            {
+                return Ok(Some(entry.path()));
+            }
+        }
+
+        Ok(None)
     }
 
     /// 解压本地 ZIP 文件到临时目录
@@ -4218,6 +4396,59 @@ mod tests {
         }
     }
 
+    struct SkillSettingsGuard(crate::settings::AppSettings);
+    impl SkillSettingsGuard {
+        fn set(storage: SkillStorageLocation, sync_method: SyncMethod) -> Self {
+            let previous = crate::settings::get_settings();
+            let mut next = previous.clone();
+            next.skill_storage_location = storage;
+            next.skill_sync_method = sync_method;
+            crate::settings::update_settings(next).expect("set test Skill settings");
+            Self(previous)
+        }
+    }
+    impl Drop for SkillSettingsGuard {
+        fn drop(&mut self) {
+            let _ = crate::settings::update_settings(self.0.clone());
+        }
+    }
+
+    fn set_test_skill_settings(storage: SkillStorageLocation, sync_method: SyncMethod) {
+        let mut settings = crate::settings::get_settings();
+        settings.skill_storage_location = storage;
+        settings.skill_sync_method = sync_method;
+        crate::settings::update_settings(settings).expect("update test Skill settings");
+    }
+
+    fn write_skill_zip(zip_path: &Path, skills: &[(&str, &str)]) {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+
+        let file = fs::File::create(zip_path).expect("create Skill ZIP");
+        let mut archive = zip::ZipWriter::new(file);
+        let options = SimpleFileOptions::default();
+
+        if skills.is_empty() {
+            archive
+                .start_file("README.md", options)
+                .expect("start README");
+            archive.write_all(b"not a skill").expect("write README");
+        } else {
+            for (directory, name) in skills {
+                archive
+                    .start_file(format!("{directory}/SKILL.md"), options)
+                    .expect("start SKILL.md");
+                archive
+                    .write_all(
+                        format!("---\nname: {name}\ndescription: ZIP test skill\n---\n").as_bytes(),
+                    )
+                    .expect("write SKILL.md");
+            }
+        }
+
+        archive.finish().expect("finish Skill ZIP");
+    }
+
     fn poisoned_skill(id: &str, directory: &str) -> InstalledSkill {
         InstalledSkill {
             id: id.to_string(),
@@ -4724,5 +4955,229 @@ mod tests {
             SkillService::doc_path_for_source(temp.path(), std::path::Path::new("/elsewhere")),
             None
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn install_from_zip_reports_managed_conflict_without_touching_existing_files() {
+        let temp = tempdir().expect("tempdir");
+        let _home_guard = TestHomeGuard::set(temp.path());
+        let _settings_guard =
+            SkillSettingsGuard::set(SkillStorageLocation::CcSwitch, SyncMethod::Copy);
+        let db = Arc::new(Database::memory().expect("memory db"));
+
+        let ssot_dir = SkillService::get_ssot_dir().expect("SSOT");
+        let existing_dir = ssot_dir.join("Case-Skill");
+        write_skill(&existing_dir, "Existing Skill");
+        fs::write(existing_dir.join("marker.txt"), "keep storage").expect("write marker");
+
+        let app_dir = SkillService::get_app_skills_dir(&AppType::Claude).expect("app dir");
+        let existing_app_dir = app_dir.join("Case-Skill");
+        write_skill(&existing_app_dir, "Existing App Skill");
+        fs::write(existing_app_dir.join("marker.txt"), "keep app").expect("write app marker");
+
+        let mut existing = poisoned_skill("local:Case-Skill", "Case-Skill");
+        existing.name = "Existing Skill".to_string();
+        existing.apps = SkillApps::only(&AppType::Claude);
+        db.save_skill(&existing).expect("seed managed Skill");
+
+        let zip_path = temp.path().join("managed-conflict.zip");
+        write_skill_zip(&zip_path, &[("case-skill", "Replacement Skill")]);
+
+        let result = SkillService::install_from_zip(&db, &zip_path, &AppType::Claude)
+            .expect("conflict should be reported as a result");
+
+        assert!(result.installed.is_empty());
+        assert_eq!(result.skipped.len(), 1);
+        assert_eq!(
+            result.skipped[0].reason,
+            ZipSkillSkipReason::ManagedConflict
+        );
+        assert_eq!(
+            result.skipped[0].existing_skill_id.as_deref(),
+            Some("local:Case-Skill")
+        );
+        assert_eq!(
+            fs::read_to_string(existing_dir.join("marker.txt")).expect("read marker"),
+            "keep storage"
+        );
+        assert_eq!(
+            fs::read_to_string(existing_app_dir.join("marker.txt")).expect("read app marker"),
+            "keep app"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn install_from_zip_preserves_unmanaged_storage_in_both_storage_modes() {
+        let temp = tempdir().expect("tempdir");
+        let _home_guard = TestHomeGuard::set(temp.path());
+        let _settings_guard =
+            SkillSettingsGuard::set(SkillStorageLocation::CcSwitch, SyncMethod::Copy);
+
+        for (storage, directory) in [
+            (SkillStorageLocation::CcSwitch, "cc-switch-orphan"),
+            (SkillStorageLocation::Unified, "agents-orphan"),
+        ] {
+            set_test_skill_settings(storage, SyncMethod::Copy);
+            let db = Arc::new(Database::memory().expect("memory db"));
+            let ssot_dir = SkillService::get_ssot_dir().expect("SSOT");
+            let orphan = ssot_dir.join(directory);
+            write_skill(&orphan, "Unmanaged Skill");
+            fs::write(orphan.join("marker.txt"), "keep unmanaged").expect("write marker");
+
+            let zip_path = temp.path().join(format!("{directory}.zip"));
+            write_skill_zip(&zip_path, &[(directory, "ZIP Skill")]);
+
+            let result = SkillService::install_from_zip(&db, &zip_path, &AppType::ClaudeDesktop)
+                .expect("storage conflict result");
+
+            assert!(result.installed.is_empty());
+            assert_eq!(result.skipped.len(), 1);
+            assert_eq!(
+                result.skipped[0].reason,
+                ZipSkillSkipReason::StorageConflict
+            );
+            assert_eq!(
+                fs::read_to_string(orphan.join("marker.txt")).expect("read marker"),
+                "keep unmanaged"
+            );
+            assert!(db
+                .get_all_installed_skills()
+                .expect("query Skills")
+                .is_empty());
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn install_from_zip_preserves_app_directory_for_copy_and_symlink_modes() {
+        let temp = tempdir().expect("tempdir");
+        let _home_guard = TestHomeGuard::set(temp.path());
+        let _settings_guard =
+            SkillSettingsGuard::set(SkillStorageLocation::CcSwitch, SyncMethod::Copy);
+
+        for (sync_method, directory) in [
+            (SyncMethod::Copy, "copy-conflict"),
+            (SyncMethod::Symlink, "symlink-conflict"),
+        ] {
+            set_test_skill_settings(SkillStorageLocation::CcSwitch, sync_method);
+            let db = Arc::new(Database::memory().expect("memory db"));
+            let ssot_dir = SkillService::get_ssot_dir().expect("SSOT");
+            let app_dir = SkillService::get_app_skills_dir(&AppType::Claude).expect("app dir");
+            let occupied = app_dir.join(directory);
+            write_skill(&occupied, "Existing App Skill");
+            fs::write(occupied.join("marker.txt"), "keep app").expect("write marker");
+
+            let zip_path = temp.path().join(format!("{directory}.zip"));
+            write_skill_zip(&zip_path, &[(directory, "ZIP Skill")]);
+
+            let result = SkillService::install_from_zip(&db, &zip_path, &AppType::Claude)
+                .expect("app conflict result");
+
+            assert!(result.installed.is_empty());
+            assert_eq!(result.skipped.len(), 1);
+            assert_eq!(
+                result.skipped[0].reason,
+                ZipSkillSkipReason::AppDirectoryConflict
+            );
+            assert!(!ssot_dir.join(directory).exists());
+            assert_eq!(
+                fs::read_to_string(occupied.join("marker.txt")).expect("read marker"),
+                "keep app"
+            );
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn install_from_zip_installs_non_conflicting_items_and_reports_skipped_items() {
+        let temp = tempdir().expect("tempdir");
+        let _home_guard = TestHomeGuard::set(temp.path());
+        let _settings_guard =
+            SkillSettingsGuard::set(SkillStorageLocation::CcSwitch, SyncMethod::Copy);
+        let db = Arc::new(Database::memory().expect("memory db"));
+
+        let ssot_dir = SkillService::get_ssot_dir().expect("SSOT");
+        write_skill(&ssot_dir.join("existing-skill"), "Existing Skill");
+        let existing = poisoned_skill("local:existing-skill", "existing-skill");
+        db.save_skill(&existing).expect("seed existing Skill");
+
+        let zip_path = temp.path().join("mixed.zip");
+        write_skill_zip(
+            &zip_path,
+            &[
+                ("existing-skill", "Existing Replacement"),
+                ("fresh-skill", "Fresh Skill"),
+            ],
+        );
+
+        let result = SkillService::install_from_zip(&db, &zip_path, &AppType::Claude)
+            .expect("mixed install result");
+
+        assert_eq!(result.installed.len(), 1);
+        assert_eq!(result.installed[0].directory, "fresh-skill");
+        assert_eq!(result.skipped.len(), 1);
+        assert_eq!(
+            result.skipped[0].reason,
+            ZipSkillSkipReason::ManagedConflict
+        );
+        assert!(ssot_dir.join("fresh-skill").join("SKILL.md").is_file());
+        assert!(SkillService::get_app_skills_dir(&AppType::Claude)
+            .expect("app dir")
+            .join("fresh-skill")
+            .join("SKILL.md")
+            .is_file());
+        assert_eq!(
+            db.get_all_installed_skills().expect("query Skills").len(),
+            2
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn install_from_zip_rejects_all_archive_entries_with_duplicate_install_names() {
+        let temp = tempdir().expect("tempdir");
+        let _home_guard = TestHomeGuard::set(temp.path());
+        let _settings_guard =
+            SkillSettingsGuard::set(SkillStorageLocation::CcSwitch, SyncMethod::Copy);
+        let db = Arc::new(Database::memory().expect("memory db"));
+
+        let zip_path = temp.path().join("duplicates.zip");
+        write_skill_zip(
+            &zip_path,
+            &[("first/shared", "First"), ("second/shared", "Second")],
+        );
+
+        let result = SkillService::install_from_zip(&db, &zip_path, &AppType::ClaudeDesktop)
+            .expect("duplicate result");
+
+        assert!(result.installed.is_empty());
+        assert_eq!(result.skipped.len(), 2);
+        assert!(result
+            .skipped
+            .iter()
+            .all(|item| item.reason == ZipSkillSkipReason::DuplicateInArchive));
+        assert!(!SkillService::get_ssot_dir()
+            .expect("SSOT")
+            .join("shared")
+            .exists());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn install_from_zip_keeps_no_skills_error_distinct_from_conflicts() {
+        let temp = tempdir().expect("tempdir");
+        let _home_guard = TestHomeGuard::set(temp.path());
+        let _settings_guard =
+            SkillSettingsGuard::set(SkillStorageLocation::CcSwitch, SyncMethod::Copy);
+        let db = Arc::new(Database::memory().expect("memory db"));
+        let zip_path = temp.path().join("no-skills.zip");
+        write_skill_zip(&zip_path, &[]);
+
+        let error = SkillService::install_from_zip(&db, &zip_path, &AppType::ClaudeDesktop)
+            .expect_err("ZIP without SKILL.md must fail");
+
+        assert!(error.to_string().contains("NO_SKILLS_IN_ZIP"));
     }
 }

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -371,28 +371,48 @@ const UnifiedSkillsPanel = React.forwardRef<
       const filePath = await skillsApi.openZipFileDialog();
       if (!filePath) return;
 
-      const installed = await installFromZipMutation.mutateAsync({
+      const result = await installFromZipMutation.mutateAsync({
         filePath,
         currentApp,
       });
+      const { installed, skipped } = result;
 
-      if (installed.length === 0) {
-        toast.info(t("skills.installFromZip.noSkillsFound"), {
-          closeButton: true,
-        });
-      } else if (installed.length === 1) {
+      if (installed.length === 1) {
         toast.success(
           t("skills.installFromZip.successSingle", {
             name: installed[0].name,
           }),
           { closeButton: true },
         );
-      } else {
+      } else if (installed.length > 1) {
         toast.success(
           t("skills.installFromZip.successMultiple", {
             count: installed.length,
           }),
           { closeButton: true },
+        );
+      }
+
+      if (skipped.length > 0) {
+        const visible = skipped.slice(0, 3).map((item) =>
+          t("skills.installFromZip.skippedItem", {
+            name: item.name,
+            reason: t(`skills.installFromZip.skipReasons.${item.reason}`),
+          }),
+        );
+        const remaining = skipped.length - visible.length;
+        if (remaining > 0) {
+          visible.push(
+            t("skills.installFromZip.skippedRemaining", { count: remaining }),
+          );
+        }
+
+        toast.warning(
+          t("skills.installFromZip.skipped", { count: skipped.length }),
+          {
+            description: visible.join("\n"),
+            closeButton: true,
+          },
         );
       }
     } catch (error) {

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -295,10 +295,10 @@ export function useInstallSkillsFromZip() {
       filePath: string;
       currentApp: AppId;
     }) => skillsApi.installFromZip(filePath, currentApp),
-    onSuccess: (installedSkills) => {
+    onSuccess: (result) => {
       queryClient.setQueryData<InstalledSkill[]>(
         ["skills", "installed"],
-        (oldData) => mergeImportedSkills(oldData, installedSkills),
+        (oldData) => mergeImportedSkills(oldData, result.installed),
       );
     },
     // A ZIP can install multiple Skills before a later item or config sync

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2435,7 +2435,16 @@
       "installing": "Installing...",
       "successSingle": "Skill {{name}} installed",
       "successMultiple": "Successfully installed {{count}} skills",
-      "noSkillsFound": "No skills found in ZIP file (requires SKILL.md file)"
+      "noSkillsFound": "No skills found in ZIP file (requires SKILL.md file)",
+      "skipped": "Skipped {{count}} conflicting skill(s)",
+      "skippedItem": "{{name}}: {{reason}}",
+      "skippedRemaining": "{{count}} more conflict(s)",
+      "skipReasons": {
+        "managed_conflict": "a skill with this directory is already managed by CC Switch",
+        "storage_conflict": "the primary storage already contains this path",
+        "app_directory_conflict": "the current app directory already contains this path",
+        "duplicate_in_archive": "the ZIP contains duplicate skill directory names"
+      }
     }
   },
   "deeplink": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2435,7 +2435,16 @@
       "installing": "インストール中...",
       "successSingle": "スキル {{name}} をインストールしました",
       "successMultiple": "{{count}} 件のスキルをインストールしました",
-      "noSkillsFound": "ZIP ファイルにスキルが見つかりません（SKILL.md が必要です）"
+      "noSkillsFound": "ZIP ファイルにスキルが見つかりません（SKILL.md が必要です）",
+      "skipped": "競合する {{count}} 件のスキルをスキップしました",
+      "skippedItem": "{{name}}：{{reason}}",
+      "skippedRemaining": "他 {{count}} 件の競合",
+      "skipReasons": {
+        "managed_conflict": "同名のスキルはすでに CC Switch で管理されています",
+        "storage_conflict": "プライマリストレージに同名のパスが存在します",
+        "app_directory_conflict": "現在のアプリディレクトリに同名のパスが存在します",
+        "duplicate_in_archive": "ZIP 内に重複するスキルディレクトリ名があります"
+      }
     }
   },
   "deeplink": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2436,7 +2436,16 @@
       "installing": "安裝中...",
       "successSingle": "技能 {{name}} 已安裝",
       "successMultiple": "成功安裝 {{count}} 個技能",
-      "noSkillsFound": "ZIP 檔案中未找到技能（需包含 SKILL.md 檔案）"
+      "noSkillsFound": "ZIP 檔案中未找到技能（需包含 SKILL.md 檔案）",
+      "skipped": "略過 {{count}} 個衝突技能",
+      "skippedItem": "{{name}}：{{reason}}",
+      "skippedRemaining": "另有 {{count}} 個衝突項目",
+      "skipReasons": {
+        "managed_conflict": "同名技能已由 CC Switch 管理",
+        "storage_conflict": "主要儲存目錄中已存在同名路徑",
+        "app_directory_conflict": "目前應用程式目錄中已存在同名路徑",
+        "duplicate_in_archive": "ZIP 內包含重複的技能目錄名稱"
+      }
     }
   },
   "deeplink": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2435,7 +2435,16 @@
       "installing": "安装中...",
       "successSingle": "技能 {{name}} 已安装",
       "successMultiple": "成功安装 {{count}} 个技能",
-      "noSkillsFound": "ZIP 文件中未找到技能（需包含 SKILL.md 文件）"
+      "noSkillsFound": "ZIP 文件中未找到技能（需包含 SKILL.md 文件）",
+      "skipped": "跳过 {{count}} 个冲突技能",
+      "skippedItem": "{{name}}：{{reason}}",
+      "skippedRemaining": "另有 {{count}} 个冲突项",
+      "skipReasons": {
+        "managed_conflict": "同名技能已由 CC Switch 管理",
+        "storage_conflict": "主存储目录中已存在同名路径",
+        "app_directory_conflict": "当前应用目录中已存在同名路径",
+        "duplicate_in_archive": "ZIP 内包含重复的技能目录名"
+      }
     }
   },
   "deeplink": {

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -40,6 +40,24 @@ export interface InstalledSkill {
   updatedAt: number;
 }
 
+export type ZipSkillSkipReason =
+  | "managed_conflict"
+  | "storage_conflict"
+  | "app_directory_conflict"
+  | "duplicate_in_archive";
+
+export interface ZipSkillSkippedItem {
+  directory: string;
+  name: string;
+  reason: ZipSkillSkipReason;
+  existingSkillId?: string;
+}
+
+export interface ZipSkillInstallResult {
+  installed: InstalledSkill[];
+  skipped: ZipSkillSkippedItem[];
+}
+
 export interface SkillUninstallResult {
   backupPath?: string;
 }
@@ -279,7 +297,7 @@ export const skillsApi = {
   async installFromZip(
     filePath: string,
     currentApp: AppId,
-  ): Promise<InstalledSkill[]> {
+  ): Promise<ZipSkillInstallResult> {
     return await invoke("install_skills_from_zip", { filePath, currentApp });
   },
 };

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -11,6 +11,7 @@ import type {
   SkillBackupEntry,
   SkillUpdateInfo,
 } from "@/lib/api/skills";
+import { skillsApi } from "@/lib/api/skills";
 
 const scanUnmanagedMock = vi.fn();
 const toggleSkillAppMock = vi.fn();
@@ -23,10 +24,14 @@ const bulkToggleSkillAppMock = vi.fn();
 const checkUpdatesMock = vi.fn();
 const updateSkillMock = vi.fn();
 const refetchSkillBackupsMock = vi.fn();
-const { toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
-  toastErrorMock: vi.fn(),
-  toastSuccessMock: vi.fn(),
-}));
+const { toastErrorMock, toastSuccessMock, toastWarningMock, toastInfoMock } =
+  vi.hoisted(() => ({
+    toastErrorMock: vi.fn(),
+    toastSuccessMock: vi.fn(),
+    toastWarningMock: vi.fn(),
+    toastInfoMock: vi.fn(),
+  }));
+const openZipFileDialogMock = vi.spyOn(skillsApi, "openZipFileDialog");
 let installedSkillsMock: InstalledSkill[] = [];
 let skillBackupsMock: SkillBackupEntry[] = [];
 let skillUpdatesMock: SkillUpdateInfo[] = [];
@@ -44,7 +49,8 @@ vi.mock("sonner", () => ({
   toast: {
     success: toastSuccessMock,
     error: toastErrorMock,
-    info: vi.fn(),
+    warning: toastWarningMock,
+    info: toastInfoMock,
   },
 }));
 
@@ -172,6 +178,10 @@ describe("UnifiedSkillsPanel", () => {
     bulkToggleSkillAppMock.mockResolvedValue({ succeeded: [], failed: [] });
     toastErrorMock.mockReset();
     toastSuccessMock.mockReset();
+    toastWarningMock.mockReset();
+    toastInfoMock.mockReset();
+    openZipFileDialogMock.mockReset();
+    openZipFileDialogMock.mockResolvedValue("C:\\skills.zip");
     uninstallSkillMock.mockReset();
     importSkillsMock.mockReset();
     installFromZipMock.mockReset();
@@ -184,6 +194,83 @@ describe("UnifiedSkillsPanel", () => {
     updateSkillMock.mockReset();
     updateSkillMock.mockImplementation(async (id: string) =>
       makeInstalledSkill({ id }),
+    );
+  });
+
+  it("reports a managed ZIP conflict instead of claiming the archive has no skills", async () => {
+    installFromZipMock.mockResolvedValue({
+      installed: [],
+      skipped: [
+        {
+          directory: "alpha-skill",
+          name: "Alpha Skill",
+          reason: "managed_conflict",
+          existingSkillId: "owner/repo:alpha-skill",
+        },
+      ],
+    });
+    const ref = createRef<UnifiedSkillsPanelHandle>();
+    render(
+      <UnifiedSkillsPanel
+        ref={ref}
+        onOpenDiscovery={() => {}}
+        currentApp="claude"
+      />,
+    );
+
+    await act(async () => {
+      await ref.current?.openInstallFromZip();
+    });
+
+    expect(installFromZipMock).toHaveBeenCalledWith({
+      filePath: "C:\\skills.zip",
+      currentApp: "claude",
+    });
+    expect(toastWarningMock).toHaveBeenCalledWith(
+      "skills.installFromZip.skipped",
+      {
+        description: "skills.installFromZip.skippedItem",
+        closeButton: true,
+      },
+    );
+    expect(toastInfoMock).not.toHaveBeenCalled();
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+  });
+
+  it("reports installed and skipped items separately for a mixed ZIP", async () => {
+    installFromZipMock.mockResolvedValue({
+      installed: [makeInstalledSkill({ id: "local:fresh", name: "Fresh" })],
+      skipped: [
+        {
+          directory: "alpha-skill",
+          name: "Alpha Skill",
+          reason: "storage_conflict",
+        },
+      ],
+    });
+    const ref = createRef<UnifiedSkillsPanelHandle>();
+    render(
+      <UnifiedSkillsPanel
+        ref={ref}
+        onOpenDiscovery={() => {}}
+        currentApp="claude"
+      />,
+    );
+
+    await act(async () => {
+      await ref.current?.openInstallFromZip();
+    });
+
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "skills.installFromZip.successSingle",
+      { closeButton: true },
+    );
+    expect(toastWarningMock).toHaveBeenCalledWith(
+      "skills.installFromZip.skipped",
+      {
+        description: "skills.installFromZip.skippedItem",
+        closeButton: true,
+      },
     );
   });
 

--- a/tests/hooks/useImportSkillsFromApps.test.tsx
+++ b/tests/hooks/useImportSkillsFromApps.test.tsx
@@ -172,7 +172,16 @@ describe("Skills install and import mutation hooks", () => {
     const last = makeSkill({ name: "Last ZIP Value" });
     const second = makeSkill({ id: "skill-b", name: "Skill B" });
     queryClient.setQueryData(["skills", "installed"], [stale]);
-    apiMocks.installFromZip.mockResolvedValueOnce([first, last, second]);
+    apiMocks.installFromZip.mockResolvedValueOnce({
+      installed: [first, last, second],
+      skipped: [
+        {
+          directory: "conflict",
+          name: "Conflict",
+          reason: "managed_conflict",
+        },
+      ],
+    });
     const { result } = renderHook(() => useInstallSkillsFromZip(), {
       wrapper: createWrapper(queryClient),
     });


### PR DESCRIPTION
## Summary / 概述

修复重复导入同名 Skill ZIP 时，错误提示为“ZIP 文件中未找到技能”的问题。

### 问题原因

已复现 #3749 描述的问题：

1. 第一次导入包含 `SKILL.md` 的 ZIP 时可以正常安装。
2. 再次导入同名 ZIP 时，后端检测到已存在的 Skill 后静默跳过。
3. 当 ZIP 中的所有 Skill 都被跳过时，后端返回空数组。
4. 前端将空数组统一解释为“ZIP 中没有 Skill”，因此显示了与实际原因不符的提示。

此外，原有逻辑在数据库中没有对应记录、但当前主存储目录已经存在同名路径时，会删除该路径后重新写入，可能覆盖未由 CC Switch 管理的内容。

### 修复方案

- 将 ZIP 安装结果调整为结构化返回值，分别返回实际安装成功的 `installed` 和因冲突跳过的 `skipped`。
- 区分已纳管 Skill、当前主存储路径、当前应用目录和 ZIP 内部重名四类冲突。
- ZIP 导入仅检查并写入当前选中的主存储目录，不访问另一个未启用的存储目录，也不会触发存储迁移。
- 冲突检测同时保护当前目标应用的 Skills 目录，兼容文件复制和软链接同步模式。
- 使用同一主存储下的临时目录完成复制，确认无冲突后再移动到正式位置。
- 数据库写入或应用同步失败时回滚本次安装，避免留下半成品。
- 前端分别显示安装成功提示和冲突跳过提示，只有实际安装成功的项目会写入缓存。
- ZIP 中确实没有 `SKILL.md` 时，仍保留原有的无 Skill 错误。
- 更新英文、简体中文、繁体中文和日文提示。

本次修复不会自动覆盖已有目录。冲突项采用安全跳过策略，避免误删 CC Switch 未纳管的 Skill；覆盖或更新应通过单独的用户确认流程实现。

## Related Issue / 关联 Issue

Fixes #3749

## Reproduction and Verification / 复现与验证

修复前已复现：首次导入正常，再次导入同名 ZIP 时错误显示“ZIP 文件中未找到技能”。

修复后验证了以下场景：

- 大小写不同的已纳管 Skill 冲突。
- 两种主存储设置下存在未纳管同名目录；每次导入只操作当前选中的主存储。
- 文件复制和软链接模式下，当前应用目录存在同名内容。
- 同一 ZIP 同时包含可安装项和冲突项。
- ZIP 内多个 Skill 解析为相同安装目录。
- ZIP 中确实不存在 `SKILL.md`。

验证结果：

- `cargo test --lib services::skill::tests`：45 passed
- ZIP 导入新增场景：6 passed
- `cargo clippy --lib -- -D warnings`
- `pnpm typecheck`
- 相关组件及 Hook 测试：40 passed
- `pnpm build:renderer`
- `pnpm format:check`
- `git diff --check`

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
