### PR TITLE
fix(usage): prevent Codex session sync gaps after sync-pass refactor

### DIFF
--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -53,7 +53,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 16;
+pub(crate) const SCHEMA_VERSION: i32 = 17;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -1537,6 +1537,10 @@ impl Database {
                 "last_file_size",
                 "INTEGER NOT NULL DEFAULT 0",
             )?;
+            crate::services::session_usage_codex::reset_codex_sync_cursors_on_conn(
+                conn,
+                &crate::codex_config::get_codex_config_dir(),
+            )?;
         }
         Ok(())
     }
@@ -3270,22 +3274,41 @@ mod tests {
                 last_line_offset INTEGER NOT NULL DEFAULT 0,
                 last_synced_at INTEGER NOT NULL
              );
-             INSERT INTO session_log_sync
-                (file_path, last_modified, last_line_offset, last_synced_at)
-             VALUES ('rollout.jsonl', 11, 22, 33);",
+            ",
+        )?;
+        let codex_cursor =
+            "/old/.codex/sessions/rollout-00000000-0000-4000-8000-000000000001.jsonl";
+        conn.execute(
+            "INSERT INTO session_log_sync
+             (file_path, last_modified, last_line_offset, last_synced_at)
+             VALUES (?1, 11, 22, 33)",
+            [codex_cursor],
+        )?;
+        conn.execute(
+            "INSERT INTO session_log_sync
+             (file_path, last_modified, last_line_offset, last_synced_at)
+             VALUES ('/gemini/tmp/session-123.json', 44, 55, 66)",
+            [],
         )?;
         Database::set_user_version(&conn, 16)?;
 
         Database::apply_schema_migrations_on_conn(&conn)?;
 
         assert_eq!(Database::get_user_version(&conn)?, SCHEMA_VERSION);
-        let state: (i64, i64, i64) = conn.query_row(
+        let codex_state: (i64, i64, i64) = conn.query_row(
             "SELECT last_modified, last_line_offset, last_file_size
-             FROM session_log_sync WHERE file_path = 'rollout.jsonl'",
+             FROM session_log_sync WHERE file_path = ?1",
+            [codex_cursor],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(codex_state, (0, 0, 0));
+        let non_codex_state: (i64, i64, i64) = conn.query_row(
+            "SELECT last_modified, last_line_offset, last_file_size
+             FROM session_log_sync WHERE file_path = '/gemini/tmp/session-123.json'",
             [],
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )?;
-        assert_eq!(state, (11, 22, 0));
+        assert_eq!(non_codex_state, (44, 55, 0));
         Ok(())
     }
 }

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -302,6 +302,7 @@ impl Database {
                 file_path TEXT PRIMARY KEY,
                 last_modified INTEGER NOT NULL,
                 last_line_offset INTEGER NOT NULL DEFAULT 0,
+                last_file_size INTEGER NOT NULL DEFAULT 0,
                 last_synced_at INTEGER NOT NULL
             )",
             [],
