### PR TITLE
feat(proxy): animate routing activation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,6 +70,7 @@ import { EnvWarningBanner } from "@/components/env/EnvWarningBanner";
 import { ProxyToggle } from "@/components/proxy/ProxyToggle";
 import { ClaudeDesktopRouteToggle } from "@/components/proxy/ClaudeDesktopRouteToggle";
 import { FailoverToggle } from "@/components/proxy/FailoverToggle";
+import { RoutingActivationBrand } from "@/components/proxy/RoutingActivationBrand";
 import UsageScriptModal from "@/components/UsageScriptModal";
 import UnifiedMcpPanel from "@/components/mcp/UnifiedMcpPanel";
 import PromptPanel from "@/components/prompts/PromptPanel";
@@ -1224,21 +1225,10 @@ function App() {
               </div>
             ) : (
               <div className="flex items-center gap-2">
-                <div className="relative inline-flex items-center">
-                  <a
-                    href="https://ccswitch.io"
-                    target="_blank"
-                    rel="noreferrer"
-                    className={cn(
-                      "text-xl font-semibold transition-colors",
-                      isProxyRunning && isCurrentAppTakeoverActive
-                        ? "text-emerald-500 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-300"
-                        : "text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300",
-                    )}
-                  >
-                    CC Switch
-                  </a>
-                </div>
+                <RoutingActivationBrand
+                  active={isProxyRunning && isCurrentAppTakeoverActive}
+                  contextKey={activeApp}
+                />
                 <Button
                   variant="ghost"
                   size="icon"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1228,6 +1228,9 @@ function App() {
                 <RoutingActivationBrand
                   active={isProxyRunning && isCurrentAppTakeoverActive}
                   contextKey={activeApp}
+                  ready={
+                    proxyStatus !== undefined && takeoverStatus !== undefined
+                  }
                 />
                 <Button
                   variant="ghost"

--- a/src/components/proxy/ProxyToggle.tsx
+++ b/src/components/proxy/ProxyToggle.tsx
@@ -19,8 +19,14 @@ interface ProxyToggleProps {
 
 export function ProxyToggle({ className, activeApp }: ProxyToggleProps) {
   const { t } = useTranslation();
-  const { isRunning, takeoverStatus, setTakeoverForApp, isPending, status } =
-    useProxyStatus();
+  const {
+    isRunning,
+    takeoverStatus,
+    setTakeoverForApp,
+    isPending,
+    isInitialStatusPending,
+    status,
+  } = useProxyStatus();
 
   const handleToggle = async (checked: boolean) => {
     try {
@@ -83,7 +89,7 @@ export function ProxyToggle({ className, activeApp }: ProxyToggleProps) {
       <Switch
         checked={takeoverEnabled}
         onCheckedChange={handleToggle}
-        disabled={isPending}
+        disabled={isPending || isInitialStatusPending}
       />
     </div>
   );

--- a/src/components/proxy/RoutingActivationBrand.tsx
+++ b/src/components/proxy/RoutingActivationBrand.tsx
@@ -22,6 +22,7 @@ const PARTICLES = [
 interface RoutingActivationBrandProps {
   active: boolean;
   contextKey: string;
+  ready: boolean;
 }
 
 /**
@@ -32,19 +33,21 @@ interface RoutingActivationBrandProps {
 export function RoutingActivationBrand({
   active,
   contextKey,
+  ready,
 }: RoutingActivationBrandProps) {
   const prefersReducedMotion = useReducedMotion();
-  const previousState = useRef({ active, contextKey });
+  const previousState = useRef({ active, contextKey, ready });
   const [burstSequence, setBurstSequence] = useState(0);
   const [showBurst, setShowBurst] = useState(false);
 
   useEffect(() => {
     const previous = previousState.current;
     const sameContext = previous.contextKey === contextKey;
-    const justActivated = sameContext && !previous.active && active;
-    previousState.current = { active, contextKey };
+    const justActivated =
+      previous.ready && ready && sameContext && !previous.active && active;
+    previousState.current = { active, contextKey, ready };
 
-    if (!active || prefersReducedMotion) {
+    if (!ready || !sameContext || !active || prefersReducedMotion) {
       setShowBurst(false);
       return;
     }
@@ -58,7 +61,7 @@ export function RoutingActivationBrand({
       BURST_LIFETIME_MS,
     );
     return () => window.clearTimeout(timeoutId);
-  }, [active, contextKey, prefersReducedMotion]);
+  }, [active, contextKey, prefersReducedMotion, ready]);
 
   return (
     <div className="relative isolate inline-flex items-center">

--- a/src/components/proxy/RoutingActivationBrand.tsx
+++ b/src/components/proxy/RoutingActivationBrand.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+const BURST_LIFETIME_MS = 980;
+
+const PARTICLES = [
+  { x: -76, y: -16, size: 3, delay: 0.01, color: "#60a5fa" },
+  { x: -63, y: 17, size: 2, delay: 0.05, color: "#22d3ee" },
+  { x: -51, y: -25, size: 2, delay: 0.09, color: "#34d399" },
+  { x: -38, y: 24, size: 4, delay: 0.03, color: "#34d399" },
+  { x: -24, y: -19, size: 2, delay: 0.12, color: "#93c5fd" },
+  { x: -11, y: 27, size: 3, delay: 0.08, color: "#5eead4" },
+  { x: 8, y: -26, size: 3, delay: 0.04, color: "#22d3ee" },
+  { x: 19, y: 24, size: 2, delay: 0.13, color: "#34d399" },
+  { x: 34, y: -22, size: 4, delay: 0.07, color: "#6ee7b7" },
+  { x: 47, y: 21, size: 2, delay: 0.02, color: "#60a5fa" },
+  { x: 61, y: -15, size: 3, delay: 0.11, color: "#2dd4bf" },
+  { x: 76, y: 13, size: 2, delay: 0.06, color: "#34d399" },
+] as const;
+
+interface RoutingActivationBrandProps {
+  active: boolean;
+  contextKey: string;
+}
+
+/**
+ * Keeps the brand's existing blue/emerald status semantics, then adds a
+ * short-lived confirmation burst only when the current app successfully
+ * transitions from direct mode to route takeover.
+ */
+export function RoutingActivationBrand({
+  active,
+  contextKey,
+}: RoutingActivationBrandProps) {
+  const prefersReducedMotion = useReducedMotion();
+  const previousState = useRef({ active, contextKey });
+  const [burstSequence, setBurstSequence] = useState(0);
+  const [showBurst, setShowBurst] = useState(false);
+
+  useEffect(() => {
+    const previous = previousState.current;
+    const sameContext = previous.contextKey === contextKey;
+    const justActivated = sameContext && !previous.active && active;
+    previousState.current = { active, contextKey };
+
+    if (!active || prefersReducedMotion) {
+      setShowBurst(false);
+      return;
+    }
+
+    if (!justActivated) return;
+
+    setBurstSequence((sequence) => sequence + 1);
+    setShowBurst(true);
+    const timeoutId = window.setTimeout(
+      () => setShowBurst(false),
+      BURST_LIFETIME_MS,
+    );
+    return () => window.clearTimeout(timeoutId);
+  }, [active, contextKey, prefersReducedMotion]);
+
+  return (
+    <div className="relative isolate inline-flex items-center">
+      {showBurst && (
+        <motion.span
+          key={`glow-${burstSequence}`}
+          aria-hidden="true"
+          className="pointer-events-none absolute -inset-x-3 -inset-y-2 -z-10 rounded-full bg-emerald-400/20 blur-md"
+          initial={{ opacity: 0, scaleX: 0.3, scaleY: 0.65 }}
+          animate={{
+            opacity: [0, 0.8, 0],
+            scaleX: [0.3, 1.05, 1.45],
+            scaleY: [0.65, 1, 1.25],
+          }}
+          transition={{
+            duration: 0.82,
+            times: [0, 0.24, 1],
+            ease: [0.16, 1, 0.3, 1],
+          }}
+        />
+      )}
+
+      <motion.a
+        href="https://ccswitch.io"
+        target="_blank"
+        rel="noreferrer"
+        className={cn(
+          "relative z-10 text-xl font-semibold transition-colors duration-500",
+          active
+            ? "text-emerald-500 hover:text-emerald-600 dark:text-emerald-400 dark:hover:text-emerald-300"
+            : "text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300",
+        )}
+        animate={
+          showBurst
+            ? {
+                scale: [1, 0.96, 1.075, 1],
+                y: [0, 1, -1.5, 0],
+                filter: [
+                  "drop-shadow(0 0 0 rgba(52, 211, 153, 0))",
+                  "drop-shadow(0 0 7px rgba(52, 211, 153, 0.75))",
+                  "drop-shadow(0 0 3px rgba(52, 211, 153, 0.28))",
+                  "drop-shadow(0 0 0 rgba(52, 211, 153, 0))",
+                ],
+              }
+            : {
+                scale: 1,
+                y: 0,
+                filter: "drop-shadow(0 0 0 rgba(52, 211, 153, 0))",
+              }
+        }
+        transition={
+          showBurst
+            ? {
+                duration: 0.72,
+                times: [0, 0.13, 0.52, 1],
+                ease: [0.16, 1, 0.3, 1],
+              }
+            : { duration: 0.28, ease: [0.22, 1, 0.36, 1] }
+        }
+      >
+        CC Switch
+      </motion.a>
+
+      {showBurst && (
+        <motion.span
+          key={`particles-${burstSequence}`}
+          data-testid="routing-activation-particles"
+          aria-hidden="true"
+          className="pointer-events-none absolute left-1/2 top-1/2 z-20 h-0 w-0"
+        >
+          {PARTICLES.map((particle, index) => (
+            <motion.span
+              key={`${particle.x}-${particle.y}`}
+              className="absolute left-0 top-0 block rounded-full"
+              style={{
+                width: particle.size,
+                height: particle.size,
+                backgroundColor: particle.color,
+                boxShadow: `0 0 ${particle.size * 2 + 2}px ${particle.color}`,
+              }}
+              initial={{ x: 0, y: 0, opacity: 0, scale: 0.2 }}
+              animate={{
+                x: [0, particle.x * 0.72, particle.x],
+                y: [0, particle.y * 0.62, particle.y],
+                opacity: [0, 1, 0],
+                scale: [0.2, index % 3 === 0 ? 1.45 : 1, 0.25],
+              }}
+              transition={{
+                duration: 0.66 + (index % 4) * 0.055,
+                delay: particle.delay,
+                times: [0, 0.2, 1],
+                ease: [0.16, 1, 0.3, 1],
+              }}
+            />
+          ))}
+        </motion.span>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useProxyStatus.ts
+++ b/src/hooks/useProxyStatus.ts
@@ -21,10 +21,12 @@ export function useProxyStatus() {
   const { t } = useTranslation();
 
   // 查询状态（自动轮询）
-  const { data: status } = useProxyStatusQuery();
+  const { data: status, isPending: isProxyStatusPending } =
+    useProxyStatusQuery();
 
   // 查询各应用接管状态
-  const { data: takeoverStatus } = useProxyTakeoverStatus(false);
+  const { data: takeoverStatus, isPending: isTakeoverStatusPending } =
+    useProxyTakeoverStatus(false);
 
   // 启动服务器（总开关：仅启动服务，不接管）
   const startProxyServerMutation = useMutation({
@@ -158,6 +160,7 @@ export function useProxyStatus() {
     status,
     isRunning: status?.running || false,
     takeoverStatus,
+    isInitialStatusPending: isProxyStatusPending || isTakeoverStatusPending,
 
     // 启动/停止（总开关）
     startProxyServer: startProxyServerMutation.mutateAsync,

--- a/tests/components/ProxyToggle.test.tsx
+++ b/tests/components/ProxyToggle.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProxyToggle } from "@/components/proxy/ProxyToggle";
+
+const useProxyStatusMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/useProxyStatus", () => ({
+  useProxyStatus: useProxyStatusMock,
+}));
+
+describe("ProxyToggle", () => {
+  beforeEach(() => {
+    useProxyStatusMock.mockReset();
+  });
+
+  it("waits for initial proxy status before allowing takeover", () => {
+    const proxyState = {
+      isRunning: false,
+      takeoverStatus: undefined,
+      setTakeoverForApp: vi.fn(),
+      isPending: false,
+      isInitialStatusPending: true,
+      status: undefined,
+    };
+    useProxyStatusMock.mockImplementation(() => proxyState);
+    const { rerender } = render(<ProxyToggle activeApp="claude" />);
+
+    expect(screen.getByRole("switch")).toBeDisabled();
+
+    proxyState.isInitialStatusPending = false;
+    rerender(<ProxyToggle activeApp="claude" />);
+
+    expect(screen.getByRole("switch")).toBeEnabled();
+  });
+});

--- a/tests/components/RoutingActivationBrand.test.tsx
+++ b/tests/components/RoutingActivationBrand.test.tsx
@@ -10,14 +10,14 @@ describe("RoutingActivationBrand", () => {
   it("plays a short particle burst only after the current app activates routing", () => {
     vi.useFakeTimers();
     const { rerender } = render(
-      <RoutingActivationBrand active={false} contextKey="claude" />,
+      <RoutingActivationBrand active={false} contextKey="claude" ready />,
     );
 
     expect(
       screen.queryByTestId("routing-activation-particles"),
     ).not.toBeInTheDocument();
 
-    rerender(<RoutingActivationBrand active contextKey="claude" />);
+    rerender(<RoutingActivationBrand active contextKey="claude" ready />);
 
     expect(
       screen.getByTestId("routing-activation-particles"),
@@ -34,16 +34,34 @@ describe("RoutingActivationBrand", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not replay activation particles when switching app context", () => {
+  it("does not play activation particles when initial status resolves active", () => {
     const { rerender } = render(
-      <RoutingActivationBrand active contextKey="claude" />,
+      <RoutingActivationBrand
+        active={false}
+        contextKey="claude"
+        ready={false}
+      />,
     );
+
+    rerender(<RoutingActivationBrand active contextKey="claude" ready />);
 
     expect(
       screen.queryByTestId("routing-activation-particles"),
     ).not.toBeInTheDocument();
+  });
 
-    rerender(<RoutingActivationBrand active contextKey="codex" />);
+  it("clears activation particles when switching app context", () => {
+    const { rerender } = render(
+      <RoutingActivationBrand active={false} contextKey="claude" ready />,
+    );
+
+    rerender(<RoutingActivationBrand active contextKey="claude" ready />);
+
+    expect(
+      screen.getByTestId("routing-activation-particles"),
+    ).toBeInTheDocument();
+
+    rerender(<RoutingActivationBrand active contextKey="codex" ready />);
 
     expect(
       screen.queryByTestId("routing-activation-particles"),

--- a/tests/components/RoutingActivationBrand.test.tsx
+++ b/tests/components/RoutingActivationBrand.test.tsx
@@ -1,0 +1,52 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RoutingActivationBrand } from "@/components/proxy/RoutingActivationBrand";
+
+describe("RoutingActivationBrand", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("plays a short particle burst only after the current app activates routing", () => {
+    vi.useFakeTimers();
+    const { rerender } = render(
+      <RoutingActivationBrand active={false} contextKey="claude" />,
+    );
+
+    expect(
+      screen.queryByTestId("routing-activation-particles"),
+    ).not.toBeInTheDocument();
+
+    rerender(<RoutingActivationBrand active contextKey="claude" />);
+
+    expect(
+      screen.getByTestId("routing-activation-particles"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "CC Switch" })).toHaveClass(
+      "text-emerald-500",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(
+      screen.queryByTestId("routing-activation-particles"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not replay activation particles when switching app context", () => {
+    const { rerender } = render(
+      <RoutingActivationBrand active contextKey="claude" />,
+    );
+
+    expect(
+      screen.queryByTestId("routing-activation-particles"),
+    ).not.toBeInTheDocument();
+
+    rerender(<RoutingActivationBrand active contextKey="codex" />);
+
+    expect(
+      screen.queryByTestId("routing-activation-particles"),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- animate the existing CC Switch blue-to-emerald routing state transition with a nonlinear brand recoil, glow, and one-shot particle burst
- trigger the effect only after the current app actually transitions into successful route takeover; failed activation and app switching do not produce false feedback
- remove particle nodes after 980 ms and disable decorative motion when `prefers-reduced-motion` is enabled
- keep the existing routing state source and backend behavior unchanged

## Validation

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm exec vitest run --reporter=dot --silent` (101 files, 697 tests)