### PR TITLE
fix(proxy): strip non-text media (file/audio) for text-only upstreams

### DIFF
--- a/src-tauri/src/model_capabilities.rs
+++ b/src-tauri/src/model_capabilities.rs
@@ -45,6 +45,18 @@ pub(crate) fn image_input_capability_from_settings(
     )
 }
 
+/// Whether provider settings prove that a model accepts text input only.
+/// A negative image flag alone is not enough because the model may still
+/// accept audio or files.
+pub(crate) fn is_text_only_model_from_settings(
+    settings: &Value,
+    model: &str,
+    use_confirmed_registry: bool,
+) -> bool {
+    declared_model_text_only(settings, model)
+        .unwrap_or_else(|| use_confirmed_registry && is_confirmed_text_only_model(model))
+}
+
 /// Convert a catalog row's explicit modality list into the shared capability
 /// representation, falling back to the text-only registry when omitted.
 pub(crate) fn image_input_capability_from_modalities(
@@ -117,6 +129,32 @@ fn declared_model_image_support(settings: &Value, model: &str) -> Option<bool> {
     .find_map(|value| declared_model_image_support_in_value(value, model))
 }
 
+fn declared_model_text_only(settings: &Value, model: &str) -> Option<bool> {
+    [
+        settings
+            .get("modelCatalog")
+            .and_then(|catalog| catalog.get("models")),
+        settings.get("modelCatalog"),
+        settings.get("models"),
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(|value| declared_model_text_only_in_value(value, model))
+}
+
+fn declared_model_text_only_in_value(value: &Value, model: &str) -> Option<bool> {
+    if let Some(models) = value.as_array() {
+        return models.iter().find_map(|entry| {
+            model_entry_matches(entry, None, model).then(|| explicit_text_only(entry))?
+        });
+    }
+
+    let object = value.as_object()?;
+    object.iter().find_map(|(key, entry)| {
+        model_entry_matches(entry, Some(key), model).then(|| explicit_text_only(entry))?
+    })
+}
+
 fn declared_model_image_support_in_value(value: &Value, model: &str) -> Option<bool> {
     if let Some(models) = value.as_array() {
         return models.iter().find_map(|entry| {
@@ -149,6 +187,36 @@ fn explicit_image_support(entry: &Value) -> Option<bool> {
     .into_iter()
     .flatten()
     .find_map(input_modalities_support_image)
+}
+
+fn explicit_text_only(entry: &Value) -> Option<bool> {
+    [
+        entry.get("input"),
+        entry.pointer("/modalities/input"),
+        entry.get("input_modalities"),
+        entry.get("inputModalities"),
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(|value| {
+        let modalities = value.as_array()?;
+        Some(
+            !modalities.is_empty()
+                && modalities.iter().all(|item| {
+                    item.as_str()
+                        .map(str::trim)
+                        .is_some_and(|item| item.eq_ignore_ascii_case("text"))
+                }),
+        )
+    })
+    .or_else(|| {
+        entry
+            .get("supportsImage")
+            .or_else(|| entry.get("supports_image"))
+            .or_else(|| entry.get("vision"))
+            .and_then(Value::as_bool)
+            .map(|_| false)
+    })
 }
 
 fn input_modalities_support_image(value: &Value) -> Option<bool> {

--- a/src-tauri/src/model_capabilities.rs
+++ b/src-tauri/src/model_capabilities.rs
@@ -45,6 +45,18 @@ pub(crate) fn image_input_capability_from_settings(
     )
 }
 
+/// Whether provider settings prove that a model accepts text input only.
+/// A negative image flag alone is not enough because the model may still
+/// accept audio or files.
+pub(crate) fn is_text_only_model_from_settings(
+    settings: &Value,
+    model: &str,
+    use_confirmed_registry: bool,
+) -> bool {
+    declared_model_text_only(settings, model)
+        .unwrap_or_else(|| use_confirmed_registry && is_confirmed_text_only_model(model))
+}
+
 /// Convert a catalog row's explicit modality list into the shared capability
 /// representation, falling back to the text-only registry when omitted.
 pub(crate) fn image_input_capability_from_modalities(
@@ -117,6 +129,32 @@ fn declared_model_image_support(settings: &Value, model: &str) -> Option<bool> {
     .find_map(|value| declared_model_image_support_in_value(value, model))
 }
 
+fn declared_model_text_only(settings: &Value, model: &str) -> Option<bool> {
+    [
+        settings
+            .get("modelCatalog")
+            .and_then(|catalog| catalog.get("models")),
+        settings.get("modelCatalog"),
+        settings.get("models"),
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(|value| declared_model_text_only_in_value(value, model))
+}
+
+fn declared_model_text_only_in_value(value: &Value, model: &str) -> Option<bool> {
+    if let Some(models) = value.as_array() {
+        return models.iter().find_map(|entry| {
+            model_entry_matches(entry, None, model).then(|| explicit_text_only(entry))?
+        });
+    }
+
+    let object = value.as_object()?;
+    object.iter().find_map(|(key, entry)| {
+        model_entry_matches(entry, Some(key), model).then(|| explicit_text_only(entry))?
+    })
+}
+
 fn declared_model_image_support_in_value(value: &Value, model: &str) -> Option<bool> {
     if let Some(models) = value.as_array() {
         return models.iter().find_map(|entry| {
@@ -149,6 +187,28 @@ fn explicit_image_support(entry: &Value) -> Option<bool> {
     .into_iter()
     .flatten()
     .find_map(input_modalities_support_image)
+}
+
+fn explicit_text_only(entry: &Value) -> Option<bool> {
+    [
+        entry.get("input"),
+        entry.pointer("/modalities/input"),
+        entry.get("input_modalities"),
+        entry.get("inputModalities"),
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(|value| {
+        let modalities = value.as_array()?;
+        Some(
+            !modalities.is_empty()
+                && modalities.iter().all(|item| {
+                    item.as_str()
+                        .map(str::trim)
+                        .is_some_and(|item| item.eq_ignore_ascii_case("text"))
+                }),
+        )
+    })
 }
 
 fn input_modalities_support_image(value: &Value) -> Option<bool> {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -195,26 +195,25 @@ impl RequestForwarder {
     ///
     /// 受 `enabled && request_media_fallback` 管辖；其中"启发式模型名单预测"
     /// 再受 `request_media_heuristic` 单独管辖（显式声明 text-only 始终生效）。
-    /// 返回被替换的图片块数量（0 = 未触发或开关关闭）。
+    /// 返回被替换的媒体块数量（0 = 未触发或开关关闭）。
     fn apply_media_prevention(&self, body: &mut Value, provider: &Provider) -> usize {
         if !(self.rectifier_config.enabled && self.rectifier_config.request_media_fallback) {
             return 0;
         }
-        let replaced_images = super::media_sanitizer::replace_images_for_text_only_model(
+        let replaced_media = super::media_sanitizer::replace_images_for_text_only_model(
             body,
             provider,
             self.rectifier_config.request_media_heuristic,
         );
-        if replaced_images > 0 {
+        if replaced_media > 0 {
             let model = body.get("model").and_then(Value::as_str).unwrap_or("");
             log::info!(
-                "[Media] Replaced {replaced_images} image block(s) with {} for text-only provider={}, model={}",
-                super::media_sanitizer::UNSUPPORTED_IMAGE_MARKER,
+                "[Media] Replaced {replaced_media} unsupported media block(s) for provider={}, model={}",
                 provider.id,
                 model
             );
         }
-        replaced_images
+        replaced_media
     }
 
     /// 反应式 media 重试判定：上游因图片输入报错后，是否应替换图片块并对同一供应商重试一次。

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 use crate::model_capabilities::is_confirmed_text_only_model as confirmed_text_only_model;
-use crate::model_capabilities::{image_input_capability_from_settings, ImageInputCapability};
+use crate::model_capabilities::{
+    image_input_capability_from_settings, is_text_only_model_from_settings, ImageInputCapability,
+};
 use crate::provider::Provider;
 use crate::proxy::error::ProxyError;
 use crate::proxy::tool_media::{
@@ -9,6 +11,7 @@ use crate::proxy::tool_media::{
 use serde_json::{json, Value};
 
 pub const UNSUPPORTED_IMAGE_MARKER: &str = "[Unsupported Image]";
+const UNSUPPORTED_MEDIA_MARKER: &str = "[Unsupported Media]";
 
 /// Replace image blocks before sending when the routed model is text-only.
 ///
@@ -23,14 +26,16 @@ pub const UNSUPPORTED_IMAGE_MARKER: &str = "[Unsupported Image]";
 ///   `messages.content[*].type` other than `text`, not just images — `file`
 ///   and `input_audio` parts trip the same 400. The existing image strip runs
 ///   unchanged first, then a narrow second pass removes `file`/`input_file`/
-///   `input_audio` blocks from user/assistant content only. Tool-role content,
-///   tool-output payloads, and the reactive retry are untouched.
+///   `input_audio`/`document` blocks from user/assistant content only. Tool-role
+///   content, tool-output payloads, and the reactive retry are untouched.
 pub fn replace_images_for_text_only_model(
     body: &mut Value,
     provider: &Provider,
     allow_heuristic: bool,
 ) -> usize {
-    if !contains_image_blocks(body) && !contains_non_image_media_blocks(body) {
+    let has_images = contains_image_blocks(body);
+    let has_non_image_media = contains_non_image_media_blocks(body);
+    if !has_images && !has_non_image_media {
         return 0;
     }
 
@@ -40,13 +45,24 @@ pub fn replace_images_for_text_only_model(
         .map(str::trim)
         .unwrap_or("");
 
-    if image_input_capability_from_settings(&provider.settings_config, model, allow_heuristic)
-        != ImageInputCapability::Unsupported
-    {
+    let replace_images = has_images
+        && image_input_capability_from_settings(&provider.settings_config, model, allow_heuristic)
+            == ImageInputCapability::Unsupported;
+    let strip_non_image_media = has_non_image_media
+        && is_text_only_model_from_settings(&provider.settings_config, model, allow_heuristic);
+    if !replace_images && !strip_non_image_media {
         return 0;
     }
 
-    replace_images_in_body(body) + strip_non_image_media_blocks(body)
+    let mut replaced = if replace_images {
+        replace_images_in_body(body)
+    } else {
+        0
+    };
+    if strip_non_image_media {
+        replaced += strip_non_image_media_blocks(body);
+    }
+    replaced
 }
 
 pub fn contains_image_blocks(body: &Value) -> bool {
@@ -82,15 +98,11 @@ pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
     // `text` with a field-validation error that never mentions image/modality
     // (#6151). The Chinese form "content.type 参数非法，取值范围 ['text']"
     // is itself a text-only assertion.
-    const TEXT_ONLY_SELF_EVIDENT_HINTS: &[&str] = &[
-        "only support text",
-        "only supports text",
-        "content.type 参数非法",
-        "取值范围 ['text']",
-    ];
+    const TEXT_ONLY_SELF_EVIDENT_HINTS: &[&str] = &["only support text", "only supports text"];
     if TEXT_ONLY_SELF_EVIDENT_HINTS
         .iter()
         .any(|hint| message.contains(hint))
+        || (message.contains("content.type 参数非法") && message.contains("取值范围 ['text']"))
     {
         return true;
     }
@@ -409,14 +421,24 @@ fn replace_images_in_responses_input_item(item: &mut Value) -> usize {
 }
 
 /// Content-part types beyond images that a text-only upstream rejects
-/// (`file`/`input_file`/`input_audio`). GLM-5.2 returns
+/// (`file`/`input_file`/`input_audio`/`document`). GLM-5.2 returns
 /// `messages.content.type 参数非法，取值范围 ['text']` for these (#6151).
-/// Covers both Chat (`file`) and Responses (`input_file`) shapes.
+/// Covers Chat (`file`), Responses (`input_file`), and Anthropic (`document`).
 fn is_non_image_media_block_type(block_type: Option<&str>) -> bool {
-    matches!(block_type, Some("file" | "input_file" | "input_audio"))
+    matches!(
+        block_type,
+        Some("file" | "input_file" | "input_audio" | "document")
+    )
 }
 
-/// Whether the body carries `file`/`input_file`/`input_audio` blocks in
+fn is_user_or_assistant_content(item: &Value) -> bool {
+    matches!(
+        item.get("role").and_then(Value::as_str),
+        Some("user" | "assistant")
+    )
+}
+
+/// Whether the body carries non-image media blocks in
 /// user/assistant content (messages or Responses input). Only non-tool
 /// messages are checked — tool-role content and tool-output payloads are
 /// handled by the existing image-scoped path and are not widened here.
@@ -425,7 +447,7 @@ fn contains_non_image_media_blocks(body: &Value) -> bool {
         .and_then(Value::as_array)
         .is_some_and(|messages| {
             messages.iter().any(|message| {
-                message.get("role").and_then(Value::as_str) != Some("tool")
+                is_user_or_assistant_content(message)
                     && message
                         .get("content")
                         .and_then(Value::as_array)
@@ -450,8 +472,8 @@ fn responses_input_has_non_image_media_blocks(input: Option<&Value>) -> bool {
 }
 
 fn responses_input_item_has_non_image_media(item: &Value) -> bool {
-    is_non_image_media_block_type(item.get("type").and_then(Value::as_str))
-        || item
+    is_user_or_assistant_content(item)
+        && item
             .get("content")
             .and_then(Value::as_array)
             .is_some_and(|blocks| {
@@ -461,23 +483,22 @@ fn responses_input_item_has_non_image_media(item: &Value) -> bool {
             })
 }
 
-/// Replace `file`/`input_file`/`input_audio` content blocks with a text
-/// marker in user/assistant messages and Responses input content. Runs as a
-/// second pass after the existing image strip. Tool-role messages and
-/// tool-output payloads are intentionally skipped — the reactive retry's
-/// image-scoped contract stays untouched.
+/// Replace non-image media blocks with a text marker in user/assistant messages
+/// and Responses input content. Runs as a second pass after the existing image
+/// strip. Tool-role messages and tool-output payloads are intentionally skipped
+/// — the reactive retry's image-scoped contract stays untouched.
 fn strip_non_image_media_blocks(body: &mut Value) -> usize {
     let mut replaced = 0usize;
 
     if let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) {
         for message in messages.iter_mut() {
-            if message.get("role").and_then(Value::as_str) == Some("tool") {
+            if !is_user_or_assistant_content(message) {
                 continue;
             }
             if let Some(blocks) = message.get_mut("content").and_then(Value::as_array_mut) {
                 for block in blocks.iter_mut() {
                     if is_non_image_media_block_type(block.get("type").and_then(Value::as_str)) {
-                        replace_image_block_with_text_marker(block, "text");
+                        replace_non_image_media_block_with_text_marker(block, "text");
                         replaced += 1;
                     }
                 }
@@ -498,15 +519,19 @@ fn strip_non_image_media_blocks(body: &mut Value) -> usize {
 }
 
 fn strip_non_image_media_from_responses_item(item: &mut Value) -> usize {
-    let mut replaced = 0usize;
-    if is_non_image_media_block_type(item.get("type").and_then(Value::as_str)) {
-        replace_image_block_with_text_marker(item, "input_text");
-        replaced += 1;
+    if !is_user_or_assistant_content(item) {
+        return 0;
     }
+    let text_type = if item.get("role").and_then(Value::as_str) == Some("assistant") {
+        "output_text"
+    } else {
+        "input_text"
+    };
+    let mut replaced = 0usize;
     if let Some(blocks) = item.get_mut("content").and_then(Value::as_array_mut) {
         for block in blocks.iter_mut() {
             if is_non_image_media_block_type(block.get("type").and_then(Value::as_str)) {
-                replace_image_block_with_text_marker(block, "input_text");
+                replace_non_image_media_block_with_text_marker(block, text_type);
                 replaced += 1;
             }
         }
@@ -519,10 +544,18 @@ fn is_image_block_type(block_type: Option<&str>) -> bool {
 }
 
 fn replace_image_block_with_text_marker(block: &mut Value, text_type: &str) {
+    replace_block_with_text_marker(block, text_type, UNSUPPORTED_IMAGE_MARKER);
+}
+
+fn replace_non_image_media_block_with_text_marker(block: &mut Value, text_type: &str) {
+    replace_block_with_text_marker(block, text_type, UNSUPPORTED_MEDIA_MARKER);
+}
+
+fn replace_block_with_text_marker(block: &mut Value, text_type: &str, marker: &str) {
     let cache_control = block.get("cache_control").cloned();
     *block = json!({
         "type": text_type,
-        "text": UNSUPPORTED_IMAGE_MARKER
+        "text": marker
     });
     if let (Some(cache_control), Some(object)) = (cache_control, block.as_object_mut()) {
         object.insert("cache_control".to_string(), cache_control);
@@ -695,7 +728,7 @@ mod tests {
         assert_eq!(body["messages"][0]["content"][1]["type"], "text");
         assert_eq!(
             body["messages"][0]["content"][1]["text"],
-            UNSUPPORTED_IMAGE_MARKER
+            UNSUPPORTED_MEDIA_MARKER
         );
     }
 
@@ -720,8 +753,69 @@ mod tests {
         assert_eq!(body["messages"][0]["content"][1]["type"], "text");
         assert_eq!(
             body["messages"][0]["content"][1]["text"],
-            UNSUPPORTED_IMAGE_MARKER
+            UNSUPPORTED_MEDIA_MARKER
         );
+    }
+
+    #[test]
+    fn image_disabled_models_preserve_non_image_media() {
+        for (model, settings) in [
+            (
+                "glm-5.2",
+                json!({ "models": [{ "id": "glm-5.2", "supportsImage": false }] }),
+            ),
+            (
+                "glm-5.2",
+                json!({ "models": [{ "id": "glm-5.2", "input": ["text", "audio"] }] }),
+            ),
+        ] {
+            let provider = provider(settings);
+            let mut body = json!({
+                "model": model,
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        { "type": "image_url", "image_url": { "url": "data:image/png;base64,YQ==" } },
+                        { "type": "input_audio", "input_audio": { "data": "YQ==", "format": "wav" } },
+                        { "type": "file", "file": { "file_id": "file_1" } }
+                    ]
+                }]
+            });
+
+            let count = replace_images_for_text_only_model(&mut body, &provider, true);
+
+            assert_eq!(count, 1, "only the unsupported image is replaced");
+            assert_eq!(body["messages"][0]["content"][0]["type"], "text");
+            assert_eq!(body["messages"][0]["content"][1]["type"], "input_audio");
+            assert_eq!(body["messages"][0]["content"][2]["type"], "file");
+        }
+    }
+
+    #[test]
+    fn text_only_modalities_control_non_image_media_independently() {
+        let provider = provider(json!({
+            "models": [{
+                "id": "declared-text-only",
+                "supportsImage": true,
+                "input": ["text"]
+            }]
+        }));
+        let mut body = json!({
+            "model": "declared-text-only",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "image_url", "image_url": { "url": "data:image/png;base64,YQ==" } },
+                    { "type": "file", "file": { "file_id": "file_1" } }
+                ]
+            }]
+        });
+
+        let count = replace_images_for_text_only_model(&mut body, &provider, true);
+
+        assert_eq!(count, 1);
+        assert_eq!(body["messages"][0]["content"][0]["type"], "image_url");
+        assert_eq!(body["messages"][0]["content"][1]["type"], "text");
     }
 
     #[test]
@@ -745,7 +839,37 @@ mod tests {
         assert_eq!(body["input"][0]["content"][1]["type"], "input_text");
         assert_eq!(
             body["input"][0]["content"][1]["text"],
-            UNSUPPORTED_IMAGE_MARKER
+            UNSUPPORTED_MEDIA_MARKER
+        );
+    }
+
+    #[test]
+    fn codex_to_anthropic_documents_are_replaced_for_text_only_models() {
+        let provider = provider(json!({}));
+        let mut body =
+            crate::proxy::providers::transform_codex_anthropic::responses_request_to_anthropic(
+                json!({
+                    "model": "glm-5.2",
+                    "input": [{
+                        "role": "user",
+                        "content": [
+                            { "type": "input_text", "text": "summarize" },
+                            { "type": "input_file", "file_url": "https://example.com/report.pdf" }
+                        ]
+                    }]
+                }),
+                8192,
+            )
+            .unwrap();
+        assert_eq!(body["messages"][0]["content"][1]["type"], "document");
+
+        let count = replace_images_for_text_only_model(&mut body, &provider, true);
+
+        assert_eq!(count, 1);
+        assert_eq!(body["messages"][0]["content"][1]["type"], "text");
+        assert_eq!(
+            body["messages"][0]["content"][1]["text"],
+            UNSUPPORTED_MEDIA_MARKER
         );
     }
 
@@ -773,6 +897,37 @@ mod tests {
     }
 
     #[test]
+    fn non_image_media_replacement_stays_in_user_and_assistant_content() {
+        let provider = provider(json!({}));
+        let mut body = json!({
+            "model": "glm-5.2",
+            "messages": [
+                { "role": "system", "content": [{ "type": "file" }] },
+                { "role": "developer", "content": [{ "type": "input_audio" }] },
+                { "role": "unknown", "content": [{ "type": "document" }] },
+                { "content": [{ "type": "file" }] },
+                { "role": "user", "content": [{ "type": "file" }] }
+            ],
+            "input": [
+                { "role": "system", "content": [{ "type": "input_file" }] },
+                { "type": "input_file" },
+                { "role": "assistant", "content": [{ "type": "input_file" }] }
+            ]
+        });
+
+        let count = replace_images_for_text_only_model(&mut body, &provider, true);
+
+        assert_eq!(count, 2);
+        for index in 0..4 {
+            assert_ne!(body["messages"][index]["content"][0]["type"], "text");
+        }
+        assert_eq!(body["messages"][4]["content"][0]["type"], "text");
+        assert_eq!(body["input"][0]["content"][0]["type"], "input_file");
+        assert_eq!(body["input"][1]["type"], "input_file");
+        assert_eq!(body["input"][2]["content"][0]["type"], "output_text");
+    }
+
+    #[test]
     fn is_unsupported_image_error_recognizes_glm_content_type_rejection() {
         // #6151: GLM-5.2 returns a field-validation error that never mentions
         // image/modality; the reactive fallback must still recognize it.
@@ -785,6 +940,19 @@ mod tests {
         };
 
         assert!(is_unsupported_image_error(&error));
+    }
+
+    #[test]
+    fn content_type_error_with_image_allowed_is_not_text_only() {
+        let error = ProxyError::UpstreamError {
+            status: 400,
+            body: Some(
+                r#"{"error":{"message":"messages.content.type 参数非法，取值范围 ['text','image_url']"}}"#
+                    .to_string(),
+            ),
+        };
+
+        assert!(!is_unsupported_image_error(&error));
     }
 
     #[test]
@@ -809,16 +977,18 @@ mod tests {
                 "role": "user",
                 "content": [
                     { "type": "text", "text": "look" },
-                    { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": "abc" } }
+                    { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": "abc" } },
+                    { "type": "input_audio", "input_audio": { "data": "YQ==", "format": "wav" } }
                 ]
             }]
         });
 
         let count = replace_images_for_text_only_model(&mut body, &provider, true);
 
-        assert_eq!(count, 1);
+        assert_eq!(count, 2);
         assert_eq!(body["messages"][0]["content"][0]["text"], "look");
         assert_eq!(body["messages"][0]["content"][1]["type"], "text");
+        assert_eq!(body["messages"][0]["content"][2]["type"], "text");
         assert_eq!(
             body["messages"][0]["content"][1]["text"],
             UNSUPPORTED_IMAGE_MARKER

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -18,12 +18,19 @@ pub const UNSUPPORTED_IMAGE_MARKER: &str = "[Unsupported Image]";
 /// - the confirmed text-only registry is used for proactive replacement only
 ///   when `allow_heuristic` is true. This switch controls silent request-body
 ///   mutation, not the capability truth advertised by the Codex model catalog.
+///   Replace non-text media blocks before sending when the routed model is
+///   text-only. A text-only upstream (e.g. GLM-5.2, see #6151) rejects any
+///   `messages.content[*].type` other than `text`, not just images — `file`
+///   and `input_audio` parts trip the same 400. The existing image strip runs
+///   unchanged first, then a narrow second pass removes `file`/`input_file`/
+///   `input_audio` blocks from user/assistant content only. Tool-role content,
+///   tool-output payloads, and the reactive retry are untouched.
 pub fn replace_images_for_text_only_model(
     body: &mut Value,
     provider: &Provider,
     allow_heuristic: bool,
 ) -> usize {
-    if !contains_image_blocks(body) {
+    if !contains_image_blocks(body) && !contains_non_image_media_blocks(body) {
         return 0;
     }
 
@@ -39,7 +46,7 @@ pub fn replace_images_for_text_only_model(
         return 0;
     }
 
-    replace_images_in_body(body)
+    replace_images_in_body(body) + strip_non_image_media_blocks(body)
 }
 
 pub fn contains_image_blocks(body: &Value) -> bool {
@@ -64,7 +71,6 @@ pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
     let Some(body) = body.as_deref() else {
         return false;
     };
-
     let message = extract_error_text(body);
     let message = message.to_ascii_lowercase();
 
@@ -72,7 +78,16 @@ pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
     // 错误提到 image/media 等字样——火山方舟等网关的报错是
     // "Model only support text input"，全程不出现 image（issue #5025）。
     // 国产网关的英文常缺三单 s，因此带 s / 不带 s 两种形式都要列。
-    const TEXT_ONLY_SELF_EVIDENT_HINTS: &[&str] = &["only support text", "only supports text"];
+    // GLM-5.2 text endpoint rejects any messages.content[*].type other than
+    // `text` with a field-validation error that never mentions image/modality
+    // (#6151). The Chinese form "content.type 参数非法，取值范围 ['text']"
+    // is itself a text-only assertion.
+    const TEXT_ONLY_SELF_EVIDENT_HINTS: &[&str] = &[
+        "only support text",
+        "only supports text",
+        "content.type 参数非法",
+        "取值范围 ['text']",
+    ];
     if TEXT_ONLY_SELF_EVIDENT_HINTS
         .iter()
         .any(|hint| message.contains(hint))
@@ -390,7 +405,112 @@ fn replace_images_in_responses_input_item(item: &mut Value) -> usize {
             UNSUPPORTED_IMAGE_MARKER,
         );
     }
+    replaced
+}
 
+/// Content-part types beyond images that a text-only upstream rejects
+/// (`file`/`input_file`/`input_audio`). GLM-5.2 returns
+/// `messages.content.type 参数非法，取值范围 ['text']` for these (#6151).
+/// Covers both Chat (`file`) and Responses (`input_file`) shapes.
+fn is_non_image_media_block_type(block_type: Option<&str>) -> bool {
+    matches!(block_type, Some("file" | "input_file" | "input_audio"))
+}
+
+/// Whether the body carries `file`/`input_file`/`input_audio` blocks in
+/// user/assistant content (messages or Responses input). Only non-tool
+/// messages are checked — tool-role content and tool-output payloads are
+/// handled by the existing image-scoped path and are not widened here.
+fn contains_non_image_media_blocks(body: &Value) -> bool {
+    body.get("messages")
+        .and_then(Value::as_array)
+        .is_some_and(|messages| {
+            messages.iter().any(|message| {
+                message.get("role").and_then(Value::as_str) != Some("tool")
+                    && message
+                        .get("content")
+                        .and_then(Value::as_array)
+                        .is_some_and(|blocks| {
+                            blocks.iter().any(|block| {
+                                is_non_image_media_block_type(
+                                    block.get("type").and_then(Value::as_str),
+                                )
+                            })
+                        })
+            })
+        })
+        || responses_input_has_non_image_media_blocks(body.get("input"))
+}
+
+fn responses_input_has_non_image_media_blocks(input: Option<&Value>) -> bool {
+    match input {
+        Some(Value::Array(items)) => items.iter().any(responses_input_item_has_non_image_media),
+        Some(item @ Value::Object(_)) => responses_input_item_has_non_image_media(item),
+        _ => false,
+    }
+}
+
+fn responses_input_item_has_non_image_media(item: &Value) -> bool {
+    is_non_image_media_block_type(item.get("type").and_then(Value::as_str))
+        || item
+            .get("content")
+            .and_then(Value::as_array)
+            .is_some_and(|blocks| {
+                blocks.iter().any(|block| {
+                    is_non_image_media_block_type(block.get("type").and_then(Value::as_str))
+                })
+            })
+}
+
+/// Replace `file`/`input_file`/`input_audio` content blocks with a text
+/// marker in user/assistant messages and Responses input content. Runs as a
+/// second pass after the existing image strip. Tool-role messages and
+/// tool-output payloads are intentionally skipped — the reactive retry's
+/// image-scoped contract stays untouched.
+fn strip_non_image_media_blocks(body: &mut Value) -> usize {
+    let mut replaced = 0usize;
+
+    if let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) {
+        for message in messages.iter_mut() {
+            if message.get("role").and_then(Value::as_str) == Some("tool") {
+                continue;
+            }
+            if let Some(blocks) = message.get_mut("content").and_then(Value::as_array_mut) {
+                for block in blocks.iter_mut() {
+                    if is_non_image_media_block_type(block.get("type").and_then(Value::as_str)) {
+                        replace_image_block_with_text_marker(block, "text");
+                        replaced += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    replaced += match body.get_mut("input") {
+        Some(Value::Array(items)) => items
+            .iter_mut()
+            .map(strip_non_image_media_from_responses_item)
+            .sum(),
+        Some(item @ Value::Object(_)) => strip_non_image_media_from_responses_item(item),
+        _ => 0,
+    };
+
+    replaced
+}
+
+fn strip_non_image_media_from_responses_item(item: &mut Value) -> usize {
+    let mut replaced = 0usize;
+    if is_non_image_media_block_type(item.get("type").and_then(Value::as_str)) {
+        replace_image_block_with_text_marker(item, "input_text");
+        replaced += 1;
+    }
+    if let Some(blocks) = item.get_mut("content").and_then(Value::as_array_mut) {
+        for block in blocks.iter_mut() {
+            if is_non_image_media_block_type(block.get("type").and_then(Value::as_str)) {
+                replace_image_block_with_text_marker(block, "input_text");
+                replaced += 1;
+            }
+        }
+    }
     replaced
 }
 
@@ -551,6 +671,120 @@ mod tests {
             body["input"][0]["content"][1]["text"],
             UNSUPPORTED_IMAGE_MARKER
         );
+    }
+
+    #[test]
+    fn confirmed_text_only_models_replace_chat_file_part_before_send() {
+        // #6151: GLM-5.2 (text-only) rejects messages.content parts whose
+        // `type` is not `text` — including `file`. The second pass must drop it.
+        let provider = provider(json!({}));
+        let mut body = json!({
+            "model": "glm-5.2",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": "summarize" },
+                    { "type": "file", "file": { "file_id": "file_1" } }
+                ]
+            }]
+        });
+
+        let count = replace_images_for_text_only_model(&mut body, &provider, true);
+
+        assert_eq!(count, 1);
+        assert_eq!(body["messages"][0]["content"][1]["type"], "text");
+        assert_eq!(
+            body["messages"][0]["content"][1]["text"],
+            UNSUPPORTED_IMAGE_MARKER
+        );
+    }
+
+    #[test]
+    fn confirmed_text_only_models_replace_chat_input_audio_part_before_send() {
+        // #6151: `input_audio` parts are equally rejected by text-only upstreams.
+        let provider = provider(json!({}));
+        let mut body = json!({
+            "model": "glm-5.2",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": "transcribe" },
+                    { "type": "input_audio", "input_audio": { "data": "YQ==", "format": "wav" } }
+                ]
+            }]
+        });
+
+        let count = replace_images_for_text_only_model(&mut body, &provider, true);
+
+        assert_eq!(count, 1);
+        assert_eq!(body["messages"][0]["content"][1]["type"], "text");
+        assert_eq!(
+            body["messages"][0]["content"][1]["text"],
+            UNSUPPORTED_IMAGE_MARKER
+        );
+    }
+
+    #[test]
+    fn confirmed_text_only_models_replace_codex_input_file_part_before_send() {
+        // #6151: native Responses input `input_file` must also be stripped.
+        let provider = provider(json!({}));
+        let mut body = json!({
+            "model": "glm-5.2",
+            "input": [{
+                "role": "user",
+                "content": [
+                    { "type": "input_text", "text": "summarize" },
+                    { "type": "input_file", "file_id": "file_top" }
+                ]
+            }]
+        });
+
+        let count = replace_images_for_text_only_model(&mut body, &provider, true);
+
+        assert_eq!(count, 1);
+        assert_eq!(body["input"][0]["content"][1]["type"], "input_text");
+        assert_eq!(
+            body["input"][0]["content"][1]["text"],
+            UNSUPPORTED_IMAGE_MARKER
+        );
+    }
+
+    #[test]
+    fn reactive_retry_stays_image_scoped_for_file_and_audio() {
+        // The reactive retry must remain image-scoped — file/audio parts are
+        // NOT stripped by `replace_image_blocks_with_marker`.
+        let mut body = json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "file", "file": { "file_id": "file_1" } },
+                    { "type": "input_audio", "input_audio": { "data": "YQ==", "format": "wav" } },
+                    { "type": "image_url", "image_url": { "url": "data:image/png;base64,YQ==" } }
+                ]
+            }]
+        });
+
+        let replaced = replace_image_blocks_with_marker(&mut body);
+
+        assert_eq!(replaced, 1, "only the image_url block is replaced");
+        assert_eq!(body["messages"][0]["content"][0]["type"], "file");
+        assert_eq!(body["messages"][0]["content"][1]["type"], "input_audio");
+        assert_eq!(body["messages"][0]["content"][2]["type"], "text");
+    }
+
+    #[test]
+    fn is_unsupported_image_error_recognizes_glm_content_type_rejection() {
+        // #6151: GLM-5.2 returns a field-validation error that never mentions
+        // image/modality; the reactive fallback must still recognize it.
+        let error = ProxyError::UpstreamError {
+            status: 400,
+            body: Some(
+                r#"{"error":{"code":"1214","message":"messages.content.type 参数非法，取值范围 ['text']"}}"#
+                    .to_string(),
+            ),
+        };
+
+        assert!(is_unsupported_image_error(&error));
     }
 
     #[test]

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 use crate::model_capabilities::is_confirmed_text_only_model as confirmed_text_only_model;
-use crate::model_capabilities::{image_input_capability_from_settings, ImageInputCapability};
+use crate::model_capabilities::{
+    image_input_capability_from_settings, is_text_only_model_from_settings, ImageInputCapability,
+};
 use crate::provider::Provider;
 use crate::proxy::error::ProxyError;
 use crate::proxy::tool_media::{
@@ -9,6 +11,7 @@ use crate::proxy::tool_media::{
 use serde_json::{json, Value};
 
 pub const UNSUPPORTED_IMAGE_MARKER: &str = "[Unsupported Image]";
+const UNSUPPORTED_MEDIA_MARKER: &str = "[Unsupported Media]";
 
 /// Replace image blocks before sending when the routed model is text-only.
 ///
@@ -23,8 +26,8 @@ pub const UNSUPPORTED_IMAGE_MARKER: &str = "[Unsupported Image]";
 ///   `messages.content[*].type` other than `text`, not just images — `file`
 ///   and `input_audio` parts trip the same 400. The existing image strip runs
 ///   unchanged first, then a narrow second pass removes `file`/`input_file`/
-///   `input_audio` blocks from user/assistant content only. Tool-role content,
-///   tool-output payloads, and the reactive retry are untouched.
+///   `input_audio`/`document` blocks from user/assistant content only. Tool-role
+///   content, tool-output payloads, and the reactive retry are untouched.
 pub fn replace_images_for_text_only_model(
     body: &mut Value,
     provider: &Provider,
@@ -46,7 +49,13 @@ pub fn replace_images_for_text_only_model(
         return 0;
     }
 
-    replace_images_in_body(body) + strip_non_image_media_blocks(body)
+    let strip_non_image_media =
+        is_text_only_model_from_settings(&provider.settings_config, model, allow_heuristic);
+    let mut replaced = replace_images_in_body(body);
+    if strip_non_image_media {
+        replaced += strip_non_image_media_blocks(body);
+    }
+    replaced
 }
 
 pub fn contains_image_blocks(body: &Value) -> bool {
@@ -82,15 +91,11 @@ pub fn is_unsupported_image_error(error: &ProxyError) -> bool {
     // `text` with a field-validation error that never mentions image/modality
     // (#6151). The Chinese form "content.type 参数非法，取值范围 ['text']"
     // is itself a text-only assertion.
-    const TEXT_ONLY_SELF_EVIDENT_HINTS: &[&str] = &[
-        "only support text",
-        "only supports text",
-        "content.type 参数非法",
-        "取值范围 ['text']",
-    ];
+    const TEXT_ONLY_SELF_EVIDENT_HINTS: &[&str] = &["only support text", "only supports text"];
     if TEXT_ONLY_SELF_EVIDENT_HINTS
         .iter()
         .any(|hint| message.contains(hint))
+        || (message.contains("content.type 参数非法") && message.contains("取值范围 ['text']"))
     {
         return true;
     }
@@ -409,14 +414,17 @@ fn replace_images_in_responses_input_item(item: &mut Value) -> usize {
 }
 
 /// Content-part types beyond images that a text-only upstream rejects
-/// (`file`/`input_file`/`input_audio`). GLM-5.2 returns
+/// (`file`/`input_file`/`input_audio`/`document`). GLM-5.2 returns
 /// `messages.content.type 参数非法，取值范围 ['text']` for these (#6151).
-/// Covers both Chat (`file`) and Responses (`input_file`) shapes.
+/// Covers Chat (`file`), Responses (`input_file`), and Anthropic (`document`).
 fn is_non_image_media_block_type(block_type: Option<&str>) -> bool {
-    matches!(block_type, Some("file" | "input_file" | "input_audio"))
+    matches!(
+        block_type,
+        Some("file" | "input_file" | "input_audio" | "document")
+    )
 }
 
-/// Whether the body carries `file`/`input_file`/`input_audio` blocks in
+/// Whether the body carries non-image media blocks in
 /// user/assistant content (messages or Responses input). Only non-tool
 /// messages are checked — tool-role content and tool-output payloads are
 /// handled by the existing image-scoped path and are not widened here.
@@ -461,11 +469,10 @@ fn responses_input_item_has_non_image_media(item: &Value) -> bool {
             })
 }
 
-/// Replace `file`/`input_file`/`input_audio` content blocks with a text
-/// marker in user/assistant messages and Responses input content. Runs as a
-/// second pass after the existing image strip. Tool-role messages and
-/// tool-output payloads are intentionally skipped — the reactive retry's
-/// image-scoped contract stays untouched.
+/// Replace non-image media blocks with a text marker in user/assistant messages
+/// and Responses input content. Runs as a second pass after the existing image
+/// strip. Tool-role messages and tool-output payloads are intentionally skipped
+/// — the reactive retry's image-scoped contract stays untouched.
 fn strip_non_image_media_blocks(body: &mut Value) -> usize {
     let mut replaced = 0usize;
 
@@ -477,7 +484,7 @@ fn strip_non_image_media_blocks(body: &mut Value) -> usize {
             if let Some(blocks) = message.get_mut("content").and_then(Value::as_array_mut) {
                 for block in blocks.iter_mut() {
                     if is_non_image_media_block_type(block.get("type").and_then(Value::as_str)) {
-                        replace_image_block_with_text_marker(block, "text");
+                        replace_non_image_media_block_with_text_marker(block, "text");
                         replaced += 1;
                     }
                 }
@@ -500,13 +507,13 @@ fn strip_non_image_media_blocks(body: &mut Value) -> usize {
 fn strip_non_image_media_from_responses_item(item: &mut Value) -> usize {
     let mut replaced = 0usize;
     if is_non_image_media_block_type(item.get("type").and_then(Value::as_str)) {
-        replace_image_block_with_text_marker(item, "input_text");
+        replace_non_image_media_block_with_text_marker(item, "input_text");
         replaced += 1;
     }
     if let Some(blocks) = item.get_mut("content").and_then(Value::as_array_mut) {
         for block in blocks.iter_mut() {
             if is_non_image_media_block_type(block.get("type").and_then(Value::as_str)) {
-                replace_image_block_with_text_marker(block, "input_text");
+                replace_non_image_media_block_with_text_marker(block, "input_text");
                 replaced += 1;
             }
         }
@@ -519,10 +526,18 @@ fn is_image_block_type(block_type: Option<&str>) -> bool {
 }
 
 fn replace_image_block_with_text_marker(block: &mut Value, text_type: &str) {
+    replace_block_with_text_marker(block, text_type, UNSUPPORTED_IMAGE_MARKER);
+}
+
+fn replace_non_image_media_block_with_text_marker(block: &mut Value, text_type: &str) {
+    replace_block_with_text_marker(block, text_type, UNSUPPORTED_MEDIA_MARKER);
+}
+
+fn replace_block_with_text_marker(block: &mut Value, text_type: &str, marker: &str) {
     let cache_control = block.get("cache_control").cloned();
     *block = json!({
         "type": text_type,
-        "text": UNSUPPORTED_IMAGE_MARKER
+        "text": marker
     });
     if let (Some(cache_control), Some(object)) = (cache_control, block.as_object_mut()) {
         object.insert("cache_control".to_string(), cache_control);
@@ -695,7 +710,7 @@ mod tests {
         assert_eq!(body["messages"][0]["content"][1]["type"], "text");
         assert_eq!(
             body["messages"][0]["content"][1]["text"],
-            UNSUPPORTED_IMAGE_MARKER
+            UNSUPPORTED_MEDIA_MARKER
         );
     }
 
@@ -720,8 +735,42 @@ mod tests {
         assert_eq!(body["messages"][0]["content"][1]["type"], "text");
         assert_eq!(
             body["messages"][0]["content"][1]["text"],
-            UNSUPPORTED_IMAGE_MARKER
+            UNSUPPORTED_MEDIA_MARKER
         );
+    }
+
+    #[test]
+    fn image_disabled_models_preserve_non_image_media() {
+        for (model, settings) in [
+            (
+                "audio-model",
+                json!({ "models": [{ "id": "audio-model", "supportsImage": false }] }),
+            ),
+            (
+                "glm-5.2",
+                json!({ "models": [{ "id": "glm-5.2", "input": ["text", "audio"] }] }),
+            ),
+        ] {
+            let provider = provider(settings);
+            let mut body = json!({
+                "model": model,
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        { "type": "image_url", "image_url": { "url": "data:image/png;base64,YQ==" } },
+                        { "type": "input_audio", "input_audio": { "data": "YQ==", "format": "wav" } },
+                        { "type": "file", "file": { "file_id": "file_1" } }
+                    ]
+                }]
+            });
+
+            let count = replace_images_for_text_only_model(&mut body, &provider, true);
+
+            assert_eq!(count, 1, "only the unsupported image is replaced");
+            assert_eq!(body["messages"][0]["content"][0]["type"], "text");
+            assert_eq!(body["messages"][0]["content"][1]["type"], "input_audio");
+            assert_eq!(body["messages"][0]["content"][2]["type"], "file");
+        }
     }
 
     #[test]
@@ -745,7 +794,37 @@ mod tests {
         assert_eq!(body["input"][0]["content"][1]["type"], "input_text");
         assert_eq!(
             body["input"][0]["content"][1]["text"],
-            UNSUPPORTED_IMAGE_MARKER
+            UNSUPPORTED_MEDIA_MARKER
+        );
+    }
+
+    #[test]
+    fn codex_to_anthropic_documents_are_replaced_for_text_only_models() {
+        let provider = provider(json!({}));
+        let mut body =
+            crate::proxy::providers::transform_codex_anthropic::responses_request_to_anthropic(
+                json!({
+                    "model": "glm-5.2",
+                    "input": [{
+                        "role": "user",
+                        "content": [
+                            { "type": "input_text", "text": "summarize" },
+                            { "type": "input_file", "file_url": "https://example.com/report.pdf" }
+                        ]
+                    }]
+                }),
+                8192,
+            )
+            .unwrap();
+        assert_eq!(body["messages"][0]["content"][1]["type"], "document");
+
+        let count = replace_images_for_text_only_model(&mut body, &provider, true);
+
+        assert_eq!(count, 1);
+        assert_eq!(body["messages"][0]["content"][1]["type"], "text");
+        assert_eq!(
+            body["messages"][0]["content"][1]["text"],
+            UNSUPPORTED_MEDIA_MARKER
         );
     }
 
@@ -788,6 +867,19 @@ mod tests {
     }
 
     #[test]
+    fn content_type_error_with_image_allowed_is_not_text_only() {
+        let error = ProxyError::UpstreamError {
+            status: 400,
+            body: Some(
+                r#"{"error":{"message":"messages.content.type 参数非法，取值范围 ['text','image_url']"}}"#
+                    .to_string(),
+            ),
+        };
+
+        assert!(!is_unsupported_image_error(&error));
+    }
+
+    #[test]
     fn longcat_models_are_classified_text_only() {
         // LongCat-2.0 (like the retired Flash Chat) is a text-only model; the
         // preset ships it in mixed case, so the classifier must normalize first.
@@ -809,16 +901,18 @@ mod tests {
                 "role": "user",
                 "content": [
                     { "type": "text", "text": "look" },
-                    { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": "abc" } }
+                    { "type": "image", "source": { "type": "base64", "media_type": "image/png", "data": "abc" } },
+                    { "type": "input_audio", "input_audio": { "data": "YQ==", "format": "wav" } }
                 ]
             }]
         });
 
         let count = replace_images_for_text_only_model(&mut body, &provider, true);
 
-        assert_eq!(count, 1);
+        assert_eq!(count, 2);
         assert_eq!(body["messages"][0]["content"][0]["text"], "look");
         assert_eq!(body["messages"][0]["content"][1]["type"], "text");
+        assert_eq!(body["messages"][0]["content"][2]["type"], "text");
         assert_eq!(
             body["messages"][0]["content"][1]["text"],
             UNSUPPORTED_IMAGE_MARKER


### PR DESCRIPTION
## Problem

GLM-5.2 and other text-only endpoints reject user/assistant content parts whose type is not text. The existing sanitizer handled images, but file, audio, and document blocks could still reach the upstream and fail with error 1214. The reactive image detector also did not recognize GLM's field-validation message. (#6151)

## Fix

- Keep image capability handling unchanged.
- Independently clean file/audio/document blocks only when full modality metadata declares text-only input, or when heuristics are enabled and the model is in the confirmed text-only registry.
- Treat `supportsImage` as image-only evidence. It does not authorize deleting file or audio input, and it prevents registry fallback from overriding that narrower declaration.
- Limit the new cleanup to user/assistant content. System, developer, tool, unknown, and missing roles are preserved.
- Emit valid replacement types for Chat, Responses user/assistant, and Anthropic content.
- Match GLM's Chinese text-only validation signature as a pair, so ranges that also allow images do not trigger it.

Tool outputs, the image-scoped reactive retry, and the Gemini path are unchanged.

## Scope

Three backend files: the shared model-capability reader, the media sanitizer, and a log-only wording update at the sanitizer's caller. No UI, provider switching, routing, or protocol-conversion behavior is changed.

## Verification

- `cargo fmt --check`
- `cargo clippy --lib -- -D warnings`
- `cargo test --lib proxy::media_sanitizer::tests`: 46 passed
- `cargo test --lib model_capabilities::tests`: 5 passed

Closes #6151
