### PR TITLE
tools(codex): add model picker fix utility for custom providers

### DIFF
--- a/tools/codex-model-picker-fix/.gitignore
+++ b/tools/codex-model-picker-fix/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.bak-*/
+package-lock.json

--- a/tools/codex-model-picker-fix/README.md
+++ b/tools/codex-model-picker-fix/README.md
@@ -1,0 +1,62 @@
+# Codex Desktop Model Picker Fix
+
+Codex Desktop hides custom-provider models returned by `model/list` because the
+renderer applies a Statsig allowlist (`use_hidden_models: true` +
+`available_models` containing only OpenAI stock models). This is tracked
+upstream as [openai/codex#19694](https://github.com/openai/codex/issues/19694).
+
+This project patches the cached Statsig evaluations in the Codex Desktop
+`Local Storage` LevelDB so that:
+
+- `use_hidden_models` becomes `false`
+- your custom model IDs are added to `available_models`
+- the cache timestamp is pushed 30 days into the future
+- `ab.chatgpt.com` is blocked in `hosts` so the remote allowlist cannot be
+  refreshed back over the network
+
+## Requirements
+
+- Windows with the MSIX Codex Desktop app (`OpenAI.Codex_*` under
+  `%LOCALAPPDATA%\Packages`)
+- Node.js
+- Administrator rights (for the `hosts` file update)
+
+## Usage
+
+1. Fully quit Codex Desktop, including the system tray icon.
+2. Run the script as administrator:
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File .\fix-codex-model-picker.ps1
+   ```
+
+   The script automatically elevates itself when needed.
+
+3. Relaunch Codex Desktop. The model picker should now show the models from
+   your `model_catalog_json`.
+
+To change the model list, pass `-ModelIds`:
+
+```powershell
+.\fix-codex-model-picker.ps1 -ModelIds "model-a,model-b"
+```
+
+## What it changes
+
+- `%LOCALAPPDATA%\Packages\OpenAI.Codex_*\LocalCache\Roaming\Codex\web\Codex\Default\Local Storage\leveldb`
+  (a backup is created next to it before patching)
+- `C:\Windows\System32\drivers\etc\hosts` (`127.0.0.1 ab.chatgpt.com`)
+
+## Rollback
+
+- Remove the `127.0.0.1 ab.chatgpt.com` line from `hosts`.
+- Replace the patched `leveldb` folder with the `leveldb.bak-<timestamp>`
+  backup created by the script.
+
+## Why a script instead of a Codex setting
+
+The filter lives in the Desktop renderer and is driven by a remote Statsig
+dynamic config (`107580212`). There is no user-facing setting to disable it,
+and CC Switch's upstream fix
+([farion1231/cc-switch#5265](https://github.com/farion1231/cc-switch/pull/5265))
+has not been merged yet.

--- a/tools/codex-model-picker-fix/README.md
+++ b/tools/codex-model-picker-fix/README.md
@@ -9,7 +9,8 @@ This project patches the cached Statsig evaluations in the Codex Desktop
 `Local Storage` LevelDB so that:
 
 - `use_hidden_models` becomes `false`
-- your custom model IDs are added to `available_models`
+- every model ID from `~/.codex/cc-switch-model-catalog.json` is added to
+  `available_models` (so all models configured in CC Switch are shown)
 - the cache timestamp is pushed 30 days into the future
 - `ab.chatgpt.com` is blocked in `hosts` so the remote allowlist cannot be
   refreshed back over the network
@@ -32,10 +33,12 @@ This project patches the cached Statsig evaluations in the Codex Desktop
 
    The script automatically elevates itself when needed.
 
-3. Relaunch Codex Desktop. The model picker should now show the models from
+3. Relaunch Codex Desktop. The model picker should now show every model from
    your `model_catalog_json`.
 
-To change the model list, pass `-ModelIds`:
+By default the script reads all model IDs from the CC Switch catalog. If you
+add or remove models in CC Switch, just run the script again. To override the
+list manually, pass `-ModelIds`:
 
 ```powershell
 .\fix-codex-model-picker.ps1 -ModelIds "model-a,model-b"

--- a/tools/codex-model-picker-fix/README.md
+++ b/tools/codex-model-picker-fix/README.md
@@ -10,8 +10,9 @@ This project patches the cached Statsig evaluations in the Codex Desktop
 
 - `use_hidden_models` becomes `false`
 - the cache timestamp is pushed 30 days into the future
-- `ab.chatgpt.com` is blocked in `hosts` so the remote policy cannot be
-  refreshed back over the network
+- the Statsig endpoints (`ab.chatgpt.com`, `statsigapi.net`, `api.statsigcdn.com`,
+  `prodregistryv2.org`, `featureassets.org`) are blocked in `hosts` and added to the
+  system proxy bypass list so the remote policy cannot be refreshed back over the network
 
 No model whitelist is written. With `use_hidden_models=false`, the renderer
 shows every non-hidden model returned by `model/list`, so models added to
@@ -49,11 +50,17 @@ CC Switch later appear automatically after restarting Codex.
 
 - `%LOCALAPPDATA%\Packages\OpenAI.Codex_*\LocalCache\Roaming\Codex\web\Codex\Default\Local Storage\leveldb`
   (a backup is created next to it before patching)
-- `C:\Windows\System32\drivers\etc\hosts` (`127.0.0.1 ab.chatgpt.com`)
+- `C:\Windows\System32\drivers\etc\hosts` (`127.0.0.1 <statsig-domain>` for every
+  Statsig endpoint used by the renderer)
+- `HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ProxyOverride`
+  (Statsig domains are added when a system proxy is active)
 
 ## Rollback
 
-- Remove the `127.0.0.1 ab.chatgpt.com` line from `hosts`.
+- Remove the `127.0.0.1 <statsig-domain>` lines added by the script from `hosts`.
+- Remove the Statsig domains from `ProxyOverride` in
+  `HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings` if you no
+  longer want them bypassed.
 - Replace the patched `leveldb` folder with the `leveldb.bak-<timestamp>`
   backup created by the script.
 

--- a/tools/codex-model-picker-fix/README.md
+++ b/tools/codex-model-picker-fix/README.md
@@ -9,11 +9,13 @@ This project patches the cached Statsig evaluations in the Codex Desktop
 `Local Storage` LevelDB so that:
 
 - `use_hidden_models` becomes `false`
-- every model ID from `~/.codex/cc-switch-model-catalog.json` is added to
-  `available_models` (so all models configured in CC Switch are shown)
 - the cache timestamp is pushed 30 days into the future
-- `ab.chatgpt.com` is blocked in `hosts` so the remote allowlist cannot be
+- `ab.chatgpt.com` is blocked in `hosts` so the remote policy cannot be
   refreshed back over the network
+
+No model whitelist is written. With `use_hidden_models=false`, the renderer
+shows every non-hidden model returned by `model/list`, so models added to
+CC Switch later appear automatically after restarting Codex.
 
 ## Requirements
 
@@ -33,12 +35,11 @@ This project patches the cached Statsig evaluations in the Codex Desktop
 
    The script automatically elevates itself when needed.
 
-3. Relaunch Codex Desktop. The model picker should now show every model from
-   your `model_catalog_json`.
+3. Relaunch Codex Desktop. The model picker shows every model from your
+   `model_catalog_json`, including models added later.
 
-By default the script reads all model IDs from the CC Switch catalog. If you
-add or remove models in CC Switch, just run the script again. To override the
-list manually, pass `-ModelIds`:
+`-ModelIds` is optional and only adds extra model IDs to the Statsig
+`available_models` list as a belt-and-suspenders measure:
 
 ```powershell
 .\fix-codex-model-picker.ps1 -ModelIds "model-a,model-b"

--- a/tools/codex-model-picker-fix/fix-codex-model-picker.ps1
+++ b/tools/codex-model-picker-fix/fix-codex-model-picker.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$ModelIds = "deepseek-v4-flash-0731,glm-5.2"
+    [string]$ModelIds = ""
 )
 
 $ErrorActionPreference = 'Stop'
@@ -18,18 +18,6 @@ $codexProcess = Get-Process -Name 'codex' -ErrorAction SilentlyContinue
 if ($codexProcess) {
     Write-Host "Codex is still running. Fully quit Codex (including the system tray icon), then run this script again."
     exit 1
-}
-
-$catalogPath = Join-Path $env:USERPROFILE '.codex\cc-switch-model-catalog.json'
-if ([string]::IsNullOrWhiteSpace($ModelIds) -and (Test-Path -LiteralPath $catalogPath)) {
-    $catalog = Get-Content -LiteralPath $catalogPath -Raw -Encoding UTF8 | ConvertFrom-Json
-    $ModelIds = @($catalog.models | ForEach-Object { $_.slug } | Where-Object { $_ }) -join ','
-    if (-not [string]::IsNullOrWhiteSpace($ModelIds)) {
-        Write-Host "Using all models from CC Switch catalog: $ModelIds"
-    }
-}
-if ([string]::IsNullOrWhiteSpace($ModelIds)) {
-    $ModelIds = "deepseek-v4-flash-0731,glm-5.2"
 }
 
 $pkgRoot = Join-Path $env:LOCALAPPDATA 'Packages'

--- a/tools/codex-model-picker-fix/fix-codex-model-picker.ps1
+++ b/tools/codex-model-picker-fix/fix-codex-model-picker.ps1
@@ -5,8 +5,7 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent())
-    .IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
 if (-not $isAdmin) {
     Write-Host "Requesting administrator privileges to update the hosts file..."
@@ -19,6 +18,18 @@ $codexProcess = Get-Process -Name 'codex' -ErrorAction SilentlyContinue
 if ($codexProcess) {
     Write-Host "Codex is still running. Fully quit Codex (including the system tray icon), then run this script again."
     exit 1
+}
+
+$catalogPath = Join-Path $env:USERPROFILE '.codex\cc-switch-model-catalog.json'
+if ([string]::IsNullOrWhiteSpace($ModelIds) -and (Test-Path -LiteralPath $catalogPath)) {
+    $catalog = Get-Content -LiteralPath $catalogPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $ModelIds = @($catalog.models | ForEach-Object { $_.slug } | Where-Object { $_ }) -join ','
+    if (-not [string]::IsNullOrWhiteSpace($ModelIds)) {
+        Write-Host "Using all models from CC Switch catalog: $ModelIds"
+    }
+}
+if ([string]::IsNullOrWhiteSpace($ModelIds)) {
+    $ModelIds = "deepseek-v4-flash-0731,glm-5.2"
 }
 
 $pkgRoot = Join-Path $env:LOCALAPPDATA 'Packages'

--- a/tools/codex-model-picker-fix/fix-codex-model-picker.ps1
+++ b/tools/codex-model-picker-fix/fix-codex-model-picker.ps1
@@ -35,17 +35,47 @@ if (-not (Test-Path -LiteralPath $leveldb)) {
     exit 1
 }
 
-# Block the remote Statsig endpoint so Codex cannot refresh the allowlist over
-# the network and overwrite the patched cache.
+# Block the remote Statsig endpoints so Codex cannot refresh the allowlist
+# over the network and overwrite the patched cache. The renderer is configured
+# to use ab.chatgpt.com; the others are Statsig fallback/exception endpoints.
 $hostsFile = 'C:\Windows\System32\drivers\etc\hosts'
-$hostsLine = '127.0.0.1 ab.chatgpt.com'
+$statsigHosts = @(
+    'ab.chatgpt.com',
+    'statsigapi.net',
+    'api.statsigcdn.com',
+    'prodregistryv2.org',
+    'featureassets.org'
+)
 $hostsContent = Get-Content -LiteralPath $hostsFile -Raw
-if ($hostsContent -notmatch 'ab\.chatgpt\.com') {
-    Add-Content -LiteralPath $hostsFile -Value "`n$hostsLine" -Encoding Ascii
-    Write-Host "Added hosts entry: $hostsLine"
-} else {
-    Write-Host "Hosts entry already present: $hostsLine"
+foreach ($hostName in $statsigHosts) {
+    $hostsLine = "127.0.0.1 $hostName"
+    if ($hostsContent -notmatch [regex]::Escape($hostName)) {
+        Add-Content -LiteralPath $hostsFile -Value "`n$hostsLine" -Encoding Ascii
+        Write-Host "Added hosts entry: $hostsLine"
+    } else {
+        Write-Host "Hosts entry already present: $hostsLine"
+    }
 }
+
+# If a system proxy is active, Statsig requests go through it and bypass the
+# hosts block. Add the domains to the proxy bypass list so they resolve locally.
+$internetSettings = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Internet Settings'
+$proxyEnable = (Get-ItemProperty -Path $internetSettings -ErrorAction SilentlyContinue).ProxyEnable
+if ($proxyEnable -eq 1) {
+    $current = [string](Get-ItemProperty -Path $internetSettings).ProxyOverride
+    $missing = $statsigHosts | Where-Object { $current -notmatch [regex]::Escape($_) }
+    if ($missing) {
+        $newOverride = ($current.TrimEnd(';') + ';' + ($missing -join ';')).TrimStart(';')
+        Set-ItemProperty -Path $internetSettings -Name ProxyOverride -Value $newOverride
+        Write-Host "Added Statsig domains to system proxy bypass: $($missing -join ', ')"
+    } else {
+        Write-Host "Statsig domains already in system proxy bypass"
+    }
+} else {
+    Write-Host "System proxy is off; hosts entries are sufficient"
+}
+
+& ipconfig /flushdns | Out-Null
 
 $stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
 $backup = "$leveldb.bak-$stamp"

--- a/tools/codex-model-picker-fix/fix-codex-model-picker.ps1
+++ b/tools/codex-model-picker-fix/fix-codex-model-picker.ps1
@@ -1,0 +1,79 @@
+[CmdletBinding()]
+param(
+    [string]$ModelIds = "deepseek-v4-flash-0731,glm-5.2"
+)
+
+$ErrorActionPreference = 'Stop'
+
+$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent())
+    .IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+if (-not $isAdmin) {
+    Write-Host "Requesting administrator privileges to update the hosts file..."
+    $argsFlat = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', "`"$PSCommandPath`"", '-ModelIds', "`"$ModelIds`"")
+    Start-Process -FilePath 'powershell.exe' -ArgumentList $argsFlat -Verb RunAs -Wait
+    exit $LASTEXITCODE
+}
+
+$codexProcess = Get-Process -Name 'codex' -ErrorAction SilentlyContinue
+if ($codexProcess) {
+    Write-Host "Codex is still running. Fully quit Codex (including the system tray icon), then run this script again."
+    exit 1
+}
+
+$pkgRoot = Join-Path $env:LOCALAPPDATA 'Packages'
+$pkg = Get-ChildItem -Path $pkgRoot -Directory -Filter 'OpenAI.Codex_*' -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime -Descending |
+    Select-Object -First 1
+if (-not $pkg) {
+    Write-Host "Codex package folder not found under $pkgRoot"
+    exit 1
+}
+
+$leveldb = Join-Path $pkg.FullName 'LocalCache\Roaming\Codex\web\Codex\Default\Local Storage\leveldb'
+if (-not (Test-Path -LiteralPath $leveldb)) {
+    Write-Host "LevelDB folder not found: $leveldb"
+    exit 1
+}
+
+# Block the remote Statsig endpoint so Codex cannot refresh the allowlist over
+# the network and overwrite the patched cache.
+$hostsFile = 'C:\Windows\System32\drivers\etc\hosts'
+$hostsLine = '127.0.0.1 ab.chatgpt.com'
+$hostsContent = Get-Content -LiteralPath $hostsFile -Raw
+if ($hostsContent -notmatch 'ab\.chatgpt\.com') {
+    Add-Content -LiteralPath $hostsFile -Value "`n$hostsLine" -Encoding Ascii
+    Write-Host "Added hosts entry: $hostsLine"
+} else {
+    Write-Host "Hosts entry already present: $hostsLine"
+}
+
+$stamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+$backup = "$leveldb.bak-$stamp"
+Copy-Item -LiteralPath $leveldb -Destination $backup -Recurse -Force
+Write-Host "Backup created: $backup"
+
+$toolDir = $PSScriptRoot
+$nodeModules = Join-Path $toolDir 'node_modules'
+if (-not (Test-Path (Join-Path $nodeModules 'classic-level'))) {
+    Write-Host "Installing classic-level dependency..."
+    Push-Location $toolDir
+    try {
+        cmd /c "npm install classic-level@1.4.1 --no-audit --no-fund --loglevel=error"
+        if ($LASTEXITCODE -ne 0) { throw "npm install failed" }
+    } finally {
+        Pop-Location
+    }
+}
+$env:NODE_PATH = $nodeModules
+$node = (Get-Command node -ErrorAction Stop).Source
+
+& $node (Join-Path $toolDir 'patch-statsig.js') $leveldb $ModelIds
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Patching failed. Restore from backup: $backup"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Patch applied. Relaunch Codex and open the model picker."
+Write-Host "The remote Statsig endpoint (ab.chatgpt.com) is blocked, so the allowlist will not be overwritten on restart."

