### PR TITLE
fix(proxy): wrap object tool-result content into array after image replacement

### DIFF
--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -234,11 +234,8 @@ fn replace_images_in_content_with_text_type(content: &mut Value, text_type: &str
                 // replacement; a wrapper object keeps its shape, so wrapping
                 // it into an array would put a non-block object into content.
                 let root_was_media = nested_content.is_object()
-                    && chat_media_part_from_tool_part(
-                        nested_content,
-                        ToolMediaScope::ImagesOnly,
-                    )
-                    .is_some();
+                    && chat_media_part_from_tool_part(nested_content, ToolMediaScope::ImagesOnly)
+                        .is_some();
                 replaced += replace_images_in_content_with_text_type(nested_content, text_type);
                 let replacement_block = json!({
                     "type":text_type,
@@ -1312,7 +1309,10 @@ mod tests {
 
         assert_eq!(count, 1);
         let content = &body["messages"][0]["content"][0]["content"];
-        assert!(content.is_array(), "tool_result.content 必须是数组，实际: {content}");
+        assert!(
+            content.is_array(),
+            "tool_result.content 必须是数组，实际: {content}"
+        );
         assert_eq!(content[0]["type"], "text");
         assert_eq!(content[0]["text"], UNSUPPORTED_IMAGE_MARKER);
         assert!(!body.to_string().contains("MCP_IMG_SENTINEL"));
@@ -1339,7 +1339,10 @@ mod tests {
 
         assert_eq!(count, 1);
         let content = &body["messages"][0]["content"];
-        assert!(content.is_array(), "tool 消息 content 必须是数组，实际: {content}");
+        assert!(
+            content.is_array(),
+            "tool 消息 content 必须是数组，实际: {content}"
+        );
         assert_eq!(content[0]["type"], "text");
         assert_eq!(content[0]["text"], UNSUPPORTED_IMAGE_MARKER);
     }
@@ -1398,7 +1401,10 @@ mod tests {
 
         assert_eq!(count, 1);
         let content = &body["messages"][0]["content"][0]["content"];
-        assert!(content.is_object(), "包装对象应保持对象结构，实际: {content}");
+        assert!(
+            content.is_object(),
+            "包装对象应保持对象结构，实际: {content}"
+        );
         assert_eq!(content["status"], "ok");
         assert_eq!(content["content"][0]["type"], "text");
         assert_eq!(content["content"][0]["text"], UNSUPPORTED_IMAGE_MARKER);
@@ -1429,7 +1435,10 @@ mod tests {
 
         assert_eq!(replaced, 1);
         let output = &body["input"][0]["output"];
-        assert!(output.is_object(), "包装对象 output 应保持对象结构，实际: {output}");
+        assert!(
+            output.is_object(),
+            "包装对象 output 应保持对象结构，实际: {output}"
+        );
         assert_eq!(output["status"], "ok");
         assert_eq!(output["content"][0]["text"], "caption");
         assert_eq!(output["content"][1]["type"], "input_text");

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -4,7 +4,8 @@ use crate::model_capabilities::{image_input_capability_from_settings, ImageInput
 use crate::provider::Provider;
 use crate::proxy::error::ProxyError;
 use crate::proxy::tool_media::{
-    strip_media_from_tool_value, tool_output_contains_media, ToolMediaScope,
+    chat_media_part_from_tool_part, strip_media_from_tool_value, tool_output_contains_media,
+    ToolMediaScope,
 };
 use serde_json::{json, Value};
 
@@ -158,6 +159,14 @@ fn replace_images_in_message(message: &mut Value) -> usize {
         // including Anthropic cache_control on the replacement text block.
         // The shared traversal then handles JSON strings, MCP wrappers, and
         // loose data-URL shapes that the legacy recursion does not recognize.
+        //
+        // Only a root object that IS a media block gets whole-object
+        // replacement by the shared traversal. A wrapper object (e.g.
+        // {"content":[...], "status":"ok"}) keeps its shape with nested media
+        // replaced, so wrapping it into an array would put a non-block object
+        // into the content array. Detect that before recursing.
+        let root_was_media = content.is_object()
+            && chat_media_part_from_tool_part(content, ToolMediaScope::ImagesOnly).is_some();
         let mut replaced = replace_images_in_content(content);
         let replacement_block = json!({
             "type":"text",
@@ -171,7 +180,9 @@ fn replace_images_in_message(message: &mut Value) -> usize {
             &replacement_block,
             UNSUPPORTED_IMAGE_MARKER,
         );
-        wrap_object_content_after_replacement(content, replaced);
+        if root_was_media {
+            wrap_object_content_after_replacement(content, replaced);
+        }
         replaced
     } else {
         replace_images_in_content(content)
@@ -180,12 +191,12 @@ fn replace_images_in_message(message: &mut Value) -> usize {
 
 /// Anthropic 协议要求 message / tool_result 的 content 必须是字符串或 block 数组。
 ///
-/// `strip_media_from_tool_value` 会把裸 image 对象（MCP / 自定义工具直接以
-/// `{"type":"image",...}` 对象作为 tool_result content 输出）整体替换成 text
-/// 对象——若 content 本身就是该对象，替换后 content 会变成非法对象结构，
-/// 被 SenseNova 等严格网关以 "The content field is a required field" 拒绝
-/// （issue #6170）。这里把替换后的对象包装成单元素数组，恢复合法的
-/// Anthropic 结构。非对象 content（字符串 / 数组）不受影响。
+/// 仅在根对象本身是 media block 且被 `strip_media_from_tool_value` 整体替换成
+/// text 对象后调用（MCP / 自定义工具直接以 `{"type":"image",...}` 对象作为
+/// tool_result content 输出）：把替换后的对象包装成单元素数组，恢复合法的
+/// Anthropic 结构（issue #6170）。包装对象（含嵌套 media、根对象自身不是
+/// media block）不经过此函数——它的对象形态是上游原始结构，不属于媒体替换
+/// 引入的回归。非对象 content（字符串 / 数组）不受影响。
 fn wrap_object_content_after_replacement(content: &mut Value, replaced: usize) {
     if replaced > 0 && content.is_object() {
         let wrapped = std::mem::take(content);
@@ -218,6 +229,16 @@ fn replace_images_in_content_with_text_type(content: &mut Value, text_type: &str
                 // payload-aware traversal. This makes replacement a superset
                 // of detection and preserves cache_control on Anthropic image
                 // blocks, while the second pass covers alternate tool shapes.
+                //
+                // Only a root object that IS a media block gets whole-object
+                // replacement; a wrapper object keeps its shape, so wrapping
+                // it into an array would put a non-block object into content.
+                let root_was_media = nested_content.is_object()
+                    && chat_media_part_from_tool_part(
+                        nested_content,
+                        ToolMediaScope::ImagesOnly,
+                    )
+                    .is_some();
                 replaced += replace_images_in_content_with_text_type(nested_content, text_type);
                 let replacement_block = json!({
                     "type":text_type,
@@ -235,7 +256,9 @@ fn replace_images_in_content_with_text_type(content: &mut Value, text_type: &str
                 // MCP / 自定义工具可能把图片作为裸对象输出（tool_result.content
                 // 为对象而非数组/字符串）。strip 将其替换成 text 对象后必须包装成
                 // 数组，保证 Anthropic content 结构合法（issue #6170）。
-                wrap_object_content_after_replacement(nested_content, nested_replaced);
+                if root_was_media {
+                    wrap_object_content_after_replacement(nested_content, nested_replaced);
+                }
             } else {
                 replaced += replace_images_in_content_with_text_type(nested_content, text_type);
             }
@@ -398,6 +421,14 @@ fn replace_images_in_responses_input_item(item: &mut Value) -> usize {
     if let Some(output) = item.get_mut("output") {
         // The image-capability fallback deliberately strips images only.
         // Tool-output files/audio remain a known unsupported-modality gap.
+        //
+        // Only an output that IS a bare media object becomes the string
+        // marker (Responses function_call_output.output must be a string).
+        // A wrapper object containing nested media keeps its object shape
+        // with the nested images replaced, preserving captions and any
+        // non-image results (see detects_and_replaces_responses_function_output_images).
+        let root_was_media = output.is_object()
+            && chat_media_part_from_tool_part(output, ToolMediaScope::ImagesOnly).is_some();
         let replacement_block = json!({
             "type": "input_text",
             "text": UNSUPPORTED_IMAGE_MARKER
@@ -411,9 +442,7 @@ fn replace_images_in_responses_input_item(item: &mut Value) -> usize {
             UNSUPPORTED_IMAGE_MARKER,
         );
         replaced += output_replaced;
-        // Responses function_call_output.output 必须是字符串。裸 image 对象被
-        // 替换成对象后需还原为字符串标记，避免向严格网关发送对象结构。
-        if output_replaced > 0 && output.is_object() {
+        if root_was_media && output_replaced > 0 {
             *output = Value::String(UNSUPPORTED_IMAGE_MARKER.to_string());
         }
     }
@@ -1340,6 +1369,71 @@ mod tests {
             body["input"][0]["output"],
             Value::String(UNSUPPORTED_IMAGE_MARKER.to_string())
         );
+    }
+
+    #[test]
+    fn wrapper_object_tool_result_content_keeps_object_shape() {
+        // review 反馈：包装对象（根对象自身不是 media block，如
+        // {"content":[...], "status":"ok"}）只替换嵌套 media，不应被包装成
+        // 数组——数组元素不是合法 Anthropic content block。
+        let mut body = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": {
+                        "status": "ok",
+                        "content": [
+                            { "type": "image", "data": "WRAP_TOOL_IMG", "mimeType": "image/png" }
+                        ]
+                    }
+                }]
+            }]
+        });
+
+        assert!(contains_image_blocks(&body));
+        let count = replace_image_blocks_with_marker(&mut body);
+
+        assert_eq!(count, 1);
+        let content = &body["messages"][0]["content"][0]["content"];
+        assert!(content.is_object(), "包装对象应保持对象结构，实际: {content}");
+        assert_eq!(content["status"], "ok");
+        assert_eq!(content["content"][0]["type"], "text");
+        assert_eq!(content["content"][0]["text"], UNSUPPORTED_IMAGE_MARKER);
+        assert!(!body.to_string().contains("WRAP_TOOL_IMG"));
+    }
+
+    #[test]
+    fn wrapper_object_responses_output_keeps_object_shape() {
+        // review 反馈：Responses output 是包装对象时保留对象结构（含 caption
+        // 等非图片内容），只替换嵌套 media，而不是整体丢弃为单个标记。
+        let mut body = json!({
+            "model": "text-model",
+            "input": [{
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": {
+                    "status": "ok",
+                    "content": [
+                        { "type": "input_text", "text": "caption" },
+                        { "type": "input_image", "image_url": "data:image/png;base64,WRAP_OUT" }
+                    ]
+                }
+            }]
+        });
+
+        assert!(contains_image_blocks(&body));
+        let replaced = replace_image_blocks_with_marker(&mut body);
+
+        assert_eq!(replaced, 1);
+        let output = &body["input"][0]["output"];
+        assert!(output.is_object(), "包装对象 output 应保持对象结构，实际: {output}");
+        assert_eq!(output["status"], "ok");
+        assert_eq!(output["content"][0]["text"], "caption");
+        assert_eq!(output["content"][1]["type"], "input_text");
+        assert_eq!(output["content"][1]["text"], UNSUPPORTED_IMAGE_MARKER);
     }
 
     #[test]

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -171,9 +171,25 @@ fn replace_images_in_message(message: &mut Value) -> usize {
             &replacement_block,
             UNSUPPORTED_IMAGE_MARKER,
         );
+        wrap_object_content_after_replacement(content, replaced);
         replaced
     } else {
         replace_images_in_content(content)
+    }
+}
+
+/// Anthropic 协议要求 message / tool_result 的 content 必须是字符串或 block 数组。
+///
+/// `strip_media_from_tool_value` 会把裸 image 对象（MCP / 自定义工具直接以
+/// `{"type":"image",...}` 对象作为 tool_result content 输出）整体替换成 text
+/// 对象——若 content 本身就是该对象，替换后 content 会变成非法对象结构，
+/// 被 SenseNova 等严格网关以 "The content field is a required field" 拒绝
+/// （issue #6170）。这里把替换后的对象包装成单元素数组，恢复合法的
+/// Anthropic 结构。非对象 content（字符串 / 数组）不受影响。
+fn wrap_object_content_after_replacement(content: &mut Value, replaced: usize) {
+    if replaced > 0 && content.is_object() {
+        let wrapped = std::mem::take(content);
+        *content = json!([wrapped]);
     }
 }
 
@@ -208,13 +224,18 @@ fn replace_images_in_content_with_text_type(content: &mut Value, text_type: &str
                     "text":UNSUPPORTED_IMAGE_MARKER
                 });
                 let mut discarded_media = Vec::new();
-                replaced += strip_media_from_tool_value(
+                let nested_replaced = strip_media_from_tool_value(
                     nested_content,
                     &mut discarded_media,
                     ToolMediaScope::ImagesOnly,
                     &replacement_block,
                     UNSUPPORTED_IMAGE_MARKER,
                 );
+                replaced += nested_replaced;
+                // MCP / 自定义工具可能把图片作为裸对象输出（tool_result.content
+                // 为对象而非数组/字符串）。strip 将其替换成 text 对象后必须包装成
+                // 数组，保证 Anthropic content 结构合法（issue #6170）。
+                wrap_object_content_after_replacement(nested_content, nested_replaced);
             } else {
                 replaced += replace_images_in_content_with_text_type(nested_content, text_type);
             }
@@ -382,13 +403,19 @@ fn replace_images_in_responses_input_item(item: &mut Value) -> usize {
             "text": UNSUPPORTED_IMAGE_MARKER
         });
         let mut discarded_media = Vec::new();
-        replaced += strip_media_from_tool_value(
+        let output_replaced = strip_media_from_tool_value(
             output,
             &mut discarded_media,
             ToolMediaScope::ImagesOnly,
             &replacement_block,
             UNSUPPORTED_IMAGE_MARKER,
         );
+        replaced += output_replaced;
+        // Responses function_call_output.output 必须是字符串。裸 image 对象被
+        // 替换成对象后需还原为字符串标记，避免向严格网关发送对象结构。
+        if output_replaced > 0 && output.is_object() {
+            *output = Value::String(UNSUPPORTED_IMAGE_MARKER.to_string());
+        }
     }
 
     replaced
@@ -1227,6 +1254,92 @@ mod tests {
         assert_eq!(block["type"], "text");
         assert_eq!(block["text"], UNSUPPORTED_IMAGE_MARKER);
         assert_eq!(block["cache_control"]["type"], "ephemeral");
+    }
+
+    #[test]
+    fn tool_result_object_image_content_is_wrapped_into_array() {
+        // issue #6170: MCP / 自定义工具可能把图片作为裸对象输出
+        // （tool_result.content 为对象而非数组/字符串）。替换后 content 必须是
+        // string 或数组，否则 SenseNova 等严格网关报
+        // "The content field is a required field"。
+        let mut body = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": {
+                        "type": "image",
+                        "data": "MCP_IMG_SENTINEL",
+                        "mimeType": "image/png"
+                    }
+                }]
+            }]
+        });
+
+        assert!(contains_image_blocks(&body));
+        let count = replace_image_blocks_with_marker(&mut body);
+
+        assert_eq!(count, 1);
+        let content = &body["messages"][0]["content"][0]["content"];
+        assert!(content.is_array(), "tool_result.content 必须是数组，实际: {content}");
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], UNSUPPORTED_IMAGE_MARKER);
+        assert!(!body.to_string().contains("MCP_IMG_SENTINEL"));
+    }
+
+    #[test]
+    fn tool_message_object_image_content_is_wrapped_into_array() {
+        // role=tool 消息的 content 是裸 image 对象时，替换后必须包装成数组。
+        let mut body = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [{
+                "role": "tool",
+                "tool_call_id": "toolu_1",
+                "content": {
+                    "type": "image",
+                    "data": "TOOL_MSG_IMG_SENTINEL",
+                    "mimeType": "image/png"
+                }
+            }]
+        });
+
+        assert!(contains_image_blocks(&body));
+        let count = replace_image_blocks_with_marker(&mut body);
+
+        assert_eq!(count, 1);
+        let content = &body["messages"][0]["content"];
+        assert!(content.is_array(), "tool 消息 content 必须是数组，实际: {content}");
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], UNSUPPORTED_IMAGE_MARKER);
+    }
+
+    #[test]
+    fn responses_output_object_image_becomes_string_marker() {
+        // Responses function_call_output.output 必须是字符串；裸 image 对象
+        // 替换后应还原为字符串标记而不是对象。
+        let mut body = json!({
+            "model": "text-model",
+            "input": [{
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": {
+                    "type": "image",
+                    "data": "RESP_OUTPUT_IMG_SENTINEL",
+                    "mimeType": "image/png"
+                }
+            }]
+        });
+
+        assert!(contains_image_blocks(&body));
+        let replaced = replace_image_blocks_with_marker(&mut body);
+
+        assert_eq!(replaced, 1);
+        assert_eq!(
+            body["input"][0]["output"],
+            Value::String(UNSUPPORTED_IMAGE_MARKER.to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -167,6 +167,10 @@ fn replace_images_in_message(message: &mut Value) -> usize {
         // into the content array. Detect that before recursing.
         let root_was_media = content.is_object()
             && chat_media_part_from_tool_part(content, ToolMediaScope::ImagesOnly).is_some();
+        // strip 会把根 media 对象整体替换成 replacement_block；cache_control
+        // 需在替换前提取，替换后再迁移回标记 block（与数组路径
+        // replace_image_block_with_text_marker 的行为保持一致）。
+        let cache_control = content.get("cache_control").cloned();
         let mut replaced = replace_images_in_content(content);
         let replacement_block = json!({
             "type":"text",
@@ -181,7 +185,7 @@ fn replace_images_in_message(message: &mut Value) -> usize {
             UNSUPPORTED_IMAGE_MARKER,
         );
         if root_was_media {
-            wrap_object_content_after_replacement(content, replaced);
+            wrap_object_content_after_replacement(content, replaced, cache_control);
         }
         replaced
     } else {
@@ -193,12 +197,20 @@ fn replace_images_in_message(message: &mut Value) -> usize {
 ///
 /// 仅在根对象本身是 media block 且被 `strip_media_from_tool_value` 整体替换成
 /// text 对象后调用（MCP / 自定义工具直接以 `{"type":"image",...}` 对象作为
-/// tool_result content 输出）：把替换后的对象包装成单元素数组，恢复合法的
-/// Anthropic 结构（issue #6170）。包装对象（含嵌套 media、根对象自身不是
-/// media block）不经过此函数——它的对象形态是上游原始结构，不属于媒体替换
-/// 引入的回归。非对象 content（字符串 / 数组）不受影响。
-fn wrap_object_content_after_replacement(content: &mut Value, replaced: usize) {
+/// tool_result content 输出）：把调用方在替换前提取的 cache_control（若有）
+/// 迁移回标记 block，再把对象包装成单元素数组，恢复合法的 Anthropic 结构
+/// （issue #6170）。包装对象（含嵌套 media、根对象自身不是 media block）
+/// 不经过此函数——它的对象形态是上游原始结构，不属于媒体替换引入的回归。
+/// 非对象 content（字符串 / 数组）不受影响。
+fn wrap_object_content_after_replacement(
+    content: &mut Value,
+    replaced: usize,
+    cache_control: Option<Value>,
+) {
     if replaced > 0 && content.is_object() {
+        if let (Some(cache_control), Some(object)) = (cache_control, content.as_object_mut()) {
+            object.insert("cache_control".to_string(), cache_control);
+        }
         let wrapped = std::mem::take(content);
         *content = json!([wrapped]);
     }
@@ -236,6 +248,9 @@ fn replace_images_in_content_with_text_type(content: &mut Value, text_type: &str
                 let root_was_media = nested_content.is_object()
                     && chat_media_part_from_tool_part(nested_content, ToolMediaScope::ImagesOnly)
                         .is_some();
+                // strip 会把根 media 对象整体替换成 replacement_block；cache_control
+                // 需在替换前提取，替换后再迁移回标记 block。
+                let cache_control = nested_content.get("cache_control").cloned();
                 replaced += replace_images_in_content_with_text_type(nested_content, text_type);
                 let replacement_block = json!({
                     "type":text_type,
@@ -254,7 +269,11 @@ fn replace_images_in_content_with_text_type(content: &mut Value, text_type: &str
                 // 为对象而非数组/字符串）。strip 将其替换成 text 对象后必须包装成
                 // 数组，保证 Anthropic content 结构合法（issue #6170）。
                 if root_was_media {
-                    wrap_object_content_after_replacement(nested_content, nested_replaced);
+                    wrap_object_content_after_replacement(
+                        nested_content,
+                        nested_replaced,
+                        cache_control,
+                    );
                 }
             } else {
                 replaced += replace_images_in_content_with_text_type(nested_content, text_type);
@@ -1443,6 +1462,37 @@ mod tests {
         assert_eq!(output["content"][0]["text"], "caption");
         assert_eq!(output["content"][1]["type"], "input_text");
         assert_eq!(output["content"][1]["text"], UNSUPPORTED_IMAGE_MARKER);
+    }
+
+    #[test]
+    fn object_image_content_preserves_cache_control_after_wrap() {
+        // 裸 image 对象被替换并包装成数组后，cache_control 断点应迁移到
+        // 标记 block（与数组路径 replace_image_block_with_text_marker 一致）。
+        let mut body = json!({
+            "model": "deepseek-v4-pro",
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": {
+                        "type": "image",
+                        "data": "CC_IMG_SENTINEL",
+                        "mimeType": "image/png",
+                        "cache_control": { "type": "ephemeral" }
+                    }
+                }]
+            }]
+        });
+
+        let count = replace_image_blocks_with_marker(&mut body);
+
+        assert_eq!(count, 1);
+        let block = &body["messages"][0]["content"][0]["content"][0];
+        assert_eq!(block["type"], "text");
+        assert_eq!(block["text"], UNSUPPORTED_IMAGE_MARKER);
+        assert_eq!(block["cache_control"]["type"], "ephemeral");
+        assert!(!body.to_string().contains("CC_IMG_SENTINEL"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #6170 — 媒体替换逻辑为 SenseNova API 生成了无效的 content block。

---

## 一、问题现象

Claude Code（2.1.222）通过 cc-switch 向 SenseNova（`deepseek-v4-flash`，Anthropic 兼容端点 `/v1/messages`）发送带图片的请求时，媒体替换先执行：

```
[Media] Replaced 4 image block(s) with [Unsupported Image]
>>> 请求目标: https://token.sensenova.cn/v1/messages
❌ 400 - The content field is a required field
```

三个关键观察：

1. **纯文本对话正常** —— 没有 image block 就不触发替换，请求成功；
2. **间歇性失败** —— 部分带图片的请求成功、部分失败；
3. **SiliconFlow 上同样的请求完全正常** —— 说明替换后的结构对多数网关是合法的，但 SenseNova 的校验器更严格。

## 二、根因分析（证据链）

### 2.1 `tool_result.content` 可以是裸对象 —— Claude Code 源码实证

逆向 `@anthropic-ai/claude-code@2.1.222` 原生二进制（`claude.exe`，Bun 编译），找到工具结果构造代码：

```js
mapToolResultToToolResultBlockParam(e, t) {
  return { tool_use_id: t, type: "tool_result", content: e };  // e = 工具返回值，原样透传
}
```

以及工具执行路径 `let l = await s.run(a, ...); return {type:"tool_result", tool_use_id: i.id, content: l}`。

即：**工具返回什么，`tool_result.content` 就是什么**。MCP / 自定义工具把图片作为裸对象输出时（`{"type":"image","data":"...","mimeType":"image/png"}`），content 就是**对象**，而不是协议要求的字符串或 block 数组。`{"type":"image","data":...,"mimeType":...}` 正是 Claude Code 自己截图/图片类工具使用的 MCP 风格图片结构。

### 2.2 cc-switch 的替换把它变成"仍是对象"的结构 —— 代码实证

`media_sanitizer.rs` 中 `strip_media_from_tool_value`（`tool_media.rs`）的 Object 分支：

```rust
if let Some(media_part) = chat_media_part_from_tool_part(value, scope) {
    *value = replacement_block.clone();   // 整个对象原地替换成 {"type":"text","text":"[Unsupported Image]"}
    return 1;
}
```

当 content **本身就是**这个 image 对象时，替换后 content 变成 `{"type":"text","text":"[Unsupported Image]"}` —— **类型仍是对象**。

### 2.3 Anthropic 协议要求

`message.content` / `tool_result.content` 必须是 **string 或 block 数组**（vLLM/SGLang 等参考实现均如此建模）。对象形态是非法的。

### 2.4 SenseNova 为什么拒绝 —— 错误码溯源

`InternalError.Algo.InvalidParameter: The content field is a required field` 是**阿里系网关**（阿里云 DashScope / 商汤 SenseNova 同款校验器）的典型错误格式，同类案例：

- pydantic-ai#5287：OpenRouter→阿里 Qwen 时 `content: null` 被拒（"content field is a required field"）；
- QwenLM/qwen-code#5265、anomalyco/opencode#23561：同样错误。

阿里系校验器对 content 结构（非空、合法类型）非常严格；SiliconFlow 校验宽松，所以"结构本身有效"的判断在 SiliconFlow 成立、在 SenseNova 不成立。

### 2.5 与全部现象自洽

| 现象 | 解释 |
|---|---|
| 纯文本正常 | 无 image block → 不触发替换 |
| 带图片请求失败 | 工具输出裸 image 对象 → 替换后 content 为对象 → 400 |
| 间歇性 | 取决于工具输出是否恰好是裸 image 对象形态 |
| 日志显示替换发生 | 替换计数包含裸对象（`contains_image_blocks` 通过 `tool_output_contains_media` 对称检测） |

## 三、修复设计考虑

### 3.1 为什么选择"包装成数组"

候选方案对比：

| 方案 | 评价 |
|---|---|
| **包装成单元素数组** `[{"type":"text","text":"[Unsupported Image]"}]` | ✅ 采用：Anthropic 最标准形态，模型仍能看到替换标记；与既有替换（数组内 image block → text block）的输出形态完全一致 |
| 转成字符串 `"[Unsupported Image]"` | ❌ 改变模型看到的语义（字符串会被当作普通文本），且与既有数组替换行为不一致 |
| 删除 content / 置空 | ❌ 违反 content 必填语义，只会把"类型错误"换成"缺失错误" |

包装只发生在 `replaced > 0 && content.is_object()` 时：**非 image 的裸对象 content（Claude Code 原始行为）保持不动**，避免 cc-switch 篡改本不属于媒体替换职责的内容。

### 3.2 三处路径的差异化处理

1. **Anthropic tool 消息**（`replace_images_in_message`，role=tool）：content 对象 → 包装成数组；
2. **tool_result**（`replace_images_in_content_with_text_type`）：`nested_content` 对象 → 包装成数组；
3. **Responses `function_call_output.output`**（`replace_images_in_responses_input_item`）：Responses 协议中 `output` 必须是字符串，因此**还原为字符串标记** `"[Unsupported Image]"`，而不是数组。

三条路径的语义由各自协议决定，不能统一处理。

### 3.3 检测与替换保持对称

`contains_image_blocks` 通过 `tool_output_contains_media` 已能识别裸对象 content，替换侧修复后两者行为一致，不会出现"检测到但替换后仍非法"的缝隙。

## 四、变更内容

- 新增辅助函数 `wrap_object_content_after_replacement(content, replaced)`；
- `replace_images_in_message` / `replace_images_in_content_with_text_type` / `replace_images_in_responses_input_item` 三处调用；
- 新增 3 个回归测试：
  - `tool_result_object_image_content_is_wrapped_into_array`（#6170 主场景，MCP 裸对象）
  - `tool_message_object_image_content_is_wrapped_into_array`
  - `responses_output_object_image_becomes_string_marker`
- 既有测试全部保留（`cache_control` 迁移语义、数组/字符串路径、stringified JSON 路径均不受影响）。

## 五、验证

- `rustc` 单文件解析通过（无语法错误）；
- 用 Python 忠实复刻 `media_sanitizer` + `tool_media` 的替换逻辑（含 `strip_media_from_tool_value` 的 String/Array/Object 全部分支）做了行为验证：全部新场景通过，既有场景（数组、user 消息、完整会话混合、Responses 路径）无回归；
- 本机无 MSVC linker（缺 VS Build Tools），无法跑完整 `cargo test`，需 CI 确认。

## 六、回归风险

- 数组/字符串路径：`is_object()` 为 false，包装函数零操作；
- 既有 cache_control 保留行为不变；
- 对非 media 裸对象 content 零改动（`replaced == 0` 时不包装）。

## 七、补充发现（与本修复无关的独立问题）

SenseNova 网关还会拒绝 **assistant 消息只有 tool_use（其内部 Anthropic→OpenAI 转换后 `content: null`）** 的请求（同一阿里系校验行为，见 pydantic-ai#5287）。这是网关侧行为，媒体替换修复无法覆盖；若本修复后仍偶发 400，大概率是此路径（触发条件：模型"沉默"调用工具且该轮无文本输出）。