### PR TITLE
fix(grokbuild): align PackyCode endpoint config

### DIFF
--- a/src-tauri/src/grok_config.rs
+++ b/src-tauri/src/grok_config.rs
@@ -59,6 +59,20 @@ fn optional_non_empty_string(table: &toml::value::Table, key: &str) -> Option<St
         .map(ToString::to_string)
 }
 
+fn resolve_base_url(
+    root: &toml::value::Table,
+    selected_model: &toml::value::Table,
+) -> Option<String> {
+    optional_non_empty_string(selected_model, "base_url")
+        .or_else(|| {
+            root.get("endpoints")
+                .and_then(toml::Value::as_table)
+                .and_then(|endpoints| optional_non_empty_string(endpoints, "models_base_url"))
+        })
+        .map(|base_url| base_url.trim_end_matches('/').to_string())
+        .filter(|base_url| !base_url.is_empty())
+}
+
 /// Syntax-only validation for a Grok Build config document (empty allowed).
 ///
 /// 官方条目走 Grok CLI 自带的 xAI OAuth 登录，config.toml 不需要（通常也没有）
@@ -145,7 +159,13 @@ pub fn validate_config_toml(config_toml: &str) -> Result<(), AppError> {
         })?;
 
     required_non_empty_string(selected_model, "model")?;
-    required_non_empty_string(selected_model, "base_url")?;
+    resolve_base_url(root, selected_model).ok_or_else(|| {
+        AppError::localized(
+            "provider.grokbuild.field.missing",
+            "Grok Build 配置缺少有效的 base_url 或 endpoints.models_base_url 字段",
+            "Grok Build configuration is missing a valid base_url or endpoints.models_base_url field",
+        )
+    })?;
     required_non_empty_string(selected_model, "name")?;
     if optional_non_empty_string(selected_model, "api_key").is_none()
         && optional_non_empty_string(selected_model, "env_key").is_none()
@@ -190,11 +210,7 @@ pub fn extract_model_config(config_toml: &str) -> Option<GrokModelConfig> {
     Some(GrokModelConfig {
         profile: default_model.to_string(),
         model: selected_model.get("model")?.as_str()?.trim().to_string(),
-        base_url: selected_model
-            .get("base_url")?
-            .as_str()?
-            .trim_end_matches('/')
-            .to_string(),
+        base_url: resolve_base_url(root, selected_model)?,
         name: selected_model.get("name")?.as_str()?.trim().to_string(),
         api_key: optional_non_empty_string(selected_model, "api_key"),
         env_key: optional_non_empty_string(selected_model, "env_key"),
@@ -445,10 +461,30 @@ context_window = 500000
 "#
     }
 
+    fn valid_models_endpoint_config() -> &'static str {
+        r#"[models]
+default = "grok-4.5"
+web_search = "grok-4.5"
+
+[endpoints]
+models_base_url = "https://endpoint.example/v1/"
+
+[model."grok-4.5"]
+model = "grok-4.5"
+name = "Endpoint Example"
+api_key = "secret"
+api_backend = "responses"
+context_window = 500000
+supports_backend_search = false
+"#
+    }
+
     #[test]
     fn validates_expected_config_shape() {
         validate_config_toml(valid_config()).expect("valid Grok Build config");
         validate_config_toml(valid_env_key_config()).expect("valid env_key configuration");
+        validate_config_toml(valid_models_endpoint_config())
+            .expect("valid endpoints.models_base_url configuration");
     }
 
     #[test]
@@ -493,6 +529,39 @@ context_window = 500000
     }
 
     #[test]
