### PR TITLE
fix(ui): reduce provider editor empty space

### DIFF
--- a/src/components/JsonEditor.tsx
+++ b/src/components/JsonEditor.tsx
@@ -29,7 +29,7 @@ const JsonEditor: React.FC<JsonEditorProps> = ({
   onChange,
   placeholder: placeholderText = "",
   darkMode = false,
-  rows = 12,
+  rows = 3,
   showValidation = true,
   language = "json",
   height,

--- a/src/components/providers/forms/CodexConfigSections.tsx
+++ b/src/components/providers/forms/CodexConfigSections.tsx
@@ -81,7 +81,7 @@ export const CodexAuthSection: React.FC<CodexAuthSectionProps> = ({
         onChange={handleChange}
         placeholder={t("codexConfig.authJsonPlaceholder")}
         darkMode={isDarkMode}
-        rows={6}
+        rows={3}
         showValidation={true}
         language="json"
       />
@@ -364,7 +364,7 @@ export const CodexConfigSection: React.FC<CodexConfigSectionProps> = ({
         onChange={handleLocalChange}
         placeholder=""
         darkMode={isDarkMode}
-        rows={8}
+        rows={3}
         showValidation={false}
         language="javascript"
       />

--- a/src/components/providers/forms/CommonConfigEditor.tsx
+++ b/src/components/providers/forms/CommonConfigEditor.tsx
@@ -257,7 +257,7 @@ export function CommonConfigEditor({
   }
 }`}
           darkMode={isDarkMode}
-          rows={14}
+          rows={3}
           showValidation={true}
           language="json"
         />

--- a/src/components/providers/forms/GeminiConfigSections.tsx
+++ b/src/components/providers/forms/GeminiConfigSections.tsx
@@ -99,7 +99,7 @@ export const GeminiEnvSection: React.FC<GeminiEnvSectionProps> = ({
 GEMINI_API_KEY=sk-your-api-key-here
 GEMINI_MODEL=gemini-3.6-flash`}
         darkMode={isDarkMode}
-        rows={6}
+        rows={3}
         showValidation={false}
         language="javascript"
       />
@@ -170,7 +170,7 @@ export const GeminiConfigSection: React.FC<GeminiConfigSectionProps> = ({
   "maxRetries": 3
 }`}
         darkMode={isDarkMode}
-        rows={8}
+        rows={3}
         showValidation={true}
         language="json"
       />

--- a/src/components/providers/forms/GrokBuildProviderForm.tsx
+++ b/src/components/providers/forms/GrokBuildProviderForm.tsx
@@ -573,7 +573,7 @@ export function GrokBuildProviderForm({
                 onChange={handleRawConfigChange}
                 placeholder=""
                 darkMode={isDarkMode}
-                rows={12}
+                rows={3}
                 showValidation={false}
                 language="javascript"
               />

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -2503,7 +2503,7 @@ function ProviderFormFull({
               <JsonEditor
                 value={omoDraft.mergedOmoJsonPreview}
                 onChange={() => {}}
-                rows={14}
+                rows={3}
                 showValidation={false}
                 language="json"
                 darkMode={isDarkMode}
@@ -2528,7 +2528,7 @@ function ProviderFormFull({
   },
   "models": {}
 }`}
-                  rows={14}
+                  rows={3}
                   showValidation={true}
                   language="json"
                   darkMode={isDarkMode}
@@ -2559,7 +2559,7 @@ function ProviderFormFull({
   "models": []
 }`
                   }
-                  rows={14}
+                  rows={3}
                   showValidation={true}
                   language="json"
                   darkMode={isDarkMode}


### PR DESCRIPTION
## Summary

- reduce the default JSON editor minimum height from 12 rows to 3
- use the compact minimum for inline Claude, Codex, Gemini, Grok, OpenCode, OpenClaw, Hermes, and OMO provider editors
- keep full-screen, fill-height, script, and fixed-height preview editors unchanged

## Cause

`JsonEditor` converts `rows` into a CSS `min-height`. Inline provider editors requested 6-14 rows, so short three-line configurations retained a large empty area below their content.

## Validation

- `pnpm exec prettier --check` on changed files
- `pnpm typecheck`
- `pnpm build:renderer`

No tests added; this only changes the minimum visible height of compact editor instances.