### PR TITLE
fix(codex): prevent reasoning leak and duplication in Chat→Responses streaming

### DIFF
--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -234,6 +234,72 @@ pub(crate) fn strip_leading_think_open_tag(text: &str) -> Option<String> {
         .map(|value| value.trim().to_string())
 }
 
+/// Strip all complete `thinking…think` blocks **and** stray tag fragments
+/// from arbitrary text (not just a leading block).
+///
+/// This is used in `InlineThinkMode::Text` to prevent reasoning tags that
+/// arrive after the state machine has already committed to Text mode from
+/// leaking into `output_text.delta`.
+///
+/// It also strips a trailing partial close-tag fragment (e.g. `</t` from a
+/// `think` tag that was split across two SSE chunks) so that the fragment
+/// does not appear verbatim in the visible output.
+pub(crate) fn strip_all_think_tags(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut remaining = text;
+
+    loop {
+        match remaining.find(THINK_OPEN_TAG) {
+            Some(open_start) => {
+                // Emit text before the open tag.
+                result.push_str(&remaining[..open_start]);
+
+                let after_open = &remaining[open_start + THINK_OPEN_TAG.len()..];
+                match after_open.find(THINK_CLOSE_TAG) {
+                    Some(close_pos) => {
+                        // Complete block — skip the reasoning inside.
+                        remaining = &after_open[close_pos + THINK_CLOSE_TAG.len()..];
+                    }
+                    None => {
+                        // Open tag without a close — treat the rest as
+                        // reasoning and discard it.
+                        remaining = "";
+                    }
+                }
+            }
+            None => {
+                // No more open tags.  Strip a trailing partial close-tag
+                // fragment so it doesn't leak (e.g. `</t`, `</th`, …).
+                result.push_str(strip_trailing_close_tag_fragment(remaining));
+                break;
+            }
+        }
+    }
+
+    result
+}
+
+/// If `text` ends with a prefix of `THINK_CLOSE_TAG` (e.g. `<`, `</`, `</t`, …),
+/// return `text` without that fragment so it doesn't leak into output_text.
+fn strip_trailing_close_tag_fragment(text: &str) -> &str {
+    // THINK_CLOSE_TAG is pure ASCII (`think`), so any valid fragment
+    // prefix is also ASCII.  We must only cut at char boundaries to
+    // avoid slicing inside a multi-byte UTF-8 sequence.
+    let max_cut = THINK_CLOSE_TAG.len().min(text.len());
+
+    for cut in (1..=max_cut).rev() {
+        let split_point = text.len() - cut;
+        if !text.is_char_boundary(split_point) {
+            continue;
+        }
+        let suffix = &text[split_point..];
+        if THINK_CLOSE_TAG.starts_with(suffix) {
+            return &text[..split_point];
+        }
+    }
+    text
+}
+
 fn strip_think_answer_separator(text: &str) -> &str {
     text.trim_start_matches(['\r', '\n', '\t', ' '])
 }

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -3,7 +3,8 @@
 use super::codex_responses_sse as sse;
 use super::{
     codex_chat_common::{
-        extract_reasoning_field_text, split_leading_think_block, strip_leading_think_open_tag,
+        extract_reasoning_field_text, split_leading_think_block, strip_all_think_tags,
+        strip_leading_think_open_tag,
     },
     transform_codex_chat::{
         chat_usage_to_responses_usage, custom_tool_input_from_chat_arguments,
@@ -142,14 +143,36 @@ impl ChatToResponsesState {
         };
 
         if let Some(delta) = choice.get("delta") {
-            if let Some(reasoning) = chat_delta_reasoning_text(delta) {
-                events.extend(self.push_reasoning_delta(&reasoning));
-                self.append_reasoning_to_active_tools(&reasoning);
+            let reasoning_extracted = chat_delta_reasoning_text(delta);
+
+            if let Some(reasoning) = &reasoning_extracted {
+                events.extend(self.push_reasoning_delta(reasoning));
+                self.append_reasoning_to_active_tools(reasoning);
             }
 
             if let Some(content) = delta.get("content").and_then(|v| v.as_str()) {
                 if !content.is_empty() {
-                    events.extend(self.push_content_delta(content));
+                    // When reasoning_content was extracted from this delta,
+                    // the content field may mirror the reasoning (some providers
+                    // send both).  Strip think tags and skip if it duplicates
+                    // the reasoning text to prevent output_text duplication.
+                    let content = if let Some(ref reasoning) = reasoning_extracted {
+                        let stripped = strip_all_think_tags(content);
+                        let stripped_trimmed = stripped.trim();
+                        if stripped_trimmed.is_empty()
+                            || reasoning.contains(stripped_trimmed)
+                            || stripped_trimmed.contains(reasoning.trim())
+                        {
+                            String::new()
+                        } else {
+                            stripped
+                        }
+                    } else {
+                        content.to_string()
+                    };
+                    if !content.is_empty() {
+                        events.extend(self.push_content_delta(&content));
+                    }
                 }
             }
 
@@ -176,7 +199,14 @@ impl ChatToResponsesState {
         match self.inline_think.mode {
             InlineThinkMode::Text => {
                 let mut events = self.finalize_reasoning();
-                events.extend(self.push_text_delta(delta));
+                // Strip any stray think tags that arrive after the state
+                // machine has committed to Text mode, preventing
+                // `thinking`/`think` fragments from leaking into
+                // output_text.delta.
+                let cleaned = strip_all_think_tags(delta);
+                if !cleaned.is_empty() {
+                    events.extend(self.push_text_delta(&cleaned));
+                }
                 events
             }
             InlineThinkMode::Detecting => {
@@ -1253,4 +1283,50 @@ mod tests {
         assert!(output.contains("rate_limit_exceeded"));
         assert!(!output.contains("event: response.completed"));
     }
+    #[tokio::test]
+    async fn dedup_content_when_reasoning_content_mirrors_in_same_delta() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_dup\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"reasoning_content\":\"让我分析。\",\"content\":\"让我分析。\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_dup\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"答案是42。\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        let delta_lines: Vec<&str> = output
+            .lines()
+            .filter(|l| l.contains("response.output_text.delta"))
+            .collect();
+        for delta_line in &delta_lines {
+            assert!(
+                !delta_line.contains("让我分析"),
+                "reasoning text leaked into output_text: {delta_line}"
+            );
+        }
+        assert!(output.contains("答案是42"));
+    }
+
+    #[tokio::test]
+    async fn strips_leaked_close_tag_in_text_mode() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_leak\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"答案\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_leak\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"</think>\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_leak\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"完整。\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        let delta_lines: Vec<&str> = output
+            .lines()
+            .filter(|l| l.contains("response.output_text.delta"))
+            .collect();
+        for delta_line in &delta_lines {
+            assert!(
+                !delta_line.contains("think"),
+                "close tag leaked into output_text: {delta_line}"
+            );
+        }
+        assert!(output.contains("答案"));
+        assert!(output.contains("完整"));
+    }
+
 }


### PR DESCRIPTION
## Summary

Fixes #6303

When a Chat Completions provider (e.g. GLM-5.2) sends `reasoning_content` and `content` in the same SSE delta, the streaming converter emitted both as `reasoning_summary_text.delta` AND `output_text.delta`, causing the reasoning text to appear duplicated in the visible Codex output.

Additionally, once the inline-think state machine committed to `Text` mode, stray `thinking`/`think` tag fragments — including partial close tags like `</t` split across SSE chunks — leaked directly into `output_text.delta`.

## Changes

**`codex_chat_common.rs`** — new helpers:
- `strip_all_think_tags`: strips all complete `thinking…think` blocks and trailing partial close-tag fragments from arbitrary text
- `strip_trailing_close_tag_fragment`: strips a trailing prefix of `THINK_CLOSE_TAG` (UTF-8 char-boundary safe)

**`streaming_codex_chat.rs`** — two fixes:
- `handle_chat_chunk`: when `reasoning_content` is extracted from a delta, strip think tags from the `content` field and skip it if it duplicates the reasoning text
- `push_content_delta` Text mode: strip all think tags before emitting `output_text.delta`

## Test plan

- `dedup_content_when_reasoning_content_mirrors_in_same_delta`: verifies reasoning text does not appear in output_text when both fields carry it
- `strips_leaked_close_tag_in_text_mode`: verifies close tags do not leak into output_text
- All 19 existing tests still pass (21/21 total)