### PR TITLE
ci: run Windows backend tests against WSL2 filesystems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,81 @@ jobs:
 
       - name: Run tests
         run: cargo test --manifest-path src-tauri/Cargo.toml
+
+  backend-windows-wsl2:
+    name: Backend Checks (Windows + WSL2 home)
+    runs-on: windows-2025
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Setup WSL2
+        uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7
+        with:
+          distribution: Ubuntu-24.04
+          wsl-version: 2
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Create frontend dist placeholder
+        shell: bash
+        run: mkdir -p dist
+
+      - name: Check Rust formatting
+        run: cargo fmt --check --manifest-path src-tauri/Cargo.toml
+
+      - name: Clippy
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+
+      - name: Prepare WSL2-backed test environment
+        shell: pwsh
+        run: |
+          wsl.exe -d Ubuntu-24.04 -- bash -lc "rm -rf /tmp/cc-switch-windows-test-root && mkdir -p /tmp/cc-switch-windows-test-root/{home,temp} && chmod -R 0777 /tmp/cc-switch-windows-test-root"
+          $testRoot = "\\wsl.localhost\Ubuntu-24.04\tmp\cc-switch-windows-test-root"
+          $testHome = Join-Path $testRoot "home"
+          $testTemp = Join-Path $testRoot "temp"
+          foreach ($path in @($testRoot, $testHome, $testTemp)) {
+            if (-not (Test-Path -LiteralPath $path)) {
+              throw "WSL2-backed test path is unavailable: $path"
+            }
+          }
+          "CC_SWITCH_TEST_HOME=$testHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CC_SWITCH_WSL_TEST_DIR=$testRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "TEMP=$testTemp" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "TMP=$testTemp" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Run tests against WSL2-backed home
+        run: cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1
+
+      - name: Run Windows-to-WSL2 filesystem contract
+        shell: pwsh
+        run: |
+          $testName = "config::tests::atomic_write_replaces_existing_wsl_unc_file"
+          $testList = cargo test --manifest-path src-tauri/Cargo.toml -- --ignored --list
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          $expected = "${testName}: test"
+          if ($testList -notcontains $expected) {
+            throw "Expected ignored test was not discovered: $testName"
+          }
+          cargo test --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Compile backend tests with native temp
         # link.exe/mt.exe cannot create manifests when TEMP points at a WSL UNC path.
-        run: cargo test --tests --manifest-path src-tauri/Cargo.toml --no-run
+        run: cargo test --lib --manifest-path src-tauri/Cargo.toml --no-run
 
       - name: Run Windows-to-WSL2 filesystem contract
         shell: pwsh
@@ -165,7 +165,7 @@ jobs:
           $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $testName = "config::tests::atomic_write_replaces_existing_wsl_unc_file"
-          $testList = cargo test --tests --manifest-path src-tauri/Cargo.toml -- --ignored --list
+          $testList = cargo test --lib --manifest-path src-tauri/Cargo.toml -- --ignored --list
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -173,14 +173,7 @@ jobs:
           if ($testList -notcontains $expected) {
             throw "Expected ignored test was not discovered: $testName"
           }
-          cargo test --tests --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
+          cargo test --lib --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
-
-      - name: Run tests against WSL2-backed home
-        shell: pwsh
-        run: |
-          $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
-          $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
-          cargo test --tests --manifest-path src-tauri/Cargo.toml -- --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,6 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
-        with:
-          components: rustfmt, clippy
 
       - name: Setup WSL2
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7
@@ -141,12 +139,6 @@ jobs:
         shell: bash
         run: mkdir -p dist
 
-      - name: Check Rust formatting
-        run: cargo fmt --check --manifest-path src-tauri/Cargo.toml
-
-      - name: Clippy
-        run: cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
-
       - name: Prepare WSL2-backed test environment
         shell: pwsh
         run: |
@@ -161,17 +153,19 @@ jobs:
           }
           "CC_SWITCH_TEST_HOME=$testHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           "CC_SWITCH_WSL_TEST_DIR=$testRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "TEMP=$testTemp" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "TMP=$testTemp" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CC_SWITCH_WSL_TEST_TEMP=$testTemp" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Run tests against WSL2-backed home
