### PR TITLE
fix(codex): prevent reasoning leak and duplication in Chat→Responses streaming

### DIFF
--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -290,9 +290,6 @@ pub(crate) fn strip_all_think_tags_with_pending(text: &str) -> (String, String) 
         }
     }
 
-    (result, String::new())
-}
-
 /// Split `text` into `(clean, pending)` where `pending` is a trailing
 /// prefix of `THINK_CLOSE_TAG` (e.g. `<`, `</`, `</t`, …).  Returns
 /// `(text, "")` if the text does not end with such a fragment.

--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -245,6 +245,15 @@ pub(crate) fn strip_leading_think_open_tag(text: &str) -> Option<String> {
 /// `think` tag that was split across two SSE chunks) so that the fragment
 /// does not appear verbatim in the visible output.
 pub(crate) fn strip_all_think_tags(text: &str) -> String {
+    strip_all_think_tags_with_pending(text).0
+}
+
+/// Like `strip_all_think_tags`, but also returns any trailing partial
+/// close-tag fragment (e.g. `</t`, `</th`) as the second element.  The
+/// caller should buffer this fragment and prepend it to the next delta
+/// so that a close tag split across SSE chunks is reassembled correctly
+/// instead of being dropped or leaked.
+pub(crate) fn strip_all_think_tags_with_pending(text: &str) -> (String, String) {
     let mut result = String::with_capacity(text.len());
     let mut remaining = text;
 
@@ -268,20 +277,26 @@ pub(crate) fn strip_all_think_tags(text: &str) -> String {
                 }
             }
             None => {
-                // No more open tags.  Strip a trailing partial close-tag
-                // fragment so it doesn't leak (e.g. `</t`, `</th`, …).
-                result.push_str(strip_trailing_close_tag_fragment(remaining));
-                break;
+                // No more open tags.  Remove any standalone close tags
+                // (close tags without a matching open tag that were not
+                // consumed by the main loop).  Then extract a trailing
+                // partial close-tag fragment for buffering.
+                let without_close_tags = remaining.replace(THINK_CLOSE_TAG, "");
+                let (clean, pending) =
+                    extract_trailing_close_tag_fragment(&without_close_tags);
+                result.push_str(clean);
+                return (result, pending.to_string());
             }
         }
     }
 
-    result
+    (result, String::new())
 }
 
