### PR TITLE
fix(presets): connect OpenCode Go directly in Claude Code

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -835,7 +835,7 @@ export const providerPresets: ProviderPreset[] = [
     settingsConfig: {
       env: {
         ANTHROPIC_BASE_URL: "https://opencode.ai/zen/go",
-        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_API_KEY: "",
         ANTHROPIC_MODEL: "deepseek-v4-flash",
         ANTHROPIC_DEFAULT_HAIKU_MODEL: "deepseek-v4-flash",
         ANTHROPIC_DEFAULT_SONNET_MODEL: "deepseek-v4-flash",
@@ -843,7 +843,11 @@ export const providerPresets: ProviderPreset[] = [
       },
     },
     category: "third_party",
-    apiFormat: "openai_chat",
+    // OpenCode Go exposes DeepSeek V4 Flash through its Anthropic Messages
+    // endpoint. It expects x-api-key instead of Bearer auth, so Claude Code
+    // can connect directly without routing.
+    apiKeyField: "ANTHROPIC_API_KEY",
+    apiFormat: "anthropic",
     endpointCandidates: ["https://opencode.ai/zen/go"],
     icon: "opencode",
     iconColor: "#211E1E",

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -836,16 +836,15 @@ export const providerPresets: ProviderPreset[] = [
       env: {
         ANTHROPIC_BASE_URL: "https://opencode.ai/zen/go",
         ANTHROPIC_API_KEY: "",
-        ANTHROPIC_MODEL: "minimax-m3",
-        ANTHROPIC_DEFAULT_HAIKU_MODEL: "minimax-m3",
-        ANTHROPIC_DEFAULT_SONNET_MODEL: "minimax-m3",
-        ANTHROPIC_DEFAULT_OPUS_MODEL: "minimax-m3",
+        ANTHROPIC_MODEL: "deepseek-v4-flash",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "deepseek-v4-flash",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "deepseek-v4-flash",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "deepseek-v4-flash",
       },
     },
     category: "third_party",
-    // OpenCode Go exposes MiniMax M3 through its Anthropic Messages endpoint.
-    // DeepSeek V4 Flash is only available through Chat Completions and would
-    // still require local routing in Claude Code.
+    // OpenCode Go accepts Anthropic Messages requests and translates them to
+    // the format used by the selected model's upstream provider.
     apiKeyField: "ANTHROPIC_API_KEY",
     apiFormat: "anthropic",
     endpointCandidates: ["https://opencode.ai/zen/go"],

--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -836,16 +836,16 @@ export const providerPresets: ProviderPreset[] = [
       env: {
         ANTHROPIC_BASE_URL: "https://opencode.ai/zen/go",
         ANTHROPIC_API_KEY: "",
-        ANTHROPIC_MODEL: "deepseek-v4-flash",
-        ANTHROPIC_DEFAULT_HAIKU_MODEL: "deepseek-v4-flash",
-        ANTHROPIC_DEFAULT_SONNET_MODEL: "deepseek-v4-flash",
-        ANTHROPIC_DEFAULT_OPUS_MODEL: "deepseek-v4-flash",
+        ANTHROPIC_MODEL: "minimax-m3",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "minimax-m3",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "minimax-m3",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "minimax-m3",
       },
     },
     category: "third_party",
-    // OpenCode Go exposes DeepSeek V4 Flash through its Anthropic Messages
-    // endpoint. It expects x-api-key instead of Bearer auth, so Claude Code
-    // can connect directly without routing.
+    // OpenCode Go exposes MiniMax M3 through its Anthropic Messages endpoint.
+    // DeepSeek V4 Flash is only available through Chat Completions and would
+    // still require local routing in Claude Code.
     apiKeyField: "ANTHROPIC_API_KEY",
     apiFormat: "anthropic",
     endpointCandidates: ["https://opencode.ai/zen/go"],

--- a/tests/config/claudeProviderPresets.test.ts
+++ b/tests/config/claudeProviderPresets.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { providerPresets } from "@/config/claudeProviderPresets";
+import type { Provider } from "@/types";
+import { providerNeedsRouting } from "@/utils/providerCapabilities";
 
 describe("Kimi For Coding Provider Preset", () => {
   const kimiForCoding = providerPresets.find(
@@ -44,6 +46,39 @@ describe("Codex Provider Preset", () => {
     expect(env.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe("372000");
     expect(env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("372000");
     expect(codex!.templateValues).toBeUndefined();
+  });
+});
+
+describe("OpenCode Go Provider Preset", () => {
+  const openCodeGo = providerPresets.find((p) => p.name === "OpenCode Go");
+
+  it("should use the Anthropic endpoint with x-api-key auth", () => {
+    expect(openCodeGo).toBeDefined();
+
+    const env = (openCodeGo!.settingsConfig as any).env;
+    expect(env).toMatchObject({
+      ANTHROPIC_BASE_URL: "https://opencode.ai/zen/go",
+      ANTHROPIC_API_KEY: "",
+      ANTHROPIC_MODEL: "deepseek-v4-flash",
+    });
+    expect(env).not.toHaveProperty("ANTHROPIC_AUTH_TOKEN");
+    expect(openCodeGo!.apiFormat).toBe("anthropic");
+    expect(openCodeGo!.apiKeyField).toBe("ANTHROPIC_API_KEY");
+  });
+
+  it("should not require local routing in Claude Code", () => {
+    const provider: Provider = {
+      id: "opencode-go",
+      name: openCodeGo!.name,
+      category: openCodeGo!.category,
+      settingsConfig: openCodeGo!.settingsConfig as Record<string, any>,
+      meta: {
+        apiFormat: openCodeGo!.apiFormat,
+        apiKeyField: openCodeGo!.apiKeyField,
+      },
+    };
+
+    expect(providerNeedsRouting("claude", provider)).toBe(false);
   });
 });
 

--- a/tests/config/claudeProviderPresets.test.ts
+++ b/tests/config/claudeProviderPresets.test.ts
@@ -52,14 +52,17 @@ describe("Codex Provider Preset", () => {
 describe("OpenCode Go Provider Preset", () => {
   const openCodeGo = providerPresets.find((p) => p.name === "OpenCode Go");
 
-  it("should use the Anthropic endpoint with x-api-key auth", () => {
+  it("should use an Anthropic-compatible model with x-api-key auth", () => {
     expect(openCodeGo).toBeDefined();
 
     const env = (openCodeGo!.settingsConfig as any).env;
     expect(env).toMatchObject({
       ANTHROPIC_BASE_URL: "https://opencode.ai/zen/go",
       ANTHROPIC_API_KEY: "",
-      ANTHROPIC_MODEL: "deepseek-v4-flash",
+      ANTHROPIC_MODEL: "minimax-m3",
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "minimax-m3",
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "minimax-m3",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "minimax-m3",
     });
     expect(env).not.toHaveProperty("ANTHROPIC_AUTH_TOKEN");
     expect(openCodeGo!.apiFormat).toBe("anthropic");

--- a/tests/config/claudeProviderPresets.test.ts
+++ b/tests/config/claudeProviderPresets.test.ts
@@ -52,17 +52,17 @@ describe("Codex Provider Preset", () => {
 describe("OpenCode Go Provider Preset", () => {
   const openCodeGo = providerPresets.find((p) => p.name === "OpenCode Go");
 
-  it("should use an Anthropic-compatible model with x-api-key auth", () => {
+  it("should use the Go Anthropic compatibility endpoint with x-api-key auth", () => {
     expect(openCodeGo).toBeDefined();
 
     const env = (openCodeGo!.settingsConfig as any).env;
     expect(env).toMatchObject({
       ANTHROPIC_BASE_URL: "https://opencode.ai/zen/go",
       ANTHROPIC_API_KEY: "",
-      ANTHROPIC_MODEL: "minimax-m3",
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: "minimax-m3",
-      ANTHROPIC_DEFAULT_SONNET_MODEL: "minimax-m3",
-      ANTHROPIC_DEFAULT_OPUS_MODEL: "minimax-m3",
+      ANTHROPIC_MODEL: "deepseek-v4-flash",
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "deepseek-v4-flash",
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "deepseek-v4-flash",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "deepseek-v4-flash",
     });
     expect(env).not.toHaveProperty("ANTHROPIC_AUTH_TOKEN");
     expect(openCodeGo!.apiFormat).toBe("anthropic");


### PR DESCRIPTION
## Summary

- switch the Claude Code OpenCode Go preset from local Chat conversion to its Anthropic Messages endpoint
- use ANTHROPIC_API_KEY so Claude Code sends the x-api-key authentication required by the Go endpoint
- add regression coverage that the preset no longer requires local routing

## Tests

- .\\node_modules\\.bin\\vitest.cmd run tests/config/claudeProviderPresets.test.ts src/utils/providerCapabilities.test.ts
- .\\node_modules\\.bin\\tsc.cmd --noEmit

Fixes #6171