### PR TITLE
feat(grok-build): add OpenCode Go preset with Grok 4.5

### DIFF
--- a/src/config/grokBuildProviderPresets.test.ts
+++ b/src/config/grokBuildProviderPresets.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   extractCodexBaseUrl,
   extractCodexModelName,
+  extractCodexWireApi,
 } from "../utils/providerConfigUtils";
 import { GROK_BUILD_DEFAULT_MODEL } from "../utils/grokBuildConfig";
 
@@ -40,11 +41,25 @@ describe("grokBuildProviderPresets", () => {
       "Novita AI",
       "Nvidia",
       "AtlasCloud",
-      "OpenCode Go",
     ];
     for (const name of excluded) {
       expect(names.has(name), name).toBe(false);
     }
+  });
+
+  it("includes OpenCode Go with the Grok 4.5 chat-completions endpoint", () => {
+    const preset = grokBuildProviderPresets.find(
+      (p) => p.name === "OpenCode Go",
+    );
+    expect(preset).toBeDefined();
+    if (!preset) return;
+    expect(preset.category).toBe("third_party");
+    expect(extractCodexModelName(preset.config)).toBe(GROK_BUILD_DEFAULT_MODEL);
+    expect(extractCodexBaseUrl(preset.config)).toBe(
+      "https://opencode.ai/zen/go/v1",
+    );
+    expect(extractCodexWireApi(preset.config)).toBe("chat");
+    expect(preset.apiFormat).toBe("openai_chat");
   });
 
   it("uses a Grok default model on every preset", () => {

--- a/src/config/grokBuildProviderPresets.ts
+++ b/src/config/grokBuildProviderPresets.ts
@@ -9,9 +9,11 @@
  * - 不含官方 / 托管 OAuth 预设：Grok CLI 自带 xAI 订阅登录，官方态走
  *   独立的 "Grok Official" 条目（对应 providers_seed.rs 的 seed，
  *   空 config = 不写自定义模型表）。
- * - 不含国产模型官方直连（cn_official）与纯开源模型托管站
- *   （SiliconFlow / ModelScope / Novita / Nvidia / AtlasCloud / OpenCode Go）：
- *   这些上游没有 Grok 模型，无法在 Grok CLI 中使用。
+ * - 不含国产模型官方直连（cn_official）；纯开源模型托管站
+ *   （SiliconFlow / ModelScope / Novita / Nvidia / AtlasCloud）上游没有
+ *   Grok 模型，无法在 Grok CLI 中使用。
+ * - OpenCode Go 于 2026-08 起提供 Grok 4.5（OpenAI 兼容 chat/completions
+ *   端点），故收录；注意其 Grok 4.5 用量限额较低（每 5 小时约 120 次请求）。
  * - 只收聚合站与第三方中转站，默认模型统一为 grok-4.5；
  *   OpenRouter 系命名空间的路由站用 "x-ai/grok-4.5"。
  *
@@ -63,6 +65,7 @@ function grokPresetConfig(
   providerName: string,
   baseUrl: string,
   model = GROK_BUILD_DEFAULT_MODEL,
+  wireApi = "responses",
 ): string {
   const tomlString = (value: string) => JSON.stringify(value);
 
@@ -72,7 +75,7 @@ model = ${tomlString(model)}
 [model_providers.custom]
 name = ${tomlString(providerName)}
 base_url = ${tomlString(baseUrl)}
-wire_api = "responses"
+wire_api = ${tomlString(wireApi)}
 requires_openai_auth = true`;
 }
 
@@ -559,6 +562,25 @@ export const grokBuildProviderPresets: GrokBuildProviderPreset[] = [
     category: "aggregator",
     icon: "openrouter",
     iconColor: "#6566F1",
+  },
+  {
+    name: "OpenCode Go",
+    websiteUrl: "https://opencode.ai/go",
+    apiKeyUrl: "https://opencode.ai/go?ref=2YTRG2NGTX",
+    auth: grokAuth(),
+    config: grokPresetConfig(
+      "OpenCode Go",
+      "https://opencode.ai/zen/go/v1",
+      GROK_BUILD_DEFAULT_MODEL,
+      "chat",
+    ),
+    endpointCandidates: ["https://opencode.ai/zen/go/v1"],
+    apiFormat: "openai_chat",
+    category: "third_party",
+    isPartner: true,
+    partnerPromotionKey: "opencode_go",
+    icon: "opencode",
+    iconColor: "#211E1E",
   },
   {
     name: "TheRouter",


### PR DESCRIPTION
Closes #6249

## Summary / 摘要
OpenCode Go 已于 2026-08 提供 **Grok 4.5**（OpenAI 兼容端点），`grokBuildProviderPresets.ts` 中"上游没有 Grok 模型"的排除依据已过时。本 PR 将 OpenCode Go 加回 Grok Build 预设：

- 新增第三方预设条目：`base_url: https://opencode.ai/zen/go/v1`、`model: grok-4.5`、`wire_api: "chat"`（→ Grok CLI `api_backend = "chat_completions"`，与上游端点匹配）
- `category: "third_party"`、`isPartner: true`、`partnerPromotionKey: "opencode_go"`、图标 `opencode`
- `grokPresetConfig` 新增 `wireApi` 参数（默认 `"responses"`，所有现有预设行为不变，向后兼容）
- 同步更新头部注释与测试：移除 OpenCode Go 排除断言，新增针对该预设的 model / base_url / apiFormat 断言

## Verification / 验证
- `pnpm typecheck` ✅
- `pnpm format:check` ✅
- `pnpm test:unit` ✅ (100 files / 696 tests)

## Notes / 备注
- Grok 4.5 在 Go 套餐有较紧的速率限制（约 120 次请求 / 5 小时），已在 issue #6249 中注明