@@ -510,6 +511,11 @@ impl Database {
                         log::info!("迁移数据库从 v15 到 v16（重建 Codex 会话用量）");
                         Self::migrate_v15_to_v16(conn)?;
                         Self::set_user_version(conn, 16)?;
+                    }
+                    16 => {
+                        log::info!("迁移数据库从 v16 到 v17（记录会话日志文件大小）");
+                        Self::migrate_v16_to_v17(conn)?;
+                        Self::set_user_version(conn, 17)?;
                     }
                     _ => {
                         return Err(AppError::Database(format!(
@@ -1521,6 +1527,18 @@ impl Database {
     fn migrate_v15_to_v16(conn: &Connection) -> Result<(), AppError> {
         let codex_dir = crate::codex_config::get_codex_config_dir();
         crate::services::session_usage_codex::reset_codex_usage_on_conn(conn, &codex_dir)
+    }
+
+    fn migrate_v16_to_v17(conn: &Connection) -> Result<(), AppError> {
+        if Self::table_exists(conn, "session_log_sync")? {
+            Self::add_column_if_missing(
+                conn,
+                "session_log_sync",
+                "last_file_size",
+                "INTEGER NOT NULL DEFAULT 0",
+            )?;
+        }
+        Ok(())
     }
 
     /// 插入默认模型定价数据
@@ -3223,7 +3241,12 @@ mod tests {
 
         Database::apply_schema_migrations_on_conn(&conn)?;
 
-        assert_eq!(Database::get_user_version(&conn)?, 16);
+        assert_eq!(Database::get_user_version(&conn)?, SCHEMA_VERSION);
+        assert!(Database::has_column(
+            &conn,
+            "session_log_sync",
+            "last_file_size"
+        )?);
         let counts: (i64, i64, i64, i64) = conn.query_row(
             "SELECT
                 (SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'codex_session'),
@@ -3234,6 +3257,35 @@ mod tests {
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )?;
         assert_eq!(counts, (0, 1, 0, 1));
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_v16_to_v17_adds_session_file_size_cursor() -> Result<(), AppError> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(
+            "CREATE TABLE session_log_sync (
+                file_path TEXT PRIMARY KEY,
+                last_modified INTEGER NOT NULL,
+                last_line_offset INTEGER NOT NULL DEFAULT 0,
+                last_synced_at INTEGER NOT NULL
+             );
+             INSERT INTO session_log_sync
+                (file_path, last_modified, last_line_offset, last_synced_at)
+             VALUES ('rollout.jsonl', 11, 22, 33);",
+        )?;
+        Database::set_user_version(&conn, 16)?;
+
+        Database::apply_schema_migrations_on_conn(&conn)?;
+
+        assert_eq!(Database::get_user_version(&conn)?, SCHEMA_VERSION);
+        let state: (i64, i64, i64) = conn.query_row(
+            "SELECT last_modified, last_line_offset, last_file_size
+             FROM session_log_sync WHERE file_path = 'rollout.jsonl'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(state, (11, 22, 0));
         Ok(())
     }
 }

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -437,10 +437,15 @@ pub(crate) fn get_sync_state(db: &Database, file_path: &str) -> Result<(i64, i64
         rusqlite::params![file_path],
         |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
     );
-    Ok(result.unwrap_or((0, 0)))
+    match result {
+        Ok(state) => Ok(state),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok((0, 0)),
+        Err(error) => Err(AppError::Database(format!("读取会话同步状态失败: {error}"))),
+    }
 }
 
 /// 获取同步进度，并包含上次已处理的文件大小。
+#[cfg(test)]
 pub(crate) fn get_sync_state_with_size(
     db: &Database,
     file_path: &str,
@@ -459,7 +464,11 @@ pub(crate) fn get_sync_state_with_size(
             ))
         },
     );
-    Ok(result.unwrap_or((0, 0, 0)))
+    match result {
+        Ok(state) => Ok(state),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok((0, 0, 0)),
+        Err(error) => Err(AppError::Database(format!("读取会话同步状态失败: {error}"))),
+    }
 }
 
 /// 返回文件 mtime 的纳秒时间戳。
@@ -713,6 +722,27 @@ pub fn get_data_source_breakdown(db: &Database) -> Result<Vec<DataSourceSummary>
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sync_state_lookup_defaults_only_when_row_is_missing() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        assert_eq!(get_sync_state(&db, "missing.jsonl")?, (0, 0));
+        assert_eq!(get_sync_state_with_size(&db, "missing.jsonl")?, (0, 0, 0));
+
+        let conn = lock_conn!(db.conn);
+        conn.execute("DROP TABLE session_log_sync", [])?;
+        drop(conn);
+
+        assert!(matches!(
+            get_sync_state(&db, "missing.jsonl"),
+            Err(AppError::Database(_))
+        ));
+        assert!(matches!(
+            get_sync_state_with_size(&db, "missing.jsonl"),
+            Err(AppError::Database(_))
+        ));
+        Ok(())
+    }
 
     #[test]
     fn sync_result_notification_is_coalesced_to_one_call() {

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -440,6 +440,28 @@ pub(crate) fn get_sync_state(db: &Database, file_path: &str) -> Result<(i64, i64
     Ok(result.unwrap_or((0, 0)))
 }
 
+/// 获取同步进度，并包含上次已处理的文件大小。
+pub(crate) fn get_sync_state_with_size(
+    db: &Database,
+    file_path: &str,
+) -> Result<(i64, i64, u64), AppError> {
+    let conn = lock_conn!(db.conn);
+    let result = conn.query_row(
+        "SELECT last_modified, last_line_offset, last_file_size
+         FROM session_log_sync WHERE file_path = ?1",
+        rusqlite::params![file_path],
+        |row| {
+            let size = row.get::<_, i64>(2)?;
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                size.max(0) as u64,
+            ))
+        },
+    );
+    Ok(result.unwrap_or((0, 0, 0)))
+}
+
 /// 返回文件 mtime 的纳秒时间戳。
 ///
 /// `session_log_sync.last_modified` 旧数据是秒级时间戳；新写入纳秒值不需要
