### PR TITLE
fix: 让 models.dev 同步与应用更新走全局出站代理

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "once_cell",
  "regex",
  "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "rquickjs",
  "rusqlite",
  "rust_decimal",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,9 @@ dirs = "5.0"
 toml = "0.8"
 toml_edit = "0.22"
 reqwest = { version = "0.12", features = ["rustls-tls", "json", "stream", "socks"] }
+# 仅用于 feature 合并：tauri-plugin-updater 依赖 reqwest 0.13 且未开 socks，
+# 而应用全局代理支持 socks5/socks5h，更新走代理时需要。此依赖不直接使用。
+reqwest_socks = { package = "reqwest", version = "0.13", default-features = false, features = ["socks"] }
 arboard = "3.6"
 flate2 = "1"
 brotli = "7"

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -189,6 +189,23 @@ pub async fn restart_app(app: AppHandle) -> Result<bool, String> {
     Ok(true)
 }
 
+/// 构建应用更新器，让更新检查与安装包下载也走全局出站代理。
+///
+/// updater 插件自建 reqwest 客户端，默认只认系统代理 env，读不到 cc-switch
+/// 应用内的全局代理设置。这里把 `http_client` 记录的代理 URL 显式传给 builder；
+/// 未配置全局代理时不传，保持插件默认行为。
+fn build_updater_with_proxy(app: &AppHandle) -> Result<tauri_plugin_updater::Updater, String> {
+    let mut builder = app.updater_builder();
+    if let Some(proxy_url) = crate::proxy::http_client::get_current_proxy_url() {
+        if let Ok(parsed) = url::Url::parse(&proxy_url) {
+            builder = builder.proxy(parsed);
+        }
+    }
+    builder
+        .build()
+        .map_err(|e| format!("初始化更新器失败: {e}"))
+}
+
 /// 下载并安装应用更新，然后由后端直接重启应用。
 ///
 /// macOS 更新会原地替换 `.app` bundle。如果先返回前端、再让旧 WebView 调
