### PR TITLE
perf(about): 用轻量 npm dist-tags 接口查工具版本

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -927,15 +927,23 @@ fn pick_latest_version(
     Some(best)
 }
 
-/// 拉取 npm 包的完整 dist-tags(单次请求即含 latest/next/beta/...)。
+/// 拉取 npm 包的 dist-tags（latest/next/beta/...）。
+///
+/// 走 registry 的轻量端点 `/-/package/{package}/dist-tags`，只返回 dist-tags
+/// 一个对象（几 KB）。替代完整 packument（`registry.npmjs.org/{package}`，
+/// 同样的 dist-tags 也要几 MB，opencode-ai 全量约 24 MB），「关于」页一次
+/// 全量刷新从约 55 MB 降到约 3 KB。
 async fn fetch_npm_dist_tags(
     client: &reqwest::Client,
     package: &str,
 ) -> Option<serde_json::Map<String, serde_json::Value>> {
-    let url = format!("https://registry.npmjs.org/{package}");
+    let url = format!("https://registry.npmjs.org/-/package/{package}/dist-tags");
     let resp = client.get(&url).send().await.ok()?;
-    let json = resp.json::<serde_json::Value>().await.ok()?;
-    json.get("dist-tags")?.as_object().cloned()
+    // 该端点响应本身就是 dist-tags 对象（无外层外壳），与
+    // `pick_latest_version` 的入参形状一致，直接解析即可。
+    resp.json::<serde_json::Map<String, serde_json::Value>>()
+        .await
+        .ok()
 }
 
 /// 查询某 npm 工具要展示的"最新版本":取 `latest`,并在本地版本领先时按工具的


### PR DESCRIPTION
### 问题

「关于」页加载多个 npm 工具的最新版本，原来请求完整 packument（`registry.npmjs.org/{package}`），但只用到 `dist-tags` 一个字段。6 个 npm 包一次全量刷新约 55 MB（opencode-ai 全量约 24 MB），还要逐个把几 MB 的 JSON 解析进内存，各工具串行请求，延迟累加。

### 改动

改用 registry 的轻量端点 `/-/package/{package}/dist-tags`，响应本身就是 dist-tags 对象（合计约 3.3 KB）。`pick_latest_version` 入参形状不变，claude 的 `next` 预发布通道补查逻辑照常。

### 影响

安装/更新命令是硬编码字符串（`npm i -g <包名>@latest` / `claude update` 等），不消费本次查询结果。`latest_version` 只用于「关于」页展示和升级徽标判断，改动前后值一致。

### 验证

- 实测 6 个包两种接口体积：完整 packument 共约 55 MB，dist-tags 接口共约 3.3 KB
- `cargo test --lib pick_latest` 通过
