### PR TITLE
fix(proxy): compress inline images after upstream 413

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -780,6 +780,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "image",
  "indexmap 2.13.0",
  "json-five",
  "json5",
@@ -930,6 +931,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -2031,6 +2038,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,10 +2621,25 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,6 +73,7 @@ url = "2.5"
 auto-launch = "0.5"
 once_cell = "1.21.3"
 base64 = "0.22"
+image = { version = "0.25.10", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
 rusqlite = { version = "0.31", features = ["bundled", "backup", "hooks"] }
 indexmap = { version = "2", features = ["serde"] }
 rust_decimal = "1.33"

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -191,7 +191,8 @@ impl RequestForwarder {
             && self.rectifier_config.request_media_fallback
             && !already_retried
             && super::media_sanitizer::contains_image_blocks(provider_body)
-            && super::media_sanitizer::is_unsupported_image_error(error)
+            && (super::media_sanitizer::is_unsupported_image_error(error)
+                || matches!(error, ProxyError::UpstreamError { status: 413, .. }))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -557,23 +558,65 @@ impl RequestForwarder {
                         &provider_body,
                         &e,
                     ) {
-                        let mut media_body = provider_body.clone();
-                        let replaced_images =
-                            super::media_sanitizer::replace_image_blocks_with_marker(
-                                &mut media_body,
-                            );
+                        let is_payload_too_large =
+                            matches!(e, ProxyError::UpstreamError { status: 413, .. });
+                        let (media_body, adjusted_images, retry_description) =
+                            if is_payload_too_large {
+                                let mut retry_body = provider_body.clone();
+                                let compression = tokio::task::spawn_blocking(move || {
+                                    let stats =
+                                        super::media_sanitizer::compress_inline_images_for_retry(
+                                            &mut retry_body,
+                                        );
+                                    (retry_body, stats)
+                                })
+                                .await;
+                                let (retry_body, stats) = match compression {
+                                    Ok(result) => result,
+                                    Err(error) => {
+                                        log::warn!(
+                                            "[{app_type_str}] [Media] Inline image compression task failed: {error}"
+                                        );
+                                        (
+                                            provider_body.clone(),
+                                            super::media_sanitizer::InlineImageCompressionStats::default(),
+                                        )
+                                    }
+                                };
+                                (
+                                    retry_body,
+                                    stats.images_compressed,
+                                    format!(
+                                        "compressed inline images by {} bytes",
+                                        stats.saved_bytes()
+                                    ),
+                                )
+                            } else {
+                                let mut retry_body = provider_body.clone();
+                                let replaced =
+                                    super::media_sanitizer::replace_image_blocks_with_marker(
+                                        &mut retry_body,
+                                    );
+                                (
+                                    retry_body,
+                                    replaced,
+                                    format!(
+                                        "replaced images with {}",
+                                        super::media_sanitizer::UNSUPPORTED_IMAGE_MARKER
+                                    ),
+                                )
+                            };
 
-                        if replaced_images > 0 {
+                        if adjusted_images > 0 {
                             let _ = std::mem::replace(&mut media_rectifier_retried, true);
                             let model = media_body
                                 .get("model")
                                 .and_then(Value::as_str)
                                 .unwrap_or("");
                             log::info!(
-                                "[{app_type_str}] [Media] Upstream rejected image input; retrying provider={} model={} with {replaced_images} image block(s) replaced by {}",
+                                "[{app_type_str}] [Media] Upstream rejected request; retrying provider={} model={} after adjusting {adjusted_images} image block(s): {retry_description}",
                                 provider.id,
-                                model,
-                                super::media_sanitizer::UNSUPPORTED_IMAGE_MARKER
+                                model
                             );
 
                             match self
@@ -4842,6 +4885,14 @@ mod tests {
             ),
         }
     }
+
+    fn payload_too_large_error() -> ProxyError {
+        ProxyError::UpstreamError {
+            status: 413,
+            body: Some("Payload Too Large".to_string()),
+        }
+    }
+
     #[test]
     fn prevention_replaces_when_all_switches_on_and_model_in_heuristic_list() {
         let fwd = forwarder_with_rectifier(RectifierConfig::default());
@@ -4934,6 +4985,27 @@ mod tests {
         };
 
         assert!(fwd.media_retry_should_trigger("Codex", false, &body, &error));
+    }
+
+    #[test]
+    fn reactive_triggers_once_for_codex_image_payload_too_large() {
+        let fwd = forwarder_with_rectifier(RectifierConfig::default());
+        let body = body_with_codex_input_image("gpt-5.6-sol");
+        let error = payload_too_large_error();
+
+        assert!(fwd.media_retry_should_trigger("Codex", false, &body, &error));
+        assert!(!fwd.media_retry_should_trigger("Codex", true, &body, &error));
+    }
+
+    #[test]
+    fn reactive_does_not_treat_text_only_payload_too_large_as_media_error() {
+        let fwd = forwarder_with_rectifier(RectifierConfig::default());
+        let body = json!({
+            "model": "gpt-5.6-sol",
+            "input": [{"role": "user", "content": "large text"}]
+        });
+
+        assert!(!fwd.media_retry_should_trigger("Codex", false, &body, &payload_too_large_error()));
     }
 
     #[test]

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -6,9 +6,32 @@ use crate::proxy::error::ProxyError;
 use crate::proxy::tool_media::{
     strip_media_from_tool_value, tool_output_contains_media, ToolMediaScope,
 };
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use image::{
+    codecs::jpeg::JpegEncoder, imageops::FilterType, DynamicImage, ImageReader, Limits, Rgb,
+    RgbImage,
+};
 use serde_json::{json, Value};
+use std::io::Cursor;
 
 pub const UNSUPPORTED_IMAGE_MARKER: &str = "[Unsupported Image]";
+const INLINE_IMAGE_RETRY_BASE64_BUDGET: usize = 640 * 1024;
+const INLINE_IMAGE_RETRY_MIN_BINARY_BUDGET: usize = 96 * 1024;
+const INLINE_IMAGE_MAX_DIMENSION: u32 = 16_384;
+const INLINE_IMAGE_MAX_ALLOC: u64 = 192 * 1024 * 1024;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct InlineImageCompressionStats {
+    pub images_compressed: usize,
+    pub original_bytes: usize,
+    pub compressed_bytes: usize,
+}
+
+impl InlineImageCompressionStats {
+    pub fn saved_bytes(&self) -> usize {
+        self.original_bytes.saturating_sub(self.compressed_bytes)
+    }
+}
 
 /// Replace image blocks before sending when the routed model is text-only.
 ///
@@ -50,6 +73,21 @@ pub fn contains_image_blocks(body: &Value) -> bool {
 
 pub fn replace_image_blocks_with_marker(body: &mut Value) -> usize {
     replace_images_in_body(body)
+}
+
+/// Downsize inline image data URLs after an upstream gateway rejects the request with HTTP 413.
+/// Remote URLs and malformed/unsupported image payloads are left untouched.
+pub fn compress_inline_images_for_retry(body: &mut Value) -> InlineImageCompressionStats {
+    let image_count = count_inline_image_data_urls(body);
+    if image_count == 0 {
+        return InlineImageCompressionStats::default();
+    }
+
+    let binary_budget = (INLINE_IMAGE_RETRY_BASE64_BUDGET / image_count).saturating_mul(3) / 4;
+    let binary_budget = binary_budget.max(INLINE_IMAGE_RETRY_MIN_BINARY_BUDGET);
+    let mut stats = InlineImageCompressionStats::default();
+    compress_inline_image_values(body, binary_budget, &mut stats);
+    stats
 }
 
 pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
@@ -145,6 +183,116 @@ fn replace_images_in_body(body: &mut Value) -> usize {
             .map(replace_images_in_responses_input)
             .unwrap_or(0)
         + replace_images_in_gemini_contents(body)
+}
+
+fn count_inline_image_data_urls(value: &Value) -> usize {
+    match value {
+        Value::String(text) => parse_inline_image_data_url(text).is_some() as usize,
+        Value::Array(items) => items.iter().map(count_inline_image_data_urls).sum(),
+        Value::Object(object) => object.values().map(count_inline_image_data_urls).sum(),
+        _ => 0,
+    }
+}
+
+fn compress_inline_image_values(
+    value: &mut Value,
+    binary_budget: usize,
+    stats: &mut InlineImageCompressionStats,
+) {
+    match value {
+        Value::String(text) => {
+            let Some(compressed) = compress_inline_image_data_url(text, binary_budget) else {
+                return;
+            };
+            stats.images_compressed += 1;
+            stats.original_bytes += text.len();
+            stats.compressed_bytes += compressed.len();
+            *text = compressed;
+        }
+        Value::Array(items) => {
+            for item in items {
+                compress_inline_image_values(item, binary_budget, stats);
+            }
+        }
+        Value::Object(object) => {
+            for item in object.values_mut() {
+                compress_inline_image_values(item, binary_budget, stats);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn parse_inline_image_data_url(value: &str) -> Option<&str> {
+    let (header, payload) = value.split_once(',')?;
+    let header = header.to_ascii_lowercase();
+    (header.starts_with("data:image/") && header.ends_with(";base64") && !payload.is_empty())
+        .then_some(payload)
+}
+
+fn compress_inline_image_data_url(value: &str, binary_budget: usize) -> Option<String> {
+    let payload = parse_inline_image_data_url(value)?;
+    let bytes = STANDARD.decode(payload).ok()?;
+    if bytes.len() <= binary_budget {
+        return None;
+    }
+
+    let mut reader = ImageReader::new(Cursor::new(&bytes))
+        .with_guessed_format()
+        .ok()?;
+    let mut limits = Limits::default();
+    limits.max_image_width = Some(INLINE_IMAGE_MAX_DIMENSION);
+    limits.max_image_height = Some(INLINE_IMAGE_MAX_DIMENSION);
+    limits.max_alloc = Some(INLINE_IMAGE_MAX_ALLOC);
+    reader.limits(limits);
+    let image = reader.decode().ok()?;
+
+    let attempts = [
+        (1_600, 82),
+        (1_400, 76),
+        (1_200, 70),
+        (1_024, 64),
+        (896, 58),
+        (768, 52),
+    ];
+    let mut best: Option<Vec<u8>> = None;
+    for (max_dimension, quality) in attempts {
+        let target_dimension = max_dimension.min(image.width().max(image.height()));
+        let resized = image.resize(target_dimension, target_dimension, FilterType::Lanczos3);
+        let rgb = flatten_image_onto_white(&resized);
+        let mut encoded = Vec::new();
+        JpegEncoder::new_with_quality(&mut encoded, quality)
+            .encode_image(&rgb)
+            .ok()?;
+
+        if best
+            .as_ref()
+            .is_none_or(|current| encoded.len() < current.len())
+        {
+            best = Some(encoded);
+        }
+        if best
+            .as_ref()
+            .is_some_and(|encoded| encoded.len() <= binary_budget)
+        {
+            break;
+        }
+    }
+
+    let encoded = best?;
+    let compressed = format!("data:image/jpeg;base64,{}", STANDARD.encode(encoded));
+    (compressed.len() < value.len()).then_some(compressed)
+}
+
+fn flatten_image_onto_white(image: &DynamicImage) -> RgbImage {
+    let rgba = image.to_rgba8();
+    RgbImage::from_fn(rgba.width(), rgba.height(), |x, y| {
+        let pixel = rgba.get_pixel(x, y).0;
+        let alpha = u32::from(pixel[3]);
+        let blend =
+            |channel: u8| ((u32::from(channel) * alpha + 255 * (255 - alpha) + 127) / 255) as u8;
+        Rgb([blend(pixel[0]), blend(pixel[1]), blend(pixel[2])])
+    })
 }
 
 fn replace_images_in_message(message: &mut Value) -> usize {
@@ -437,6 +585,7 @@ fn extract_error_text(body: &str) -> String {
 mod tests {
     use super::*;
     use crate::provider::Provider;
+    use image::{codecs::png::PngEncoder, ColorType, ImageEncoder};
     use serde_json::json;
 
     fn provider(settings_config: Value) -> Provider {
@@ -461,6 +610,75 @@ mod tests {
             "data:image/png;base64,{}",
             "SANITIZER_TOOL_MEDIA_SENTINEL".repeat(400)
         )
+    }
+
+    fn png_data_url(width: u32, height: u32) -> String {
+        let mut state = 0x1234_5678_u32;
+        let mut pixels = Vec::with_capacity((width * height * 4) as usize);
+        for _ in 0..width * height {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            pixels.extend_from_slice(&[
+                (state >> 24) as u8,
+                (state >> 16) as u8,
+                (state >> 8) as u8,
+                255,
+            ]);
+        }
+
+        let mut encoded = Vec::new();
+        PngEncoder::new(&mut encoded)
+            .write_image(&pixels, width, height, ColorType::Rgba8.into())
+            .unwrap();
+        format!("data:image/png;base64,{}", STANDARD.encode(encoded))
+    }
+
+    #[test]
+    fn compresses_large_inline_image_to_decodable_jpeg_for_retry() {
+        let original = png_data_url(1_024, 1_024);
+        let mut body = json!({
+            "model": "gpt-5.6-sol",
+            "input": [{
+                "role": "user",
+                "content": [{"type": "input_image", "image_url": original.clone()}]
+            }]
+        });
+
+        let stats = compress_inline_images_for_retry(&mut body);
+        let compressed = body["input"][0]["content"][0]["image_url"]
+            .as_str()
+            .unwrap();
+        let payload = compressed
+            .strip_prefix("data:image/jpeg;base64,")
+            .expect("retry image should be encoded as JPEG");
+        let decoded = STANDARD.decode(payload).unwrap();
+        let image = image::load_from_memory(&decoded).unwrap();
+
+        assert_eq!(stats.images_compressed, 1);
+        assert_eq!(stats.original_bytes, original.len());
+        assert_eq!(stats.compressed_bytes, compressed.len());
+        assert!(stats.saved_bytes() > 0);
+        assert!(compressed.len() < original.len());
+        assert!(compressed.len() <= INLINE_IMAGE_RETRY_BASE64_BUDGET + 32);
+        assert!(image.width() <= 1_600);
+        assert!(image.height() <= 1_600);
+    }
+
+    #[test]
+    fn leaves_small_remote_and_invalid_images_unchanged() {
+        let small = png_data_url(8, 8);
+        let remote = "https://example.com/image.png";
+        let invalid = "data:image/png;base64,not-valid-base64";
+        let mut body = json!({
+            "small": small.clone(),
+            "remote": remote,
+            "invalid": invalid
+        });
+        let original = body.clone();
+
+        let stats = compress_inline_images_for_retry(&mut body);
+
+        assert_eq!(stats, InlineImageCompressionStats::default());
+        assert_eq!(body, original);
     }
 
     #[test]

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -8,10 +8,10 @@ use crate::proxy::tool_media::{
 };
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use image::{
-    codecs::jpeg::JpegEncoder, imageops::FilterType, DynamicImage, ImageReader, Limits, Rgb,
-    RgbImage,
+    codecs::jpeg::JpegEncoder, imageops::FilterType, metadata::Orientation, DynamicImage,
+    ImageDecoder, ImageReader, Limits, Rgb, RgbImage,
 };
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use std::io::Cursor;
 
 pub const UNSUPPORTED_IMAGE_MARKER: &str = "[Unsupported Image]";
@@ -75,8 +75,8 @@ pub fn replace_image_blocks_with_marker(body: &mut Value) -> usize {
     replace_images_in_body(body)
 }
 
-/// Downsize inline image data URLs after an upstream gateway rejects the request with HTTP 413.
-/// Remote URLs and malformed/unsupported image payloads are left untouched.
+/// Downsize inline data URLs and native Anthropic base64 image sources after an upstream gateway
+/// rejects the request with HTTP 413. Remote URLs and malformed/unsupported payloads are untouched.
 pub fn compress_inline_images_for_retry(body: &mut Value) -> InlineImageCompressionStats {
     let image_count = count_inline_image_data_urls(body);
     if image_count == 0 {
@@ -189,7 +189,13 @@ fn count_inline_image_data_urls(value: &Value) -> usize {
     match value {
         Value::String(text) => parse_inline_image_data_url(text).is_some() as usize,
         Value::Array(items) => items.iter().map(count_inline_image_data_urls).sum(),
-        Value::Object(object) => object.values().map(count_inline_image_data_urls).sum(),
+        Value::Object(object) => {
+            if native_anthropic_image_data(object).is_some() {
+                1
+            } else {
+                object.values().map(count_inline_image_data_urls).sum()
+            }
+        }
         _ => 0,
     }
 }
@@ -214,12 +220,21 @@ fn compress_inline_image_values(
                 compress_inline_image_values(item, binary_budget, stats);
             }
         }
-        Value::Object(object) => {
-            for item in object.values_mut() {
-                compress_inline_image_values(item, binary_budget, stats);
-            }
-        }
+        Value::Object(object) => compress_inline_image_object(object, binary_budget, stats),
         _ => {}
+    }
+}
+
+fn compress_inline_image_object(
+    object: &mut Map<String, Value>,
+    binary_budget: usize,
+    stats: &mut InlineImageCompressionStats,
+) {
+    if compress_native_anthropic_image_source(object, binary_budget, stats) {
+        return;
+    }
+    for item in object.values_mut() {
+        compress_inline_image_values(item, binary_budget, stats);
     }
 }
 
@@ -233,6 +248,55 @@ fn parse_inline_image_data_url(value: &str) -> Option<&str> {
 fn compress_inline_image_data_url(value: &str, binary_budget: usize) -> Option<String> {
     let payload = parse_inline_image_data_url(value)?;
     let bytes = STANDARD.decode(payload).ok()?;
+    let encoded = compress_image_bytes(&bytes, binary_budget)?;
+    let compressed = format!("data:image/jpeg;base64,{}", STANDARD.encode(encoded));
+    (compressed.len() < value.len()).then_some(compressed)
+}
+
+fn native_anthropic_image_data(source: &Map<String, Value>) -> Option<&str> {
+    let is_base64 = source.get("type").and_then(Value::as_str) == Some("base64");
+    let is_image = source
+        .get("media_type")
+        .and_then(Value::as_str)
+        .is_some_and(|media_type| {
+            media_type
+                .get(..6)
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("image/"))
+        });
+    (is_base64 && is_image)
+        .then(|| source.get("data").and_then(Value::as_str))
+        .flatten()
+}
+
+fn compress_native_anthropic_image_source(
+    source: &mut Map<String, Value>,
+    binary_budget: usize,
+    stats: &mut InlineImageCompressionStats,
+) -> bool {
+    let Some(original) = native_anthropic_image_data(source).map(str::to_owned) else {
+        return false;
+    };
+    let Some(encoded) = STANDARD
+        .decode(&original)
+        .ok()
+        .and_then(|bytes| compress_image_bytes(&bytes, binary_budget))
+    else {
+        return false;
+    };
+    let compressed = STANDARD.encode(encoded);
+    if compressed.len() >= original.len() {
+        return false;
+    }
+
+    stats.images_compressed += 1;
+    stats.original_bytes += original.len();
+    stats.compressed_bytes += compressed.len();
+    source.insert("media_type".to_string(), json!("image/jpeg"));
+    source.insert("data".to_string(), Value::String(compressed));
+    true
+}
+
+fn compress_image_bytes(bytes: &[u8], binary_budget: usize) -> Option<Vec<u8>> {
     if bytes.len() <= binary_budget {
         return None;
     }
@@ -245,7 +309,13 @@ fn compress_inline_image_data_url(value: &str, binary_budget: usize) -> Option<S
     limits.max_image_height = Some(INLINE_IMAGE_MAX_DIMENSION);
     limits.max_alloc = Some(INLINE_IMAGE_MAX_ALLOC);
     reader.limits(limits);
-    let image = reader.decode().ok()?;
+    let mut decoder = reader.into_decoder().ok()?;
+    if decoder.total_bytes() > INLINE_IMAGE_MAX_ALLOC {
+        return None;
+    }
+    let orientation = decoder.orientation().unwrap_or(Orientation::NoTransforms);
+    let mut image = DynamicImage::from_decoder(decoder).ok()?;
+    image.apply_orientation(orientation);
 
     let attempts = [
         (1_600, 82),
@@ -279,9 +349,7 @@ fn compress_inline_image_data_url(value: &str, binary_budget: usize) -> Option<S
         }
     }
 
-    let encoded = best?;
-    let compressed = format!("data:image/jpeg;base64,{}", STANDARD.encode(encoded));
-    (compressed.len() < value.len()).then_some(compressed)
+    best
 }
 
 fn flatten_image_onto_white(image: &DynamicImage) -> RgbImage {
@@ -585,7 +653,10 @@ fn extract_error_text(body: &str) -> String {
 mod tests {
     use super::*;
     use crate::provider::Provider;
-    use image::{codecs::png::PngEncoder, ColorType, ImageEncoder};
+    use image::{
+        codecs::{jpeg::JpegEncoder, png::PngEncoder},
+        ColorType, ImageEncoder,
+    };
     use serde_json::json;
 
     fn provider(settings_config: Value) -> Provider {
@@ -630,6 +701,34 @@ mod tests {
             .write_image(&pixels, width, height, ColorType::Rgba8.into())
             .unwrap();
         format!("data:image/png;base64,{}", STANDARD.encode(encoded))
+    }
+
+    fn oriented_jpeg_data_url(width: u32, height: u32, orientation: u16) -> String {
+        let mut state = 0x8765_4321_u32;
+        let mut pixels = Vec::with_capacity((width * height * 3) as usize);
+        for _ in 0..width * height {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            pixels.extend_from_slice(&[
+                (state >> 24) as u8,
+                (state >> 16) as u8,
+                (state >> 8) as u8,
+            ]);
+        }
+
+        let mut jpeg = Vec::new();
+        JpegEncoder::new_with_quality(&mut jpeg, 95)
+            .encode(&pixels, width, height, ColorType::Rgb8.into())
+            .unwrap();
+
+        let mut exif = vec![
+            0xff, 0xe1, 0x00, 0x22, b'E', b'x', b'i', b'f', 0x00, 0x00, b'M', b'M', 0x00, 0x2a,
+            0x00, 0x00, 0x00, 0x08, 0x00, 0x01, 0x01, 0x12, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        exif[28..30].copy_from_slice(&orientation.to_be_bytes());
+        jpeg.splice(2..2, exif);
+
+        format!("data:image/jpeg;base64,{}", STANDARD.encode(jpeg))
     }
 
     #[test]
@@ -679,6 +778,71 @@ mod tests {
 
         assert_eq!(stats, InlineImageCompressionStats::default());
         assert_eq!(body, original);
+    }
+
+    #[test]
+    fn compresses_native_anthropic_base64_image_source() {
+        let data_url = png_data_url(1_024, 1_024);
+        let original = data_url.split_once(',').unwrap().1.to_string();
+        let mut body = json!({
+            "model": "claude-compatible",
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": original.clone()
+                    }
+                }]
+            }]
+        });
+
+        let stats = compress_inline_images_for_retry(&mut body);
+        let source = &body["messages"][0]["content"][0]["source"];
+        let compressed = source["data"].as_str().unwrap();
+        let decoded = STANDARD.decode(compressed).unwrap();
+
+        assert_eq!(stats.images_compressed, 1);
+        assert_eq!(stats.original_bytes, original.len());
+        assert_eq!(stats.compressed_bytes, compressed.len());
+        assert_eq!(source["type"], "base64");
+        assert_eq!(source["media_type"], "image/jpeg");
+        assert!(compressed.len() < original.len());
+        assert!(image::load_from_memory(&decoded).is_ok());
+    }
+
+    #[test]
+    fn applies_exif_orientation_before_reencoding() {
+        let original = oriented_jpeg_data_url(1_200, 800, 6);
+        let original_bytes = STANDARD
+            .decode(original.split_once(',').unwrap().1)
+            .unwrap();
+        let mut decoder = ImageReader::new(Cursor::new(&original_bytes))
+            .with_guessed_format()
+            .unwrap()
+            .into_decoder()
+            .unwrap();
+        assert_eq!(decoder.orientation().unwrap(), Orientation::Rotate90);
+
+        let mut body = json!({
+            "input": [{
+                "role": "user",
+                "content": [{"type": "input_image", "image_url": original}]
+            }]
+        });
+
+        let stats = compress_inline_images_for_retry(&mut body);
+        let compressed = body["input"][0]["content"][0]["image_url"]
+            .as_str()
+            .unwrap();
+        let payload = compressed.strip_prefix("data:image/jpeg;base64,").unwrap();
+        let image = image::load_from_memory(&STANDARD.decode(payload).unwrap()).unwrap();
+
+        assert_eq!(stats.images_compressed, 1);
+        assert!(image.height() > image.width());
+        assert!((i64::from(image.height()) * 2 - i64::from(image.width()) * 3).abs() <= 3);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- retry Codex/Claude image requests once after an upstream HTTP 413
- recompress oversized inline data-URL images as bounded JPEGs without downloading remote images
- keep the existing unsupported-image marker fallback unchanged for modality errors

## Root cause

CC Switch accepts request bodies up to its local proxy limit, but an upstream gateway may enforce a smaller body limit. Responses requests embed images as base64 data URLs, so a single image can cause the provider gateway to reject the request before the model receives it.

## Behavior

On an upstream 413, requests containing images are inspected once. Decodable oversized inline PNG/JPEG/GIF/WebP images are resized and re-encoded on a blocking worker, then retried against the same provider. Small images, remote URLs, malformed data, and text-only 413 responses remain unchanged. The retry is provider-local and cannot leak into failover attempts.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::media_sanitizer` (38 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::forwarder` (71 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::providers` (674 passed)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `git diff --check`