@@ -196,10 +213,7 @@ pub async fn restart_app(app: AppHandle) -> Result<bool, String> {
 /// 这里把退出清理、安装和重启串在同一个后端流程中，避免依赖旧前端继续执行。
 #[tauri::command]
 pub async fn install_update_and_restart(app: AppHandle) -> Result<bool, String> {
-    let updater = app
-        .updater_builder()
-        .build()
-        .map_err(|e| format!("初始化更新器失败: {e}"))?;
+    let updater = build_updater_with_proxy(&app)?;
 
     let Some(update) = updater
         .check()
@@ -273,10 +287,7 @@ pub async fn install_update_and_restart(app: AppHandle) -> Result<bool, String> 
 /// 升级无法解决，而不是让其反复尝试。
 #[tauri::command]
 pub async fn check_app_update_available(app: AppHandle) -> Result<Option<String>, String> {
-    let updater = app
-        .updater_builder()
-        .build()
-        .map_err(|e| format!("初始化更新器失败: {e}"))?;
+    let updater = build_updater_with_proxy(&app)?;
     let update = updater
         .check()
         .await

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -228,6 +228,41 @@ pub fn record_models_dev_sync_result(
     crate::services::model_pricing::record_models_dev_sync_result(&state.db, synced_at, error)
 }
 
+/// 通过全局 HTTP 客户端（已配置全局出站代理）拉取 models.dev 定价数据。
+///
+/// 不能在 WebView 里用原生 fetch：那只会走系统代理，读不到 cc-switch 应用内的
+/// 全局代理设置。这里走 Rust 侧统一客户端，与订阅额度、版本检查等外部请求保持
+/// 同一条代理链路。
+#[tauri::command]
+pub async fn fetch_models_dev_pricing() -> Result<serde_json::Value, AppError> {
+    const URL: &str = "https://models.dev/api.json";
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+    let client = crate::proxy::http_client::get();
+    let resp = client
+        .get(URL)
+        .timeout(TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| AppError::Message(format!("拉取 models.dev 数据失败: {e}")))?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(AppError::Message(format!(
+            "拉取 models.dev 数据失败: HTTP {status}: {body}"
+        )));
+    }
+
+    // 先 bytes() 再解析：读体失败（超时/连接中断）与 JSON 解析失败能分开报错。
+    let raw = resp
+        .bytes()
+        .await
+        .map_err(|e| AppError::Message(format!("读取 models.dev 响应失败: {e}")))?;
+    serde_json::from_slice(&raw)
+        .map_err(|e| AppError::Message(format!("解析 models.dev 响应失败: {e}")))
+}
+
 /// 检查 Provider 使用限额
 #[tauri::command]
 pub fn check_provider_limits(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1539,6 +1539,7 @@ pub fn run() {
             commands::get_models_dev_sync_config,
             commands::save_models_dev_sync_config,
             commands::record_models_dev_sync_result,
+            commands::fetch_models_dev_pricing,
             commands::check_provider_limits,
             // Session usage sync
             commands::sync_session_usage,

--- a/src/lib/modelsDevPricing.ts
+++ b/src/lib/modelsDevPricing.ts
@@ -1,7 +1,5 @@
+import { invoke } from "@tauri-apps/api/core";
 import type { ModelPricing, ModelsDevSyncConfig } from "@/types/usage";
-
-export const MODELS_DEV_API_URL = "https://models.dev/api.json";
-const MODELS_DEV_FETCH_TIMEOUT_MS = 15_000;
 
 export interface ModelsDevCost {
   input?: number;
@@ -137,22 +135,9 @@ export function flattenModels(data: ModelsDevResponse): ModelsDevEntry[] {
 }
 
 export async function fetchModelsDevPricing(): Promise<ModelsDevResponse> {
-  const controller = new AbortController();
-  const timeout = window.setTimeout(
-    () => controller.abort(),
-    MODELS_DEV_FETCH_TIMEOUT_MS,
-  );
-  try {
-    const response = await fetch(MODELS_DEV_API_URL, {
-      signal: controller.signal,
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-    return (await response.json()) as ModelsDevResponse;
-  } finally {
-    window.clearTimeout(timeout);
-  }
+  // 走 Rust 侧全局 HTTP 客户端，让全局出站代理对该请求生效；
+  // 超时与错误处理在 Rust 命令内完成。
+  return invoke<ModelsDevResponse>("fetch_models_dev_pricing");
 }
 
 const COMMON_MODEL_LIMIT_PER_FAMILY = 6;

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,4 +1,5 @@
 import { getVersion } from "@tauri-apps/api/app";
+import { getGlobalProxyUrl } from "@/lib/api/globalProxy";
 
 export type UpdateChannel = "stable" | "beta";
 
@@ -31,7 +32,20 @@ export async function checkForUpdate(
   const { check } = await import("@tauri-apps/plugin-updater");
 
   const currentVersion = await getCurrentVersion();
-  const update = await check({ timeout: opts.timeout ?? 30000 } as any);
+
+  // 让更新检查/下载也走全局出站代理：JS 插件的 check({ proxy }) 会把代理传给
+  // 插件的 plugin:updater|check 命令，并随 Update 资源带到下载与安装阶段。
+  let proxyUrl: string | null = null;
+  try {
+    proxyUrl = await getGlobalProxyUrl();
+  } catch (err) {
+    console.warn("获取全局代理失败，更新检查将直连:", err);
+  }
+
+  const update = await check({
+    timeout: opts.timeout ?? 30000,
+    proxy: proxyUrl ?? undefined,
+  } as any);
 
   if (!update) {
     return { status: "up-to-date" };

--- a/tests/components/ModelsDevAutoSyncPanel.test.tsx
+++ b/tests/components/ModelsDevAutoSyncPanel.test.tsx
@@ -8,12 +8,14 @@ const {
   getModelPricing,
   openAppConfigFolder,
   syncModelsDevPricing,
+  fetchModelsDevPricing,
 } = vi.hoisted(() => ({
   getModelsDevSyncConfig: vi.fn(),
   saveModelsDevSyncConfig: vi.fn(),
   getModelPricing: vi.fn(),
   openAppConfigFolder: vi.fn(),
   syncModelsDevPricing: vi.fn(),
+  fetchModelsDevPricing: vi.fn(),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -43,6 +45,13 @@ vi.mock("@/lib/api/settings", () => ({
 vi.mock("@/lib/modelsDevAutoSync", () => ({
   MODELS_DEV_SYNC_CONFIG_QUERY_KEY: ["models-dev-sync-config"],
   syncModelsDevPricing,
+}));
+
+// fetchModelsDevPricing 已改为走 invoke（Rust 命令拉取），UI 测试直接
+// mock 数据源，聚焦面板交互本身。
+vi.mock("@/lib/modelsDevPricing", async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchModelsDevPricing,
 }));
 
 import { ModelsDevAutoSyncPanel } from "@/components/usage/ModelsDevAutoSyncPanel";
@@ -84,34 +93,28 @@ describe("ModelsDevAutoSyncPanel", () => {
       changed: 1,
       syncedAt: Date.now(),
     });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          openai: {
-            name: "OpenAI",
-            models: {
-              "gpt-5": {
-                name: "GPT-5",
-                release_date: "2025-08-01",
-                cost: { input: 1, output: 2 },
-              },
-            },
+    fetchModelsDevPricing.mockResolvedValue({
+      openai: {
+        name: "OpenAI",
+        models: {
+          "gpt-5": {
+            name: "GPT-5",
+            release_date: "2025-08-01",
+            cost: { input: 1, output: 2 },
           },
-          deepseek: {
-            name: "DeepSeek",
-            models: {
-              "deepseek-chat": {
-                name: "DeepSeek Chat",
-                release_date: "2025-12-01",
-                cost: { input: 0.3, output: 1.2 },
-              },
-            },
+        },
+      },
+      deepseek: {
+        name: "DeepSeek",
+        models: {
+          "deepseek-chat": {
+            name: "DeepSeek Chat",
+            release_date: "2025-12-01",
+            cost: { input: 0.3, output: 1.2 },
           },
-        }),
-      }),
-    );
+        },
+      },
+    });
   });
 
   it("loads automatic sync as disabled by default", async () => {

--- a/tests/lib/modelsDevAutoSync.test.ts
+++ b/tests/lib/modelsDevAutoSync.test.ts
@@ -4,10 +4,12 @@ const {
   getModelsDevSyncConfig,
   updateModelPricingBatch,
   recordModelsDevSyncResult,
+  fetchModelsDevPricing,
 } = vi.hoisted(() => ({
   getModelsDevSyncConfig: vi.fn(),
   updateModelPricingBatch: vi.fn(),
   recordModelsDevSyncResult: vi.fn(),
+  fetchModelsDevPricing: vi.fn(),
 }));
 
 vi.mock("@/lib/api/usage", () => ({
@@ -16,6 +18,13 @@ vi.mock("@/lib/api/usage", () => ({
     updateModelPricingBatch,
     recordModelsDevSyncResult,
   },
+}));
+
+// fetchModelsDevPricing 已改为走 invoke（Rust 命令拉取），测试只关心
+// syncModelsDevPricing 的编排逻辑，直接 mock 数据源即可。
+vi.mock("@/lib/modelsDevPricing", async (importOriginal) => ({
+  ...(await importOriginal()),
+  fetchModelsDevPricing,
 }));
 
 import {
@@ -40,32 +49,26 @@ describe("syncModelsDevPricing", () => {
     vi.clearAllMocks();
     updateModelPricingBatch.mockResolvedValue(2);
     recordModelsDevSyncResult.mockResolvedValue(undefined);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          openai: {
-            models: {
-              "gpt-5": {
-                name: "GPT-5",
-                release_date: "2025-08-01",
-                cost: { input: 1, output: 2 },
-              },
-            },
+    fetchModelsDevPricing.mockResolvedValue({
+      openai: {
+        models: {
+          "gpt-5": {
+            name: "GPT-5",
+            release_date: "2025-08-01",
+            cost: { input: 1, output: 2 },
           },
-          relay: {
-            models: {
-              "custom-model": {
-                name: "Custom Model",
-                release_date: "2025-07-01",
-                cost: { input: 0.5, output: 1 },
-              },
-            },
+        },
+      },
+      relay: {
+        models: {
+          "custom-model": {
+            name: "Custom Model",
+            release_date: "2025-07-01",
+            cost: { input: 0.5, output: 1 },
           },
-        }),
-      }),
-    );
+        },
+      },
+    });
   });
 
   it("skips network access when automatic sync is disabled", async () => {
@@ -77,7 +80,7 @@ describe("syncModelsDevPricing", () => {
     const result = await syncModelsDevPricing();
 
     expect(result.skipped).toBe(true);
-    expect(fetch).not.toHaveBeenCalled();
+    expect(fetchModelsDevPricing).not.toHaveBeenCalled();
     expect(updateModelPricingBatch).not.toHaveBeenCalled();
   });
 
@@ -100,7 +103,7 @@ describe("syncModelsDevPricing", () => {
       changed: 0,
       syncedAt: lastSyncAt,
     });
-    expect(fetch).not.toHaveBeenCalled();
+    expect(fetchModelsDevPricing).not.toHaveBeenCalled();
     expect(updateModelPricingBatch).not.toHaveBeenCalled();
   });
 
@@ -127,9 +130,6 @@ describe("syncModelsDevPricing", () => {
       expect.any(Number),
       null,
     );
-    const fetchOptions = vi.mocked(fetch).mock.calls[0]?.[1];
-    expect(fetchOptions).toEqual({ signal: expect.any(AbortSignal) });
-    expect(fetchOptions).not.toHaveProperty("cache");
   });
 
   it("stops a startup sync when automatic sync is disabled during download", async () => {
@@ -191,7 +191,7 @@ describe("syncModelsDevPricing", () => {
   it("persists the last error without replacing the previous success time", async () => {
     const previous = { ...state, config: { ...state.config, lastSyncAt: 123 } };
     getModelsDevSyncConfig.mockResolvedValue(previous);
-    vi.mocked(fetch).mockRejectedValueOnce(new Error("offline"));
+    vi.mocked(fetchModelsDevPricing).mockRejectedValueOnce(new Error("offline"));
 
     await expect(syncModelsDevPricing()).rejects.toThrow("offline");
     expect(recordModelsDevSyncResult).toHaveBeenCalledWith(null, "offline");


### PR DESCRIPTION
### 问题

两处出站请求没有走全局出站代理。

一是「使用统计 - 成本定价」的 models.dev 定价同步：前端用 WebView 原生 fetch 拉取 api.json，只走系统代理，读不到应用内配置的全局出站代理，所以始终直连。直连不通的环境里请求会挂到超时被中断。

二是应用更新：主流程用 `@tauri-apps/plugin-updater` 的 JS `check()` 检查更新，经插件命令自建 HTTP 客户端，默认只认系统代理 env，更新检查和安装包下载都不走全局代理，防火墙环境下会失败。

### 改动

- models.dev 定价同步：新增 `fetch_models_dev_pricing` 命令，用全局 HTTP 客户端（`proxy::http_client::get`）拉取 api.json，前端改为 `invoke` 调用。超时与错误处理在命令内完成。
- 应用更新：主流程在 `checkForUpdate` 里取全局代理 URL 传给 JS `check({ proxy })`，检查与下载都走代理；DB 恢复页的 `check_app_update_available` / `install_update_and_restart` 构建 updater 时同样把代理传给 builder。未配置代理时行为不变。

### 验证

- `cargo check` 通过
- 配置全局代理后 models.dev 同步与应用更新检查均走代理