### PR TITLE
fix(claude-desktop): align provider form frame

### DIFF
--- a/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
+++ b/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
@@ -832,7 +832,7 @@ export function ClaudeDesktopProviderForm({
       <form
         id="provider-form"
         onSubmit={form.handleSubmit(handleSubmit)}
-        className="space-y-6"
+        className="space-y-6 glass rounded-xl p-6 border border-white/10"
       >
         {!initialData && (
           <ProviderPresetSelector


### PR DESCRIPTION
## Summary

- apply the same outer glass frame used by the other provider forms to Claude Desktop
- keep the existing form fields and interactions unchanged
- cover both add and edit pages through the shared Claude Desktop provider form

## Validation

- pnpm exec prettier --check src/components/providers/forms/ClaudeDesktopProviderForm.tsx
- pnpm typecheck
- pnpm vitest run tests/components/ClaudeDesktopProviderForm.test.tsx
- visually reviewed in the macOS app before commit