@@ -484,6 +506,56 @@ pub(crate) fn update_sync_state_on_conn(
          VALUES (?1, ?2, ?3, ?4)",
     )
     .and_then(|mut stmt| stmt.execute(rusqlite::params![file_path, last_modified, last_offset, now]))
+    .map_err(|e| AppError::Database(format!("更新同步状态失败: {e}")))?;
+    Ok(())
+}
+
+/// 更新同步进度，并持久化已处理的文件大小。
+pub(crate) fn update_sync_state_with_size(
+    db: &Database,
+    file_path: &str,
+    last_modified: i64,
+    last_offset: i64,
+    last_file_size: u64,
+) -> Result<(), AppError> {
+    let conn = lock_conn!(db.conn);
+    update_sync_state_with_size_on_conn(
+        &conn,
+        file_path,
+        last_modified,
+        last_offset,
+        last_file_size,
+    )
+}
+
+/// [`update_sync_state_with_size`] 的免锁版本，供 Codex 批量写入事务使用。
+pub(crate) fn update_sync_state_with_size_on_conn(
+    conn: &rusqlite::Connection,
+    file_path: &str,
+    last_modified: i64,
+    last_offset: i64,
+    last_file_size: u64,
+) -> Result<(), AppError> {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let last_file_size = last_file_size.min(i64::MAX as u64) as i64;
+
+    conn.prepare_cached(
+        "INSERT OR REPLACE INTO session_log_sync
+         (file_path, last_modified, last_line_offset, last_file_size, last_synced_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+    )
+    .and_then(|mut stmt| {
+        stmt.execute(rusqlite::params![
+            file_path,
+            last_modified,
+            last_offset,
+            last_file_size,
+            now
+        ])
+    })
     .map_err(|e| AppError::Database(format!("更新同步状态失败: {e}")))?;
     Ok(())
 }

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -305,6 +305,46 @@ fn sqlite_column_exists(
     .map_err(|error| AppError::Database(format!("查询列 {table}.{column} 失败: {error}")))
 }
 
+fn codex_cursor_paths_on_conn(
+    conn: &rusqlite::Connection,
+    codex_dir: &Path,
+) -> Result<Vec<String>, AppError> {
+    if !sqlite_table_exists(conn, "session_log_sync")?
+        || !sqlite_column_exists(conn, "session_log_sync", "file_path")?
+    {
+        return Ok(Vec::new());
+    }
+
+    let mut statement = conn
+        .prepare("SELECT file_path FROM session_log_sync")
+        .map_err(|error| AppError::Database(format!("读取会话同步 cursor 失败: {error}")))?;
+    let paths = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|error| AppError::Database(format!("查询会话同步 cursor 失败: {error}")))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| AppError::Database(format!("解析会话同步 cursor 失败: {error}")))?;
+    Ok(paths
+        .into_iter()
+        .filter(|path| is_codex_cursor_path(path, codex_dir))
+        .collect())
+}
+
+pub(crate) fn reset_codex_sync_cursors_on_conn(
+    conn: &rusqlite::Connection,
+    codex_dir: &Path,
+) -> Result<(), AppError> {
+    for file_path in codex_cursor_paths_on_conn(conn, codex_dir)? {
+        conn.execute(
+            "UPDATE session_log_sync
+             SET last_modified = 0, last_line_offset = 0, last_file_size = 0
+             WHERE file_path = ?1",
+            [file_path],
+        )
+        .map_err(|error| AppError::Database(format!("重置 Codex 同步 cursor 失败: {error}")))?;
+    }
+    Ok(())
+}
+
 pub(crate) fn reset_codex_usage_on_conn(
     conn: &rusqlite::Connection,
     codex_dir: &Path,
@@ -327,34 +367,12 @@ pub(crate) fn reset_codex_usage_on_conn(
         )
         .map_err(|error| AppError::Database(format!("清理 Codex 用量汇总失败: {error}")))?;
     }