-        run: cargo test --manifest-path src-tauri/Cargo.toml -- --test-threads=1
+      - name: Compile backend tests with native temp
+        # link.exe/mt.exe cannot create manifests when TEMP points at a WSL UNC path.
+        run: cargo test --tests --manifest-path src-tauri/Cargo.toml --no-run
 
       - name: Run Windows-to-WSL2 filesystem contract
         shell: pwsh
         run: |
+          $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
+          $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $testName = "config::tests::atomic_write_replaces_existing_wsl_unc_file"
-          $testList = cargo test --manifest-path src-tauri/Cargo.toml -- --ignored --list
+          $testList = cargo test --tests --manifest-path src-tauri/Cargo.toml -- --ignored --list
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -179,7 +173,14 @@ jobs:
           if ($testList -notcontains $expected) {
             throw "Expected ignored test was not discovered: $testName"
           }
-          cargo test --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
+          cargo test --tests --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
+
+      - name: Run tests against WSL2-backed home
+        shell: pwsh
+        run: |
+          $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
+          $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
+          cargo test --tests --manifest-path src-tauri/Cargo.toml -- --test-threads=1

--- a/.github/workflows/wsl2-nightly.yml
+++ b/.github/workflows/wsl2-nightly.yml
@@ -1,0 +1,89 @@
+name: WSL2 Nightly
+
+# The full backend suite takes 50+ minutes on a \\wsl.localhost 9P filesystem,
+# so it runs nightly instead of per PR. The per-PR gate in ci.yml only runs the
+# atomic-write contract test against the same WSL2-backed environment.
+on:
+  schedule:
+    - cron: "23 18 * * *" # 02:23 Beijing time
+  workflow_dispatch:
+
+jobs:
+  backend-windows-wsl2-full:
+    name: Backend Full Suite (Windows + WSL2 home)
+    runs-on: windows-2025
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+
+      - name: Setup WSL2
+        uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7
+        with:
+          distribution: Ubuntu-24.04
+          wsl-version: 2
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Create frontend dist placeholder
+        shell: bash
+        run: mkdir -p dist
+
+      - name: Prepare WSL2-backed test environment
+        shell: pwsh
+        run: |
+          wsl.exe -d Ubuntu-24.04 -- bash -lc "rm -rf /tmp/cc-switch-windows-test-root && mkdir -p /tmp/cc-switch-windows-test-root/{home,temp} && chmod -R 0777 /tmp/cc-switch-windows-test-root"
+          $testRoot = "\\wsl.localhost\Ubuntu-24.04\tmp\cc-switch-windows-test-root"
+          $testHome = Join-Path $testRoot "home"
+          $testTemp = Join-Path $testRoot "temp"
+          foreach ($path in @($testRoot, $testHome, $testTemp)) {
+            if (-not (Test-Path -LiteralPath $path)) {
+              throw "WSL2-backed test path is unavailable: $path"
+            }
+          }
+          "CC_SWITCH_TEST_HOME=$testHome" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CC_SWITCH_WSL_TEST_DIR=$testRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CC_SWITCH_WSL_TEST_TEMP=$testTemp" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Compile backend tests with native temp
+        # link.exe/mt.exe cannot create manifests when TEMP points at a WSL UNC path.
+        run: cargo test --tests --manifest-path src-tauri/Cargo.toml --no-run
+
+      - name: Run Windows-to-WSL2 filesystem contract
+        shell: pwsh
+        run: |
+          $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
+          $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
+          $testName = "config::tests::atomic_write_replaces_existing_wsl_unc_file"
+          $testList = cargo test --tests --manifest-path src-tauri/Cargo.toml -- --ignored --list
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          $expected = "${testName}: test"
+          if ($testList -notcontains $expected) {
+            throw "Expected ignored test was not discovered: $testName"
+          }
+          cargo test --tests --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+      - name: Run full test suite against WSL2-backed home
+        shell: pwsh
+        run: |
+          $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
+          $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
+          cargo test --tests --manifest-path src-tauri/Cargo.toml -- --test-threads=1

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -472,6 +472,33 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
 mod tests {
     use super::*;
 
+    fn assert_atomic_write_replaces_existing_file(dir: &Path) {
+        let path = dir.join("atomic-write-contract.json");
+        std::fs::write(&path, b"old contents").unwrap();
+
+        atomic_write(&path, b"new contents").unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"new contents");
+        let tmp_prefix = "atomic-write-contract.json.tmp.";
+        let leftovers: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .map(|entry| entry.unwrap())
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with(tmp_prefix))
+            .map(|entry| entry.path())
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "temporary files remain: {leftovers:?}"
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn atomic_write_replaces_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_atomic_write_replaces_existing_file(dir.path());
+    }
+
     #[cfg(windows)]
     #[test]
     fn atomic_write_preserves_destination_when_windows_replace_fails() {
@@ -493,6 +520,39 @@ mod tests {
         drop(held_file);
         assert_eq!(std::fs::read(&path).unwrap(), b"old contents");
         assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 1);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "requires CC_SWITCH_WSL_TEST_DIR to point to a WSL2 UNC directory"]