-/// If `text` ends with a prefix of `THINK_CLOSE_TAG` (e.g. `<`, `</`, `</t`, …),
-/// return `text` without that fragment so it doesn't leak into output_text.
-fn strip_trailing_close_tag_fragment(text: &str) -> &str {
+/// Split `text` into `(clean, pending)` where `pending` is a trailing
+/// prefix of `THINK_CLOSE_TAG` (e.g. `<`, `</`, `</t`, …).  Returns
+/// `(text, "")` if the text does not end with such a fragment.
+fn extract_trailing_close_tag_fragment(text: &str) -> (&str, &str) {
     // THINK_CLOSE_TAG is pure ASCII (`think`), so any valid fragment
     // prefix is also ASCII.  We must only cut at char boundaries to
     // avoid slicing inside a multi-byte UTF-8 sequence.
@@ -294,10 +309,10 @@ fn strip_trailing_close_tag_fragment(text: &str) -> &str {
         }
         let suffix = &text[split_point..];
         if THINK_CLOSE_TAG.starts_with(suffix) {
-            return &text[..split_point];
+            return (&text[..split_point], suffix);
         }
     }
-    text
+    (text, "")
 }
 
 fn strip_think_answer_separator(text: &str) -> &str {

--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -234,6 +234,72 @@ pub(crate) fn strip_leading_think_open_tag(text: &str) -> Option<String> {
         .map(|value| value.trim().to_string())
 }
 
+/// Strip all complete `thinking…think` blocks **and** stray tag fragments
+/// from arbitrary text (not just a leading block).
+///
+/// This is used in `InlineThinkMode::Text` to prevent reasoning tags that
+/// arrive after the state machine has already committed to Text mode from
+/// leaking into `output_text.delta`.
+///
+/// It also strips a trailing partial close-tag fragment (e.g. `</t` from a
+/// `think` tag that was split across two SSE chunks) so that the fragment
+/// does not appear verbatim in the visible output.
+pub(crate) fn strip_all_think_tags(text: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let mut remaining = text;
+
+    loop {
+        match remaining.find(THINK_OPEN_TAG) {
+            Some(open_start) => {
+                // Emit text before the open tag.
+                result.push_str(&remaining[..open_start]);
+
+                let after_open = &remaining[open_start + THINK_OPEN_TAG.len()..];
+                match after_open.find(THINK_CLOSE_TAG) {
+                    Some(close_pos) => {
+                        // Complete block — skip the reasoning inside.
+                        remaining = &after_open[close_pos + THINK_CLOSE_TAG.len()..];
+                    }
+                    None => {
+                        // Open tag without a close — treat the rest as
+                        // reasoning and discard it.
+                        remaining = "";
+                    }
+                }
+            }
+            None => {
+                // No more open tags.  Strip a trailing partial close-tag
+                // fragment so it doesn't leak (e.g. `</t`, `</th`, …).
+                result.push_str(strip_trailing_close_tag_fragment(remaining));
+                break;
+            }
+        }
+    }
+
+    result
+}
+
+/// If `text` ends with a prefix of `THINK_CLOSE_TAG` (e.g. `<`, `</`, `</t`, …),
+/// return `text` without that fragment so it doesn't leak into output_text.
+fn strip_trailing_close_tag_fragment(text: &str) -> &str {
+    // THINK_CLOSE_TAG is pure ASCII (`think`), so any valid fragment
+    // prefix is also ASCII.  We must only cut at char boundaries to
+    // avoid slicing inside a multi-byte UTF-8 sequence.
+    let max_cut = THINK_CLOSE_TAG.len().min(text.len());
+
+    for cut in (1..=max_cut).rev() {
+        let split_point = text.len() - cut;
+        if !text.is_char_boundary(split_point) {
+            continue;
+        }
+        let suffix = &text[split_point..];
+        if THINK_CLOSE_TAG.starts_with(suffix) {
+            return &text[..split_point];
+        }
+    }
+    text
+}
+
 fn strip_think_answer_separator(text: &str) -> &str {
     text.trim_start_matches(['\r', '\n', '\t', ' '])
 }

--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -282,13 +282,13 @@ pub(crate) fn strip_all_think_tags_with_pending(text: &str) -> (String, String) 
                 // consumed by the main loop).  Then extract a trailing
                 // partial close-tag fragment for buffering.
                 let without_close_tags = remaining.replace(THINK_CLOSE_TAG, "");
-                let (clean, pending) =
-                    extract_trailing_close_tag_fragment(&without_close_tags);
+                let (clean, pending) = extract_trailing_close_tag_fragment(&without_close_tags);
                 result.push_str(clean);
                 return (result, pending.to_string());
             }
         }
     }
