### PR TITLE
fix(providers): don't report success when re-adding an already-seeded official provider

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -244,6 +244,7 @@
   },
   "notifications": {
     "providerAdded": "Provider added",
+    "officialProviderExists": "This official provider already exists — no need to add it again",
     "providerSaved": "Provider configuration saved",
     "providerDeleted": "Provider deleted successfully",
     "switchSuccess": "Switch successful!",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -244,6 +244,7 @@
   },
   "notifications": {
     "providerAdded": "プロバイダーを追加しました",
+    "officialProviderExists": "この公式プロバイダーは既に存在します。再度追加する必要はありません",
     "providerSaved": "プロバイダー設定を保存しました",
     "providerDeleted": "プロバイダーを削除しました",
     "switchSuccess": "切り替え成功！",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -244,6 +244,7 @@
   },
   "notifications": {
     "providerAdded": "供應商已新增",
+    "officialProviderExists": "該官方供應商已存在，無需重複新增",
     "providerSaved": "供應商設定已儲存",
     "providerDeleted": "供應商刪除成功",
     "switchSuccess": "切換成功！",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -244,6 +244,7 @@
   },
   "notifications": {
     "providerAdded": "供应商已添加",
+    "officialProviderExists": "该官方供应商已存在，无需重复添加",
     "providerSaved": "供应商配置已保存",
     "providerDeleted": "供应商删除成功",
     "switchSuccess": "切换成功！",

--- a/src/lib/query/mutations.ts
+++ b/src/lib/query/mutations.ts
@@ -39,23 +39,26 @@ export const useAddProviderMutation = (appId: AppId) => {
       } = providerInput;
 
       if (appId === "claude-desktop" && ensureClaudeDesktopOfficialSeed) {
-        await providersApi.ensureClaudeDesktopOfficialProvider();
+        // ensure* returns true only when a new seed row was inserted;
+        // false means the official provider already existed (a no-op).
+        const inserted =
+          await providersApi.ensureClaudeDesktopOfficialProvider();
         const providers = await providersApi.getAll(appId);
         const officialProvider = providers["claude-desktop-official"];
         if (!officialProvider) {
           throw new Error("Claude Desktop official provider was not created");
         }
-        return officialProvider;
+        return { provider: officialProvider, alreadyExisted: !inserted };
       }
 
       if (appId === "grokbuild" && ensureGrokBuildOfficialSeed) {
-        await providersApi.ensureGrokBuildOfficialProvider();
+        const inserted = await providersApi.ensureGrokBuildOfficialProvider();
         const providers = await providersApi.getAll(appId);
         const officialProvider = providers[GROKBUILD_OFFICIAL_PROVIDER_ID];
         if (!officialProvider) {
           throw new Error("Grok Build official provider was not created");
         }
-        return officialProvider;
+        return { provider: officialProvider, alreadyExisted: !inserted };
       }
 
       let id: string;
@@ -90,9 +93,9 @@ export const useAddProviderMutation = (appId: AppId) => {
       delete (newProvider as any).providerKey;
 
       await providersApi.add(newProvider, appId, addToLive);
-      return newProvider;
+      return { provider: newProvider, alreadyExisted: false };
     },
-    onSuccess: async () => {
+    onSuccess: async (result) => {
       await queryClient.invalidateQueries({ queryKey: ["providers", appId] });
 
       if (appId === "opencode") {
@@ -128,14 +131,29 @@ export const useAddProviderMutation = (appId: AppId) => {
         );
       }
 
-      toast.success(
-        t("notifications.providerAdded", {
-          defaultValue: "供应商已添加",
-        }),
-        {
-          closeButton: true,
-        },
-      );
+      // Official presets are seeded once per database, so "adding" an official
+      // provider (Claude Desktop / Grok Build) that already exists is a no-op.
+      // Don't claim it was added — otherwise the toast lies, the same class of
+      // bug reported for Codex in #6280.
+      if (result.alreadyExisted) {
+        toast.info(
+          t("notifications.officialProviderExists", {
+            defaultValue: "该官方供应商已存在，无需重复添加",
+          }),
+          {
+            closeButton: true,
+          },
+        );
+      } else {
+        toast.success(
+          t("notifications.providerAdded", {
+            defaultValue: "供应商已添加",
+          }),
+          {
+            closeButton: true,
+          },
+        );
+      }
     },
     onError: (error: Error) => {
       const rawDetail = extractErrorMessage(error);

--- a/tests/hooks/useAddProviderMutation.test.tsx
+++ b/tests/hooks/useAddProviderMutation.test.tsx
@@ -3,11 +3,13 @@ import { act, renderHook } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAddProviderMutation } from "@/lib/query/mutations";
+import { GROKBUILD_OFFICIAL_PROVIDER_ID } from "@/utils/providerCapabilities";
 import type { Provider } from "@/types";
 
 const apiMocks = vi.hoisted(() => ({
   add: vi.fn(),
   ensureClaudeDesktopOfficialProvider: vi.fn(),
+  ensureGrokBuildOfficialProvider: vi.fn(),
   getAll: vi.fn(),
   updateTrayMenu: vi.fn(),
 }));
@@ -20,6 +22,7 @@ const toastMocks = vi.hoisted(() => ({
   success: vi.fn(),
   error: vi.fn(),
   warning: vi.fn(),
+  info: vi.fn(),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -27,6 +30,8 @@ vi.mock("@/lib/api", () => ({
     add: (...args: unknown[]) => apiMocks.add(...args),
     ensureClaudeDesktopOfficialProvider: (...args: unknown[]) =>
       apiMocks.ensureClaudeDesktopOfficialProvider(...args),
+    ensureGrokBuildOfficialProvider: (...args: unknown[]) =>
+      apiMocks.ensureGrokBuildOfficialProvider(...args),
     getAll: (...args: unknown[]) => apiMocks.getAll(...args),
     updateTrayMenu: (...args: unknown[]) => apiMocks.updateTrayMenu(...args),
   },
@@ -62,12 +67,14 @@ beforeEach(() => {
   apiMocks.ensureClaudeDesktopOfficialProvider
     .mockReset()
     .mockResolvedValue(true);
+  apiMocks.ensureGrokBuildOfficialProvider.mockReset().mockResolvedValue(true);
   apiMocks.getAll.mockReset().mockResolvedValue({});
   apiMocks.updateTrayMenu.mockReset().mockResolvedValue(true);
   uuidMocks.generateUUID.mockReset().mockReturnValue("generated-uuid");
   toastMocks.success.mockReset();
   toastMocks.error.mockReset();
   toastMocks.warning.mockReset();
+  toastMocks.info.mockReset();
 });
 
 describe("useAddProviderMutation", () => {
@@ -78,7 +85,7 @@ describe("useAddProviderMutation", () => {
       { wrapper },
     );
 
-    const duplicatedProvider = await act(async () =>
+    const added = await act(async () =>
       result.current.mutateAsync({
         name: "Claude Desktop Official copy",
         settingsConfig: { env: {} },
@@ -97,8 +104,11 @@ describe("useAddProviderMutation", () => {
       "claude-desktop",
       undefined,
     );
-    expect(duplicatedProvider.id).toBe("generated-uuid");
-    expect(duplicatedProvider.id).not.toBe("claude-desktop-official");
+    expect(added.provider.id).toBe("generated-uuid");
+    expect(added.provider.id).not.toBe("claude-desktop-official");
+    expect(added.alreadyExisted).toBe(false);
+    expect(toastMocks.success).toHaveBeenCalledTimes(1);
+    expect(toastMocks.info).not.toHaveBeenCalled();
   });
 
   it("returns the persisted seed row for the Claude Desktop official preset", async () => {
@@ -121,7 +131,7 @@ describe("useAddProviderMutation", () => {
       { wrapper },
     );
 
-    const persistedProvider = await act(async () =>
+    const added = await act(async () =>
       result.current.mutateAsync({
         name: "Renamed by form",
         settingsConfig: { env: { ignored: true } },
@@ -137,7 +147,78 @@ describe("useAddProviderMutation", () => {
     );
     expect(apiMocks.getAll).toHaveBeenCalledWith("claude-desktop");
     expect(apiMocks.add).not.toHaveBeenCalled();
-    expect(persistedProvider).toEqual(seedProvider);
+    expect(added.provider).toEqual(seedProvider);
+    expect(added.alreadyExisted).toBe(false);
+    expect(toastMocks.success).toHaveBeenCalledTimes(1);
+    expect(toastMocks.info).not.toHaveBeenCalled();
+  });
+
+  it("reports the existing Claude Desktop official provider instead of a false 'added'", async () => {
+    // The official provider is seeded once per database, so ensure* returns
+    // false (no new row inserted). Adding it again must NOT claim success.
+    apiMocks.ensureClaudeDesktopOfficialProvider.mockResolvedValueOnce(false);
+    const seedProvider: Provider = {
+      id: "claude-desktop-official",
+      name: "Claude Desktop Official",
+      settingsConfig: { env: {} },
+      category: "official",
+    };
+    apiMocks.getAll.mockResolvedValueOnce({
+      "claude-desktop-official": seedProvider,
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useAddProviderMutation("claude-desktop"),
+      { wrapper },
+    );
+
+    const added = await act(async () =>
+      result.current.mutateAsync({
+        name: "Claude Desktop Official",
+        settingsConfig: { env: {} },
+        category: "official",
+        ensureClaudeDesktopOfficialSeed: true,
+      }),
+    );
+
+    expect(apiMocks.add).not.toHaveBeenCalled();
+    expect(added.provider).toEqual(seedProvider);
+    expect(added.alreadyExisted).toBe(true);
+    expect(toastMocks.success).not.toHaveBeenCalled();
+    expect(toastMocks.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports the existing Grok Build official provider instead of a false 'added'", async () => {
+    apiMocks.ensureGrokBuildOfficialProvider.mockResolvedValueOnce(false);
+    const seedProvider: Provider = {
+      id: GROKBUILD_OFFICIAL_PROVIDER_ID,
+      name: "Grok Build Official",
+      settingsConfig: {},
+      category: "official",
+    };
+    apiMocks.getAll.mockResolvedValueOnce({
+      [GROKBUILD_OFFICIAL_PROVIDER_ID]: seedProvider,
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddProviderMutation("grokbuild"), {
+      wrapper,
+    });
+
+    const added = await act(async () =>
+      result.current.mutateAsync({
+        name: "Grok Build Official",
+        settingsConfig: {},
+        category: "official",
+        ensureGrokBuildOfficialSeed: true,
+      }),
+    );
+
+    expect(apiMocks.ensureGrokBuildOfficialProvider).toHaveBeenCalledTimes(1);
+    expect(apiMocks.add).not.toHaveBeenCalled();
+    expect(added.provider).toEqual(seedProvider);
+    expect(added.alreadyExisted).toBe(true);
+    expect(toastMocks.success).not.toHaveBeenCalled();
+    expect(toastMocks.info).toHaveBeenCalledTimes(1);
   });
 
   it("adds a managed Codex account as a separate official card", async () => {
@@ -146,7 +227,7 @@ describe("useAddProviderMutation", () => {
       wrapper,
     });
 
-    const persistedProvider = await act(async () =>
+    const added = await act(async () =>
       result.current.mutateAsync({
         name: "OpenAI Official",
         settingsConfig: { auth: {}, config: "" },
@@ -179,7 +260,7 @@ describe("useAddProviderMutation", () => {
       "codex",
       undefined,
     );
-    expect(persistedProvider).toEqual(
+    expect(added.provider).toEqual(
       expect.objectContaining({
         id: "generated-uuid",
         meta: expect.objectContaining({
@@ -189,6 +270,7 @@ describe("useAddProviderMutation", () => {
         }),
       }),
     );
+    expect(added.alreadyExisted).toBe(false);
   });
 
   it("adds every unbound Codex Official as an independent provider", async () => {
@@ -201,7 +283,7 @@ describe("useAddProviderMutation", () => {
       wrapper,
     });
 
-    const firstProvider = await act(async () =>
+    const first = await act(async () =>
       result.current.mutateAsync({
         name: "OpenAI Official 1",
         settingsConfig: { auth: {}, config: "" },
@@ -209,7 +291,7 @@ describe("useAddProviderMutation", () => {
         meta: { providerType: "codex_oauth" },
       }),
     );
-    const secondProvider = await act(async () =>
+    const second = await act(async () =>
       result.current.mutateAsync({
         name: "OpenAI Official 2",
         settingsConfig: { auth: {}, config: "" },
@@ -237,8 +319,8 @@ describe("useAddProviderMutation", () => {
       "codex",
       undefined,
     );
-    expect(firstProvider.id).toBe("unbound-official-1");
-    expect(secondProvider.id).toBe("unbound-official-2");
+    expect(first.provider.id).toBe("unbound-official-1");
+    expect(second.provider.id).toBe("unbound-official-2");
   });
 
   it("adds a Pi provider without a separate default-model command", async () => {
@@ -247,7 +329,7 @@ describe("useAddProviderMutation", () => {
       wrapper,
     });
 
-    const provider = await act(async () =>
+    const added = await act(async () =>
       result.current.mutateAsync({
         name: "Pi Provider",
         providerKey: "pi-provider",
@@ -265,7 +347,7 @@ describe("useAddProviderMutation", () => {
       "pi",
       undefined,
     );
-    expect(provider.id).toBe("pi-provider");
+    expect(added.provider.id).toBe("pi-provider");
   });
 
   it("reports a Pi provider add failure", async () => {


### PR DESCRIPTION
## Summary

Adding an already-seeded **official** provider (Claude Desktop / Grok Build) shows a "Provider added" toast even though nothing is actually added.

> Note: this PR originally targeted the Codex case (#6280). While it was open, the **Codex official-routing rework landed on main** and gave Codex its own independent-provider add flow, which resolves #6280. This PR is now rebased on that work and scoped to the **same class of bug that still remains** for the two official apps that keep the seed-once flow.

## Root cause

Claude Desktop and Grok Build official providers are seeded **once per database**. Their add path in `useAddProviderMutation` calls `ensure*OfficialProvider`, whose command already returns a boolean:

- `true`  → a new seed row was inserted
- `false` → the official provider already existed (**no-op**)

The mutation **discarded** that boolean and its `onSuccess` unconditionally fired the `providerAdded` success toast. So on any normally-initialized install, re-adding one of these official providers is a no-op that still reports success.

## Fix

- Thread the inserted / already-existed flag through the mutation result (`{ provider, alreadyExisted }`) for both official-seed branches.
- On a no-op, show an informative notice (`officialProviderExists`, added to all four locales) instead of a misleading success toast.
- No backend change — the boolean was already returned; the frontend was ignoring it.

## Scope

Frontend-only:

- `src/lib/query/mutations.ts`
- `src/i18n/locales/{en,zh,ja,zh-TW}.json`
- `tests/hooks/useAddProviderMutation.test.tsx` (adapted to the new result shape + regression tests for both Claude Desktop and Grok Build no-op)

## Verification

- `pnpm typecheck` ✓
- `pnpm format:check` ✓
- `pnpm test:unit` ✓ (989 tests, incl. 2 new regression tests asserting no false "added" toast when `ensure*OfficialProvider` returns `false`)