### PR TITLE
fix(codex): follow provider model after switch

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -497,6 +497,14 @@ pub struct ProviderMeta {
     /// Codex OAuth FAST mode: inject `service_tier = "priority"` for ChatGPT Codex requests.
     #[serde(rename = "codexFastMode", skip_serializing_if = "Option::is_none")]
     pub codex_fast_mode: Option<bool>,
+    /// Native Codex Responses routing: replace a request model that is absent
+    /// from the current provider catalog with the provider's configured model.
+    /// Enabled by default so resumed threads follow provider switches.
+    #[serde(
+        rename = "codexNativeModelFallback",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub codex_native_model_fallback: Option<bool>,
     /// Codex Responses -> Chat Completions reasoning capability metadata.
     #[serde(rename = "codexChatReasoning", skip_serializing_if = "Option::is_none")]
     pub codex_chat_reasoning: Option<CodexChatReasoningConfig>,
@@ -572,6 +580,10 @@ impl ProviderMeta {
     /// 会按更高速率消耗 ChatGPT 订阅配额，用户需显式开启以换取更低延迟。
     pub fn codex_fast_mode_enabled(&self) -> bool {
         self.codex_fast_mode.unwrap_or(false)
+    }
+
+    pub fn codex_native_model_fallback_enabled(&self) -> bool {
+        self.codex_native_model_fallback.unwrap_or(true)
     }
 
     /// 经校验的 Provider 级自定义 User-Agent。见 [`parse_custom_user_agent`]。

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1178,6 +1178,17 @@ impl RequestForwarder {
             super::providers::apply_codex_upstream_model(provider, &mut mapped_body);
         }
 
+        if matches!(app_type, AppType::Codex)
+            && !codex_responses_to_chat
+            && !codex_responses_to_anthropic
+        {
+            super::providers::apply_codex_native_model_fallback(
+                provider,
+                endpoint,
+                &mut mapped_body,
+            );
+        }
+
         if is_copilot {
             mapped_body =
                 super::providers::copilot_model_map::apply_copilot_model_normalization(mapped_body);

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -73,7 +73,7 @@ pub fn codex_provider_uses_chat_completions(provider: &Provider) -> bool {
         .unwrap_or(false)
 }
 
-pub fn should_convert_codex_responses_to_chat(provider: &Provider, endpoint: &str) -> bool {
+fn is_codex_responses_endpoint(endpoint: &str) -> bool {
     let path = endpoint
         .split_once('?')
         .map_or(endpoint, |(path, _query)| path);
@@ -81,7 +81,11 @@ pub fn should_convert_codex_responses_to_chat(provider: &Provider, endpoint: &st
     matches!(
         path,
         "/responses" | "/v1/responses" | "/responses/compact" | "/v1/responses/compact"
-    ) && codex_provider_uses_chat_completions(provider)
+    )
+}
+
+pub fn should_convert_codex_responses_to_chat(provider: &Provider, endpoint: &str) -> bool {
+    is_codex_responses_endpoint(endpoint) && codex_provider_uses_chat_completions(provider)
 }
 
 /// Whether a converted Codex Responses request may send `prompt_cache_key` to
@@ -196,14 +200,7 @@ pub fn codex_provider_uses_anthropic(provider: &Provider) -> bool {
 }
 
 pub fn should_convert_codex_responses_to_anthropic(provider: &Provider, endpoint: &str) -> bool {
-    let path = endpoint
-        .split_once('?')
-        .map_or(endpoint, |(path, _query)| path);
-
-    matches!(
-        path,
-        "/responses" | "/v1/responses" | "/responses/compact" | "/v1/responses/compact"
-    ) && codex_provider_uses_anthropic(provider)
+    is_codex_responses_endpoint(endpoint) && codex_provider_uses_anthropic(provider)
 }
 
 /// Whether a native-Responses Codex upstream needs Codex `namespace`/plugin
@@ -325,6 +322,29 @@ pub fn apply_codex_upstream_model(provider: &Provider, body: &mut JsonValue) -> 
     let upstream_model = codex_provider_upstream_model(provider)?;
     body["model"] = JsonValue::String(upstream_model.clone());
     Some(upstream_model)
+}
+
+/// Keep resumed Codex threads aligned with the active native Responses provider.
+/// Codex persists a thread's model, so changing config.toml alone cannot refresh it.
+pub fn apply_codex_native_model_fallback(
+    provider: &Provider,
+    endpoint: &str,
+    body: &mut JsonValue,
+) -> Option<String> {
+    if !is_codex_responses_endpoint(endpoint)
+        || is_codex_official_provider(provider)
+        || provider
+            .meta
+            .as_ref()
+            .is_some_and(|meta| !meta.codex_native_model_fallback_enabled())
+    {
+        return body
+            .get("model")
+            .and_then(JsonValue::as_str)
+            .map(ToString::to_string);
+    }
+
+    apply_codex_upstream_model(provider, body)
 }
 
 pub fn resolve_codex_chat_reasoning_config(
@@ -1196,6 +1216,89 @@ wire_api = "anthropic"
             body.get("model").and_then(|v| v.as_str()),
             Some("claude-opus-4-1[1m]")
         );
+    }
+
+    #[test]
+    fn native_responses_falls_back_from_stale_provider_model() {
+        let mut provider = create_provider(json!({
+            "config": r#"model_provider = "happy"
+model = "gpt-5.6-sol-medium"
+
+[model_providers.happy]
+base_url = "https://happy.example/v1"
+wire_api = "responses"
+"#,
+            "modelCatalog": {
+                "models": [
+                    { "model": "gpt-5.6-sol-medium", "displayName": "GPT 5.6 Sol Medium" }
+                ]
+            }
+        }));
+        provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_responses".to_string()),
+            ..Default::default()
+        });
+        let mut body = json!({ "model": "deepseek-v4-flash" });
+
+        let resolved = apply_codex_native_model_fallback(&provider, "/responses", &mut body);
+
+        assert_eq!(resolved.as_deref(), Some("gpt-5.6-sol-medium"));
+        assert_eq!(body["model"], "gpt-5.6-sol-medium");
+    }
+
+    #[test]
+    fn native_responses_can_preserve_uncatalogued_direct_model() {
+        let mut provider = create_provider(json!({
+            "config": "model = \"gpt-5.6-sol-medium\"",
+            "modelCatalog": {
+                "models": [{ "model": "gpt-5.6-sol-medium" }]
+            }
+        }));
+        provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_responses".to_string()),
+            codex_native_model_fallback: Some(false),
+            ..Default::default()
+        });
+        let mut body = json!({ "model": "experimental-direct-model" });
+
+        let resolved = apply_codex_native_model_fallback(&provider, "/responses", &mut body);
+
+        assert_eq!(resolved.as_deref(), Some("experimental-direct-model"));
+        assert_eq!(body["model"], "experimental-direct-model");
+    }
+
+    #[test]
+    fn native_responses_preserves_official_model() {
+        let mut provider = create_provider(json!({
+            "config": "model = \"gpt-5.6-sol-medium\"",
+            "modelCatalog": {
+                "models": [{ "model": "gpt-5.6-sol-medium" }]
+            }
+        }));
+        provider.id = crate::database::CODEX_OFFICIAL_PROVIDER_ID.to_string();
+        provider.category = Some("official".to_string());
+        let mut body = json!({ "model": "gpt-5.6-sol" });
+
+        let resolved = apply_codex_native_model_fallback(&provider, "/responses", &mut body);
+
+        assert_eq!(resolved.as_deref(), Some("gpt-5.6-sol"));
+        assert_eq!(body["model"], "gpt-5.6-sol");
+    }
+
+    #[test]
+    fn native_responses_fallback_ignores_non_responses_endpoints() {
+        let provider = create_provider(json!({
+            "config": "model = \"gpt-5.6-sol-medium\"",
+            "modelCatalog": {
+                "models": [{ "model": "gpt-5.6-sol-medium" }]
+            }
+        }));
+        let mut body = json!({ "model": "direct-chat-model" });
+
+        let resolved = apply_codex_native_model_fallback(&provider, "/chat/completions", &mut body);
+
+        assert_eq!(resolved.as_deref(), Some("direct-chat-model"));
+        assert_eq!(body["model"], "direct-chat-model");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -57,8 +57,8 @@ pub use claude::{
 };
 pub use codex::CodexAdapter;
 pub use codex::{
-    apply_codex_chat_upstream_model, apply_codex_upstream_model, codex_provider_upstream_model,
-    inject_codex_chat_prompt_cache_key, is_codex_official_provider,
+    apply_codex_chat_upstream_model, apply_codex_native_model_fallback, apply_codex_upstream_model,
+    codex_provider_upstream_model, inject_codex_chat_prompt_cache_key, is_codex_official_provider,
     provider_needs_responses_namespace_flatten, resolve_codex_catalog_tool_profile,
     resolve_codex_chat_reasoning_config, should_convert_codex_responses_to_anthropic,
     should_convert_codex_responses_to_chat,

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -101,6 +101,8 @@ interface CodexFormFieldsProps {
   onCodexChatReasoningChange?: (value: CodexChatReasoning) => void;
   promptCacheRouting: PromptCacheRoutingMode;
   onPromptCacheRoutingChange: (value: PromptCacheRoutingMode) => void;
+  nativeModelFallback?: boolean;
+  onNativeModelFallbackChange?: (value: boolean) => void;
 
   // Model Catalog
   catalogModels?: CodexCatalogModel[];
@@ -201,6 +203,8 @@ export function CodexFormFields({
   onCodexChatReasoningChange,
   promptCacheRouting,
   onPromptCacheRoutingChange,
+  nativeModelFallback = true,
+  onNativeModelFallbackChange,
   catalogModels = [],
   onCatalogModelsChange,
   speedTestEndpoints,
@@ -696,6 +700,33 @@ export function CodexFormFields({
                     })}
                   </p>
                 </div>
+
+                {appId === "codex" &&
+                  apiFormat === "openai_responses" &&
+                  onNativeModelFallbackChange && (
+                    <div className="flex items-center justify-between gap-4 border-t border-border-default pt-3">
+                      <div className="space-y-1">
+                        <FormLabel>
+                          {t("codexConfig.nativeModelFallbackLabel", {
+                            defaultValue: "切换后跟随默认模型",
+                          })}
+                        </FormLabel>
+                        <p className="text-xs leading-relaxed text-muted-foreground">
+                          {t("codexConfig.nativeModelFallbackHint", {
+                            defaultValue:
+                              "旧会话发送的模型不在当前映射中时，改用当前供应商默认模型。若需直接请求映射外模型，请关闭。",
+                          })}
+                        </p>
+                      </div>
+                      <Switch
+                        checked={nativeModelFallback}
+                        onCheckedChange={onNativeModelFallbackChange}
+                        aria-label={t("codexConfig.nativeModelFallbackLabel", {
+                          defaultValue: "切换后跟随默认模型",
+                        })}
+                      />
+                    </div>
+                  )}
 
                 {isAnthropicFormat && (
                   <div className="space-y-1.5">

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -364,6 +364,9 @@ function ProviderFormFull({
     });
     setCodexChatReasoning(initialData?.meta?.codexChatReasoning ?? {});
     setPromptCacheRouting(initialData?.meta?.promptCacheRouting ?? "auto");
+    setCodexNativeModelFallback(
+      initialData?.meta?.codexNativeModelFallback ?? true,
+    );
     setCustomUserAgent(initialData?.meta?.customUserAgent ?? "");
     setLocalProxyHeadersOverride(
       formatRequestOverrideObject(
@@ -552,6 +555,10 @@ function ProviderFormFull({
     useState<PromptCacheRoutingMode>(
       () => initialData?.meta?.promptCacheRouting ?? "auto",
     );
+  const [codexNativeModelFallback, setCodexNativeModelFallback] =
+    useState<boolean>(
+      () => initialData?.meta?.codexNativeModelFallback ?? true,
+    );
   const [customUserAgent, setCustomUserAgent] = useState<string>(
     () => initialData?.meta?.customUserAgent ?? "",
   );
@@ -656,6 +663,7 @@ function ProviderFormFull({
       resetCodexConfig(template.auth, template.config);
       setCodexChatReasoning({});
       setPromptCacheRouting("auto");
+      setCodexNativeModelFallback(true);
     }
   }, [appId, initialData, selectedPresetId, resetCodexConfig]);
 
@@ -1595,6 +1603,13 @@ function ProviderFormFull({
         promptCacheRouting !== "auto"
           ? promptCacheRouting
           : undefined,
+      codexNativeModelFallback:
+        appId === "codex" &&
+        category !== "official" &&
+        localCodexApiFormat === "openai_responses" &&
+        !codexNativeModelFallback
+          ? false
+          : undefined,
       customUserAgent:
         (appId === "claude" || appId === "codex") && category !== "official"
           ? customUserAgent.trim() || undefined
@@ -1769,6 +1784,7 @@ function ProviderFormFull({
         resetCodexConfig(template.auth, template.config);
         setCodexChatReasoning({});
         setPromptCacheRouting("auto");
+        setCodexNativeModelFallback(true);
         setLocalCodexApiFormat(
           codexApiFormatFromWireApi(extractCodexWireApi(template.config)) ??
             "openai_responses",
@@ -1811,6 +1827,7 @@ function ProviderFormFull({
       resetCodexConfig(auth, config, preset.modelCatalog ?? []);
       setCodexChatReasoning(preset.codexChatReasoning ?? {});
       setPromptCacheRouting(preset.promptCacheRouting ?? "auto");
+      setCodexNativeModelFallback(true);
       setLocalCodexApiFormat(
         preset.apiFormat ??
           codexApiFormatFromWireApi(extractCodexWireApi(config)) ??
@@ -2319,6 +2336,8 @@ function ProviderFormFull({
               onCodexChatReasoningChange={setCodexChatReasoning}
               promptCacheRouting={promptCacheRouting}
               onPromptCacheRoutingChange={setPromptCacheRouting}
+              nativeModelFallback={codexNativeModelFallback}
+              onNativeModelFallbackChange={setCodexNativeModelFallback}
               catalogModels={codexCatalogModels}
               onCatalogModelsChange={setCodexCatalogModels}
               speedTestEndpoints={speedTestEndpoints}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1342,6 +1342,8 @@
     "promptCacheRoutingEnabled": "Enabled",
     "promptCacheRoutingDisabled": "Disabled",
     "promptCacheRoutingHint": "Auto sends prompt_cache_key only to known-compatible upstreams. Enable it for other compatible gateways, or disable it if a strict gateway rejects unknown fields with HTTP 400. Only a stable client-provided session ID is used.",
+    "nativeModelFallbackLabel": "Follow default model after switching",
+    "nativeModelFallbackHint": "When a resumed thread sends a model outside the current mapping, use this provider's default model. Disable this to send unmapped model names directly.",
     "upstreamModelName": "Upstream Model Name",
     "upstreamModelNameHint": "For Chat format, enter the real upstream model here; routing converts Codex Responses requests to Chat Completions while keeping this model.",
     "modelNamePlaceholder": "e.g., gpt-5-codex",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1342,6 +1342,8 @@
     "promptCacheRoutingEnabled": "有効",
     "promptCacheRoutingDisabled": "無効",
     "promptCacheRoutingHint": "自動モードでは、互換性を確認済みの上流にのみ prompt_cache_key を送信します。他の互換ゲートウェイでは有効にし、未知のフィールドを 400 で拒否する厳格なゲートウェイでは無効にしてください。クライアントが提供した安定したセッション ID のみを使用します。",
+    "nativeModelFallbackLabel": "切り替え後に既定モデルへ追従",
+    "nativeModelFallbackHint": "再開したスレッドのモデルが現在のマッピングにない場合、このプロバイダーの既定モデルを使用します。マッピング外のモデル名を直接送信する場合は無効にしてください。",
     "upstreamModelName": "上流モデル名",
     "upstreamModelNameHint": "Chat 形式ではここに実際の上流モデルを入力します。ルーティングで Codex の Responses リクエストを Chat Completions に変換し、このモデルを維持します。",
     "modelNamePlaceholder": "例: gpt-5-codex",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1348,6 +1348,8 @@
     "promptCacheRoutingEnabled": "開啟",
     "promptCacheRoutingDisabled": "關閉",
     "promptCacheRoutingHint": "自動模式僅對已確認相容的上游傳送 prompt_cache_key；開啟可用於其他相容閘道，關閉可避免嚴格閘道因未知欄位回傳 400。只使用客戶端提供的穩定工作階段 ID。",
+    "nativeModelFallbackLabel": "切換後跟隨預設模型",
+    "nativeModelFallbackHint": "舊工作階段傳送的模型不在目前映射中時，改用目前供應商的預設模型。如需直接請求映射外模型，請關閉。",
     "defaultModelLabel": "預設模型",
     "defaultModelPlaceholder": "例如: gpt-5.6-sol",
     "defaultModelHint": "Codex 預設請求的模型，隨時可改，無需等待軟體更新供應商範本。留空且設定了模型映射時，預設使用映射第一行。",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1342,6 +1342,8 @@
     "promptCacheRoutingEnabled": "开启",
     "promptCacheRoutingDisabled": "关闭",
     "promptCacheRoutingHint": "自动模式仅对已确认兼容的上游发送 prompt_cache_key；开启可用于其他兼容网关，关闭可避免严格网关因未知字段返回 400。只使用客户端提供的稳定会话 ID。",
+    "nativeModelFallbackLabel": "切换后跟随默认模型",
+    "nativeModelFallbackHint": "旧会话发送的模型不在当前映射中时，改用当前供应商默认模型。若需直接请求映射外模型，请关闭。",
     "upstreamModelName": "上游模型名称",
     "upstreamModelNameHint": "Chat 格式下这里填写真实上游模型；路由会把 Codex 的 Responses 请求转换为 Chat Completions 并保持该模型。",
     "modelNamePlaceholder": "例如: gpt-5-codex",

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,9 @@ export interface ProviderMeta {
   promptCacheRouting?: PromptCacheRoutingMode;
   // Codex OAuth FAST mode: injects service_tier="priority" on ChatGPT Codex requests
   codexFastMode?: boolean;
+  // Native Responses: fall back to the provider model when a resumed thread sends
+  // a model that is absent from the current catalog. Defaults to enabled.
+  codexNativeModelFallback?: boolean;
   // Codex Responses -> Chat Completions reasoning capability metadata
   codexChatReasoning?: CodexChatReasoning;
   // Codex → Anthropic path: emulate the Claude Code client (disabled by default; only an explicit true enables it)


### PR DESCRIPTION
## Summary / 概述

- Fall back to the active Codex provider's default model when a resumed
  native Responses thread sends a model outside the current provider catalog.
- Keep official Codex, non-Responses endpoints, and explicit opt-out behavior
  unchanged.
- Add an advanced setting for users who need to send uncatalogued model names
  directly, with translations for all maintained locales.
- Add regression coverage for stale models and compatibility boundaries.

## Related Issue / 关联 Issue

Fixes #6115

## Screenshots / 截图

N/A. The new control is a compact advanced setting; desktop and 320px layouts
were verified locally.

## Testing / 测试

- cargo test native_responses_ --lib (7 passed)
- cargo fmt --all -- --check
- cargo clippy --lib --tests
- corepack pnpm typecheck
- corepack pnpm format:check
- corepack pnpm test:unit
- Focused retry: corepack pnpm exec vitest run tests/integration/App.test.tsx
  (6 passed after a full-suite timeout cascade)

## Checklist / 检查清单

- [x] pnpm typecheck passes / 通过 TypeScript 类型检查
- [x] pnpm format:check passes / 通过代码格式检查
- [x] cargo clippy passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件