### PR TITLE
fix(claude-desktop): add auth field selector for proxy providers

### DIFF
--- a/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
+++ b/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
@@ -720,6 +720,12 @@ export function ClaudeDesktopProviderForm({
       }
     }
 
+    // 直连模式下 Claude Desktop 的 gateway profile 固定 bearer 鉴权，且后端
+    // direct_gateway_credentials 只认 ANTHROPIC_AUTH_TOKEN；认证字段选择仅对
+    // 走本地代理的映射模式有意义，直连一律归一化成 AUTH_TOKEN。
+    const effectiveApiKeyField: ApiKeyField =
+      effectiveMode === "proxy" ? apiKeyField : "ANTHROPIC_AUTH_TOKEN";
+
     const settingsConfig = clonePlainRecord(initialData?.settingsConfig);
     const env = clonePlainRecord(settingsConfig.env);
     delete env.ANTHROPIC_AUTH_TOKEN;
@@ -732,7 +738,7 @@ export function ClaudeDesktopProviderForm({
       : {
           ...env,
           ANTHROPIC_BASE_URL: baseUrl.trim().replace(/\/+$/, ""),
-          [apiKeyField]: apiKey.trim(),
+          [effectiveApiKeyField]: apiKey.trim(),
         };
 
     const routeMap = routeEntries.reduce<
@@ -784,7 +790,12 @@ export function ClaudeDesktopProviderForm({
             : undefined;
     meta.codexFastMode =
       activeProviderType === "codex_oauth" ? codexFastMode : undefined;
-    meta.apiKeyField = apiKeyField;
+    // 与 Claude Code 表单一致：只持久化非默认选择，缺省即 ANTHROPIC_AUTH_TOKEN
+    if (effectiveApiKeyField === "ANTHROPIC_API_KEY") {
+      meta.apiKeyField = effectiveApiKeyField;
+    } else {
+      delete meta.apiKeyField;
+    }
 
     delete meta.endpointAutoSelect;
     delete meta.isFullUrl;
@@ -888,38 +899,43 @@ export function ClaudeDesktopProviderForm({
               </div>
             ) : (
               <>
-                <div className="space-y-2">
-                  <Label>
-                    {t("providerForm.authField", {
-                      defaultValue: "认证字段",
-                    })}
-                  </Label>
-                  <Select
-                    value={apiKeyField}
-                    onValueChange={(v) => setApiKeyField(v as ApiKeyField)}
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="ANTHROPIC_AUTH_TOKEN">
-                        {t("providerForm.authFieldAuthToken", {
-                          defaultValue: "ANTHROPIC_AUTH_TOKEN（默认）",
-                        })}
-                      </SelectItem>
-                      <SelectItem value="ANTHROPIC_API_KEY">
-                        {t("providerForm.authFieldApiKey", {
-                          defaultValue: "ANTHROPIC_API_KEY",
-                        })}
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    {t("providerForm.authFieldHint", {
-                      defaultValue: "选择写入配置的认证环境变量名",
-                    })}
-                  </p>
-                </div>
+                {/* 认证字段仅在映射（本地代理）模式下生效：直连模式由 Claude
+                    Desktop 自己出网，其 gateway profile 固定 bearer 鉴权。 */}
+                {needsModelMapping && (
+                  <div className="space-y-2">
+                    <Label>
+                      {t("providerForm.authField", {
+                        defaultValue: "认证字段",
+                      })}
+                    </Label>
+                    <Select
+                      value={apiKeyField}
+                      onValueChange={(v) => setApiKeyField(v as ApiKeyField)}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="ANTHROPIC_AUTH_TOKEN">
+                          {t("providerForm.authFieldAuthToken", {
+                            defaultValue: "ANTHROPIC_AUTH_TOKEN（默认）",
+                          })}
+                        </SelectItem>
+                        <SelectItem value="ANTHROPIC_API_KEY">
+                          {t("providerForm.authFieldApiKey", {
+                            defaultValue: "ANTHROPIC_API_KEY",
+                          })}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-muted-foreground">
+                      {t("claudeDesktop.authFieldHint", {
+                        defaultValue:
+                          "选择本地代理向供应商发送凭证的方式：ANTHROPIC_AUTH_TOKEN 发 Authorization: Bearer，ANTHROPIC_API_KEY 发 x-api-key。",
+                      })}
+                    </p>
+                  </div>
+                )}
                 <ApiKeySection
                   value={apiKey}
                   onChange={setApiKey}

--- a/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
+++ b/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
@@ -273,11 +273,18 @@ export function ClaudeDesktopProviderForm({
     envString(initialData?.settingsConfig, "ANTHROPIC_AUTH_TOKEN") ||
       envString(initialData?.settingsConfig, "ANTHROPIC_API_KEY"),
   );
-  const [apiKeyField, setApiKeyField] = useState<ApiKeyField>(() =>
-    envString(initialData?.settingsConfig, "ANTHROPIC_API_KEY")
+  const [apiKeyField, setApiKeyField] = useState<ApiKeyField>(() => {
+    const fromMeta = initialData?.meta?.apiKeyField;
+    if (
+      fromMeta === "ANTHROPIC_API_KEY" ||
+      fromMeta === "ANTHROPIC_AUTH_TOKEN"
+    ) {
+      return fromMeta;
+    }
+    return envString(initialData?.settingsConfig, "ANTHROPIC_API_KEY")
       ? "ANTHROPIC_API_KEY"
-      : "ANTHROPIC_AUTH_TOKEN",
-  );
+      : "ANTHROPIC_AUTH_TOKEN";
+  });
   const [selectedGitHubAccountId, setSelectedGitHubAccountId] = useState<
     string | null
   >(() => resolveManagedAccountId(initialData?.meta, "github_copilot"));
@@ -777,6 +784,7 @@ export function ClaudeDesktopProviderForm({
             : undefined;
     meta.codexFastMode =
       activeProviderType === "codex_oauth" ? codexFastMode : undefined;
+    meta.apiKeyField = apiKeyField;
 
     delete meta.endpointAutoSelect;
     delete meta.isFullUrl;
@@ -879,15 +887,49 @@ export function ClaudeDesktopProviderForm({
                 )}
               </div>
             ) : (
-              <ApiKeySection
-                value={apiKey}
-                onChange={setApiKey}
-                category={apiKeyLinkCategory}
-                shouldShowLink={shouldShowApiKeyLink}
-                websiteUrl={apiKeyLinkWebsiteUrl}
-                isPartner={apiKeyLinkIsPartner}
-                partnerPromotionKey={apiKeyLinkPromotionKey}
-              />
+              <>
+                <div className="space-y-2">
+                  <Label>
+                    {t("providerForm.authField", {
+                      defaultValue: "认证字段",
+                    })}
+                  </Label>
+                  <Select
+                    value={apiKeyField}
+                    onValueChange={(v) => setApiKeyField(v as ApiKeyField)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="ANTHROPIC_AUTH_TOKEN">
+                        {t("providerForm.authFieldAuthToken", {
+                          defaultValue: "ANTHROPIC_AUTH_TOKEN（默认）",
+                        })}
+                      </SelectItem>
+                      <SelectItem value="ANTHROPIC_API_KEY">
+                        {t("providerForm.authFieldApiKey", {
+                          defaultValue: "ANTHROPIC_API_KEY",
+                        })}
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    {t("providerForm.authFieldHint", {
+                      defaultValue: "选择写入配置的认证环境变量名",
+                    })}
+                  </p>
+                </div>
+                <ApiKeySection
+                  value={apiKey}
+                  onChange={setApiKey}
+                  category={apiKeyLinkCategory}
+                  shouldShowLink={shouldShowApiKeyLink}
+                  websiteUrl={apiKeyLinkWebsiteUrl}
+                  isPartner={apiKeyLinkIsPartner}
+                  partnerPromotionKey={apiKeyLinkPromotionKey}
+                />
+              </>
             )}
 
             <EndpointField

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -193,6 +193,7 @@
     "mode": "Model handling",
     "modeDirect": "Direct",
     "modeProxy": "Requires routing",
+    "authFieldHint": "How the local proxy sends the credential upstream: ANTHROPIC_AUTH_TOKEN sends Authorization: Bearer, ANTHROPIC_API_KEY sends x-api-key.",
     "modelMappingToggle": "Needs model mapping",
     "modelMappingOffHint": "Direct mode works only when the provider accepts Claude Desktop's three role IDs (claude-sonnet-* / claude-opus-* / claude-haiku-*); for any other model name (including legacy IDs like claude-3-5-sonnet-…), enable this switch to use mapping.",
     "modelMappingOnHint": "Claude Desktop only accepts the three role IDs claude-sonnet-* / claude-opus-* / claude-haiku-*. When enabled, CC Switch maps these three roles to your provider's actual models and keeps local routing running while in use.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -193,6 +193,7 @@
     "mode": "モデル処理方式",
     "modeDirect": "直結",
     "modeProxy": "ルーティング必要",
+    "authFieldHint": "ローカルプロキシがプロバイダーへ認証情報を送る方式を選択します：ANTHROPIC_AUTH_TOKEN は Authorization: Bearer、ANTHROPIC_API_KEY は x-api-key を送信します。",
     "modelMappingToggle": "モデルマッピングが必要",
     "modelMappingOffHint": "プロバイダーが Claude Desktop の三つの役割 ID（claude-sonnet-* / claude-opus-* / claude-haiku-*）を受け付ける場合のみ直結できます。それ以外のモデル名（claude-3-5-sonnet-… などの旧式 ID を含む）はこのスイッチを有効にしてマッピングを使ってください。",
     "modelMappingOnHint": "Claude Desktop は claude-sonnet-* / claude-opus-* / claude-haiku-* の三つの役割 ID のみ受け付けます。有効にすると CC Switch がこの三役割をプロバイダーの実モデルにマッピングし、使用中はローカルルーティングを起動したままにします。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -193,6 +193,7 @@
     "mode": "模型處理方式",
     "modeDirect": "直連",
     "modeProxy": "需要路由",
+    "authFieldHint": "選擇本機代理向供應商傳送憑證的方式：ANTHROPIC_AUTH_TOKEN 送 Authorization: Bearer，ANTHROPIC_API_KEY 送 x-api-key。",
     "modelMappingToggle": "需要模型對應",
     "modelMappingOffHint": "僅當供應商直接接受 Claude Desktop 可識別的三檔角色 ID（claude-sonnet-* / claude-opus-* / claude-haiku-*）時才適用直連；其他模型名（含 claude-3-5-sonnet-… 等舊式 ID）請開啟此開關走對應。",
     "modelMappingOnHint": "Claude Desktop 只接受 claude-sonnet-* / claude-opus-* / claude-haiku-* 三檔角色 ID。開啟後 CC Switch 會把這三檔對應到供應商的實際模型，並在使用期間保持本地路由開啟。",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -193,6 +193,7 @@
     "mode": "模型处理方式",
     "modeDirect": "直连",
     "modeProxy": "需要路由",
+    "authFieldHint": "选择本地代理向供应商发送凭证的方式：ANTHROPIC_AUTH_TOKEN 发 Authorization: Bearer，ANTHROPIC_API_KEY 发 x-api-key。",
     "modelMappingToggle": "需要模型映射",
     "modelMappingOffHint": "仅当供应商直接接受 Claude Desktop 可识别的三档角色 ID（claude-sonnet-* / claude-opus-* / claude-haiku-*）时才适用直连；其他模型名（含 claude-3-5-sonnet-… 等旧式 ID）请打开此开关走映射。",
     "modelMappingOnHint": "Claude Desktop 只接受 claude-sonnet-* / claude-opus-* / claude-haiku-* 三档角色 ID。开启后 CC Switch 会把这三档映射到供应商的实际模型，并在使用期间保持本地路由开启。",

--- a/tests/components/ClaudeDesktopProviderForm.test.tsx
+++ b/tests/components/ClaudeDesktopProviderForm.test.tsx
@@ -260,6 +260,113 @@ describe("ClaudeDesktopProviderForm", () => {
     });
   });
 
+  it("直连模式不渲染认证字段选择器（直连固定 bearer，选了也无效）", () => {
+    renderForm({
+      name: "Direct Provider",
+      settingsConfig: {
+        env: {
+          ANTHROPIC_BASE_URL: "https://api.example.com",
+          ANTHROPIC_AUTH_TOKEN: "sk-test",
+        },
+      },
+      meta: {
+        claudeDesktopMode: "direct",
+        claudeDesktopModelRoutes: {
+          "claude-sonnet-5": { model: "claude-sonnet-5" },
+        },
+      },
+    });
+
+    expect(screen.queryByText("认证字段")).not.toBeInTheDocument();
+  });
+
+  it("代理模式渲染认证字段选择器", () => {
+    renderForm({
+      name: "Proxy Provider",
+      settingsConfig: {
+        env: {
+          ANTHROPIC_BASE_URL: "https://api.example.com",
+          ANTHROPIC_AUTH_TOKEN: "sk-test",
+        },
+      },
+      meta: {
+        claudeDesktopMode: "proxy",
+        claudeDesktopModelRoutes: {
+          "claude-sonnet-5": { model: "upstream-sonnet" },
+        },
+      },
+    });
+
+    expect(screen.getByText("认证字段")).toBeInTheDocument();
+  });
+
+  it("直连模式保存时把认证字段归一化成 ANTHROPIC_AUTH_TOKEN", async () => {
+    const onSubmit = vi.fn();
+    renderForm(
+      {
+        name: "Direct Provider",
+        settingsConfig: {
+          env: {
+            ANTHROPIC_BASE_URL: "https://api.example.com",
+            ANTHROPIC_API_KEY: "sk-test",
+          },
+        },
+        meta: {
+          claudeDesktopMode: "direct",
+          // 旧数据（或 direct 预设）残留的非默认认证字段
+          apiKeyField: "ANTHROPIC_API_KEY",
+          claudeDesktopModelRoutes: {
+            "claude-sonnet-5": { model: "claude-sonnet-5" },
+          },
+        },
+      },
+      onSubmit,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const submitted = onSubmit.mock.calls[0][0];
+    const env = JSON.parse(submitted.settingsConfig).env;
+    // 后端 direct_gateway_credentials 只认 ANTHROPIC_AUTH_TOKEN
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe("sk-test");
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(submitted.meta.apiKeyField).toBeUndefined();
+  });
+
+  it("代理模式保存时保留 ANTHROPIC_API_KEY 选择", async () => {
+    const onSubmit = vi.fn();
+    renderForm(
+      {
+        name: "Proxy Provider",
+        settingsConfig: {
+          env: {
+            ANTHROPIC_BASE_URL: "https://api.example.com",
+            ANTHROPIC_API_KEY: "sk-test",
+          },
+        },
+        meta: {
+          claudeDesktopMode: "proxy",
+          apiKeyField: "ANTHROPIC_API_KEY",
+          claudeDesktopModelRoutes: {
+            "claude-sonnet-5": { model: "upstream-sonnet" },
+          },
+        },
+      },
+      onSubmit,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    const submitted = onSubmit.mock.calls[0][0];
+    const env = JSON.parse(submitted.settingsConfig).env;
+    // 代理模式下 env 变量名决定本地代理发 x-api-key 还是 Bearer
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-test");
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(submitted.meta.apiKeyField).toBe("ANTHROPIC_API_KEY");
+  });
+
   it("保存直连模型列表时不会保留旧 route 作为隐藏映射目标", async () => {
     const onSubmit = vi.fn();
     renderForm(


### PR DESCRIPTION
## Summary

Claude Desktop provider 表单新增"认证字段"选择器（`ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY`），**仅在模型映射（本地代理）模式下显示**，持久化到 `meta.apiKeyField` 并在编辑时还原。预设默认保持 `ANTHROPIC_AUTH_TOKEN` 不变，由用户按实际端点自行选择。

## Background

OpenCode Go 的 Anthropic 兼容端点（`/v1/messages`）只接受 `x-api-key` 认证。cc-switch 的 Claude Desktop provider 配置固定使用 `ANTHROPIC_AUTH_TOKEN`，本地路由据此向上游发送 `Authorization: Bearer`，被上游忽略后返回 401 "Missing API key."。Claude Code CLI 表单已有认证字段下拉，因此 CLI 侧可选 `ANTHROPIC_API_KEY` 正常工作，而 Desktop 侧无此选项。

## 为什么限定在代理模式（review 反馈）

第一版在直连模式下也渲染该选择器，但直连模式并不经过本地代理：cc-switch 写的是 Claude Desktop 自己的 gateway profile，其中 `inferenceGatewayAuthScheme` 固定为 `"bearer"`，且 `validate_direct_provider` → `direct_gateway_credentials` 只接受 `ANTHROPIC_AUTH_TOKEN`。因此在直连模式下选择 `ANTHROPIC_API_KEY`，会得到一个表单上合法、保存时必然以 missing-auth-token 失败的组合。

该字段只在代理模式下具有意义——代理侧 `ClaudeAdapter::infer_anthropic_auth_strategy` 按 env 变量名决定发送 `Authorization: Bearer` 还是 `x-api-key`。

顺带解掉一个既有问题：AiHubMix 预设是 `mode: "direct"` + `apiKeyField: "ANTHROPIC_API_KEY"`，此前该组合同样无法保存。

## Changes

- `ClaudeDesktopProviderForm.tsx`：新增"认证字段"下拉，仅在模型映射（proxy）模式下渲染
- 直连模式提交时归一化为 `ANTHROPIC_AUTH_TOKEN`，避免代理模式下的选择在关闭映射后残留
- `meta.apiKeyField` 仅持久化非默认值（与 Claude Code 表单一致），保存时清除失效值
- 新增 `claudeDesktop.authFieldHint` 文案，覆盖 en / zh / zh-TW / ja 四个语言文件
- 补充表单测试覆盖直连与代理两种模式；其中两个直连用例在修复前的组件上会失败

## Test

- `pnpm typecheck` 通过
- `pnpm test:unit`：698/699 通过；1 个失败（`useSettingsForm.test.tsx`）为既有问题，在干净 main 上同样失败，与本次改动无关
- 与 upstream/main 合并验证：无冲突，typecheck 通过，合并后全量单测除上述既有失败外全部通过
- 本地实测：OpenCode Go + Anthropic Messages 协议下，选择 `ANTHROPIC_API_KEY` 后 Claude Desktop 正常对话；切回 `ANTHROPIC_AUTH_TOKEN` 时复现 401

Fixes #6258
