### PR TITLE
fix(windows): fall back when WSL rejects atomic replace

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -423,61 +423,10 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
 
             let replace_error = std::io::Error::last_os_error();
             // WSL UNC paths reject ReplaceFileW with ERROR_NOT_SUPPORTED (50).
-            // Fall back to rename-based replacement with a rollback backup there.
+            // std::fs::rename uses a different replace-existing API on Windows.
             let replace_not_supported =
                 replace_error.raw_os_error() == Some(ERROR_NOT_SUPPORTED as i32);
-            if replace_not_supported {
-                let mut backup_name = tmp
-                    .file_name()
-                    .expect("temporary path must have a file name")
-                    .to_os_string();
-                backup_name.push(".backup");
-                let backup = tmp.with_file_name(backup_name);
-                let backup_created = match fs::rename(path, &backup) {
-                    Ok(()) => true,
-                    Err(source) if source.kind() == std::io::ErrorKind::NotFound => false,
-                    Err(source) => {
-                        last_error = Some(source);
-                        break;
-                    }
-                };
-
-                match fs::rename(&tmp, path) {
-                    Ok(()) => {
-                        if backup_created {
-                            if let Err(source) = fs::remove_file(&backup) {
-                                log::warn!(
-                                    "Failed to remove atomic-write backup {}: {}",
-                                    backup.display(),
-                                    source
-                                );
-                            }
-                        }
-                        completed = true;
-                        break;
-                    }
-                    Err(source) => {
-                        if backup_created {
-                            if let Err(restore_error) = fs::rename(&backup, path) {
-                                return Err(AppError::IoContext {
-                                    context: format!(
-                                        "原子替换及回滚失败: {} -> {}; 原文件保留在 {}; 回滚错误: {}",
-                                        tmp.display(),
-                                        path.display(),
-                                        backup.display(),
-                                        restore_error
-                                    ),
-                                    source,
-                                });
-                            }
-                        }
-                        last_error = Some(source);
-                        break;
-                    }
-                }
-            }
-
-            if replace_error.kind() != std::io::ErrorKind::NotFound {
+            if replace_error.kind() != std::io::ErrorKind::NotFound && !replace_not_supported {
                 last_error = Some(replace_error);
                 break;
             }

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -423,23 +423,63 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
 
             let replace_error = std::io::Error::last_os_error();
             // WSL UNC paths reject ReplaceFileW with ERROR_NOT_SUPPORTED (50).
-            // Fall back to the pre-v3.19.2 remove-then-rename behavior there.
+            // Fall back to rename-based replacement with a rollback backup there.
             let replace_not_supported =
                 replace_error.raw_os_error() == Some(ERROR_NOT_SUPPORTED as i32);
-            if replace_error.kind() != std::io::ErrorKind::NotFound && !replace_not_supported {
-                last_error = Some(replace_error);
-                break;
-            }
-
             if replace_not_supported {
-                match fs::remove_file(path) {
-                    Ok(()) => {}
-                    Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+                let mut backup_name = tmp
+                    .file_name()
+                    .expect("temporary path must have a file name")
+                    .to_os_string();
+                backup_name.push(".backup");
+                let backup = tmp.with_file_name(backup_name);
+                let backup_created = match fs::rename(path, &backup) {
+                    Ok(()) => true,
+                    Err(source) if source.kind() == std::io::ErrorKind::NotFound => false,
                     Err(source) => {
                         last_error = Some(source);
                         break;
                     }
+                };
+
+                match fs::rename(&tmp, path) {
+                    Ok(()) => {
+                        if backup_created {
+                            if let Err(source) = fs::remove_file(&backup) {
+                                log::warn!(
+                                    "Failed to remove atomic-write backup {}: {}",
+                                    backup.display(),
+                                    source
+                                );
+                            }
+                        }
+                        completed = true;
+                        break;
+                    }
+                    Err(source) => {
+                        if backup_created {
+                            if let Err(restore_error) = fs::rename(&backup, path) {
+                                return Err(AppError::IoContext {
+                                    context: format!(
+                                        "原子替换及回滚失败: {} -> {}; 原文件保留在 {}; 回滚错误: {}",
+                                        tmp.display(),
+                                        path.display(),
+                                        backup.display(),
+                                        restore_error
+                                    ),
+                                    source,
+                                });
+                            }
+                        }
+                        last_error = Some(source);
+                        break;
+                    }
                 }
+            }
+
+            if replace_error.kind() != std::io::ErrorKind::NotFound {
+                last_error = Some(replace_error);
+                break;
             }
 
             match fs::rename(&tmp, path) {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -386,7 +386,9 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
     #[cfg(windows)]
     {
         use std::os::windows::ffi::OsStrExt;
-        use windows_sys::Win32::Storage::FileSystem::ReplaceFileW;
+        use windows_sys::Win32::{
+            Foundation::ERROR_NOT_SUPPORTED, Storage::FileSystem::ReplaceFileW,
+        };
 
         let replaced: Vec<u16> = path
             .as_os_str()
@@ -420,9 +422,24 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
             }
 
             let replace_error = std::io::Error::last_os_error();
-            if replace_error.kind() != std::io::ErrorKind::NotFound {
+            // WSL UNC paths reject ReplaceFileW with ERROR_NOT_SUPPORTED (50).
+            // Fall back to the pre-v3.19.2 remove-then-rename behavior there.
+            let replace_not_supported =
+                replace_error.raw_os_error() == Some(ERROR_NOT_SUPPORTED as i32);
+            if replace_error.kind() != std::io::ErrorKind::NotFound && !replace_not_supported {
                 last_error = Some(replace_error);
                 break;
+            }
+
+            if replace_not_supported {
+                match fs::remove_file(path) {
+                    Ok(()) => {}
+                    Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(source) => {
+                        last_error = Some(source);
+                        break;
+                    }
+                }
             }
 
             match fs::rename(&tmp, path) {


### PR DESCRIPTION
## Summary

- fall back to `std::fs::rename` when WSL UNC paths reject `ReplaceFileW` with `ERROR_NOT_SUPPORTED`
- preserve the existing `ReplaceFileW` behavior for local Windows filesystems and all other errors
- reuse the existing temporary-file cleanup and retry handling without deleting the destination first

## Root cause

v3.19.2 changed Windows atomic writes to use `ReplaceFileW`. The WSL UNC filesystem returns OS error 50 for that API, and the code only entered its rename fallback for `NotFound`, so Codex and Claude configuration writes failed before the temporary file could be installed.

Fixes #6224.
Also addresses #6219 and #6188 and #6247.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `git diff --check upstream/main...HEAD`
- focused static review of the final branch diff: no findings

Automated tests were not run. Reproducing OS error 50 requires a Windows host with a configured WSL UNC path.