### PR TITLE
fix(codex): handle text-only DeepSeek V4 Flash 0731 on OpenRouter

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -4431,6 +4431,16 @@ base_url = "https://production.api/v1"
                 default_reasoning_level: None,
             },
             CodexCatalogModelSpec {
+                model: "deepseek/deepseek-v4-flash-0731".to_string(),
+                display_name: Some("DeepSeek V4 Flash 0731".to_string()),
+                context_window: Some(128_000),
+                supports_parallel_tool_calls: None,
+                input_modalities: None,
+                base_instructions: None,
+                reasoning_levels: None,
+                default_reasoning_level: None,
+            },
+            CodexCatalogModelSpec {
                 model: "glm-5.2v".to_string(),
                 display_name: Some("GLM 5.2V".to_string()),
                 context_window: Some(128_000),
@@ -4480,6 +4490,11 @@ base_url = "https://production.api/v1"
 
             assert_eq!(modalities("gpt-5.4"), json!(["text", "image"]));
             assert_eq!(modalities("deepseek/deepseek-v4-pro"), json!(["text"]));
+            assert_eq!(
+                modalities("deepseek/deepseek-v4-flash-0731"),
+                json!(["text"]),
+                "OpenRouter's dated DeepSeek Flash alias is text-only"
+            );
             assert_eq!(modalities("glm-5.2v"), json!(["text", "image"]));
             assert_eq!(
                 modalities("deepseek-v4-flash"),

--- a/src-tauri/src/model_capabilities.rs
+++ b/src-tauri/src/model_capabilities.rs
@@ -74,6 +74,9 @@ pub(crate) fn is_confirmed_text_only_model(model: &str) -> bool {
         "deepseek-chat",
         "deepseek-reasoner",
         "deepseek-v4-flash",
+        // OpenRouter's dated alias for the 2026-07-31 Flash release. Keep this
+        // exact: a future `-vision` / `-vl` sibling must fail open.
+        "deepseek-v4-flash-0731",
         "deepseek-v4-pro",
         "glm-5.1",
         // Exact rather than prefix matching: GLM visual models use a `v`
@@ -216,6 +219,9 @@ mod tests {
     #[test]
     fn confirmed_text_only_registry_normalizes_namespaces_and_context_markers() {
         assert!(is_confirmed_text_only_model("deepseek/deepseek-v4-pro"));
+        assert!(is_confirmed_text_only_model(
+            "deepseek/deepseek-v4-flash-0731"
+        ));
         assert!(is_confirmed_text_only_model("GLM-5.2[1M]"));
         assert!(is_confirmed_text_only_model("qwen/qwen3-coder-plus"));
         assert!(is_confirmed_text_only_model(
@@ -229,6 +235,7 @@ mod tests {
     #[test]
     fn unconfirmed_family_suffixes_fail_open() {
         for model in [
+            "deepseek-v4-flash-vision",
             "minimax-m2.7-vision",
             "qwen3-coder-ultra",
             "qwen3-coder-vl",

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -5097,6 +5097,21 @@ mod tests {
     }
 
     #[test]
+    fn reactive_triggers_for_openrouter_no_image_endpoint_404() {
+        let fwd = forwarder_with_rectifier(RectifierConfig::default());
+        let body = body_with_codex_input_image("deepseek/deepseek-v4-flash-0731");
+        let error = ProxyError::UpstreamError {
+            status: 404,
+            body: Some(
+                r#"{"error":{"message":"No endpoints found that support image input"}}"#
+                    .to_string(),
+            ),
+        };
+
+        assert!(fwd.media_retry_should_trigger("Codex", false, &body, &error));
+    }
+
+    #[test]
     fn reactive_triggers_for_structured_and_stringified_codex_tool_images() {
         let fwd = forwarder_with_rectifier(RectifierConfig::default());
 

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -57,7 +57,8 @@ pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
         return false;
     };
 
-    if !matches!(*status, 400 | 415 | 422 | 501) {
+    let is_standard_modality_status = matches!(*status, 400 | 415 | 422 | 501);
+    if !is_standard_modality_status && *status != 404 {
         return false;
     }
 
@@ -67,6 +68,13 @@ pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
 
     let message = extract_error_text(body);
     let message = message.to_ascii_lowercase();
+
+    // OpenRouter reports routing failure as 404 when every endpoint for a
+    // model rejects image input. Keep this narrow: an ordinary missing route
+    // must not trigger a body-mutating retry.
+    if *status == 404 {
+        return message.contains("no endpoints found that support image input");
+    }
 
     // 自证性表述：这类短语本身就断言了"仅接受文本"，属于模态拒绝，无需再要求
     // 错误提到 image/media 等字样——火山方舟等网关的报错是
@@ -534,6 +542,30 @@ mod tests {
         let provider = provider(json!({}));
         let mut body = json!({
             "model": "deepseek-v4-flash",
+            "input": [{
+                "role": "user",
+                "content": [
+                    { "type": "input_text", "text": "look" },
+                    { "type": "input_image", "image_url": "data:image/png;base64,abc" }
+                ]
+            }]
+        });
+
+        let count = replace_images_for_text_only_model(&mut body, &provider, true);
+
+        assert_eq!(count, 1);
+        assert_eq!(body["input"][0]["content"][1]["type"], "input_text");
+        assert_eq!(
+            body["input"][0]["content"][1]["text"],
+            UNSUPPORTED_IMAGE_MARKER
+        );
+    }
+
+    #[test]
+    fn openrouter_dated_deepseek_replaces_codex_input_image_before_send() {
+        let provider = provider(json!({}));
+        let mut body = json!({
+            "model": "deepseek/deepseek-v4-flash-0731",
             "input": [{
                 "role": "user",
                 "content": [
@@ -1166,6 +1198,34 @@ mod tests {
         };
 
         assert!(is_unsupported_image_error(&error));
+    }
+
+    #[test]
+    fn detects_openrouter_no_image_endpoint_404() {
+        let error = ProxyError::UpstreamError {
+            status: 404,
+            body: Some(
+                r#"{"error":{"message":"No endpoints found that support image input"}}"#
+                    .to_string(),
+            ),
+        };
+
+        assert!(is_unsupported_image_error(&error));
+    }
+
+    #[test]
+    fn ignores_unrelated_404_errors() {
+        for message in [
+            "Route not found",
+            "No endpoints found that support image generation",
+        ] {
+            let error = ProxyError::UpstreamError {
+                status: 404,
+                body: Some(json!({ "error": { "message": message } }).to_string()),
+            };
+
+            assert!(!is_unsupported_image_error(&error));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Classify `deepseek/deepseek-v4-flash-0731` as text-only so generated Codex catalogs advertise `input_modalities: ["text"]` and historical image blocks are sanitized before forwarding.
- Recognize OpenRouter's `404 No endpoints found that support image input` response and retry once with image blocks replaced by `[Unsupported Image]`.
- Keep unrelated 404 responses and unconfirmed visual model variants unchanged, with regression coverage for catalog generation and proxy fallback.

## Root cause

`deepseek/deepseek-v4-flash-0731` was missing from the exact confirmed text-only registry, so it failed open as image-capable. OpenRouter's image rejection also uses HTTP 404, which the reactive media fallback did not recognize.

`supports_image_detail_original: false` is intentionally not used as the capability signal because it only describes support for the `original` image detail level, not image input as a whole.

## Testing

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- 45 focused model capability, catalog, sanitizer, and forwarding tests passed.
- Library suite: 2,338 passed and 5 ignored after excluding one pre-existing loopback reqwest test that receives HTTP 502 in this Windows environment; the same test fails in isolation and is unrelated to the changed files.

## Related issue

Fixes #6176