-    if sqlite_table_exists(conn, "session_log_sync")?
-        && sqlite_column_exists(conn, "session_log_sync", "file_path")?
-    {
-        let paths = {
-            let mut statement = conn
-                .prepare("SELECT file_path FROM session_log_sync")
-                .map_err(|error| {
-                    AppError::Database(format!("读取会话同步 cursor 失败: {error}"))
-                })?;
-            let paths = statement
-                .query_map([], |row| row.get::<_, String>(0))
-                .map_err(|error| AppError::Database(format!("查询会话同步 cursor 失败: {error}")))?
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|error| {
-                    AppError::Database(format!("解析会话同步 cursor 失败: {error}"))
-                })?;
-            paths
-        };
-        for file_path in paths
-            .into_iter()
-            .filter(|path| is_codex_cursor_path(path, codex_dir))
-        {
-            conn.execute(
-                "DELETE FROM session_log_sync WHERE file_path = ?1",
-                [file_path],
-            )
-            .map_err(|error| AppError::Database(format!("清理 Codex 同步 cursor 失败: {error}")))?;
-        }
+    for file_path in codex_cursor_paths_on_conn(conn, codex_dir)? {
+        conn.execute(
+            "DELETE FROM session_log_sync WHERE file_path = ?1",
+            [file_path],
+        )
+        .map_err(|error| AppError::Database(format!("清理 Codex 同步 cursor 失败: {error}")))?;
     }
     Ok(())
 }
@@ -512,10 +530,7 @@ fn get_codex_sync_state(
     cursors: &HashMap<String, (i64, i64, u64)>,
 ) -> Result<(i64, i64, u64), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
-    let state = cursors
-        .get(&file_path_str)
-        .copied()
-        .unwrap_or((0, 0, 0));
+    let state = cursors.get(&file_path_str).copied().unwrap_or((0, 0, 0));
     if state != (0, 0, 0)
         || file_path
             .parent()