--- a/tools/codex-model-picker-fix/package.json
+++ b/tools/codex-model-picker-fix/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "codex-model-picker-fix",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Show CC Switch / custom-provider models in the Codex Desktop model picker by patching the Statsig allowlist cache.",
+  "dependencies": {
+    "classic-level": "1.4.1"
+  }
+}

--- a/tools/codex-model-picker-fix/package.json
+++ b/tools/codex-model-picker-fix/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "Show CC Switch / custom-provider models in the Codex Desktop model picker by patching the Statsig allowlist cache.",
   "dependencies": {
-    "classic-level": "1.4.1"
+    "classic-level": "^1.4.1"
   }
 }

--- a/tools/codex-model-picker-fix/patch-statsig.js
+++ b/tools/codex-model-picker-fix/patch-statsig.js
@@ -30,6 +30,24 @@ function encodeUTF16BE(txt) {
   return be16(txt);
 }
 
+function verifyEvalValue(buf, keyName) {
+  const candidates = [];
+  for (const slice of [buf.subarray(0, buf.length - (buf.length % 2)), buf.subarray(1)]) {
+    if (slice.length % 2 === 0) {
+      candidates.push(Buffer.from(slice).swap16().toString('utf16le'));
+      candidates.push(Buffer.from(slice).toString('utf16le'));
+    }
+  }
+  candidates.push(buf.toString('utf8'));
+  const txt = candidates.find((t) => t.includes('statsig') || t.includes('use_hidden_models')) || buf.toString('utf8');
+  const hiddenOk = txt.includes('\\"use_hidden_models\\":false');
+  const modelsOk = customModels.length === 0 || customModels.every((m) => txt.includes(m));
+  if (!hiddenOk || !modelsOk) {
+    throw new Error(`${keyName}: verification failed (hidden_false=${hiddenOk}, models=${modelsOk})`);
+  }
+  return { hiddenOk, modelsOk };
+}
+
 async function main() {
   const db = new ClassicLevel(dbPath, {
     createIfMissing: false,
@@ -89,8 +107,10 @@ async function main() {
 
     if (changed) {
       await db.put(key, buf);
+      const reread = await db.get(key);
+      verifyEvalValue(reread, ks);
       const txt = decodeMaybeUTF16(buf);
-      reports.push(`${ks}: use_hidden_models replacements=${replaced}, custom models inserted=${changed && customModels.length > 0}, json-ish=${txt.includes('use_hidden_models')}`);
+      reports.push(`${ks}: use_hidden_models replacements=${replaced}, custom models inserted=${customModels.length > 0}, VERIFIED`);
     } else {
       reports.push(`${ks}: no changes`);
     }
@@ -132,7 +152,15 @@ async function main() {
       else newBody = Buffer.from(json, 'utf16le');
       if (marker) newBody = Buffer.concat([Buffer.from([0x01]), newBody]);
       await db.put(lmKey, newBody);
-      reports.push(`${lmKeyName}: timestamps bumped to ${future} (${scheme})`);
+      const reread = await db.get(lmKey);
+      const rereadBody = reread.subarray(reread[0] === 0x01 ? 1 : 0);
+      const rereadText = rereadBody.toString('utf8').includes('statsig')
+        ? rereadBody.toString('utf8')
+        : (rereadBody.length % 2 === 0 ? Buffer.from(rereadBody).swap16().toString('utf16le') : '');
+      const rereadObj = JSON.parse(rereadText);
+      const ok = evalKeys.every((ks) => Number(rereadObj[ks.replace(/^_app:\/\/-\u0000\u0001/, '')]) > Date.now());
+      if (!ok) throw new Error(`${lmKeyName}: verification failed`);
+      reports.push(`${lmKeyName}: timestamps bumped to ${future} (${scheme}), VERIFIED`);
     } else {
       reports.push(`${lmKeyName}: skipped (could not parse timestamp entry)`);
     }

--- a/tools/codex-model-picker-fix/patch-statsig.js
+++ b/tools/codex-model-picker-fix/patch-statsig.js
@@ -112,7 +112,9 @@ async function main() {
       const txt = decodeMaybeUTF16(buf);
       reports.push(`${ks}: use_hidden_models replacements=${replaced}, custom models inserted=${customModels.length > 0}, VERIFIED`);
     } else {
-      reports.push(`${ks}: no changes`);
+      const reread = await db.get(key);
+      verifyEvalValue(reread, ks);
+      reports.push(`${ks}: already false`);
     }
   }
 

--- a/tools/codex-model-picker-fix/patch-statsig.js
+++ b/tools/codex-model-picker-fix/patch-statsig.js
@@ -1,0 +1,150 @@
+const { ClassicLevel } = require('classic-level');
+const path = require('path');
+
+const dbPath = process.argv[2];
+const customModels = (process.argv[3] || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+function be16(str) {
+  const parts = [];
+  for (const ch of str) {
+    parts.push(0x00, ch.charCodeAt(0));
+  }
+  return Buffer.from(parts);
+}
+
+function decodeMaybeUTF16(buf) {
+  const options = [];
+  for (const slice of [buf, buf.subarray(1)]) {
+    if (slice.length % 2 !== 0) continue;
+    options.push(Buffer.from(slice).swap16().toString('utf16le'));
+    options.push(Buffer.from(slice).toString('utf16le'));
+  }
+  const prefer = options.filter((t) => t.includes('"') && t.includes('{'));
+  return prefer[0] || options[0] || buf.toString('utf8');
+}
+
+function encodeUTF16BE(txt) {
+  return be16(txt);
+}
+
+async function main() {
+  const db = new ClassicLevel(dbPath, {
+    createIfMissing: false,
+    errorIfExists: false,
+    valueEncoding: 'buffer',
+    keyEncoding: 'buffer',
+  });
+  await db.open();
+
+  const reports = [];
+  const evalKeys = [];
+  for await (const [k] of db.iterator()) {
+    const ks = k.toString('latin1');
+    if (ks.includes('statsig.cached.evaluations.')) {
+      evalKeys.push(ks);
+    }
+  }
+
+  // The Statsig localStorage value is an outer JSON object whose "data"
+  // field is itself a JSON string, so quotes appear backslash-escaped.
+  const truePat = be16('\\"use_hidden_models\\":true');
+  const falsePat = be16('\\"use_hidden_models\\":false');
+  const availStart = be16('\\"available_models\\":[');
+  const insertText = customModels.map((m) => `\\"${m}\\"`).join(',') + ',';
+  const insertPat = be16(insertText);
+
+  for (const ks of evalKeys) {
+    const key = Buffer.from(ks, 'latin1');
+    let val = await db.get(key);
+    let changed = false;
+    let replaced = 0;
+
+    let buf = val;
+    while (true) {
+      const i = buf.indexOf(truePat);
+      if (i < 0) break;
+      buf = Buffer.concat([buf.subarray(0, i), falsePat, buf.subarray(i + truePat.length)]);
+      replaced += 1;
+      changed = true;
+    }
+
+    if (customModels.length > 0) {
+      const ai = buf.indexOf(availStart);
+      if (ai >= 0) {
+      const after = buf.subarray(ai + availStart.length, ai + availStart.length + 400).toString('latin1');
+        const already = customModels.every((m) => after.includes(m));
+        if (!already) {
+          buf = Buffer.concat([
+            buf.subarray(0, ai + availStart.length),
+            insertPat,
+            buf.subarray(ai + availStart.length),
+          ]);
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
+      await db.put(key, buf);
+      const txt = decodeMaybeUTF16(buf);
+      reports.push(`${ks}: use_hidden_models replacements=${replaced}, custom models inserted=${changed && customModels.length > 0}, json-ish=${txt.includes('use_hidden_models')}`);
+    } else {
+      reports.push(`${ks}: no changes`);
+    }
+  }
+
+  // Bump the last-modified timestamps so a remote refresh does not immediately
+  // overwrite the patched cache.
+  const lmKeyName = 'statsig.last_modified_time.evaluations';
+  const lmKey = Buffer.from('_app://-\u0000\u0001' + lmKeyName, 'latin1');
+  try {
+    const lmVal = await db.get(lmKey);
+    const future = Date.now() + 30 * 24 * 60 * 60 * 1000;
+    const marker = lmVal[0] === 0x01 ? 1 : 0;
+    const body = lmVal.subarray(marker);
+    let parsed = null;
+    let scheme = null;
+    for (const candidate of [
+      { scheme: 'utf8', text: body.toString('utf8') },
+      { scheme: 'be', text: body.length % 2 === 0 ? Buffer.from(body).swap16().toString('utf16le') : null },
+      { scheme: 'le', text: body.length % 2 === 0 ? Buffer.from(body).toString('utf16le') : null },
+    ]) {
+      if (!candidate.text) continue;
+      try {
+        parsed = JSON.parse(candidate.text);
+        scheme = candidate.scheme;
+        break;
+      } catch (e) {
+        // try the next byte order
+      }
+    }
+    if (parsed && scheme) {
+      for (const ks of evalKeys) {
+        parsed[ks.replace(/^_app:\/\/-\u0000\u0001/, '')] = future;
+      }
+      const json = JSON.stringify(parsed);
+      let newBody;
+      if (scheme === 'utf8') newBody = Buffer.from(json, 'utf8');
+      else if (scheme === 'be') newBody = be16(json);
+      else newBody = Buffer.from(json, 'utf16le');
+      if (marker) newBody = Buffer.concat([Buffer.from([0x01]), newBody]);
+      await db.put(lmKey, newBody);
+      reports.push(`${lmKeyName}: timestamps bumped to ${future} (${scheme})`);
+    } else {
+      reports.push(`${lmKeyName}: skipped (could not parse timestamp entry)`);
+    }
+  } catch (e) {
+    reports.push(`${lmKeyName}: skipped (${e.message})`);
+  }
+
+  await db.close();
+  console.log(reports.join('\n'));
+}
+
+main().catch((e) => {
+  console.error('PATCH FAILED:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
### Summary

Adds a workaround utility for Codex Desktop's empty model picker when using CC Switch custom providers.

**Root cause:** Codex Desktop applies a Statsig allowlist (107580212: use_hidden_models=true, vailable_models only contains stock GPT ids) in the renderer, which strips every custom-provider model returned by model/list. See openai/codex#19694 and cc-switch#5797.

**What this adds:** 	ools/codex-model-picker-fix/ with:
- ix-codex-model-picker.ps1 - one-click fix: backs up the Desktop Local Storage LevelDB, sets use_hidden_models=false, adds the custom model IDs to vailable_models, pushes the cache timestamp forward, and blocks b.chatgpt.com in hosts so the remote allowlist cannot refresh back.
- patch-statsig.js - the LevelDB patcher (validated on Windows with Codex Desktop 26.803).
- README with usage/rollback instructions.

This is complementary to the code-level fix in #5265: it works with the current shipped Desktop build without repackaging the MSIX.