### PR TITLE
fix(grokbuild): restore provider form background

### DIFF
--- a/src/components/providers/forms/GrokBuildProviderForm.tsx
+++ b/src/components/providers/forms/GrokBuildProviderForm.tsx
@@ -435,7 +435,7 @@ export function GrokBuildProviderForm({
       <form
         id="provider-form"
         onSubmit={form.handleSubmit(handleSubmit)}
-        className="space-y-6"
+        className="space-y-6 glass rounded-xl p-6 border border-white/10"
       >
         {!initialData && (
           <ProviderPresetSelector


### PR DESCRIPTION
## Summary

- apply the shared glass form container styles to the Grok Build provider form
- match the background, border, radius, and padding used by the other provider forms

## Verification

- `pnpm exec prettier --check src/components/providers/forms/GrokBuildProviderForm.tsx`
- `pnpm typecheck`
- `pnpm build:renderer`