### PR TITLE
fix(proxy): flatten Responses tool schemas for strict Chat gateways

### DIFF
--- a/PR_DRAFT_01_6101.md
+++ b/PR_DRAFT_01_6101.md
@@ -1,0 +1,17 @@
+# PR draft: #6101
+
+## Title
+
+fix(proxy): flatten Responses tool schemas for strict Chat gateways
+
+## Summary
+
+Strict Chat Completions gateways can reject Responses tool schemas that still contain root `oneOf`, `$defs`, or other unsupported JSON Schema metadata. The transform expands local `$ref` definitions, flattens union branches into the tool's object properties, keeps fields required by every union branch, and removes unsupported root keywords. It also avoids walking an already expanded schema a second time.
+
+## Validation
+
+- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
+- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
+- `cargo test --manifest-path src-tauri/Cargo.toml --lib transform_codex_chat`
+
+Submission status: the independent branch is pushed to `KDB-Wind/cc-switch`; this draft targets `farion1231/cc-switch`.

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -314,7 +314,26 @@ pub fn responses_to_chat_completions_with_reasoning(
 
     let tools = tool_context.chat_tools();
     if !tools.is_empty() {
-        result["tools"] = json!(tools);
+        // The shared tool context preserves native JSON Schema shapes so
+        // Anthropic and other upstreams keep `oneOf`/`$defs`. Strict Chat
+        // Completions gateways need root combinators flattened and local
+        // references inlined, so harden each tool only on this path.
+        let chat_tools: Vec<Value> = tools
+            .iter()
+            .map(|tool| {
+                let mut tool = tool.clone();
+                if let Some(function) = tool.get_mut("function").and_then(Value::as_object_mut) {
+                    if let Some(parameters) = function.get("parameters").cloned() {
+                        function.insert(
+                            "parameters".to_string(),
+                            harden_chat_function_parameters(parameters),
+                        );
+                    }
+                }
+                tool
+            })
+            .collect();
+        result["tools"] = json!(chat_tools);
     }
 
     if let Some(tool_choice) = body.get("tool_choice") {
@@ -1294,12 +1313,95 @@ fn inline_local_schema_refs(value: &Value, root: &Value, stack: &mut Vec<String>
     }
 }
 
+/// Flatten combinators nested inside a union branch. Generated schemas often
+/// express a branch through `allOf` (inherited types); without this, the root
+/// flattening finds no direct `properties` and silently discards the branch.
+fn flatten_branch_combinators(branch: Value) -> Value {
+    let Value::Object(mut obj) = branch else {
+        return branch;
+    };
+    let mut properties = match obj.remove("properties") {
+        Some(Value::Object(properties)) => properties,
+        _ => Map::new(),
+    };
+    let mut required = Vec::new();
+    let mut has_combinator = false;
+
+    for key in ["oneOf", "anyOf", "allOf"] {
+        let Some(values) = obj.remove(key).and_then(|value| value.as_array().cloned()) else {
+            continue;
+        };
+        has_combinator = true;
+        let mut union_required = Vec::new();
+        for member in values {
+            let member = flatten_branch_combinators(member);
+            if let Some(member_properties) = member.get("properties").and_then(Value::as_object) {
+                for (name, value) in member_properties {
+                    properties
+                        .entry(name.clone())
+                        .or_insert_with(|| value.clone());
+                }
+            }
+            if key == "allOf" {
+                append_unique(&mut required, schema_required_fields(&member));
+            } else {
+                union_required.push(schema_required_fields(&member));
+            }
+        }
+        if key != "allOf" {
+            // A nested union can require only fields common to every member;
+            // branch-specific requirements would reject valid arguments.
+            if let Some(first) = union_required.first() {
+                let common = first
+                    .iter()
+                    .filter(|name| {
+                        union_required
+                            .iter()
+                            .all(|fields| fields.iter().any(|field| field == *name))
+                    })
+                    .cloned();
+                append_unique(&mut required, common);
+            }
+        }
+    }
+
+    if !properties.is_empty() {
+        obj.insert("properties".to_string(), Value::Object(properties));
+    }
+    if has_combinator && !required.is_empty() {
+        obj.insert(
+            "required".to_string(),
+            Value::Array(required.into_iter().map(Value::String).collect()),
+        );
+    }
+    Value::Object(obj)
+}
+
+/// Recursively scan for local JSON Schema references that survive inlining.
+/// Recursive or mutually recursive schemas keep their innermost `$ref`, so the
+/// definitions it points to must be retained for the schema to stay valid.
+fn schema_has_local_refs(value: &Value) -> bool {
+    match value {
+        Value::Object(object) => {
+            if object
+                .get("$ref")
+                .and_then(Value::as_str)
+                .is_some_and(|reference| reference.starts_with("#/"))
+            {
+                return true;
+            }
+            object.values().any(schema_has_local_refs)
+        }
+        Value::Array(array) => array.iter().any(schema_has_local_refs),
+        _ => false,
+    }
+}
+
 /// Flatten root-level JSON Schema unions into an object schema accepted by
 /// strict Chat Completions providers. The original Responses tool contract is
 /// flat (arguments are not wrapped), so branch properties are merged directly
 /// instead of being nested under a synthetic `value` field.
 fn flatten_root_schema_combinators(schema: &mut Map<String, Value>) {
-    let root = Value::Object(schema.clone());
     let mut branches = Vec::new();
     let mut all_of_required = Vec::new();
     let mut union_required = Vec::new();
@@ -1322,7 +1424,13 @@ fn flatten_root_schema_combinators(schema: &mut Map<String, Value>) {
 
         for branch in values {
             if branch.is_object() {
-                let branch = inline_local_schema_refs(branch, &root, &mut Vec::new());
+                // Branches were already inlined against the full schema by the
+                // caller (`harden_chat_function_parameters`); re-inlining with
+                // a fresh stack would expand recursive refs one extra level.
+                // A resolved branch may itself be expressed through combinators
+                // (inherited types via `allOf`); merge those before collecting
+                // properties so the branch is not silently dropped.
+                let branch = flatten_branch_combinators(branch.clone());
                 let required = schema_required_fields(&branch);
                 if key == "allOf" {
                     append_unique(&mut all_of_required, required);
@@ -1354,12 +1462,17 @@ fn flatten_root_schema_combinators(schema: &mut Map<String, Value>) {
         }
     }
     schema.insert("properties".to_string(), Value::Object(properties));
-    // Local references have been expanded above. These metadata definitions
-    // are not part of the flat Chat Completions function contract and can be
-    // rejected as unsupported root keywords by strict gateways.
-    schema.remove("$schema");
-    schema.remove("$defs");
-    schema.remove("definitions");
+    // Local references have been expanded above. These metadata definitions are
+    // not part of the flat Chat Completions function contract and can be
+    // rejected as unsupported root keywords by strict gateways. Recursive or
+    // mutually recursive schemas keep their innermost `$ref` intact though, so
+    // retain the definitions while any local reference survives; removing them
+    // would leave a dangling `$ref` in the forwarded tool schema.
+    if !schema_has_local_refs(&Value::Object(schema.clone())) {
+        schema.remove("$schema");
+        schema.remove("$defs");
+        schema.remove("definitions");
+    }
 
     let mut required = schema_required_fields(&Value::Object(schema.clone()));
     if has_all_of {
@@ -1395,22 +1508,46 @@ fn flatten_root_schema_combinators(schema: &mut Map<String, Value>) {
 ///
 /// Some Responses tools carry `parameters: null` or `parameters: {"type": null}`,
 /// but OpenAI Chat Completions strictly requires `{"type": "object", "properties": {...}}`.
+/// This runs on the shared tool context, so it must stay shape-preserving:
+/// combinator flattening is applied only on the Chat Completions emission path
+/// (see `harden_chat_function_parameters`) where strict gateways require it.
 fn normalize_function_parameters(params: Option<&Value>) -> Value {
     let mut params = match params {
         Some(Value::Object(obj)) => Value::Object(obj.clone()),
         _ => json!({"type": "object", "properties": {}}),
     };
+    if let Some(obj) = params.as_object_mut() {
+        match obj.get("type").and_then(|v| v.as_str()) {
+            Some("object") => {}
+            _ => {
+                obj.insert("type".to_string(), json!("object"));
+            }
+        }
+    }
+    params
+}
+
+/// Harden tool parameters for strict Chat Completions gateways.
+///
+/// Databricks and some OpenAI-compatible gateways reject root combinators and
+/// scalar constraints in a function schema. Inline local references, flatten
+/// unions while preserving the tool's flat argument names, then drop root
+/// keywords those upstreams do not support. Only the Chat Completions path
+/// calls this; Anthropic upstreams keep their native `oneOf`/`$defs` shapes.
+fn harden_chat_function_parameters(parameters: Value) -> Value {
+    let mut params = match parameters {
+        Value::Object(obj) => Value::Object(obj),
+        _ => json!({"type": "object", "properties": {}}),
+    };
     let root = params.clone();
     params = inline_local_schema_refs(&params, &root, &mut Vec::new());
     if let Some(obj) = params.as_object_mut() {
-        // Databricks and some OpenAI-compatible gateways reject combinators and
-        // scalar constraints at the root of a function schema. Flatten unions
-        // while preserving the tool's flat argument names.
         flatten_root_schema_combinators(obj);
+        // Recursive schemas keep their innermost `$ref`; retain the definitions
+        // they point to instead of leaving a dangling reference.
+        let keep_defs = schema_has_local_refs(&Value::Object(obj.clone()));
         for key in [
             "$schema",
-            "$defs",
-            "definitions",
             "$id",
             "$anchor",
             "$comment",
@@ -1425,6 +1562,10 @@ fn normalize_function_parameters(params: Option<&Value>) -> Value {
             "patternProperties",
         ] {
             obj.remove(key);
+        }
+        if !keep_defs {
+            obj.remove("$defs");
+            obj.remove("definitions");
         }
         match obj.get("type").and_then(|v| v.as_str()) {
             Some("object") => {}
@@ -2629,6 +2770,98 @@ mod tests {
         assert!(parameters.get("$defs").is_none());
         assert!(parameters.get("$schema").is_none());
         assert!(parameters.get("required").is_none());
+    }
+
+    #[test]
+    fn responses_request_to_chat_flattens_all_of_inside_union_branches() {
+        // A resolved union branch may itself be expressed through `allOf`
+        // (inherited types). Its properties must be collected instead of the
+        // branch being silently discarded when the root combinator is removed.
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "lookup",
+                "parameters": {
+                    "oneOf": [
+                        {
+                            "allOf": [
+                                {
+                                    "type": "object",
+                                    "properties": {"id": {"type": "string"}}
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {"mode": {"type": "string"}}
+                                }
+                            ]
+                        },
+                        {
+                            "type": "object",
+                            "properties": {"slug": {"type": "string"}}
+                        }
+                    ]
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let parameters = &result["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["type"], "object");
+        assert_eq!(
+            parameters["properties"],
+            json!({
+                "id": {"type": "string"},
+                "mode": {"type": "string"},
+                "slug": {"type": "string"}
+            })
+        );
+        assert!(parameters.get("oneOf").is_none());
+        assert!(parameters.get("allOf").is_none());
+    }
+
+    #[test]
+    fn responses_request_to_chat_keeps_defs_for_recursive_schema_refs() {
+        // Recursive schemas keep their innermost `$ref` intact after inlining;
+        // the definitions it points to must survive so the forwarded schema has
+        // no dangling local reference.
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "walk",
+                "parameters": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "oneOf": [
+                        { "$ref": "#/$defs/node" },
+                        { "type": "object", "properties": { "root": { "type": "string" } } }
+                    ],
+                    "$defs": {
+                        "node": {
+                            "type": "object",
+                            "properties": {
+                                "name": { "type": "string" },
+                                "next": { "$ref": "#/$defs/node" }
+                            }
+                        }
+                    }
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let parameters = &result["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["type"], "object");
+        assert!(parameters.get("oneOf").is_none());
+        assert!(
+            parameters.get("$defs").is_some(),
+            "recursive $defs must be kept"
+        );
+        assert!(parameters["properties"]["next"]["$ref"].is_string());
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -22,7 +22,7 @@ use crate::proxy::{
         TOOL_RESULT_MEDIA_MOVED_MARKER,
     },
 };
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use std::collections::{HashMap, HashSet};
 
 const EXTRA_CHAT_PASSTHROUGH_FIELDS: &[&str] = &[
@@ -1212,6 +1212,185 @@ fn serialize_tool_definition_for_description(tool: &Value) -> String {
     canonical_json_string(tool)
 }
 
+fn schema_required_fields(schema: &Value) -> Vec<String> {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(ToString::to_string)
+        .collect()
+}
+
+fn append_unique(values: &mut Vec<String>, additions: impl IntoIterator<Item = String>) {
+    for value in additions {
+        if !values.iter().any(|existing| existing == &value) {
+            values.push(value);
+        }
+    }
+}
+
+fn resolve_local_schema_ref<'a>(root: &'a Value, reference: &str) -> Option<&'a Value> {
+    let mut current = root;
+    let path = reference.strip_prefix("#/")?;
+    for raw_token in path.split('/') {
+        let token = raw_token.replace("~1", "/").replace("~0", "~");
+        current = match current {
+            Value::Object(object) => object.get(&token)?,
+            Value::Array(array) => array.get(token.parse::<usize>().ok()?)?,
+            _ => return None,
+        };
+    }
+    Some(current)
+}
+
+/// Inline local JSON Schema references before removing `$defs`/`definitions`.
+/// Codex tool schemas commonly put the branches of a root `oneOf` there, while
+/// strict Chat Completions gateways do not reliably support those references.
+fn inline_local_schema_refs(value: &Value, root: &Value, stack: &mut Vec<String>) -> Value {
+    match value {
+        Value::Object(object) => {
+            if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+                if !stack.iter().any(|item| item == reference) {
+                    if let Some(target) = resolve_local_schema_ref(root, reference) {
+                        stack.push(reference.to_string());
+                        let mut resolved = inline_local_schema_refs(target, root, stack);
+                        stack.pop();
+
+                        if let Value::Object(resolved_object) = &mut resolved {
+                            for (key, value) in object {
+                                if key != "$ref" {
+                                    resolved_object.insert(
+                                        key.clone(),
+                                        inline_local_schema_refs(value, root, stack),
+                                    );
+                                }
+                            }
+                            // The referenced target and every override value have
+                            // already been expanded above. Re-walking the merged
+                            // object here only repeats the same work and can make
+                            // deeply nested schemas unnecessarily expensive.
+                            return resolved;
+                        }
+                    }
+                }
+            }
+
+            Value::Object(
+                object
+                    .iter()
+                    .map(|(key, value)| (key.clone(), inline_local_schema_refs(value, root, stack)))
+                    .collect(),
+            )
+        }
+        Value::Array(array) => Value::Array(
+            array
+                .iter()
+                .map(|value| inline_local_schema_refs(value, root, stack))
+                .collect(),
+        ),
+        _ => value.clone(),
+    }
+}
+
+/// Flatten root-level JSON Schema unions into an object schema accepted by
+/// strict Chat Completions providers. The original Responses tool contract is
+/// flat (arguments are not wrapped), so branch properties are merged directly
+/// instead of being nested under a synthetic `value` field.
+fn flatten_root_schema_combinators(schema: &mut Map<String, Value>) {
+    let root = Value::Object(schema.clone());
+    let mut branches = Vec::new();
+    let mut all_of_required = Vec::new();
+    let mut union_required = Vec::new();
+    let mut has_all_of = false;
+    let mut has_union = false;
+
+    for key in ["oneOf", "anyOf", "allOf"] {
+        let Some(value) = schema.remove(key) else {
+            continue;
+        };
+        let Some(values) = value.as_array() else {
+            continue;
+        };
+
+        if key == "allOf" {
+            has_all_of = true;
+        } else {
+            has_union = true;
+        }
+
+        for branch in values {
+            if branch.is_object() {
+                let branch = inline_local_schema_refs(branch, &root, &mut Vec::new());
+                let required = schema_required_fields(&branch);
+                if key == "allOf" {
+                    append_unique(&mut all_of_required, required);
+                } else {
+                    union_required.push(required);
+                }
+                branches.push(branch);
+            }
+        }
+    }
+
+    if branches.is_empty() {
+        return;
+    }
+
+    let mut properties = match schema.remove("properties") {
+        Some(Value::Object(properties)) => properties,
+        _ => Map::new(),
+    };
+    for branch in branches {
+        if let Some(branch_properties) = branch.get("properties").and_then(Value::as_object) {
+            for (name, value) in branch_properties {
+                // Keep an explicitly supplied root property and the first
+                // branch definition when union branches disagree.
+                properties
+                    .entry(name.clone())
+                    .or_insert_with(|| value.clone());
+            }
+        }
+    }
+    schema.insert("properties".to_string(), Value::Object(properties));
+    // Local references have been expanded above. These metadata definitions
+    // are not part of the flat Chat Completions function contract and can be
+    // rejected as unsupported root keywords by strict gateways.
+    schema.remove("$schema");
+    schema.remove("$defs");
+    schema.remove("definitions");
+
+    let mut required = schema_required_fields(&Value::Object(schema.clone()));
+    if has_all_of {
+        append_unique(&mut required, all_of_required);
+    } else if has_union {
+        // A union can require only fields common to every branch. Requiring a
+        // branch-specific field would make the flattened schema reject valid
+        // arguments for the other branch; omitting non-common requirements is
+        // the safe compatibility fallback.
+        if let Some(first) = union_required.first() {
+            let common = first
+                .iter()
+                .filter(|name| {
+                    union_required
+                        .iter()
+                        .all(|required| required.iter().any(|item| item == *name))
+                })
+                .cloned();
+            append_unique(&mut required, common);
+        }
+    }
+    if required.is_empty() {
+        schema.remove("required");
+    } else {
+        schema.insert(
+            "required".to_string(),
+            Value::Array(required.into_iter().map(Value::String).collect()),
+        );
+    }
+}
+
 /// Normalize a function's `parameters` JSON Schema so `type` is always `"object"`.
 ///
 /// Some Responses tools carry `parameters: null` or `parameters: {"type": null}`,
@@ -1221,7 +1400,32 @@ fn normalize_function_parameters(params: Option<&Value>) -> Value {
         Some(Value::Object(obj)) => Value::Object(obj.clone()),
         _ => json!({"type": "object", "properties": {}}),
     };
+    let root = params.clone();
+    params = inline_local_schema_refs(&params, &root, &mut Vec::new());
     if let Some(obj) = params.as_object_mut() {
+        // Databricks and some OpenAI-compatible gateways reject combinators and
+        // scalar constraints at the root of a function schema. Flatten unions
+        // while preserving the tool's flat argument names.
+        flatten_root_schema_combinators(obj);
+        for key in [
+            "$schema",
+            "$defs",
+            "definitions",
+            "$id",
+            "$anchor",
+            "$comment",
+            "enum",
+            "const",
+            "not",
+            "if",
+            "then",
+            "else",
+            "prefixItems",
+            "pattern",
+            "patternProperties",
+        ] {
+            obj.remove(key);
+        }
         match obj.get("type").and_then(|v| v.as_str()) {
             Some("object") => {}
             _ => {
@@ -2312,7 +2516,7 @@ mod tests {
     }
 
     #[test]
-    fn responses_request_to_chat_defaults_top_level_one_of_tool_parameters_to_object() {
+    fn responses_request_to_chat_flattens_top_level_one_of_tool_parameters() {
         let input = json!({
             "model": "gpt-5.4",
             "tools": [{
@@ -2339,18 +2543,121 @@ mod tests {
 
         assert_eq!(parameters["type"], "object");
         assert_eq!(
-            parameters["oneOf"],
-            json!([
-                {
-                    "type": "object",
-                    "properties": {"id": {"type": "string"}}
-                },
-                {
-                    "type": "object",
-                    "properties": {"slug": {"type": "string"}}
-                }
-            ])
+            parameters["properties"],
+            json!({
+                "id": {"type": "string"},
+                "slug": {"type": "string"}
+            })
         );
+        assert!(parameters.get("oneOf").is_none());
+    }
+
+    #[test]
+    fn responses_request_to_chat_keeps_only_common_union_required_fields() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "lookup",
+                "parameters": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {"id": {"type": "string"}},
+                            "required": ["id"]
+                        },
+                        {
+                            "type": "object",
+                            "properties": {"slug": {"type": "string"}},
+                            "required": ["slug"]
+                        }
+                    ]
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let parameters = &result["tools"][0]["function"]["parameters"];
+
+        assert!(parameters.get("required").is_none());
+        assert!(parameters.get("oneOf").is_none());
+    }
+
+    #[test]
+    fn responses_request_to_chat_inlines_defs_before_flattening_tool_union() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "automation_update",
+                "parameters": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "oneOf": [
+                        { "$ref": "#/$defs/update_by_id" },
+                        { "$ref": "#/$defs/update_by_slug" }
+                    ],
+                    "$defs": {
+                        "update_by_id": {
+                            "type": "object",
+                            "properties": { "id": { "type": "string" } },
+                            "required": ["id"]
+                        },
+                        "update_by_slug": {
+                            "type": "object",
+                            "properties": { "slug": { "type": "string" } },
+                            "required": ["slug"]
+                        }
+                    }
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let parameters = &result["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["type"], "object");
+        assert_eq!(
+            parameters["properties"],
+            json!({
+                "id": { "type": "string" },
+                "slug": { "type": "string" }
+            })
+        );
+        assert!(parameters.get("oneOf").is_none());
+        assert!(parameters.get("$defs").is_none());
+        assert!(parameters.get("$schema").is_none());
+        assert!(parameters.get("required").is_none());
+    }
+
+    #[test]
+    fn responses_request_to_chat_removes_strictly_unsupported_root_constraints() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "lookup",
+                "parameters": {
+                    "type": "string",
+                    "$id": "https://example.com/lookup",
+                    "$anchor": "lookup",
+                    "$comment": "unsupported root metadata",
+                    "enum": ["id", "slug"],
+                    "const": "id",
+                    "not": {"type": "null"}
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let parameters = &result["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["type"], "object");
+        for key in ["$id", "$anchor", "$comment", "enum", "const", "not"] {
+            assert!(parameters.get(key).is_none(), "unexpected root key: {key}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
# PR draft: #6101

## Title

fix(proxy): flatten Responses tool schemas for strict Chat gateways

## Summary

Strict Chat Completions gateways can reject Responses tool schemas that still contain root `oneOf`, `$defs`, or other unsupported JSON Schema metadata. The transform expands local `$ref` definitions, flattens union branches into the tool's object properties, keeps fields required by every union branch, and removes unsupported root keywords. It also avoids walking an already expanded schema a second time.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib transform_codex_chat`

Submission status: the independent branch is pushed to `KDB-Wind/cc-switch`; this draft targets `farion1231/cc-switch`.