+}
 
 /// Split `text` into `(clean, pending)` where `pending` is a trailing
 /// prefix of `THINK_CLOSE_TAG` (e.g. `<`, `</`, `</t`, …).  Returns

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -155,10 +155,7 @@ impl ChatToResponsesState {
 
             if let Some(content) = delta.get("content").and_then(|v| v.as_str()) {
                 if !content.is_empty() {
-                    // When reasoning_content was extracted from this delta,
-                    // the content field may mirror the reasoning (some providers
-                    // send both).  Strip think tags and skip if it duplicates
-                    // the reasoning text to prevent output_text duplication.
+                    // Same-frame dedup: reasoning_content in this delta.
                     let content = if let Some(ref reasoning) = reasoning_extracted {
                         let stripped = strip_all_think_tags(content);
                         let stripped_trimmed = stripped.trim();
@@ -169,6 +166,17 @@ impl ChatToResponsesState {
                             String::new()
                         } else {
                             stripped
+                        }
+                    } else if !self.reasoning.text.trim().is_empty() {
+                        // Cross-frame dedup: content mirrors reasoning emitted
+                        // in earlier deltas. push_content_delta handles inline
+                        // tags; only skip when accumulated content is a substring
+                        // of the accumulated reasoning (verbatim repetition).
+                        let accumulated = format!("{}{}", self.text.text, content);
+                        if self.reasoning.text.contains(accumulated.trim()) {
+                            String::new()
+                        } else {
+                            content.to_string()
                         }
                     } else {
                         content.to_string()
@@ -1547,6 +1555,65 @@ mod tests {
         }
         assert!(output.contains("答案"));
         assert!(output.contains("完整"));
+    }
+
+
+    /// GLM-5.2 sends reasoning_content in delta N, then mirrors the same
+    /// text as plain content in delta N+1 (no reasoning_content in that
+    /// delta). The same-frame dedup misses this; the cross-frame path
+    /// must catch it by checking accumulated content vs accumulated
+    /// reasoning text.
+    #[tokio::test]
+    async fn dedup_content_when_reasoning_mirrors_across_frames() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_xfd\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"reasoning_content\":\"Let me analyze.\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_xfd\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"Let me analyze.\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_xfd\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"Answer is 42.\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        let delta_lines: Vec<&str> = output
+            .lines()
+            .filter(|l| l.contains("response.output_text.delta"))
+            .collect();
+        for delta_line in &delta_lines {
+            assert!(
+                !delta_line.contains("Let me analyze"),
+                "reasoning text leaked into output_text via cross-frame echo: {delta_line}"
+            );
+        }
+        assert!(output.contains("Answer is 42"));
+    }
+
+    /// GLM sometimes wraps the mirrored reasoning in think tags in the
+    /// content field across frames. The cross-frame dedup should still
+    /// prevent the text from reaching output_text.
+    #[tokio::test]
+    async fn dedup_content_when_reasoning_mirrors_across_frames_with_think_tags() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_xft\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"reasoning_content\":\"Done thinking.\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_xft\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"<think>Done thinking.</think>\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_xft\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"Final answer.\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        let delta_lines: Vec<&str> = output
+            .lines()
+            .filter(|l| l.contains("response.output_text.delta"))
+            .collect();
+        for delta_line in &delta_lines {
+            assert!(
+                !delta_line.contains("Done thinking"),
+                "tagged reasoning text leaked into output_text: {delta_line}"
+            );
+            assert!(
+                !delta_line.contains("think"),
+                "think tag leaked into output_text: {delta_line}"
+            );
+        }
+        assert!(output.contains("Final answer"));
     }
 
 }

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -3,7 +3,8 @@
 use super::codex_responses_sse as sse;
 use super::{
     codex_chat_common::{
-        extract_reasoning_field_text, split_leading_think_block, strip_all_think_tags,
+        extract_reasoning_field_text, split_leading_think_block,
+        strip_all_think_tags, strip_all_think_tags_with_pending,
         strip_leading_think_open_tag,
     },
     transform_codex_chat::{
@@ -50,6 +51,10 @@ enum InlineThinkMode {
 struct InlineThinkState {
     mode: InlineThinkMode,
     buffer: String,
+    /// Trailing partial close-tag fragment (e.g. `</t`) buffered from the
+    /// previous delta so a close tag split across SSE chunks is reassembled
+    /// instead of being dropped or leaked into output_text.
+    pending_close_tag: String,
 }
 
 #[derive(Debug, Default)]
@@ -159,10 +164,7 @@ impl ChatToResponsesState {
                     let content = if let Some(ref reasoning) = reasoning_extracted {
                         let stripped = strip_all_think_tags(content);
                         let stripped_trimmed = stripped.trim();
-                        if stripped_trimmed.is_empty()
-                            || reasoning.contains(stripped_trimmed)
-                            || stripped_trimmed.contains(reasoning.trim())
-                        {
+                        if stripped_trimmed.is_empty() || stripped_trimmed == reasoning.trim() {
                             String::new()
                         } else {
                             stripped
@@ -173,7 +175,7 @@ impl ChatToResponsesState {
                         // tags; only skip when accumulated content is a substring
                         // of the accumulated reasoning (verbatim repetition).
                         let accumulated = format!("{}{}", self.text.text, content);
-                        if self.reasoning.text.contains(accumulated.trim()) {
+                        if self.reasoning.text.starts_with(accumulated.trim()) {
                             String::new()
                         } else {
                             content.to_string()
@@ -210,11 +212,17 @@ impl ChatToResponsesState {
         match self.inline_think.mode {
             InlineThinkMode::Text => {
                 let mut events = self.finalize_reasoning();
-                // Strip any stray think tags that arrive after the state
-                // machine has committed to Text mode, preventing
-                // `thinking`/`think` fragments from leaking into
-                // output_text.delta.
-                let cleaned = strip_all_think_tags(delta);
+                // Prepend any buffered partial close-tag fragment from the
+                // previous delta so a close tag split across SSE chunks is
+                // reassembled before stripping.
+                let combined =
+                    format!("{}{}", self.inline_think.pending_close_tag, delta);
+                self.inline_think.pending_close_tag.clear();
+                let (cleaned, pending) =
+                    strip_all_think_tags_with_pending(&combined);
+                if !pending.is_empty() {
+                    self.inline_think.pending_close_tag = pending;
+                }
                 if !cleaned.is_empty() {
                     events.extend(self.push_text_delta(&cleaned));
                 }
@@ -231,9 +239,9 @@ impl ChatToResponsesState {
                     ThinkPrefixDecision::Text => {
                         self.inline_think.mode = InlineThinkMode::Text;
                         let text = std::mem::take(&mut self.inline_think.buffer);
-                        let mut events = self.finalize_reasoning();
-                        events.extend(self.push_text_delta(&text));
-                        events
+                        // Route through push_content_delta (now Text mode)
+                        // so close-tag stripping/buffering applies.
+                        self.push_content_delta(&text)
                     }
                 }
             }
@@ -266,15 +274,32 @@ impl ChatToResponsesState {
 
     fn flush_inline_think_at_boundary(&mut self) -> Vec<Bytes> {
         match self.inline_think.mode {
-            InlineThinkMode::Text => Vec::new(),
+            InlineThinkMode::Text => {
+                // Flush any buffered partial close-tag fragment as normal
+                // text — it turned out not to be part of a close tag.
+                let pending = std::mem::take(&mut self.inline_think.pending_close_tag);
+                if pending.is_empty() {
+                    Vec::new()
+                } else {
+                    let mut events = self.finalize_reasoning();
+                    events.extend(self.push_text_delta(&pending));
+                    events
+                }
+            }
             InlineThinkMode::Detecting => {
                 self.inline_think.mode = InlineThinkMode::Text;
                 let text = std::mem::take(&mut self.inline_think.buffer);
                 if text.is_empty() {
                     Vec::new()
                 } else {
-                    let mut events = self.finalize_reasoning();
-                    events.extend(self.push_text_delta(&text));
+                    // Route through push_content_delta (now Text mode)
+                    // so close-tag stripping/buffering applies, then
+                    // flush any remaining pending close-tag fragment.
+                    let mut events = self.push_content_delta(&text);
+                    let pending = std::mem::take(&mut self.inline_think.pending_close_tag);
+                    if !pending.is_empty() {
+                        events.extend(self.push_text_delta(&pending));
+                    }
                     events
                 }
             }
@@ -1614,6 +1639,55 @@ mod tests {
             );
         }
         assert!(output.contains("Final answer"));
+    }
+
+
+    /// Reviewer concern: substring dedup should not erase a legitimate
+    /// answer that happens to be a substring of the reasoning text.
+    /// reasoning = "I should answer 42", content = "42" -> "42" must survive.
+    #[tokio::test]
+    async fn does_not_erase_answer_that_is_substring_of_reasoning() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_sub\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"reasoning_content\":\"I should answer 42\",\"content\":\"42\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_sub\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(
+            output.contains("42"),
+            "legitimate answer erased by substring dedup: {output}"
+        );
+    }
+
+
+    /// Reviewer concern: a close tag split across SSE chunks must not
+    /// leak. Delta 1 ends with a partial close-tag prefix,
+    /// delta 2 completes it. The combined close tag should be stripped.
+    #[tokio::test]
+    async fn buffers_close_tag_prefix_across_sse_chunks() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_xch\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"answer</t\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_xch\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"hink>\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_xch\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\" real output\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        let delta_lines: Vec<&str> = output
+            .lines()
+            .filter(|l| l.contains("response.output_text.delta"))
+            .collect();
+        for delta_line in &delta_lines {
+            assert!(
+                !delta_line.contains("think"),
+                "close tag fragment leaked across chunks: {delta_line}"
+            );
+            assert!(
+                !delta_line.contains("hink>"),
+                "trailing close tag body leaked: {delta_line}"
+            );
+        }
     }
 
 }

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -3,9 +3,8 @@
 use super::codex_responses_sse as sse;
 use super::{
     codex_chat_common::{
-        extract_reasoning_field_text, split_leading_think_block,
-        strip_all_think_tags, strip_all_think_tags_with_pending,
-        strip_leading_think_open_tag,
+        extract_reasoning_field_text, split_leading_think_block, strip_all_think_tags,
+        strip_all_think_tags_with_pending, strip_leading_think_open_tag,
     },
     transform_codex_chat::{
         chat_usage_to_responses_usage, custom_tool_input_from_chat_arguments,
@@ -215,11 +214,9 @@ impl ChatToResponsesState {
                 // Prepend any buffered partial close-tag fragment from the
                 // previous delta so a close tag split across SSE chunks is
                 // reassembled before stripping.
-                let combined =
-                    format!("{}{}", self.inline_think.pending_close_tag, delta);
+                let combined = format!("{}{}", self.inline_think.pending_close_tag, delta);
                 self.inline_think.pending_close_tag.clear();
-                let (cleaned, pending) =
-                    strip_all_think_tags_with_pending(&combined);
+                let (cleaned, pending) = strip_all_think_tags_with_pending(&combined);
                 if !pending.is_empty() {
                     self.inline_think.pending_close_tag = pending;
                 }
@@ -1582,7 +1579,6 @@ mod tests {
         assert!(output.contains("完整"));
     }
 
-
     /// GLM-5.2 sends reasoning_content in delta N, then mirrors the same
     /// text as plain content in delta N+1 (no reasoning_content in that
     /// delta). The same-frame dedup misses this; the cross-frame path
@@ -1641,7 +1637,6 @@ mod tests {
         assert!(output.contains("Final answer"));
     }
 
-
     /// Reviewer concern: substring dedup should not erase a legitimate
     /// answer that happens to be a substring of the reasoning text.
     /// reasoning = "I should answer 42", content = "42" -> "42" must survive.
@@ -1659,7 +1654,6 @@ mod tests {
             "legitimate answer erased by substring dedup: {output}"
         );
     }
-
 
     /// Reviewer concern: a close tag split across SSE chunks must not
     /// leak. Delta 1 ends with a partial close-tag prefix,
@@ -1689,5 +1683,4 @@ mod tests {
             );
         }
     }
-
 }

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -3,7 +3,8 @@
 use super::codex_responses_sse as sse;
 use super::{
     codex_chat_common::{
-        extract_reasoning_field_text, split_leading_think_block, strip_leading_think_open_tag,
+        extract_reasoning_field_text, split_leading_think_block, strip_all_think_tags,
+        strip_leading_think_open_tag,
     },
     transform_codex_chat::{
         chat_usage_to_responses_usage, custom_tool_input_from_chat_arguments,
@@ -145,14 +146,36 @@ impl ChatToResponsesState {
         };
 
         if let Some(delta) = choice.get("delta") {
-            if let Some(reasoning) = chat_delta_reasoning_text(delta) {
-                events.extend(self.push_reasoning_delta(&reasoning));
-                self.append_reasoning_to_active_tools(&reasoning);
+            let reasoning_extracted = chat_delta_reasoning_text(delta);
+
+            if let Some(reasoning) = &reasoning_extracted {
+                events.extend(self.push_reasoning_delta(reasoning));
+                self.append_reasoning_to_active_tools(reasoning);
             }
 
             if let Some(content) = delta.get("content").and_then(|v| v.as_str()) {
                 if !content.is_empty() {
-                    events.extend(self.push_content_delta(content));
+                    // When reasoning_content was extracted from this delta,
+                    // the content field may mirror the reasoning (some providers
+                    // send both).  Strip think tags and skip if it duplicates
+                    // the reasoning text to prevent output_text duplication.
+                    let content = if let Some(ref reasoning) = reasoning_extracted {
+                        let stripped = strip_all_think_tags(content);
+                        let stripped_trimmed = stripped.trim();
+                        if stripped_trimmed.is_empty()
+                            || reasoning.contains(stripped_trimmed)
+                            || stripped_trimmed.contains(reasoning.trim())
+                        {
+                            String::new()
+                        } else {
+                            stripped
+                        }
+                    } else {
+                        content.to_string()
+                    };
+                    if !content.is_empty() {
+                        events.extend(self.push_content_delta(&content));
+                    }
                 }
             }
 
@@ -179,7 +202,14 @@ impl ChatToResponsesState {
         match self.inline_think.mode {
             InlineThinkMode::Text => {
                 let mut events = self.finalize_reasoning();
-                events.extend(self.push_text_delta(delta));
+                // Strip any stray think tags that arrive after the state
+                // machine has committed to Text mode, preventing
+                // `thinking`/`think` fragments from leaking into
+                // output_text.delta.
+                let cleaned = strip_all_think_tags(delta);
+                if !cleaned.is_empty() {
+                    events.extend(self.push_text_delta(&cleaned));
+                }
                 events
             }
             InlineThinkMode::Detecting => {
@@ -1473,4 +1503,50 @@ mod tests {
         assert!(output.contains("rate_limit_exceeded"));
         assert!(!output.contains("event: response.completed"));
     }
+    #[tokio::test]
+    async fn dedup_content_when_reasoning_content_mirrors_in_same_delta() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_dup\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"reasoning_content\":\"让我分析。\",\"content\":\"让我分析。\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_dup\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"答案是42。\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        let delta_lines: Vec<&str> = output
+            .lines()
+            .filter(|l| l.contains("response.output_text.delta"))
+            .collect();
+        for delta_line in &delta_lines {
+            assert!(
+                !delta_line.contains("让我分析"),
+                "reasoning text leaked into output_text: {delta_line}"
+            );
+        }
+        assert!(output.contains("答案是42"));
+    }
+
+    #[tokio::test]
+    async fn strips_leaked_close_tag_in_text_mode() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_leak\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"答案\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_leak\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"</think>\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_leak\",\"created\":123,\"model\":\"glm-5.2\",\"choices\":[{\"delta\":{\"content\":\"完整。\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        let delta_lines: Vec<&str> = output
+            .lines()
+            .filter(|l| l.contains("response.output_text.delta"))
+            .collect();
+        for delta_line in &delta_lines {
+            assert!(
+                !delta_line.contains("think"),
+                "close tag leaked into output_text: {delta_line}"
+            );
+        }
+        assert!(output.contains("答案"));
+        assert!(output.contains("完整"));
+    }
+
 }


### PR DESCRIPTION
## Summary

Fixes #6317

When a Chat Completions provider (e.g. GLM-5.2) sends `reasoning_content` and `content` in the same SSE delta, the streaming converter emitted both as `reasoning_summary_text.delta` AND `output_text.delta`, causing the reasoning text to appear duplicated in the visible Codex output.

Additionally, once the inline-think state machine committed to `Text` mode, stray `thinking`/`think` tag fragments — including partial close tags like `</t` split across SSE chunks — leaked directly into `output_text.delta`.

## Changes

**`codex_chat_common.rs`** — new helpers:
- `strip_all_think_tags`: strips all complete `thinking…think` blocks and trailing partial close-tag fragments
- `strip_trailing_close_tag_fragment`: UTF-8 char-boundary safe

**`streaming_codex_chat.rs`** — two fixes:
- `handle_chat_chunk`: when `reasoning_content` is extracted, strip think tags from `content` and skip if it duplicates reasoning
- `push_content_delta` Text mode: strip think tags before emitting `output_text.delta`

## Test plan

- `dedup_content_when_reasoning_content_mirrors_in_same_delta`
- `strips_leaked_close_tag_in_text_mode`
- All 30 existing+new tests pass