+    fn atomic_write_replaces_existing_wsl_unc_file() {
+        let root = PathBuf::from(
+            std::env::var_os("CC_SWITCH_WSL_TEST_DIR").expect("CC_SWITCH_WSL_TEST_DIR must be set"),
+        );
+        let home = get_home_dir();
+        let temp = std::env::temp_dir();
+        for (name, path) in [
+            ("test root", root.as_path()),
+            ("test home", home.as_path()),
+            ("temporary directory", temp.as_path()),
+        ] {
+            let unc = path.to_string_lossy();
+            assert!(
+                unc.starts_with(r"\\wsl.localhost\") || unc.starts_with(r"\\wsl$\"),
+                "expected {name} to be a WSL UNC path, got {unc}"
+            );
+            assert!(
+                path.starts_with(&root),
+                "expected {name} to be under {}, got {unc}",
+                root.display()
+            );
+        }
+
+        let dir = tempfile::Builder::new()
+            .prefix("atomic-write-contract-")
+            .tempdir_in(&root)
+            .unwrap();
+        assert_atomic_write_replaces_existing_file(dir.path());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a Windows 2025 CI job that installs Ubuntu 24.04 under WSL2 while keeping Rust and cc-switch tests running as native Windows processes
- point `CC_SWITCH_TEST_HOME`, `TEMP`, and `TMP` at directories under a real `\\wsl.localhost\...` root
- run the complete existing backend test suite serially against that WSL2-backed filesystem
- add an atomic-write contract that replaces an existing file, verifies its contents, and checks that no temporary files remain
- explicitly verify that the WSL test root, resolved cc-switch home, and Windows temporary directory are all UNC paths under the configured WSL2 root

## Why

The existing OS matrix tests native Linux, Windows, and macOS filesystems, but it does not test a Windows cc-switch process writing into a WSL2 filesystem. That gap allowed the `ReplaceFileW` regression reported in #6224 to reach v3.19.2.

This job also covers future tests without requiring authors to write WSL-specific copies. Tests using `tempfile`, `std::env::temp_dir()`, or cc-switch's test-home override automatically execute once on NTFS in the normal Windows job and once on the WSL2 filesystem in this job.

## Regression coverage

The dedicated ignored contract creates a unique child directory on the WSL2 filesystem, writes an existing file, calls `atomic_write`, verifies replacement, and checks cleanup. CI confirms the exact ignored test is discovered before running it so a renamed or missing test cannot silently pass.

## Dependency

This PR is ready for review but depends on #6232. Against the current unpatched `main`, the WSL2 atomic-write contract is expected to fail with Windows error 50. After #6232 lands and this branch is rebased, this job becomes the regression gate for that behavior.

## Validation

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `pnpm exec prettier --check .github/workflows/ci.yml`
- `git diff --check`
- `cargo check --tests --manifest-path src-tauri/Cargo.toml`
- `open-code-review`: 0 findings

The revised WSL2 job itself is validated by GitHub Actions rather than the local Windows checkout.