+    fn rejects_config_without_model_or_endpoint_base_url() {
+        let config = valid_config().replace("base_url = \"https://example.com/v1\"\n", "");
+        let error = validate_config_toml(&config).expect_err("base URL should be required");
+        assert!(error.to_string().contains("base_url"));
+    }
+
+    #[test]
+    fn extracts_models_endpoint_base_url() {
+        let selected =
+            extract_model_config(valid_models_endpoint_config()).expect("selected model");
+
+        assert_eq!(selected.base_url, "https://endpoint.example/v1");
+        assert_eq!(
+            extract_credentials(valid_models_endpoint_config()),
+            Some((
+                "https://endpoint.example/v1".to_string(),
+                "secret".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn model_base_url_takes_precedence_over_models_endpoint() {
+        let config = valid_models_endpoint_config().replace(
+            "model = \"grok-4.5\"\n",
+            "model = \"grok-4.5\"\nbase_url = \"https://model.example/v1\"\n",
+        );
+
+        let selected = extract_model_config(&config).expect("selected model");
+        assert_eq!(selected.base_url, "https://model.example/v1");
+    }
+
+    #[test]
     fn extracts_selected_model_and_updates_takeover_fields() {
         let selected = extract_model_config(valid_config()).expect("selected model");
         assert_eq!(selected.profile, "grok-4.5");
@@ -509,6 +578,20 @@ context_window = 500000
         assert_eq!(selected.base_url, "http://127.0.0.1:15721/grokbuild/v1");
         assert_eq!(selected.api_key.as_deref(), Some("PROXY_MANAGED"));
         assert!(has_proxy_placeholder(&updated, "PROXY_MANAGED"));
+    }
+
+    #[test]
+    fn takeover_overrides_models_endpoint_with_model_base_url() {
+        let updated = apply_proxy_takeover(
+            valid_models_endpoint_config(),
+            "http://127.0.0.1:15721/grokbuild/v1",
+            "PROXY_MANAGED",
+        )
+        .expect("takeover config");
+
+        let selected = extract_model_config(&updated).expect("updated selected model");
+        assert_eq!(selected.base_url, "http://127.0.0.1:15721/grokbuild/v1");
+        assert!(updated.contains("models_base_url = \"https://endpoint.example/v1/\""));
     }
 
     #[test]

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -864,6 +864,35 @@ mod tests {
     }
 
     #[test]
+    fn validate_grok_provider_settings_accepts_models_endpoint_base_url() {
+        let provider = Provider::with_id(
+            "packycode".into(),
+            "PackyCode".into(),
+            json!({
+                "config": r#"[models]
+default = "grok-4.5"
+web_search = "grok-4.5"
+
+[endpoints]
+models_base_url = "https://endpoint.example/v1"
+
+[model."grok-4.5"]
+model = "grok-4.5"
+name = "PackyCode"
+api_key = "secret"
+api_backend = "responses"
+context_window = 500000
+supports_backend_search = false
+"#
+            }),
+            None,
+        );
+
+        ProviderService::validate_provider_settings(&AppType::GrokBuild, &provider)
+            .expect("models endpoint configuration should be accepted on provider update");
+    }
+
+    #[test]
     fn extract_gemini_common_config_strips_credentials_keeps_shareable() {
         // Gemini 的共享片段会被 deep-merge 回**其它** Gemini 供应商的 env
         // (live.rs::apply_common_config_to_settings)，因此任何凭据都不得进入片段。

--- a/src/components/providers/forms/GrokBuildProviderForm.tsx
+++ b/src/components/providers/forms/GrokBuildProviderForm.tsx
@@ -97,7 +97,9 @@ export function GrokBuildProviderForm({
   const [isPartner, setIsPartner] = useState(
     initialData?.meta?.isPartner ?? false,
   );
-  const [partnerPromotionKey, setPartnerPromotionKey] = useState<string>();
+  const [partnerPromotionKey, setPartnerPromotionKey] = useState(
+    initialData?.meta?.partnerPromotionKey,
+  );
   const [profile, setProfile] = useState(initialConfig.model);
   const [upstreamModel, setUpstreamModel] = useState(
     initialConfig.upstreamModel ?? initialConfig.model,
@@ -155,6 +157,13 @@ export function GrokBuildProviderForm({
   const [presetEndpoints, setPresetEndpoints] = useState<string[]>([]);
   const [draftCustomEndpoints, setDraftCustomEndpoints] = useState<string[]>(
     [],
+  );
+  const configOptions = useMemo(
+    () =>
+      grokBuildProviderPresets.find(
+        (preset) => preset.partnerPromotionKey === partnerPromotionKey,
+      )?.configOptions,
+    [partnerPromotionKey],
   );
 
   const form = useForm<ProviderFormData>({
@@ -220,7 +229,9 @@ export function GrokBuildProviderForm({
       ...overrides,
       apiBackend: GROK_BUILD_DEFAULT_API_BACKEND,
     };
-    setRawConfig((current) => updateGrokBuildConfig(current, next));
+    setRawConfig((current) =>
+      updateGrokBuildConfig(current, next, configOptions),
+    );
   };
 
   const handlePresetChange = (presetId: string) => {
@@ -276,15 +287,18 @@ export function GrokBuildProviderForm({
     setApiFormat(presetApiFormat);
     setPresetEndpoints(preset.endpointCandidates ?? []);
     setRawConfig(
-      buildGrokBuildConfig({
-        model: profile,
-        upstreamModel: presetModel,
-        baseUrl: presetBaseUrl,
-        name: presetName,
-        apiKey: presetApiKey,
-        apiBackend: GROK_BUILD_DEFAULT_API_BACKEND,
-        contextWindow: Number.parseInt(contextWindow, 10),
-      }),
+      buildGrokBuildConfig(
+        {
+          model: profile,
+          upstreamModel: presetModel,
+          baseUrl: presetBaseUrl,
+          name: presetName,
+          apiKey: presetApiKey,
+          apiBackend: GROK_BUILD_DEFAULT_API_BACKEND,
+          contextWindow: Number.parseInt(contextWindow, 10),
+        },
+        preset.configOptions,
+      ),
     );
   };
 
@@ -344,15 +358,19 @@ export function GrokBuildProviderForm({
       return;
     }
 
-    const finalConfig = updateGrokBuildConfig(rawConfig, {
-      model: profile,
-      upstreamModel,
-      baseUrl,
-      name,
-      apiKey,
-      apiBackend: GROK_BUILD_DEFAULT_API_BACKEND,
-      contextWindow: parsedContextWindow,
-    });
+    const finalConfig = updateGrokBuildConfig(
+      rawConfig,
+      {
+        model: profile,
+        upstreamModel,
+        baseUrl,
+        name,
+        apiKey,
+        apiBackend: GROK_BUILD_DEFAULT_API_BACKEND,
+        contextWindow: parsedContextWindow,
+      },
+      configOptions,
+    );
     const configError = validateGrokBuildConfig(finalConfig);
     if (configError) {
       toast.error(

--- a/src/components/providers/forms/GrokBuildProviderForm.tsx
+++ b/src/components/providers/forms/GrokBuildProviderForm.tsx
@@ -35,6 +35,8 @@ import { ProviderPresetSelector } from "./ProviderPresetSelector";
 import {
   grokBuildOfficialPreset,
   grokBuildProviderPresets,
+  isKnownPackyCodeEndpoint,
+  resolveGrokBuildConfigOptions,
   type GrokBuildProviderPreset,
 } from "@/config/grokBuildProviderPresets";
 import {
@@ -160,10 +162,12 @@ export function GrokBuildProviderForm({
   );
   const configOptions = useMemo(
     () =>
-      grokBuildProviderPresets.find(
-        (preset) => preset.partnerPromotionKey === partnerPromotionKey,
-      )?.configOptions,
-    [partnerPromotionKey],
+      resolveGrokBuildConfigOptions({
+        partnerPromotionKey,
+        isPartner,
+        baseUrl,
+      }),
+    [baseUrl, isPartner, partnerPromotionKey],
   );
 
   const form = useForm<ProviderFormData>({
@@ -400,6 +404,11 @@ export function GrokBuildProviderForm({
     const parsedMaxOutputTokens = Number.parseInt(maxOutputTokens, 10);
     const initialMeta = { ...(initialData?.meta ?? {}) };
     delete initialMeta.custom_endpoints;
+    const resolvedPartnerPromotionKey =
+      partnerPromotionKey?.trim() ||
+      (isPartner && isKnownPackyCodeEndpoint(baseUrl)
+        ? "packycode"
+        : undefined);
     const meta: ProviderMeta = {
       ...initialMeta,
       apiFormat,
@@ -407,7 +416,7 @@ export function GrokBuildProviderForm({
       isFullUrl,
       endpointAutoSelect,
       isPartner,
-      partnerPromotionKey,
+      partnerPromotionKey: resolvedPartnerPromotionKey,
       impersonateClaudeCode,
       promptCacheRouting,
       codexChatReasoning,

--- a/src/config/grokBuildProviderPresets.test.ts
+++ b/src/config/grokBuildProviderPresets.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   grokBuildOfficialPreset,
   grokBuildProviderPresets,
+  isKnownPackyCodeEndpoint,
+  resolveGrokBuildConfigOptions,
 } from "./grokBuildProviderPresets";
 import {
   extractCodexBaseUrl,
@@ -85,5 +87,31 @@ describe("grokBuildProviderPresets", () => {
       webSearchModel: GROK_BUILD_DEFAULT_MODEL,
       supportsBackendSearch: false,
     });
+  });
+
+  it("falls back to Packy options for keyless partner records on a known endpoint", () => {
+    const packy = grokBuildProviderPresets.find(
+      (preset) => preset.name === "PackyCode",
+    );
+
+    expect(
+      resolveGrokBuildConfigOptions({
+        isPartner: true,
+        baseUrl: "https://www.packyapi.com/v1/",
+      }),
+    ).toEqual(packy?.configOptions);
+    expect(isKnownPackyCodeEndpoint("https://www.packyapi.com/v1/")).toBe(true);
+    expect(
+      resolveGrokBuildConfigOptions({
+        isPartner: true,
+        baseUrl: "https://api.zetaapi.ai/v1",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveGrokBuildConfigOptions({
+        isPartner: false,
+        baseUrl: "https://www.packyapi.ai/v1",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/config/grokBuildProviderPresets.test.ts
+++ b/src/config/grokBuildProviderPresets.test.ts
@@ -74,4 +74,16 @@ describe("grokBuildProviderPresets", () => {
     expect(grokBuildOfficialPreset.config).toBe("");
     expect(grokBuildOfficialPreset.auth).toEqual({});
   });
+
+  it("uses PackyCode's shared endpoint without backend search", () => {
+    const packy = grokBuildProviderPresets.find(
+      (preset) => preset.name === "PackyCode",
+    );
+
+    expect(packy?.configOptions).toEqual({
+      baseUrlMode: "models_endpoint",
+      webSearchModel: GROK_BUILD_DEFAULT_MODEL,
+      supportsBackendSearch: false,
+    });
+  });
 });

--- a/src/config/grokBuildProviderPresets.ts
+++ b/src/config/grokBuildProviderPresets.ts
@@ -23,7 +23,10 @@
  */
 import type { ProviderCategory } from "../types";
 import type { CodexApiFormat } from "../types";
-import { GROK_BUILD_DEFAULT_MODEL } from "../utils/grokBuildConfig";
+import {
+  GROK_BUILD_DEFAULT_MODEL,
+  type GrokBuildConfigOptions,
+} from "../utils/grokBuildConfig";
 
 export interface GrokBuildProviderPreset {
   name: string;
@@ -40,6 +43,7 @@ export interface GrokBuildProviderPreset {
   icon?: string;
   iconColor?: string;
   apiFormat?: CodexApiFormat;
+  configOptions?: GrokBuildConfigOptions;
 }
 
 // 官方条目与后端 seed（providers_seed.rs 的 "Grok Official"）对应：
@@ -86,6 +90,11 @@ export const grokBuildProviderPresets: GrokBuildProviderPreset[] = [
     apiKeyUrl: "https://www.packyapi.ai/register?aff=cc-switch",
     auth: grokAuth(),
     config: grokPresetConfig("PackyCode", "https://www.packyapi.ai/v1"),
+    configOptions: {
+      baseUrlMode: "models_endpoint",
+      webSearchModel: GROK_BUILD_DEFAULT_MODEL,
+      supportsBackendSearch: false,
+    },
     endpointCandidates: [
       "https://www.packyapi.ai/v1",
       "https://cf.api.fan/v1",

--- a/src/config/grokBuildProviderPresets.ts
+++ b/src/config/grokBuildProviderPresets.ts
@@ -60,6 +60,47 @@ export const grokBuildOfficialPreset: GrokBuildProviderPreset = {
   iconColor: "currentColor",
 };
 
+const normalizeEndpointUrl = (url: string): string =>
+  url.trim().replace(/\/+$/, "");
+
+const findGrokBuildPresetByPromotionKey = (key: string) =>
+  grokBuildProviderPresets.find((preset) => preset.partnerPromotionKey === key);
+
+/** Exact known Packy Grok endpoints, ignoring only trailing slashes. */
+export function isKnownPackyCodeEndpoint(url?: string): boolean {
+  const current = url ? normalizeEndpointUrl(url) : "";
+  if (!current) return false;
+  const packy = findGrokBuildPresetByPromotionKey("packycode");
+  return (packy?.endpointCandidates ?? []).some(
+    (candidate) => normalizeEndpointUrl(candidate) === current,
+  );
+}
+
+/**
+ * Resolve Grok Build writer options for a saved or in-progress provider.
+ *
+ * Prefer `partnerPromotionKey`. Providers edited before that field was
+ * persisted can lose it; fall back only for partner records whose endpoint
+ * is an exact known Packy URL.
+ */
+export function resolveGrokBuildConfigOptions(params: {
+  partnerPromotionKey?: string;
+  isPartner?: boolean;
+  baseUrl?: string;
+}): GrokBuildConfigOptions | undefined {
+  const key = params.partnerPromotionKey?.trim();
+  if (key) {
+    const byKey = findGrokBuildPresetByPromotionKey(key)?.configOptions;
+    if (byKey) return byKey;
+  }
+
+  if (params.isPartner && isKnownPackyCodeEndpoint(params.baseUrl)) {
+    return findGrokBuildPresetByPromotionKey("packycode")?.configOptions;
+  }
+
+  return undefined;
+}
+
 /** OpenRouter 系命名空间路由站的 Grok 模型 id */
 const OPENROUTER_STYLE_GROK_MODEL = "x-ai/grok-4.5";
 

--- a/src/utils/grokBuildConfig.test.ts
+++ b/src/utils/grokBuildConfig.test.ts
@@ -57,6 +57,47 @@ describe("Grok Build config", () => {
     expect(extractGrokBuildBaseUrl(config)).toBe("https://api.example.com");
   });
 
+  it("supports the shared models endpoint and backend-search overrides", () => {
+    const config = buildGrokBuildConfig(
+      {
+        model: "grok-4.5",
+        baseUrl: "https://relay.example.com/v1",
+        name: "Relay",
+        apiKey: "secret",
+        apiBackend: "responses",
+        contextWindow: 500000,
+      },
+      {
+        baseUrlMode: "models_endpoint",
+        webSearchModel: "grok-4.5",
+        supportsBackendSearch: false,
+      },
+    );
+    const parsed = parseToml(config) as any;
+
+    expect(parsed.models.web_search).toBe("grok-4.5");
+    expect(parsed.endpoints.models_base_url).toBe(
+      "https://relay.example.com/v1",
+    );
+    expect(parsed.model["grok-4.5"]).not.toHaveProperty("base_url");
+    expect(parsed.model["grok-4.5"].supports_backend_search).toBe(false);
+    expect(validateGrokBuildConfig(config)).toBeNull();
+    expect(extractGrokBuildBaseUrl(config)).toBe(
+      "https://relay.example.com/v1",
+    );
+
+    const updated = updateGrokBuildConfig(config, {
+      ...parseGrokBuildConfig(config),
+      baseUrl: "https://updated.example.com/v1",
+    });
+    const updatedParsed = parseToml(updated) as any;
+    expect(updatedParsed.endpoints.models_base_url).toBe(
+      "https://updated.example.com/v1",
+    );
+    expect(updatedParsed.model["grok-4.5"]).not.toHaveProperty("base_url");
+    expect(updatedParsed.model["grok-4.5"].supports_backend_search).toBe(false);
+  });
+
   it("accepts env_key credentials without adding an empty api_key", () => {
     const config = `[models]
 default = "env-profile"

--- a/src/utils/grokBuildConfig.test.ts
+++ b/src/utils/grokBuildConfig.test.ts
@@ -180,4 +180,44 @@ context_window = 500000
     expect(parsed.model["new-profile"].model).toBe("grok-upstream");
     expect(parsed.model).not.toHaveProperty("old-profile");
   });
+
+  it("retargets web_search when both profile and upstream model change", () => {
+    const original = buildGrokBuildConfig(
+      {
+        model: "grok-4.5",
+        upstreamModel: "grok-4.5",
+        baseUrl: "https://www.packyapi.ai/v1",
+        name: "PackyCode",
+        apiKey: "secret",
+        apiBackend: "responses",
+        contextWindow: 500000,
+      },
+      {
+        baseUrlMode: "models_endpoint",
+        webSearchModel: "grok-4.5",
+        supportsBackendSearch: false,
+      },
+    );
+
+    const renamed = updateGrokBuildConfig(
+      original,
+      {
+        ...parseGrokBuildConfig(original),
+        model: "custom-profile",
+        upstreamModel: "grok-4",
+      },
+      {
+        baseUrlMode: "models_endpoint",
+        webSearchModel: "grok-4.5",
+        supportsBackendSearch: false,
+      },
+    );
+    const parsed = parseToml(renamed) as any;
+
+    expect(parsed.models.default).toBe("custom-profile");
+    expect(parsed.models.web_search).toBe("custom-profile");
+    expect(parsed.model["custom-profile"].model).toBe("grok-4");
+    expect(parsed.model).not.toHaveProperty("grok-4.5");
+    expect(validateGrokBuildConfig(renamed)).toBeNull();
+  });
 });

--- a/src/utils/grokBuildConfig.ts
+++ b/src/utils/grokBuildConfig.ts
@@ -167,6 +167,14 @@ export function updateGrokBuildConfig(
     delete (config.model as Record<string, unknown>)[previousProfile];
   }
 
+  // models.web_search is a model-table id. If the selected profile was
+  // renamed, the old table is gone — retarget so Grok Build can resolve it.
+  const nextTables = config.model as Record<string, unknown>;
+  const webSearch = asString(updatedModels.web_search).trim();
+  if (webSearch && !(webSearch in nextTables)) {
+    updatedModels.web_search = profile;
+  }
+
   return `${stringifyToml(config).trim()}\n`;
 }
 

--- a/src/utils/grokBuildConfig.ts
+++ b/src/utils/grokBuildConfig.ts
@@ -17,6 +17,12 @@ export interface GrokBuildConfigValues {
   contextWindow: number;
 }
 
+export interface GrokBuildConfigOptions {
+  baseUrlMode?: "model" | "models_endpoint";
+  webSearchModel?: string;
+  supportsBackendSearch?: boolean;
+}
+
 const asRecord = (value: unknown): Record<string, unknown> | undefined =>
   value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -47,12 +53,15 @@ export function parseGrokBuildConfig(
     const defaultModel = asString(models?.default, GROK_BUILD_DEFAULT_MODEL);
     const modelTables = asRecord(root?.model);
     const selectedModel = asRecord(modelTables?.[defaultModel]);
+    const endpoints = asRecord(root?.endpoints);
     const rawContextWindow = selectedModel?.context_window;
 
     return {
       model: defaultModel,
       upstreamModel: asString(selectedModel?.model, defaultModel),
-      baseUrl: asString(selectedModel?.base_url),
+      baseUrl:
+        asString(selectedModel?.base_url).trim() ||
+        asString(endpoints?.models_base_url),
       name: asString(selectedModel?.name, fallbackName),
       apiKey: asString(selectedModel?.api_key),
       envKey: asString(selectedModel?.env_key),
@@ -72,13 +81,17 @@ export function parseGrokBuildConfig(
   }
 }
 
-export function buildGrokBuildConfig(values: GrokBuildConfigValues): string {
-  return updateGrokBuildConfig(undefined, values);
+export function buildGrokBuildConfig(
+  values: GrokBuildConfigValues,
+  options?: GrokBuildConfigOptions,
+): string {
+  return updateGrokBuildConfig(undefined, values, options);
 }
 
 export function updateGrokBuildConfig(
   configToml: string | undefined,
   values: GrokBuildConfigValues,
+  options: GrokBuildConfigOptions = {},
 ): string {
   const profile = values.model.trim() || GROK_BUILD_DEFAULT_MODEL;
   const upstreamModel = values.upstreamModel?.trim() || profile;
@@ -92,20 +105,35 @@ export function updateGrokBuildConfig(
 
   const existingModels = asRecord(config.models) ?? {};
   const previousProfile = asString(existingModels.default, profile);
-  config.models = { ...existingModels, default: profile };
+  const updatedModels: Record<string, unknown> = {
+    ...existingModels,
+    default: profile,
+  };
+  if (options.webSearchModel !== undefined) {
+    const webSearchModel = options.webSearchModel.trim();
+    if (webSearchModel) updatedModels.web_search = webSearchModel;
+    else delete updatedModels.web_search;
+  }
+  config.models = updatedModels;
 
   const modelTables = asRecord(config.model) ?? {};
   const existingSelected =
     asRecord(modelTables[profile]) ??
     asRecord(modelTables[previousProfile]) ??
     {};
+  const existingEndpoints = asRecord(config.endpoints) ?? {};
+  const baseUrlMode =
+    options.baseUrlMode ??
+    (!asString(existingSelected.base_url).trim() &&
+    asString(existingEndpoints.models_base_url).trim()
+      ? "models_endpoint"
+      : "model");
   const apiKey = values.apiKey.trim();
   const envKey =
     values.envKey?.trim() || asString(existingSelected.env_key).trim();
   const updatedSelected: Record<string, unknown> = {
     ...existingSelected,
     model: upstreamModel,
-    base_url: values.baseUrl.trim(),
     name: values.name.trim(),
     api_backend: values.apiBackend.trim() || GROK_BUILD_DEFAULT_API_BACKEND,
     context_window:
@@ -113,6 +141,18 @@ export function updateGrokBuildConfig(
         ? values.contextWindow
         : GROK_BUILD_DEFAULT_CONTEXT_WINDOW,
   };
+  if (baseUrlMode === "models_endpoint") {
+    delete updatedSelected.base_url;
+    config.endpoints = {
+      ...existingEndpoints,
+      models_base_url: values.baseUrl.trim(),
+    };
+  } else {
+    updatedSelected.base_url = values.baseUrl.trim();
+  }
+  if (options.supportsBackendSearch !== undefined) {
+    updatedSelected.supports_backend_search = options.supportsBackendSearch;
+  }
   if (apiKey) updatedSelected.api_key = apiKey;
   else delete updatedSelected.api_key;
   if (envKey) updatedSelected.env_key = envKey;
@@ -138,8 +178,15 @@ export function validateGrokBuildConfig(configToml: string): string | null {
     const profile = asString(models?.default).trim();
     const selected = asRecord(asRecord(root?.model)?.[profile]);
     if (!profile || !selected) return "Missing [models] default model table";
-    for (const field of ["model", "base_url", "name", "api_backend"]) {
+    for (const field of ["model", "name", "api_backend"]) {
       if (!asString(selected[field]).trim()) return `Missing ${field}`;
+    }
+    const modelBaseUrl = asString(selected.base_url).trim();
+    const modelsBaseUrl = asString(
+      asRecord(root?.endpoints)?.models_base_url,
+    ).trim();
+    if (!modelBaseUrl && !modelsBaseUrl) {
+      return "Missing base_url or endpoints.models_base_url";
     }
     if (
       !asString(selected.api_key).trim() &&

--- a/tests/components/GrokBuildProviderForm.test.tsx
+++ b/tests/components/GrokBuildProviderForm.test.tsx
@@ -292,6 +292,122 @@ context_window = 500000
     expect(submitted.meta.partnerPromotionKey).toBe("packycode");
   });
 
+  it("migrates a keyless legacy PackyCode provider on a known endpoint", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const config = `[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "grok-4.5"
+base_url = "https://www.packyapi.com/v1"
+name = "PackyCode"
+api_key = "existing-key"
+api_backend = "responses"
+context_window = 500000
+`;
+    render(
+      <GrokBuildProviderForm
+        providerId="legacy-packy"
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+        initialData={{
+          name: "PackyCode",
+          websiteUrl: "https://www.packyapi.ai",
+          settingsConfig: { config },
+          meta: {
+            isPartner: true,
+          },
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][0];
+    const settings = JSON.parse(submitted.settingsConfig);
+    const migrated = parseToml(settings.config) as any;
+    const selected = migrated.model[migrated.models.default];
+
+    expect(migrated.models.web_search).toBe("grok-4.5");
+    expect(migrated.endpoints.models_base_url).toBe(
+      "https://www.packyapi.com/v1",
+    );
+    expect(selected.base_url).toBeUndefined();
+    expect(selected.supports_backend_search).toBe(false);
+    expect(submitted.meta.partnerPromotionKey).toBe("packycode");
+  });
+
+  it("keeps web_search aligned when the selected profile is renamed", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const config = `[models]
+default = "grok-4.5"
+web_search = "grok-4.5"
+
+[model."grok-4.5"]
+model = "grok-4.5"
+base_url = "https://www.packyapi.ai/v1"
+name = "PackyCode"
+api_key = "existing-key"
+api_backend = "responses"
+context_window = 500000
+`;
+    render(
+      <GrokBuildProviderForm
+        providerId="rename-packy"
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+        initialData={{
+          name: "PackyCode",
+          websiteUrl: "https://www.packyapi.ai",
+          settingsConfig: { config },
+          meta: {
+            isPartner: true,
+            partnerPromotionKey: "packycode",
+          },
+        }}
+      />,
+    );
+
+    // Profile is no longer a dedicated field after the Codex-aligned form.
+    // Rename through raw config.toml so the writer still retargets web_search.
+    fireEvent.change(screen.getByLabelText("raw-config"), {
+      target: {
+        value: `[models]
+default = "custom-profile"
+web_search = "grok-4.5"
+
+[model."custom-profile"]
+model = "grok-4"
+base_url = "https://www.packyapi.ai/v1"
+name = "PackyCode"
+api_key = "existing-key"
+api_backend = "responses"
+context_window = 500000
+`,
+      },
+    });
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][0];
+    const settings = JSON.parse(submitted.settingsConfig);
+    const renamed = parseToml(settings.config) as any;
+
+    expect(renamed.models.default).toBe("custom-profile");
+    expect(renamed.models.web_search).toBe("custom-profile");
+    expect(renamed.model["custom-profile"].model).toBe("grok-4");
+    expect(renamed.model["grok-4.5"]).toBeUndefined();
+    expect(renamed.endpoints.models_base_url).toBe(
+      "https://www.packyapi.ai/v1",
+    );
+    expect(renamed.model["custom-profile"].supports_backend_search).toBe(false);
+  });
+
   // #6427 复用 Codex 表单时把 Codex 专属文案原样带进了 Grok Build 表单。
   // 按 appId 分流后，Grok 表单不得再出现 Codex 字样或不适用条款（模型映射）。
   it("uses Grok-specific copy for the model field and collapsed advanced section", async () => {

--- a/tests/components/GrokBuildProviderForm.test.tsx
+++ b/tests/components/GrokBuildProviderForm.test.tsx
@@ -89,6 +89,33 @@ describe("GrokBuildProviderForm", () => {
     });
   });
 
+  it("submits PackyCode with its shared endpoint and backend search disabled", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <GrokBuildProviderForm
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /PackyCode/ }));
+    await user.type(screen.getByLabelText("API Key"), "secret-key");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][0];
+    const settings = JSON.parse(submitted.settingsConfig);
+    const config = parseToml(settings.config) as any;
+    const selected = config.model[config.models.default];
+
+    expect(config.models.web_search).toBe("grok-4.5");
+    expect(config.endpoints.models_base_url).toBe("https://www.packyapi.ai/v1");
+    expect(selected.base_url).toBeUndefined();
+    expect(selected.supports_backend_search).toBe(false);
+  });
+
   it("uses the Codex-style advanced section without redundant Grok fields", () => {
     const { container } = render(
       <GrokBuildProviderForm
@@ -214,6 +241,55 @@ context_window = 250000
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit.mock.calls[0][0].meta.custom_endpoints).toBeUndefined();
+  });
+
+  it("migrates an existing PackyCode provider when saving", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const config = `[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "grok-4.5"
+base_url = "https://www.packyapi.ai/v1"
+name = "PackyCode"
+api_key = "existing-key"
+api_backend = "responses"
+context_window = 500000
+`;
+    render(
+      <GrokBuildProviderForm
+        providerId="existing-packy"
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+        initialData={{
+          name: "PackyCode",
+          websiteUrl: "https://www.packyapi.ai",
+          settingsConfig: { config },
+          meta: {
+            isPartner: true,
+            partnerPromotionKey: "packycode",
+          },
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][0];
+    const settings = JSON.parse(submitted.settingsConfig);
+    const migrated = parseToml(settings.config) as any;
+    const selected = migrated.model[migrated.models.default];
+
+    expect(migrated.models.web_search).toBe("grok-4.5");
+    expect(migrated.endpoints.models_base_url).toBe(
+      "https://www.packyapi.ai/v1",
+    );
+    expect(selected.base_url).toBeUndefined();
+    expect(selected.supports_backend_search).toBe(false);
+    expect(submitted.meta.partnerPromotionKey).toBe("packycode");
   });
 
   // #6427 复用 Codex 表单时把 Codex 专属文案原样带进了 Grok Build 表单。


### PR DESCRIPTION
## Summary / 概述

- update the Grok Build PackyCode preset to use Packy's documented `[endpoints].models_base_url` format and explicitly disable unsupported backend search injection
- accept endpoint-level and legacy model-level base URLs across frontend and Rust validation/extraction, with model-level precedence for proxy takeover compatibility
- migrate existing PackyCode providers on save while preserving the selected endpoint and credential, with frontend and backend regression coverage

## Related Issue / 关联 Issue

Fixes #6271

## Root Cause / 根因

The existing PackyCode preset used a model-level `base_url` and inherited Grok Build's backend-search capability. Grok Build therefore injected the hosted `x_search` tool, which Packy does not support and rejects with HTTP 403. Packy's current Grok Build template instead uses `[endpoints].models_base_url`, but CC Switch's Rust provider validation previously required `[model.*].base_url` and rejected that documented shape.

## Testing / 测试

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit` — 100 files, 699 tests passed
- `cargo fmt --check`
- `cargo clippy`
- full `cargo test` passed once locally — 2357 passed, 5 ignored, all integration test binaries passed
- final Rust rerun hit the existing macOS loopback timing test `proxy::hyper_client::tests::bytes_with_limit_aborts_reqwest_response_before_full_body_arrives`; rerunning the complete suite with only that test skipped passed — 2356 passed, 5 ignored, 1 filtered, all integration test binaries passed
- built and installed the app locally; saving an existing PackyCode provider produced the endpoint-level config and a real `grok-4.5` request succeeded without `--disallowed-tools x_search`

## Screenshots / 截图

N/A — configuration and provider-routing behavior only.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 未新增或修改用户可见文案，无需更新 i18n
