### PR TITLE
fix(tray): preserve automatic failover when switching providers

### DIFF
--- a/PR_DRAFT_03_6022.md
+++ b/PR_DRAFT_03_6022.md
@@ -1,0 +1,20 @@
+# PR draft: #6022
+
+## Title
+
+fix(proxy): honor the selected provider before failover fallback
+
+## Summary
+
+Switching providers from the tray now keeps the stored `auto_failover_enabled` value instead of turning automatic failover off.
+
+When automatic failover is enabled, the proxy now tries the selected provider first, then follows the configured failover queue. A provider already in the queue is skipped after the first attempt, and an unavailable current provider still falls back to the next available queue entry. The switch does not change the queue itself.
+
+## Validation
+
+- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
+- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::provider_router` (7 passed)
+- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
+- `cargo test --manifest-path src-tauri/Cargo.toml --lib` (2312 passed; 2 Windows symlink tests could not run because the process lacked privilege 1314)
+
+Submission status: the independent branch targets `farion1231/cc-switch`. The updated commit is local and has not been pushed.

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -7,7 +7,7 @@ use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
 use crate::proxy::circuit_breaker::{AllowResult, CircuitBreaker, CircuitBreakerConfig};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -33,7 +33,7 @@ impl ProviderRouter {
     ///
     /// 返回按优先级排序的可用供应商列表：
     /// - 故障转移关闭时：仅返回当前供应商
-    /// - 故障转移开启时：仅使用故障转移队列，按队列顺序依次尝试（P1 → P2 → ...）
+    /// - 故障转移开启时：当前供应商优先，其后按故障转移队列顺序依次尝试
     pub async fn select_providers(&self, app_type: &str) -> Result<Vec<Provider>, AppError> {
         let mut result = Vec::new();
         let mut total_providers = 0usize;
@@ -49,20 +49,46 @@ impl ProviderRouter {
         };
 
         if auto_failover_enabled {
-            // 故障转移开启：仅按队列顺序依次尝试（P1 → P2 → ...）
+            // 故障转移开启：先尝试当前供应商，再按队列顺序依次回退。
+            // 托盘切换不会修改故障转移队列，因此当前供应商可能不在队列中。
             let all_providers = self.db.get_all_providers(app_type)?;
 
             // 使用 DAO 返回的排序结果，确保和前端展示一致
-            let ordered_ids: Vec<String> = self
+            let queued_ids: Vec<String> = self
                 .db
                 .get_failover_queue(app_type)?
                 .into_iter()
                 .map(|item| item.provider_id)
                 .collect();
 
-            total_providers = ordered_ids.len();
+            let current_id = AppType::from_str(app_type)
+                .ok()
+                .and_then(|app_enum| {
+                    crate::settings::get_effective_current_provider(&self.db, &app_enum)
+                        .ok()
+                        .flatten()
+                })
+                .or_else(|| self.db.get_current_provider(app_type).ok().flatten());
 
-            for provider_id in ordered_ids {
+            let mut candidate_ids = Vec::with_capacity(queued_ids.len() + 1);
+            let mut seen_provider_ids = HashSet::with_capacity(queued_ids.len() + 1);
+
+            if let Some(current_id) = current_id {
+                if all_providers.contains_key(&current_id) {
+                    seen_provider_ids.insert(current_id.clone());
+                    candidate_ids.push(current_id);
+                }
+            }
+
+            for provider_id in queued_ids {
+                if seen_provider_ids.insert(provider_id.clone()) {
+                    candidate_ids.push(provider_id);
+                }
+            }
+
+            total_providers = candidate_ids.len();
+
+            for provider_id in candidate_ids {
                 let Some(provider) = all_providers.get(&provider_id).cloned() else {
                     continue;
                 };
@@ -362,7 +388,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn test_failover_enabled_uses_queue_order_ignoring_current() {
+    async fn test_failover_enabled_uses_current_before_queue_and_deduplicates_it() {
         let _home = TempHome::new();
         let db = Arc::new(Database::memory().unwrap());
 
@@ -390,14 +416,14 @@ mod tests {
         let providers = router.select_providers("claude").await.unwrap();
 
         assert_eq!(providers.len(), 2);
-        // 故障转移开启时：仅按队列顺序选择（忽略当前供应商）
-        assert_eq!(providers[0].id, "b");
-        assert_eq!(providers[1].id, "a");
+        // 当前供应商优先，即使它在队列的较后位置，也不能被重复尝试。
+        assert_eq!(providers[0].id, "a");
+        assert_eq!(providers[1].id, "b");
     }
 
     #[tokio::test]
     #[serial]
-    async fn test_failover_enabled_uses_queue_only_even_if_current_not_in_queue() {
+    async fn test_failover_enabled_uses_current_before_queue_when_not_in_queue() {
         let _home = TempHome::new();
         let db = Arc::new(Database::memory().unwrap());
 
@@ -419,6 +445,46 @@ mod tests {
         db.update_proxy_config_for_app(config).await.unwrap();
 
         let router = ProviderRouter::new(db.clone());
+        let providers = router.select_providers("claude").await.unwrap();
+
+        assert_eq!(providers.len(), 2);
+        assert_eq!(providers[0].id, "a");
+        assert_eq!(providers[1].id, "b");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_failover_enabled_skips_circuit_open_current_and_uses_queue() {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().unwrap());
+
+        let provider_a =
+            Provider::with_id("a".to_string(), "Provider A".to_string(), json!({}), None);
+        let provider_b =
+            Provider::with_id("b".to_string(), "Provider B".to_string(), json!({}), None);
+
+        db.save_provider("claude", &provider_a).unwrap();
+        db.save_provider("claude", &provider_b).unwrap();
+        db.set_current_provider("claude", "a").unwrap();
+        db.add_to_failover_queue("claude", "b").unwrap();
+
+        db.update_circuit_breaker_config(&CircuitBreakerConfig {
+            failure_threshold: 1,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+        let mut config = db.get_proxy_config_for_app("claude").await.unwrap();
+        config.auto_failover_enabled = true;
+        db.update_proxy_config_for_app(config).await.unwrap();
+
+        let router = ProviderRouter::new(db.clone());
+        router
+            .record_result("a", "claude", false, false, Some("fail".to_string()))
+            .await
+            .unwrap();
+
         let providers = router.select_providers("claude").await.unwrap();
 
         assert_eq!(providers.len(), 1);

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -601,11 +601,15 @@ fn handle_provider_click(
     if let Some(app_state) = app.try_state::<AppState>() {
         let app_type_str = app_type.as_str();
 
-        // 获取当前 proxy 状态，保持 enabled 不变，只关闭 auto_failover
-        let (proxy_enabled, _) = app_state.db.get_proxy_flags_sync(app_type_str);
+        // 获取当前 proxy 状态。手动切换供应商不应改变用户配置的
+        // auto_failover_enabled；故障转移队列和托盘 provider 切换是两个独立操作。
+        let (proxy_enabled, auto_failover_enabled) =
+            app_state.db.get_proxy_flags_sync(app_type_str);
+        // Persist the pair before switching. The synchronous setter also refreshes
+        // updated_at, so this intentionally is not removed as a no-op write.
         app_state
             .db
-            .set_proxy_flags_sync(app_type_str, proxy_enabled, false)?;
+            .set_proxy_flags_sync(app_type_str, proxy_enabled, auto_failover_enabled)?;
 
         // 切换供应商。需要本地路由的供应商也不在这里自动启动代理，
         // 由用户在页面/设置中手动开启。
@@ -622,7 +626,7 @@ fn handle_provider_click(
         let event_data = serde_json::json!({
             "appType": app_type_str,
             "proxyEnabled": proxy_enabled,
-            "autoFailoverEnabled": false,
+            "autoFailoverEnabled": auto_failover_enabled,
             "providerId": provider_id
         });
         if let Err(e) = app.emit("proxy-flags-changed", event_data.clone()) {


### PR DESCRIPTION
# PR draft: #6022

## Title

fix(tray): preserve automatic failover when switching providers

## Summary

Switching providers from the tray now preserves the stored `auto_failover_enabled` value. The flag pair is written back before the switch, which also refreshes its `updated_at` timestamp. The tray event reports the stored value instead of a false disabled state. Manual provider switching and automatic failover remain separate operations.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- Rust library tests covering proxy and tray behavior

Submission status: the independent branch is pushed to `KDB-Wind/cc-switch`; this draft targets `farion1231/cc-switch`.
