### PR TITLE
fix(codex): reproject MCP after takeover writes

### DIFF
--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -2,6 +2,7 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use crate::app_config::{AppType, McpServer};
+use crate::database::Database;
 use crate::error::AppError;
 use crate::mcp;
 use crate::store::AppState;
@@ -163,6 +164,10 @@ impl McpService {
     }
 
     fn remove_server_from_app(_state: &AppState, id: &str, app: &AppType) -> Result<(), AppError> {
+        Self::remove_server_from_app_no_config(id, app)
+    }
+
+    fn remove_server_from_app_no_config(id: &str, app: &AppType) -> Result<(), AppError> {
         match app {
             AppType::Claude => mcp::remove_server_from_claude(id)?,
             AppType::ClaudeDesktop => {
@@ -196,7 +201,7 @@ impl McpService {
 
         let mut failures: Vec<String> = Vec::new();
         for app in AppType::all() {
-            if let Err(err) = Self::project_servers_to_app(state, &servers, &app) {
+            if let Err(err) = Self::project_servers_to_app(&servers, &app) {
                 log::warn!("同步 MCP 到 {app:?} 失败: {err}");
                 failures.push(format!("{}: {err}", app.as_str()));
             }
@@ -216,12 +221,17 @@ impl McpService {
     /// 定向重投影，避免把无关应用的失败面（如 ~/.claude.json 坏 JSON）
     /// 牵连进目标应用的关键路径。
     pub fn sync_enabled_for_app(state: &AppState, app: &AppType) -> Result<(), AppError> {
-        let servers = Self::get_all_servers(state)?;
-        Self::project_servers_to_app(state, &servers, app)
+        Self::sync_enabled_for_app_from_db(state.db.as_ref(), app)
+    }
+
+    /// 从数据库读取启用状态并投影到单个应用。供只持有数据库句柄、但会
+    /// 整体重写 live 配置的服务使用。
+    pub fn sync_enabled_for_app_from_db(db: &Database, app: &AppType) -> Result<(), AppError> {
+        let servers = db.get_all_mcp_servers()?;
+        Self::project_servers_to_app(&servers, app)
     }
 
     fn project_servers_to_app(
-        state: &AppState,
         servers: &IndexMap<String, McpServer>,
         app: &AppType,
     ) -> Result<(), AppError> {
@@ -231,9 +241,9 @@ impl McpService {
 
         for server in servers.values() {
             if server.apps.is_enabled_for(app) {
-                Self::sync_server_to_app(state, server, app)?;
+                Self::sync_server_to_app_no_config(server, app)?;
             } else {
-                Self::remove_server_from_app(state, &server.id, app)?;
+                Self::remove_server_from_app_no_config(&server.id, app)?;
             }
         }
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -9,6 +9,7 @@ use crate::provider::Provider;
 use crate::proxy::server::ProxyServer;
 use crate::proxy::switch_lock::SwitchLockManager;
 use crate::proxy::types::*;
+use crate::services::mcp::McpService;
 use crate::services::provider::{
     build_effective_settings_with_common_config, write_live_with_common_config,
 };
@@ -2947,10 +2948,15 @@ impl ProxyService {
             };
             crate::codex_config::write_codex_live_config_atomic(Some(&live_config))
                 .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
-            return Ok(());
+        } else {
+            self.write_codex_live_for_provider(config, provider)?;
         }
 
-        self.write_codex_live_for_provider(config, provider)
+        // Codex takeover rewrites config.toml as a whole. Reproject the MCP
+        // state immediately so restart repair cannot leave DB-enabled servers
+        // missing from the live file (#6265).
+        McpService::sync_enabled_for_app_from_db(self.db.as_ref(), &AppType::Codex)
+            .map_err(|e| format!("重投影 Codex MCP 失败: {e}"))
     }
 
     fn write_codex_live_verbatim(&self, config: &Value) -> Result<(), String> {
@@ -3225,6 +3231,7 @@ impl ProxyService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app_config::{McpApps, McpServer};
     use crate::provider::ProviderMeta;
     use serial_test::serial;
     use std::env;
@@ -4637,6 +4644,115 @@ wire_api = "responses"
             "Codex live config should still be detected as taken over"
         );
 
+        crate::settings::update_settings(crate::settings::AppSettings::default())
+            .expect("reset settings");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_set_takeover_reprojects_enabled_mcp_when_backup_missing() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        crate::settings::update_settings(crate::settings::AppSettings {
+            preserve_codex_official_auth_on_switch: true,
+            ..Default::default()
+        })
+        .expect("enable Codex official auth preservation");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        use_ephemeral_proxy_port(&db).await;
+        let service = ProxyService::new(db.clone());
+        let oauth_auth = json!({
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "id_token": "oauth-id",
+                "access_token": "oauth-access"
+            }
+        });
+        let deepseek_live_config = r#"model_provider = "deepseek"
+model = "deepseek-v4-flash"
+
+[model_providers.deepseek]
+name = "DeepSeek"
+base_url = "https://api.deepseek.com/v1"
+wire_api = "responses"
+experimental_bearer_token = "deepseek-key"
+"#;
+        crate::codex_config::write_codex_live_atomic(&oauth_auth, Some(deepseek_live_config))
+            .expect("seed Codex live config without MCP projection");
+
+        let provider = Provider::with_id(
+            "deepseek".to_string(),
+            "DeepSeek".to_string(),
+            json!({
+                "auth": {
+                    "OPENAI_API_KEY": "deepseek-key"
+                },
+                "config": deepseek_live_config
+            }),
+            None,
+        );
+        db.save_provider("codex", &provider)
+            .expect("save DeepSeek provider");
+        db.set_current_provider("codex", "deepseek")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some("deepseek"))
+            .expect("set local current provider");
+        db.save_mcp_server(&McpServer {
+            id: "codegraph".to_string(),
+            name: "codegraph".to_string(),
+            server: json!({
+                "command": "codegraph",
+                "args": ["serve", "--mcp"]
+            }),
+            apps: McpApps {
+                codex: true,
+                ..Default::default()
+            },
+            description: None,
+            homepage: None,
+            docs: None,
+            tags: Vec::new(),
+        })
+        .expect("save enabled Codex MCP server");
+        assert!(
+            db.get_live_backup("codex")
+                .await
+                .expect("get initial Codex live backup")
+                .is_none(),
+            "startup repair scenario begins without a live backup"
+        );
+
+        let mut proxy_config = db
+            .get_proxy_config_for_app("codex")
+            .await
+            .expect("get Codex proxy config");
+        proxy_config.enabled = true;
+        db.update_proxy_config_for_app(proxy_config)
+            .await
+            .expect("mark Codex takeover enabled before restart repair");
+
+        service
+            .set_takeover_for_app("codex", true)
+            .await
+            .expect("repair Codex takeover after restart");
+
+        let live_config = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
+            .expect("read repaired Codex live config");
+        let live_toml: toml::Value = toml::from_str(&live_config).expect("parse live config");
+        let codegraph = live_toml
+            .get("mcp_servers")
+            .and_then(|servers| servers.get("codegraph"))
+            .expect("enabled DB MCP must be reprojected after startup takeover repair");
+        assert_eq!(
+            codegraph.get("command").and_then(toml::Value::as_str),
+            Some("codegraph")
+        );
+
+        service
+            .set_takeover_for_app("codex", false)
+            .await
+            .expect("disable Codex takeover");
         crate::settings::update_settings(crate::settings::AppSettings::default())
             .expect("reset settings");
     }

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2954,9 +2954,16 @@ impl ProxyService {
 
         // Codex takeover rewrites config.toml as a whole. Reproject the MCP
         // state immediately so restart repair cannot leave DB-enabled servers
-        // missing from the live file (#6265).
-        McpService::sync_enabled_for_app_from_db(self.db.as_ref(), &AppType::Codex)
-            .map_err(|e| format!("重投影 Codex MCP 失败: {e}"))
+        // missing from the live file (#6265). The live write has already
+        // succeeded here, so projection failure must not surface as a false
+        // "save failed" result; a later switch or MCP update will retry it.
+        if let Err(err) =
+            McpService::sync_enabled_for_app_from_db(self.db.as_ref(), &AppType::Codex)
+        {
+            log::warn!("写入 Codex 接管配置后重投影 MCP 失败（将在下次同步时自愈）: {err}");
+        }
+
+        Ok(())
     }
 
     fn write_codex_live_verbatim(&self, config: &Value) -> Result<(), String> {
@@ -3953,6 +3960,62 @@ wire_api = "responses"
 
         crate::settings::update_settings(crate::settings::AppSettings::default())
             .expect("reset settings");
+    }
+
+    #[test]
+    #[serial]
+    fn codex_takeover_live_write_succeeds_when_mcp_reprojection_fails() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+        let provider = Provider::with_id(
+            "rightcode".to_string(),
+            "RightCode".to_string(),
+            json!({
+                "auth": { "OPENAI_API_KEY": "rightcode-key" },
+                "config": r#"model_provider = "rightcode"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "https://rightcode.example/v1"
+wire_api = "responses"
+"#
+            }),
+            None,
+        );
+        let takeover_settings = json!({
+            "auth": { "OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER },
+            "config": r#"model_provider = "rightcode"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "responses"
+"#
+        });
+
+        db.conn
+            .lock()
+            .expect("lock database")
+            .execute_batch("DROP TABLE mcp_servers")
+            .expect("drop MCP table to force reprojection failure");
+
+        service
+            .write_codex_takeover_live_for_provider(&takeover_settings, Some(&provider))
+            .expect("the completed live write must not report MCP reprojection failure");
+
+        let live_config = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
+            .expect("read written live config");
+        assert!(
+            live_config.contains("http://127.0.0.1:15721/v1"),
+            "the takeover route must remain written despite MCP reprojection failure"
+        );
+        assert!(
+            live_config.contains(PROXY_TOKEN_PLACEHOLDER),
+            "the takeover token must remain written despite MCP reprojection failure"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary / 概述

- Reproject Codex MCP servers from the database after every takeover-owned `config.toml` write.
- Add a database-based targeted MCP sync entry point so `ProxyService` can restore Codex MCP state without an `AppState`.
- Add a regression test for startup repair when takeover is enabled, the live backup is missing, and an MCP remains enabled in the database.

## Root Cause / 根因

When CC Switch restarts with Codex takeover still marked enabled but no live backup, `set_takeover_for_app` rebuilds the takeover configuration. That write replaces `config.toml`, but the takeover path did not run the MCP projection used by normal provider synchronization. The database still reported `enabled_codex = true` while the live `[mcp_servers.*]` table stayed missing.

The fix hooks the targeted database projection into the common Codex takeover write helper, so startup repair, best-effort recovery, initial takeover, and active-provider refresh all get the same behavior.

## Related Issue / 关联 Issue

Fixes #6265

Related open PRs do not cover this recovery state:

- #4203 preserves MCP entries that are still present in the current live file during provider writes.
- #4381 preserves current live user settings while restoring an older backup.
- This issue starts after the MCP entry is already absent from live configuration, so it must be reconstructed from the database source of truth.

## Screenshots / 截图

Not applicable; backend-only configuration repair.

## Tests / 测试

- `cargo test --manifest-path src-tauri/Cargo.toml` — 2341 passed, 5 ignored
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `pnpm typecheck`
- `pnpm format:check`
- Regression: `services::proxy::tests::codex_set_takeover_reprojects_enabled_mcp_when_backup_missing`

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 无用户可见文本变更