### PR TITLE
refactor(opencode): clarify provider form hierarchy

### DIFF
--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -4,11 +4,6 @@ import { FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import {
   Select,
   SelectContent,
   SelectItem,
@@ -210,15 +205,6 @@ export function OpenCodeFormFields({
 
   const [fetchedModels, setFetchedModels] = useState<FetchedModel[]>([]);
   const [isFetchingModels, setIsFetchingModels] = useState(false);
-  const [extraOptionsOpen, setExtraOptionsOpen] = useState(
-    () => Object.keys(extraOptions).length > 0,
-  );
-
-  useEffect(() => {
-    if (Object.keys(extraOptions).length > 0) {
-      setExtraOptionsOpen(true);
-    }
-  }, [extraOptions]);
 
   const handleFetchModels = useCallback(() => {
     if (!baseUrl || !apiKey) {
@@ -691,46 +677,26 @@ export function OpenCodeFormFields({
       </div>
 
       {/* Extra Options Editor */}
-      <Collapsible
-        open={extraOptionsOpen}
-        onOpenChange={setExtraOptionsOpen}
-        className="space-y-2 border-l border-border-default pl-3"
-      >
+      <div className="space-y-2 border-l border-border-default pl-3">
         <div className="flex items-start justify-between gap-3">
-          <CollapsibleTrigger asChild>
-            <button
-              type="button"
-              className="flex min-w-0 max-w-3xl flex-1 items-start gap-2 text-left"
-            >
-              <ChevronRight
-                className={cn(
-                  "mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-                  extraOptionsOpen && "rotate-90",
-                )}
-              />
-              <span className="space-y-1">
-                <span className="block text-sm font-medium text-foreground">
-                  {t("opencode.extraOptions", {
-                    defaultValue: "Extra SDK Options",
-                  })}
-                </span>
-                <span className="block text-xs text-muted-foreground">
-                  {t("opencode.extraOptionsHint", {
-                    defaultValue:
-                      "Advanced SDK options not exposed by the structured fields.",
-                  })}
-                </span>
-              </span>
-            </button>
-          </CollapsibleTrigger>
+          <div className="max-w-3xl space-y-1">
+            <FormLabel>
+              {t("opencode.extraOptions", {
+                defaultValue: "Extra SDK Options",
+              })}
+            </FormLabel>
+            <p className="text-xs text-muted-foreground">
+              {t("opencode.extraOptionsHint", {
+                defaultValue:
+                  "Advanced SDK options not exposed by the structured fields.",
+              })}
+            </p>
+          </div>
           <Button
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => {
-              setExtraOptionsOpen(true);
-              handleAddExtraOption();
-            }}
+            onClick={handleAddExtraOption}
             className="h-7 gap-1"
           >
             <Plus className="h-3.5 w-3.5" />
@@ -738,7 +704,7 @@ export function OpenCodeFormFields({
           </Button>
         </div>
 
-        <CollapsibleContent className="max-w-3xl space-y-2">
+        <div className="max-w-3xl">
           {Object.keys(extraOptions).length === 0 ? (
             <p className="text-sm text-muted-foreground py-1">
               {t("opencode.noExtraOptions", {
@@ -790,11 +756,11 @@ export function OpenCodeFormFields({
               ))}
             </div>
           )}
-        </CollapsibleContent>
-      </Collapsible>
+        </div>
+      </div>
 
       {/* Models Editor */}
-      <div className="space-y-3">
+      <div className="space-y-3 border-l border-border-default pl-3">
         <div className="flex items-center justify-between">
           <FormLabel>
             {t("opencode.models", { defaultValue: "Models" })}

--- a/tests/components/OpenCodeFormFields.test.tsx
+++ b/tests/components/OpenCodeFormFields.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import type { ComponentProps, PropsWithChildren } from "react";
 import { useForm } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
@@ -140,6 +140,39 @@ describe("OpenCodeFormFields", () => {
 
     expect(screen.getByDisplayValue("option-mode")).toBeInTheDocument();
     expect(screen.getByDisplayValue("legacy")).toBeInTheDocument();
+  });
+
+  it("shows extra options as an always-visible addable section", () => {
+    const onExtraOptionsChange = vi.fn();
+    renderOpenCodeForm({ onExtraOptionsChange });
+
+    const heading = screen.getByText("Extra SDK Options");
+    const section = heading.closest("div.border-l");
+    expect(section).not.toBeNull();
+    expect(
+      within(section as HTMLElement).getByText(
+        "No extra SDK options configured",
+      ),
+    ).toBeVisible();
+    expect(
+      within(section as HTMLElement).queryByRole("button", {
+        name: /Extra SDK Options/,
+      }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      within(section as HTMLElement).getByRole("button", { name: "Add" }),
+    );
+
+    const nextOptions = onExtraOptionsChange.mock.calls[0][0];
+    expect(Object.keys(nextOptions)[0]).toMatch(/^draft-option:/);
+  });
+
+  it("uses the family section divider for model configuration", () => {
+    renderOpenCodeForm();
+
+    const section = screen.getByText("Models").closest("div.border-l");
+    expect(section).toHaveClass("border-border-default", "pl-3");
   });
 
   it("surfaces existing model token limits", () => {


### PR DESCRIPTION
## Summary

- add the existing left-border section treatment to OpenCode model configuration
- replace the collapsible Extra Options wrapper with the same always-visible heading, hint, Add action, and row list used by the surrounding form sections
- remove the unnecessary expansion state while preserving all existing option editing behavior

This makes Headers, Extra Options, and Models easier to scan as sibling configuration groups without introducing a separate interaction pattern for extra options.

## Scope

Frontend form structure only. No backend, schema, or configuration-format changes.

## Validation

- pnpm typecheck
- pnpm format:check
- focused OpenCode form tests: 11 passed
- full frontend suite: 100 test files, 697 tests passed