### PR TITLE
fix(windows): support WSL UNC atomic writes

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -324,6 +324,14 @@ pub fn write_text_file(path: &Path, data: &str) -> Result<(), AppError> {
 }
 
 /// 原子写入：写入临时文件后 rename 替换，避免半写状态
+#[cfg(windows)]
+fn should_fallback_to_rename(error: &std::io::Error) -> bool {
+    use windows_sys::Win32::Foundation::ERROR_NOT_SUPPORTED;
+
+    error.kind() == std::io::ErrorKind::NotFound
+        || error.raw_os_error() == Some(ERROR_NOT_SUPPORTED as i32)
+}
+
 pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
@@ -420,7 +428,9 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
             }
 
             let replace_error = std::io::Error::last_os_error();
-            if replace_error.kind() != std::io::ErrorKind::NotFound {
+            // WSL UNC paths reject ReplaceFileW with ERROR_NOT_SUPPORTED (50).
+            // std::fs::rename uses MoveFileExW with replace-existing semantics.
+            if !should_fallback_to_rename(&replace_error) {
                 last_error = Some(replace_error);
                 break;
             }
@@ -471,6 +481,22 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn replace_file_fallback_error_filter_is_narrow() {
+        use windows_sys::Win32::Foundation::{
+            ERROR_ACCESS_DENIED, ERROR_FILE_NOT_FOUND, ERROR_NOT_SUPPORTED,
+        };
+
+        let not_supported = std::io::Error::from_raw_os_error(ERROR_NOT_SUPPORTED as i32);
+        let not_found = std::io::Error::from_raw_os_error(ERROR_FILE_NOT_FOUND as i32);
+        let access_denied = std::io::Error::from_raw_os_error(ERROR_ACCESS_DENIED as i32);
+
+        assert!(should_fallback_to_rename(&not_supported));
+        assert!(should_fallback_to_rename(&not_found));
+        assert!(!should_fallback_to_rename(&access_denied));
+    }
 
     #[cfg(windows)]
     #[test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -323,7 +323,6 @@ pub fn write_text_file(path: &Path, data: &str) -> Result<(), AppError> {
     atomic_write(path, data.as_bytes())
 }
 
-/// 原子写入：写入临时文件后 rename 替换，避免半写状态
 #[cfg(windows)]
 fn should_fallback_to_rename(error: &std::io::Error) -> bool {
     use windows_sys::Win32::Foundation::ERROR_NOT_SUPPORTED;
@@ -332,6 +331,8 @@ fn should_fallback_to_rename(error: &std::io::Error) -> bool {
         || error.raw_os_error() == Some(ERROR_NOT_SUPPORTED as i32)
 }
 
+/// 原子写入：先写入同目录临时文件，再使用平台对应的原子替换操作，避免半写状态。
+/// Windows 优先使用 `ReplaceFileW`，仅在受支持的错误场景下回退到 `rename`。
 pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;


### PR DESCRIPTION
## Summary / 概述

- fall back to `std::fs::rename` when WSL UNC paths reject `ReplaceFileW` with `ERROR_NOT_SUPPORTED` (50)
- keep the fallback allowlist narrow: missing destinations and unsupported filesystems only
- add a Windows regression test covering error 50, the existing missing-file path, and an unrelated access-denied error
- preserve the existing retry, destination-preservation, and temporary-file cleanup behavior

This is a focused alternative to #6232. It keeps that PR's minimal behavior change while adding regression coverage in a single commit.

## Root cause / 根因

Windows `ReplaceFileW` is not supported by the WSL 9P UNC provider. Rust's Windows `std::fs::rename` path uses `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)`, which the provider accepts.

## Related Issue / 关联 Issue

Fixes #6224

Related: #6188, #6219, #6247, #6232

## Validation / 验证

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- [x] `git diff --check`
- [x] reproduced against a real `\\wsl.localhost\Ubuntu\...` path: `ReplaceFileW` returned 50; `MoveFileExW` replaced the destination and the final contents were correct
- [x] full CI passed for the same commit in the fork: [frontend + Ubuntu + Windows + macOS](https://github.com/DTSFO/cc-switch/actions/runs/31249110336)
  - frontend typecheck, formatting, and unit tests
  - `cargo fmt`, `cargo clippy -- -D warnings`, and `cargo test` on all three backend platforms
  - the new `#[cfg(windows)]` regression test compiled and ran on `windows-latest`

The upstream CI run is awaiting first-time fork-contributor approval; the fork run above uses the same workflow and commit (`89950bfb`).

## Screenshots / 截图

Not applicable; backend-only fix.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes / 通过 Clippy 检查
- [x] Updated i18n files if user-facing text changed / 无用户可见文本变更
