### PR TITLE
fix(proxy): normalize Claude Code >=2.1.154 system messages for InternLM compatibility

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1457,6 +1457,52 @@ impl RequestForwarder {
         // suffix and add the context-1m beta header.
         let mut codex_anthropic_one_m = false;
 
+        // Claude Code >= 2.1.154 ("Lean system prompt") may send the system prompt
+        // as `role: "system"` messages inside `messages` instead of the top-level
+        // `system` field. Normalize to the top-level field so all transform paths
+        // and passthrough upstream providers handle it correctly.
+        let mapped_body = if self.rectifier_config.enabled && self.rectifier_config.normalize_system_messages {
+            let before = mapped_body.clone();
+            let normalized = super::providers::transform::normalize_system_messages(mapped_body);
+
+            // Log if normalization actually happened
+            if before != normalized {
+                let system_count = before
+                    .get("messages")
+                    .and_then(|m| m.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("system"))
+                            .count()
+                    })
+                    .unwrap_or(0);
+
+                let system_type = match normalized.get("system") {
+                    Some(serde_json::Value::String(_)) => "string",
+                    Some(serde_json::Value::Array(_)) => "array",
+                    _ => "none",
+                };
+
+                log::info!(
+                    "[Rectifier] System messages normalized: moved {} system message(s) from messages array to top-level system field (system type: {})",
+                    system_count,
+                    system_type
+                );
+
+                // DEBUG: Log the actual system field structure
+                if let Some(system) = normalized.get("system") {
+                    log::debug!(
+                        "[Rectifier] Normalized system field: {}",
+                        serde_json::to_string_pretty(system).unwrap_or_else(|_| format!("{:?}", system))
+                    );
+                }
+            }
+
+            normalized
+        } else {
+            mapped_body
+        };
+
         // 转换请求体（如果需要）
         let mut request_body = if codex_responses_to_chat {
             let mut mapped_body = mapped_body;

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1501,11 +1501,18 @@ impl RequestForwarder {
                     system_type
                 );
 
-                // DEBUG: Log the actual system field structure
+                // Log a content fingerprint (not the prompt itself) so troubleshooting
+                // can correlate runs without persisting workspace instructions, paths,
+                // or credentials that the system prompt may contain.
                 if let Some(system) = normalized.get("system") {
+                    use std::collections::hash_map::DefaultHasher;
+                    use std::hash::{Hash, Hasher};
+                    let mut hasher = DefaultHasher::new();
+                    system.to_string().hash(&mut hasher);
                     log::debug!(
-                        "[Rectifier] Normalized system field: {}",
-                        serde_json::to_string_pretty(system).unwrap_or_else(|_| format!("{:?}", system))
+                        "[Rectifier] Normalized system field fingerprint: {:016x} (type: {})",
+                        hasher.finish(),
+                        system_type
                     );
                 }
             }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1462,8 +1462,20 @@ impl RequestForwarder {
         // `system` field. Normalize to the top-level field so all transform paths
         // and passthrough upstream providers handle it correctly.
         let mapped_body = if self.rectifier_config.enabled && self.rectifier_config.normalize_system_messages {
-            let before = mapped_body.clone();
-            let normalized = super::providers::transform::normalize_system_messages(mapped_body);
+            // Cheap pre-scan: only clone + normalize when there are actually
+            // role:system messages to move. Request bodies can be large, so avoid
+            // cloning the whole thing on the common (no system-role) path.
+            let has_system_in_messages = mapped_body
+                .get("messages")
+                .and_then(|m| m.as_array())
+                .is_some_and(|msgs| {
+                    msgs.iter()
+                        .any(|m| m.get("role").and_then(|r| r.as_str()) == Some("system"))
+                });
+
+            if has_system_in_messages {
+                let before = mapped_body.clone();
+                let normalized = super::providers::transform::normalize_system_messages(mapped_body);
 
             // Log if normalization actually happened
             if before != normalized {
@@ -1498,7 +1510,10 @@ impl RequestForwarder {
                 }
             }
 
-            normalized
+                normalized
+            } else {
+                mapped_body
+            }
         } else {
             mapped_body
         };

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1461,7 +1461,9 @@ impl RequestForwarder {
         // as `role: "system"` messages inside `messages` instead of the top-level
         // `system` field. Normalize to the top-level field so all transform paths
         // and passthrough upstream providers handle it correctly.
-        let mapped_body = if self.rectifier_config.enabled && self.rectifier_config.normalize_system_messages {
+        let mapped_body = if self.rectifier_config.enabled
+            && self.rectifier_config.normalize_system_messages
+        {
             // Cheap pre-scan: only clone + normalize when there are actually
             // role:system messages to move. Request bodies can be large, so avoid
             // cloning the whole thing on the common (no system-role) path.
@@ -1475,47 +1477,50 @@ impl RequestForwarder {
 
             if has_system_in_messages {
                 let before = mapped_body.clone();
-                let normalized = super::providers::transform::normalize_system_messages(mapped_body);
+                let normalized =
+                    super::providers::transform::normalize_system_messages(mapped_body);
 
-            // Log if normalization actually happened
-            if before != normalized {
-                let system_count = before
-                    .get("messages")
-                    .and_then(|m| m.as_array())
-                    .map(|arr| {
-                        arr.iter()
-                            .filter(|msg| msg.get("role").and_then(|r| r.as_str()) == Some("system"))
-                            .count()
-                    })
-                    .unwrap_or(0);
+                // Log if normalization actually happened
+                if before != normalized {
+                    let system_count = before
+                        .get("messages")
+                        .and_then(|m| m.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter(|msg| {
+                                    msg.get("role").and_then(|r| r.as_str()) == Some("system")
+                                })
+                                .count()
+                        })
+                        .unwrap_or(0);
 
-                let system_type = match normalized.get("system") {
-                    Some(serde_json::Value::String(_)) => "string",
-                    Some(serde_json::Value::Array(_)) => "array",
-                    _ => "none",
-                };
+                    let system_type = match normalized.get("system") {
+                        Some(serde_json::Value::String(_)) => "string",
+                        Some(serde_json::Value::Array(_)) => "array",
+                        _ => "none",
+                    };
 
-                log::info!(
+                    log::info!(
                     "[Rectifier] System messages normalized: moved {} system message(s) from messages array to top-level system field (system type: {})",
                     system_count,
                     system_type
                 );
 
-                // Log a content fingerprint (not the prompt itself) so troubleshooting
-                // can correlate runs without persisting workspace instructions, paths,
-                // or credentials that the system prompt may contain.
-                if let Some(system) = normalized.get("system") {
-                    use std::collections::hash_map::DefaultHasher;
-                    use std::hash::{Hash, Hasher};
-                    let mut hasher = DefaultHasher::new();
-                    system.to_string().hash(&mut hasher);
-                    log::debug!(
-                        "[Rectifier] Normalized system field fingerprint: {:016x} (type: {})",
-                        hasher.finish(),
-                        system_type
-                    );
+                    // Log a content fingerprint (not the prompt itself) so troubleshooting
+                    // can correlate runs without persisting workspace instructions, paths,
+                    // or credentials that the system prompt may contain.
+                    if let Some(system) = normalized.get("system") {
+                        use std::collections::hash_map::DefaultHasher;
+                        use std::hash::{Hash, Hasher};
+                        let mut hasher = DefaultHasher::new();
+                        system.to_string().hash(&mut hasher);
+                        log::debug!(
+                            "[Rectifier] Normalized system field fingerprint: {:016x} (type: {})",
+                            hasher.finish(),
+                            system_type
+                        );
+                    }
                 }
-            }
 
                 normalized
             } else {

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -562,12 +562,7 @@ pub fn normalize_system_messages(mut body: Value) -> Value {
                             if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
                                 let text = strip_leading_anthropic_billing_header(text);
                                 if !text.is_empty() {
-                                    let mut part = json!({"text": text});
-                                    // Preserve cache_control for proxy cache compatibility
-                                    if let Some(cc) = block.get("cache_control") {
-                                        part["cache_control"] = cc.clone();
-                                    }
-                                    extracted_parts.push(part);
+                                    extracted_parts.push(json!({"text": text}));
                                 }
                             }
                         }

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -528,13 +528,13 @@ fn convert_message_to_openai(
 /// The function is a no-op when no `role: "system"` messages are present.
 pub fn normalize_system_messages(mut body: Value) -> Value {
     // Quick check: are there any system messages in the array?
-    let has_system_in_messages = body
-        .get("messages")
-        .and_then(|m| m.as_array())
-        .is_some_and(|msgs| {
-            msgs.iter()
-                .any(|m| m.get("role").and_then(|r| r.as_str()) == Some("system"))
-        });
+    let has_system_in_messages =
+        body.get("messages")
+            .and_then(|m| m.as_array())
+            .is_some_and(|msgs| {
+                msgs.iter()
+                    .any(|m| m.get("role").and_then(|r| r.as_str()) == Some("system"))
+            });
 
     if !has_system_in_messages {
         return body;
@@ -587,10 +587,8 @@ pub fn normalize_system_messages(mut body: Value) -> Value {
 
     // Add existing system text
     match existing_system {
-        Some(Value::String(text)) => {
-            if !text.is_empty() {
-                all_texts.push(text);
-            }
+        Some(Value::String(text)) if !text.is_empty() => {
+            all_texts.push(text);
         }
         Some(Value::Array(arr)) => {
             for part in arr {

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -514,6 +514,118 @@ fn convert_message_to_openai(
     Ok(result)
 }
 
+/// Extract `role: "system"` messages from the `messages` array and promote them
+/// to the top-level `system` field.
+///
+/// Claude Code >= 2.1.154 ("Lean system prompt becomes default") may send the
+/// system prompt as `role: "system"` messages inside `messages` instead of the
+/// top-level `system` field. Most third-party providers — and the Anthropic API
+/// spec itself — do not support `role: "system"` in the messages array. This
+/// function extracts such messages and merges them into the standard top-level
+/// `system` field so that all downstream transform paths (anthropic passthrough,
+/// openai_chat, openai_responses, gemini_native) handle them correctly.
+///
+/// The function is a no-op when no `role: "system"` messages are present.
+pub fn normalize_system_messages(mut body: Value) -> Value {
+    // Quick check: are there any system messages in the array?
+    let has_system_in_messages = body
+        .get("messages")
+        .and_then(|m| m.as_array())
+        .is_some_and(|msgs| {
+            msgs.iter()
+                .any(|m| m.get("role").and_then(|r| r.as_str()) == Some("system"))
+        });
+
+    if !has_system_in_messages {
+        return body;
+    }
+
+    // Extract system message contents from the messages array
+    let mut extracted_parts: Vec<Value> = Vec::new();
+    if let Some(messages) = body.get_mut("messages").and_then(|m| m.as_array_mut()) {
+        messages.retain(|msg| {
+            if msg.get("role").and_then(|r| r.as_str()) != Some("system") {
+                return true;
+            }
+
+            // Extract content from this system message
+            if let Some(content) = msg.get("content") {
+                match content {
+                    Value::String(text) => {
+                        let text = strip_leading_anthropic_billing_header(text);
+                        if !text.is_empty() {
+                            extracted_parts.push(json!({"text": text}));
+                        }
+                    }
+                    Value::Array(blocks) => {
+                        for block in blocks {
+                            if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                                let text = strip_leading_anthropic_billing_header(text);
+                                if !text.is_empty() {
+                                    let mut part = json!({"text": text});
+                                    // Preserve cache_control for proxy cache compatibility
+                                    if let Some(cc) = block.get("cache_control") {
+                                        part["cache_control"] = cc.clone();
+                                    }
+                                    extracted_parts.push(part);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            false // remove from messages array
+        });
+    }
+
+    if extracted_parts.is_empty() {
+        return body;
+    }
+
+    // Merge extracted parts with existing top-level system
+    // Always produce a string format for maximum provider compatibility
+    let existing_system = body.get("system").cloned();
+
+    // Collect all text parts (existing + extracted)
+    let mut all_texts: Vec<String> = Vec::new();
+
+    // Add existing system text
+    match existing_system {
+        Some(Value::String(text)) => {
+            if !text.is_empty() {
+                all_texts.push(text);
+            }
+        }
+        Some(Value::Array(arr)) => {
+            for part in arr {
+                if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                    if !text.is_empty() {
+                        all_texts.push(text.to_string());
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+
+    // Add extracted text parts
+    for part in &extracted_parts {
+        if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+            if !text.is_empty() {
+                all_texts.push(text.to_string());
+            }
+        }
+    }
+
+    // Always use string format for maximum compatibility
+    if !all_texts.is_empty() {
+        body["system"] = json!(all_texts.join("\n\n"));
+    }
+
+    body
+}
+
 /// 清理工具参数的 JSON schema，并为根 schema 补齐 OpenAI 要求的 object 类型。
 pub fn clean_schema(schema: Value) -> Value {
     clean_schema_inner(schema, true)
@@ -1996,5 +2108,122 @@ mod tests {
             run_tool_choice(json!({"type": "tool", "name": "search"})),
             json!({"type": "function", "function": {"name": "search"}}),
         );
+    }
+
+    // --- normalize_system_messages tests ---
+
+    #[test]
+    fn normalize_system_messages_noop_when_no_system_in_messages() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "system": "You are helpful.",
+            "messages": [
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body.clone());
+        assert_eq!(result, body);
+    }
+
+    #[test]
+    fn normalize_system_messages_extracts_string_system_to_top_level() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        assert_eq!(result["system"], "You are a helpful assistant.");
+        assert_eq!(result["messages"].as_array().unwrap().len(), 1);
+        assert_eq!(result["messages"][0]["role"], "user");
+    }
+
+    #[test]
+    fn normalize_system_messages_extracts_array_system_to_top_level() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "messages": [
+                {"role": "system", "content": [
+                    {"type": "text", "text": "You are a helpful assistant."}
+                ]},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        // Single part without cache_control → promoted to string
+        assert_eq!(result["system"], "You are a helpful assistant.");
+        assert_eq!(result["messages"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn normalize_system_messages_merges_with_existing_string_system() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "system": "Existing system prompt.",
+            "messages": [
+                {"role": "system", "content": "Additional system prompt."},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        // Both should be joined as a string
+        assert_eq!(
+            result["system"],
+            "Existing system prompt.\n\nAdditional system prompt."
+        );
+        assert_eq!(result["messages"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn normalize_system_messages_extracts_cache_control_as_string() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "messages": [
+                {"role": "system", "content": [
+                    {"type": "text", "text": "Cached system prompt.", "cache_control": {"type": "ephemeral"}}
+                ]},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        // cache_control is dropped for maximum compatibility
+        assert_eq!(result["system"], "Cached system prompt.");
+    }
+
+    #[test]
+    fn normalize_system_messages_strips_billing_header() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "messages": [
+                {"role": "system", "content": "x-anthropic-billing-header: cc_version=2.1.154; cch=abc;\n\nYou are helpful."},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        assert_eq!(result["system"], "You are helpful.");
+    }
+
+    #[test]
+    fn normalize_system_messages_multiple_system_messages_merged() {
+        let body = json!({
+            "model": "claude-3-opus",
+            "messages": [
+                {"role": "system", "content": "Part 1."},
+                {"role": "system", "content": "Part 2."},
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+                {"role": "system", "content": "Part 3."}
+            ]
+        });
+        let result = normalize_system_messages(body);
+        // All parts joined as a string
+        assert_eq!(result["system"], "Part 1.\n\nPart 2.\n\nPart 3.");
+        // Only user and assistant messages remain
+        let messages = result["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[1]["role"], "assistant");
     }
 }

--- a/src-tauri/src/proxy/thinking_budget_rectifier.rs
+++ b/src-tauri/src/proxy/thinking_budget_rectifier.rs
@@ -148,6 +148,7 @@ mod tests {
             enabled: true,
             request_thinking_signature: true,
             request_thinking_budget: true,
+            normalize_system_messages: true,
             request_media_fallback: true,
             request_media_heuristic: true,
         }
@@ -158,6 +159,7 @@ mod tests {
             enabled: true,
             request_thinking_signature: true,
             request_thinking_budget: false,
+            normalize_system_messages: true,
             request_media_fallback: true,
             request_media_heuristic: true,
         }
@@ -168,6 +170,7 @@ mod tests {
             enabled: false,
             request_thinking_signature: true,
             request_thinking_budget: true,
+            normalize_system_messages: true,
             request_media_fallback: true,
             request_media_heuristic: true,
         }

--- a/src-tauri/src/proxy/thinking_rectifier.rs
+++ b/src-tauri/src/proxy/thinking_rectifier.rs
@@ -251,6 +251,7 @@ mod tests {
             enabled: true,
             request_thinking_signature: true,
             request_thinking_budget: true,
+            normalize_system_messages: true,
             request_media_fallback: true,
             request_media_heuristic: true,
         }
@@ -261,6 +262,7 @@ mod tests {
             enabled: true,
             request_thinking_signature: false,
             request_thinking_budget: false,
+            normalize_system_messages: true,
             request_media_fallback: true,
             request_media_heuristic: true,
         }
@@ -271,6 +273,7 @@ mod tests {
             enabled: false,
             request_thinking_signature: true,
             request_thinking_budget: true,
+            normalize_system_messages: true,
             request_media_fallback: true,
             request_media_heuristic: true,
         }

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -205,6 +205,13 @@ pub struct RectifierConfig {
     /// 处理错误：budget_tokens + thinking 相关约束
     #[serde(default = "default_true")]
     pub request_thinking_budget: bool,
+    /// 请求整流：启用 system 消息归一化（默认开启）
+    ///
+    /// Claude Code >= 2.1.154 ("Lean system prompt") 将 system prompt 作为
+    /// `role: "system"` 消息放在 messages 数组中。许多第三方 provider 不支持
+    /// 此格式，需要将其提升到 Anthropic API 标准的顶层 `system` 字段。
+    #[serde(default = "default_true")]
+    pub normalize_system_messages: bool,
     /// 请求整流：不支持的图片降级（默认开启）
     ///
     /// 上游拒绝图片输入时，把图片块替换为 [Unsupported Image] 标记，
@@ -234,6 +241,7 @@ impl Default for RectifierConfig {
             enabled: true,
             request_thinking_signature: true,
             request_thinking_budget: true,
+            normalize_system_messages: true,
             request_media_fallback: true,
             request_media_heuristic: true,
         }

--- a/src/components/settings/RectifierConfigPanel.tsx
+++ b/src/components/settings/RectifierConfigPanel.tsx
@@ -15,6 +15,7 @@ export function RectifierConfigPanel() {
     enabled: true,
     requestThinkingSignature: true,
     requestThinkingBudget: true,
+    normalizeSystemMessages: true,
     requestMediaFallback: true,
     requestMediaHeuristic: true,
   });
@@ -109,6 +110,25 @@ export function RectifierConfigPanel() {
             disabled={!config.enabled}
             onCheckedChange={(checked) =>
               handleChange({ requestThinkingBudget: checked })
+            }
+          />
+        </div>
+        <div className="flex items-center justify-between pl-4">
+          <div className="space-y-0.5">
+            <Label>
+              {t("settings.advanced.rectifier.normalizeSystemMessages")}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {t(
+                "settings.advanced.rectifier.normalizeSystemMessagesDescription",
+              )}
+            </p>
+          </div>
+          <Switch
+            checked={config.normalizeSystemMessages}
+            disabled={!config.enabled}
+            onCheckedChange={(checked) =>
+              handleChange({ normalizeSystemMessages: checked })
             }
           />
         </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -406,6 +406,8 @@
         "thinkingSignatureDescription": "When an Anthropic-type provider returns thinking signature incompatibility or illegal request errors, automatically removes incompatible thinking-related blocks and retries once with the same provider",
         "thinkingBudget": "Thinking Budget Rectification",
         "thinkingBudgetDescription": "When an Anthropic-type provider returns budget_tokens constraint errors (such as at least 1024), automatically normalizes thinking to enabled, sets thinking budget to 32000, and raises max_tokens to 64000 if needed, then retries once",
+        "normalizeSystemMessages": "System Message Normalization",
+        "normalizeSystemMessagesDescription": "Promote Claude Code >= 2.1.154 role:system messages to the top-level system field for third-party providers that reject this format",
         "mediaFallback": "Unsupported Image Fallback",
         "mediaFallbackDescription": "When a provider does not support image input (it declares text-only capability, or the upstream returns an unsupported-image error), automatically replaces image blocks with an [Unsupported Image] marker so the conversation is not interrupted",
         "mediaHeuristic": "Text-Only Model Preflight",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -406,6 +406,8 @@
         "thinkingSignatureDescription": "Anthropic タイプのプロバイダーが thinking 署名の非互換性や不正なリクエストエラーを返した場合、互換性のない thinking 関連ブロックを自動削除し、同じプロバイダーで 1 回リトライします",
         "thinkingBudget": "Thinking Budget 整流",
         "thinkingBudgetDescription": "Anthropic タイプのプロバイダーが budget_tokens 制約エラー（例: 1024 以上）を返した場合、thinking を enabled に正規化し、thinking 予算を 32000 に設定し、必要に応じて max_tokens を 64000 に引き上げて 1 回リトライします",
+        "normalizeSystemMessages": "システムメッセージ正規化",
+        "normalizeSystemMessagesDescription": "この形式を拒否するサードパーティプロバイダー向けに、Claude Code >= 2.1.154 の role:system メッセージを最上位の system フィールドに昇格します",
         "mediaFallback": "非対応画像フォールバック",
         "mediaFallbackDescription": "プロバイダーが画像入力に対応していない場合（テキストのみの能力が宣言されている、または上流が画像非対応エラーを返した場合）、画像ブロックを [Unsupported Image] マーカーに自動置換し、会話を中断させません",
         "mediaHeuristic": "テキスト専用モデルの事前判定",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -406,6 +406,8 @@
         "thinkingSignatureDescription": "當 Anthropic 類型供應商回傳 thinking 簽章不相容或非法請求等錯誤時，自動移除不相容的 thinking 相關區塊，並對同一供應商重試一次",
         "thinkingBudget": "Thinking Budget 整流",
         "thinkingBudgetDescription": "當 Anthropic 類型供應商回傳 budget_tokens 限制錯誤（如至少 1024）時，自動將 thinking 規範為 enabled，並將 budget 設為 32000，同時在需要時將 max_tokens 設為 64000，然後重試一次",
+        "normalizeSystemMessages": "System 訊息正規化",
+        "normalizeSystemMessagesDescription": "將 Claude Code ≥ 2.1.154 的 role:system 訊息提升到頂層 system 欄位，相容不支援此格式的第三方 Provider",
         "mediaFallback": "不支援圖片降級",
         "mediaFallbackDescription": "當供應商不支援圖片輸入時（已宣告純文字能力，或上游回傳不支援圖片的錯誤），自動將圖片區塊替換為 [Unsupported Image] 標記，使對話不中斷",
         "mediaHeuristic": "純文字模型預判",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -406,6 +406,8 @@
         "thinkingSignatureDescription": "当 Anthropic 类型供应商返回 thinking 签名不兼容或非法请求等错误时，自动移除不兼容的 thinking 相关块并对同一供应商重试一次",
         "thinkingBudget": "Thinking Budget 整流",
         "thinkingBudgetDescription": "当 Anthropic 类型供应商返回 budget_tokens 约束错误（如至少 1024）时，自动将 thinking 规范为 enabled 并将 budget 设为 32000，同时在需要时将 max_tokens 设为 64000，然后重试一次",
+        "normalizeSystemMessages": "System 消息归一化",
+        "normalizeSystemMessagesDescription": "将 Claude Code ≥ 2.1.154 的 role:system 消息提升到顶层 system 字段，兼容不支持此格式的第三方 Provider",
         "mediaFallback": "不支持图片降级",
         "mediaFallbackDescription": "当供应商不支持图片输入时（已声明纯文本能力，或上游返回不支持图片的错误），自动将图片块替换为 [Unsupported Image] 标记，使对话不中断",
         "mediaHeuristic": "纯文本模型预判",

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -325,6 +325,7 @@ export interface RectifierConfig {
   enabled: boolean;
   requestThinkingSignature: boolean;
   requestThinkingBudget: boolean;
+  normalizeSystemMessages: boolean;
   requestMediaFallback: boolean;
   requestMediaHeuristic: boolean;
 }


### PR DESCRIPTION
## 问题背景
Claude Code v2.1.154+ 将 system 提示词塞进 `messages[0]`（`role:system`），而 InternLM / 书生浦语 等 provider 禁止 messages 数组中出现 `role:system`，只接受顶层字符串 `system` 字段，否则返回 **400 validation error**：
> message[1]: invalid message role: system

## 改动
- 在 `proxy/providers/transform.rs` 新增 `normalize_system_messages()`：从 `messages` 提取 `role:system` 文本，合并为**顶层字符串** `system` 字段（非 Anthropic 数组格式，正是 InternLM 所需）。
- 在 `forwarder.rs` 请求体转换前调用。
- 新增 `RectifierConfig.normalize_system_messages` 开关（默认开启），配套 UI 开关 + i18n（zh/en/ja/zh-TW）。

## 说明
- 移植自 PR #3297（原 PR 基于老代码库，无法直接 merge 到 v3.19.2），已适配当前结构。
- 上游 #3775（归一化为 Anthropic 数组 system）已被 revert，因此本构建输出纯字符串 system，恰好满足 InternLM 要求，无需额外折叠步骤。

## 验证
- `cargo check --target x86_64-pc-windows-gnu` 通过。
- 单元逻辑测试 7/7 通过（role:system → 顶层字符串 system）。
- 已交叉编译出 Windows 便携版 exe，修复确认编译进产物。