@@ -2423,6 +2438,54 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(count, 2);
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn migrated_cursor_rescans_an_empty_rollout_before_same_mtime_append() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let sessions_dir = temp.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).unwrap();
+        let rollout = rollout_path(&sessions_dir, PARENT_ID);
+        fs::File::create(&rollout).unwrap();
+        let original_metadata = fs::metadata(&rollout).unwrap();
+        let original_modified = original_metadata.modified().unwrap();
+        let original_modified_nanos = metadata_modified_nanos(&original_metadata);
+
+        update_sync_state_with_size(
+            &db,
+            &rollout.to_string_lossy(),
+            original_modified_nanos,
+            99,
+            0,
+        )?;
+        {
+            let conn = lock_conn!(db.conn);
+            reset_codex_sync_cursors_on_conn(&conn, temp.path())?;
+        }
+        assert_eq!(
+            get_sync_state_with_size(&db, &rollout.to_string_lossy())?,
+            (0, 0, 0)
+        );
+
+        assert_eq!(sync_test_file(&db, &rollout, &[&rollout])?.imported, 0);
+        append_jsonl(
+            &rollout,
+            &[
+                session_meta(PARENT_ID),
+                turn_context(),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:02Z"),
+            ],
+        );
+        let file = fs::OpenOptions::new().write(true).open(&rollout).unwrap();
+        file.set_times(fs::FileTimes::new().set_modified(original_modified))
+            .unwrap();
+        drop(file);
+
+        assert_eq!(sync_test_file(&db, &rollout, &[&rollout])?.imported, 1);
         Ok(())
     }
 

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -19,7 +19,8 @@ use crate::error::AppError;
 use crate::proxy::usage::calculator::{CostCalculator, ModelPricing};
 use crate::proxy::usage::parser::TokenUsage;
 use crate::services::session_usage::{
-    metadata_modified_nanos, update_sync_state, update_sync_state_on_conn, SessionSyncResult,
+    metadata_modified_nanos, update_sync_state_with_size, update_sync_state_with_size_on_conn,
+    SessionSyncResult,
 };
 use crate::services::usage_stats::{
     find_model_pricing, has_suspected_codex_session_duplicate, should_skip_session_insert, DedupKey,
@@ -144,6 +145,7 @@ struct ParentTokenTimeline {
     events: Vec<TimestampedTokenSignature>,
     max_timestamp: Option<DateTime<Utc>>,
     has_token_without_timestamp: bool,
+    ends_at_completed_turn: bool,
 }
 
 impl ParentTokenTimeline {
@@ -161,6 +163,7 @@ impl ParentTokenTimeline {
         if self
             .max_timestamp
             .is_none_or(|timestamp| timestamp < cutoff)
+            && !self.ends_at_completed_turn
         {
             return Err(format!(
                 "父 rollout {} 尚未写到 child fork 时刻",
@@ -469,7 +472,7 @@ fn token_snapshot_source(payload: &serde_json::Value) -> Option<String> {
 /// - `pricing`：模型定价 pass 级缓存。定价表在 pass 进行中被修改时本 pass
 ///   仍用旧价，下一个同步 pass 生效。
 struct CodexSyncPass {
-    cursors: HashMap<String, (i64, i64)>,
+    cursors: HashMap<String, (i64, i64, u64)>,
     pricing: HashMap<String, Option<ModelPricing>>,
 }
 
@@ -477,13 +480,21 @@ impl CodexSyncPass {
     fn load(db: &Database) -> Result<Self, AppError> {
         let conn = lock_conn!(db.conn);
         let mut stmt = conn
-            .prepare("SELECT file_path, last_modified, last_line_offset FROM session_log_sync")
+            .prepare(
+                "SELECT file_path, last_modified, last_line_offset, last_file_size
+                 FROM session_log_sync",
+            )
             .map_err(|e| AppError::Database(format!("预载同步游标失败: {e}")))?;
         let cursors = stmt
             .query_map([], |row| {
+                let size = row.get::<_, i64>(3)?;
                 Ok((
                     row.get::<_, String>(0)?,
-                    (row.get::<_, i64>(1)?, row.get::<_, i64>(2)?),
+                    (
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                        size.max(0) as u64,
+                    ),
                 ))
             })
             .and_then(|rows| rows.collect::<Result<HashMap<_, _>, _>>())
@@ -498,11 +509,14 @@ impl CodexSyncPass {
 fn get_codex_sync_state(
     db: &Database,
     file_path: &Path,
-    cursors: &HashMap<String, (i64, i64)>,
-) -> Result<(i64, i64), AppError> {
+    cursors: &HashMap<String, (i64, i64, u64)>,
+) -> Result<(i64, i64, u64), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
-    let state = cursors.get(&file_path_str).copied().unwrap_or((0, 0));
-    if state != (0, 0)
+    let state = cursors
+        .get(&file_path_str)
+        .copied()
+        .unwrap_or((0, 0, 0));
+    if state != (0, 0, 0)
         || file_path
             .parent()
             .and_then(Path::file_name)
@@ -525,13 +539,13 @@ fn get_codex_sync_state(
             path.as_str() != file_path_str
                 && (path.ends_with(&slash_suffix) || path.ends_with(&backslash_suffix))
         })
-        .map(|(_, &(modified, offset))| (offset, modified))
-        .max();
+        .map(|(_, &(modified, offset, size))| (offset, modified, size))
+        .max_by_key(|&(offset, modified, _)| (offset, modified));
 
     match inherited {
-        Some((offset, modified)) => {
-            update_sync_state(db, &file_path_str, modified, offset)?;
-            Ok((modified, offset))
+        Some((offset, modified, size)) => {
+            update_sync_state_with_size(db, &file_path_str, modified, offset, size)?;
+            Ok((modified, offset, size))
         }
         None => Ok(state),
     }
@@ -989,6 +1003,7 @@ fn parent_signatures_before(
     let mut events = Vec::new();
     let mut max_timestamp: Option<DateTime<Utc>> = None;
     let mut has_token_without_timestamp = false;
+    let mut ends_at_completed_turn = false;
 
     // 必须扫描完整父文件，不能在首个未来时间戳处 break：rollout 写入顺序
     // 不承诺时间戳严格单调。缓存完整时间线后，不同 child cutoff 只需内存过滤。
@@ -1002,6 +1017,19 @@ fn parent_signatures_before(
         let timestamp = parse_timestamp(value.get("timestamp"));
         if let Some(timestamp) = timestamp {
             max_timestamp = Some(max_timestamp.map_or(timestamp, |current| current.max(timestamp)));
+        }
+        if value.get("type").and_then(serde_json::Value::as_str) == Some("event_msg") {
+            match value
+                .get("payload")
+                .and_then(|payload| payload.get("type"))
+                .and_then(serde_json::Value::as_str)
+            {
+                Some("task_started" | "turn_started") => ends_at_completed_turn = false,
+                Some("task_complete" | "turn_complete" | "turn_aborted") => {
+                    ends_at_completed_turn = timestamp.is_some();
+                }
+                _ => {}
+            }
         }
         if value.get("type").and_then(serde_json::Value::as_str) != Some("event_msg")
             || value
@@ -1036,6 +1064,7 @@ fn parent_signatures_before(
         events,
         max_timestamp,
         has_token_without_timestamp,
+        ends_at_completed_turn,
     });
     let result = timeline.signatures_before(parent_path, cutoff);
     if let (Some(stamp), Ok(mut caches)) = (stamp, replay_caches().lock()) {
@@ -1145,10 +1174,11 @@ fn sync_single_codex_file(
     let file_size = metadata.len();
 
     // 检查同步状态
-    let (last_modified, last_offset) = get_codex_sync_state(db, file_path, &pass.cursors)?;
+    let (last_modified, last_offset, last_file_size) =
+        get_codex_sync_state(db, file_path, &pass.cursors)?;
 
     // 文件未变化则跳过
-    if file_modified <= last_modified {
+    if file_modified <= last_modified && file_size == last_file_size {
         return Ok(CodexFileSyncResult::default());
     }
 
@@ -1181,7 +1211,13 @@ fn sync_single_codex_file(
 
     let parsed = parse_codex_file(file_path, thread_id_from_filename(file_path))?;
     if !parsed.has_billable_tokens {
-        update_sync_state(db, &file_path_str, file_modified, parsed.line_offset)?;
+        update_sync_state_with_size(
+            db,
+            &file_path_str,
+            file_modified,
+            parsed.line_offset,
+            file_size,
+        )?;
         return Ok(CodexFileSyncResult::default());
     }
     let Some(root_thread_id) = parsed.root_thread_id.as_deref() else {
@@ -1331,7 +1367,13 @@ fn sync_single_codex_file(
         if is_last_batch {
             // 游标推进与最后一批数据同事务提交：中途崩溃时两者一起回滚，
             // 不会出现"游标已推进但数据缺失"的丢数据窗口。
-            update_sync_state_on_conn(&tx, &file_path_str, file_modified, parsed.line_offset)?;
+            update_sync_state_with_size_on_conn(
+                &tx,
+                &file_path_str,
+                file_modified,
+                parsed.line_offset,
+                file_size,
+            )?;
         }
         tx.commit()
             .map_err(|e| AppError::Database(format!("提交 Codex 会话写入事务失败: {e}")))?;
@@ -1342,7 +1384,13 @@ fn sync_single_codex_file(
     }
 
     if to_insert.is_empty() {
-        update_sync_state(db, &file_path_str, file_modified, parsed.line_offset)?;
+        update_sync_state_with_size(
+            db,
+            &file_path_str,
+            file_modified,
+            parsed.line_offset,
+            file_size,
+        )?;
     }
     Ok(result)
 }
@@ -1507,7 +1555,10 @@ fn find_codex_pricing(conn: &rusqlite::Connection, model_id: &str) -> Option<Mod
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::services::session_usage::get_sync_state;
+    use crate::services::session_usage::{
+        get_sync_state, get_sync_state_with_size, update_sync_state,
+    };
+    use std::io::Write;
     use tempfile::tempdir;
 
     const PARENT_ID: &str = "00000000-0000-4000-8000-000000000001";
@@ -1522,6 +1573,14 @@ mod tests {
             .join("\n")
             + "\n";
         fs::write(path, contents).unwrap();
+    }
+
+    fn append_jsonl(path: &Path, values: &[serde_json::Value]) {
+        let mut file = fs::OpenOptions::new().append(true).open(path).unwrap();
+        for value in values {
+            writeln!(file, "{value}").unwrap();
+        }
+        file.flush().unwrap();
     }
 
     fn rollout_path(dir: &Path, thread_id: &str) -> PathBuf {
@@ -1573,6 +1632,14 @@ mod tests {
 
     fn turn_context() -> serde_json::Value {
         turn_context_at("2026-07-10T03:00:01Z")
+    }
+
+    fn lifecycle_event_at(event_type: &str, timestamp: &str) -> serde_json::Value {
+        serde_json::json!({
+            "timestamp": timestamp,
+            "type": "event_msg",
+            "payload": { "type": event_type }
+        })
     }
 
     fn token_count_at(input: u64, cached: u64, output: u64, timestamp: &str) -> serde_json::Value {
@@ -2239,6 +2306,123 @@ mod tests {
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )?;
         assert_eq!(usage, (300, 150, 50));
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_completed_parent_before_fork_allows_child_sync() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let child = rollout_path(temp.path(), CHILD_A_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                lifecycle_event_at("task_started", "2026-07-10T03:00:00.500Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+                lifecycle_event_at("task_complete", "2026-07-10T03:00:04Z"),
+            ],
+        );
+        write_jsonl(
+            &child,
+            &[
+                session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:00:05Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:06Z"),
+                token_count_at(200, 100, 20, "2026-07-10T03:00:07Z"),
+            ],
+        );
+
+        let result = sync_test_file(&db, &child, &[&parent, &child])?;
+
+        assert_eq!(
+            (result.imported, result.skipped, result.deferred),
+            (1, 1, false)
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_active_parent_before_fork_remains_deferred() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let parent = rollout_path(temp.path(), PARENT_ID);
+        let child = rollout_path(temp.path(), CHILD_A_ID);
+        write_jsonl(
+            &parent,
+            &[
+                session_meta(PARENT_ID),
+                lifecycle_event_at("task_started", "2026-07-10T03:00:00.500Z"),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:01Z"),
+            ],
+        );
+        write_jsonl(
+            &child,
+            &[
+                session_meta_at(CHILD_A_ID, Some(PARENT_ID), None, "2026-07-10T03:00:05Z"),
+                token_count_at(200, 100, 20, "2026-07-10T03:00:06Z"),
+            ],
+        );
+
+        let result = sync_test_file(&db, &child, &[&parent, &child])?;
+
+        assert!(result.deferred);
+        assert_eq!(get_sync_state(&db, &child.to_string_lossy())?, (0, 0));
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_same_mtime_size_growth_is_synced() -> Result<(), AppError> {
+        clear_codex_replay_caches();
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let rollout = rollout_path(temp.path(), CHILD_A_ID);
+        write_jsonl(
+            &rollout,
+            &[
+                session_meta(CHILD_A_ID),
+                turn_context(),
+                token_count_at(100, 50, 10, "2026-07-10T03:00:02Z"),
+            ],
+        );
+        let original_metadata = fs::metadata(&rollout).unwrap();
+        let original_modified = original_metadata.modified().unwrap();
+        let original_modified_nanos = metadata_modified_nanos(&original_metadata);
+
+        assert_eq!(sync_test_file(&db, &rollout, &[&rollout])?.imported, 1);
+
+        append_jsonl(
+            &rollout,
+            &[token_count_at(200, 100, 20, "2026-07-10T03:00:03Z")],
+        );
+        let file = fs::OpenOptions::new().write(true).open(&rollout).unwrap();
+        file.set_times(fs::FileTimes::new().set_modified(original_modified))
+            .unwrap();
+        drop(file);
+        let grown_metadata = fs::metadata(&rollout).unwrap();
+        assert!(grown_metadata.len() > original_metadata.len());
+        assert_eq!(
+            metadata_modified_nanos(&grown_metadata),
+            original_modified_nanos
+        );
+
+        assert_eq!(sync_test_file(&db, &rollout, &[&rollout])?.imported, 1);
+        assert_eq!(sync_test_file(&db, &rollout, &[&rollout])?.imported, 0);
+        let sync_state = get_sync_state_with_size(&db, &rollout.to_string_lossy())?;
+        assert_eq!(sync_state.2, grown_metadata.len());
+
+        let conn = lock_conn!(db.conn);
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'codex_session'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 2);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- persist each processed Codex rollout file size alongside mtime and line offset, so appended usage is still synced when Windows leaves an open JSONL file's mtime unchanged
- allow a child fork to sync after its parent has emitted an explicit terminal lifecycle event, while continuing to defer children of active or incomplete parents
- integrate the size-aware cursor with the current `CodexSyncPass` preload and batched insert transactions, keeping the final data batch and cursor advance atomic
- add the v16 to v17 schema migration and reset only Codex rollout cursors once so existing installations establish a consistent `(mtime, offset, size)` state

## Why a new PR

This supersedes #5997. Since that PR was opened, `main` gained the batched Codex insert and preloaded-cursor refactor in `baf07a2701`. This branch is rebuilt on the current `main` and preserves those performance and crash-consistency guarantees instead of layering the old implementation over them.

## Behavior and safety

- unchanged: token delta calculation, replay-prefix deduplication, request IDs, pricing, proxy request ingestion, and non-Codex session sync
- same-mtime files are skipped only when their size is also unchanged
- only explicit `task_complete`, `turn_complete`, or `turn_aborted` events make a parent timeline terminal
- active parents remain deferred until sufficient history is available
- SQLite lookup failures are propagated; only a genuinely missing cursor defaults to zero
- migration resets Codex rollout cursors only; Gemini and other session cursors are preserved

## Validation

- `cargo fmt -- --check`
- `cargo clippy --locked --lib -- -D warnings`
- `cargo test --locked session_usage_codex --lib` (48 passed, 1 ignored)
- `cargo test --locked migrate_v16_to_v17_adds_session_file_size_cursor --lib`
- `cargo test --locked sync_state_lookup_defaults_only_when_row_is_missing --lib`
- `cargo test --locked --lib` (2342 passed, 5 ignored)

