### PR TITLE
fix(codex): strip stale third-party OPENAI_API_KEY when OAuth tokens coexist

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -483,7 +483,7 @@ pub fn codex_live_auth_is_stale_third_party_residue(live_auth: &Value) -> bool {
 /// what heals official API-key logins into the DB row, and this cleanup's
 /// safety depends on it — do not align the two guards.
 ///
-/// Returns Ok(true) when the file was deleted.
+/// Returns Ok(true) when the file was deleted or a stale key was stripped.
 pub fn clear_stale_codex_live_auth_after_official_switch(
     db_auth: &Value,
 ) -> Result<bool, AppError> {
@@ -497,11 +497,41 @@ pub fn clear_stale_codex_live_auth_after_official_switch(
         return Ok(false);
     }
     let live_auth: Value = read_json_file(&auth_path)?;
-    if !codex_live_auth_is_stale_third_party_residue(&live_auth) {
-        return Ok(false);
+
+    // Case 1: No credential login material, just a stale third-party
+    // OPENAI_API_KEY (possibly alongside metadata like auth_mode /
+    // last_refresh).  Delete the file so Codex shows its login screen.
+    if codex_live_auth_is_stale_third_party_residue(&live_auth) {
+        delete_file(&auth_path)?;
+        return Ok(true);
     }
-    delete_file(&auth_path)?;
-    Ok(true)
+
+    // Case 2: OAuth credential login material (tokens) coexists with a
+    // stale third-party OPENAI_API_KEY left by a previous preserve-off
+    // switch.  `codex_live_auth_is_stale_third_party_residue` returns
+    // false here because it treats credential-bearing auth as non-stale
+    // — but the OPENAI_API_KEY is still a third-party residue that must
+    // not leak into the official endpoint.  Strip just that field,
+    // preserving the OAuth tokens so the official login stays intact.
+    if codex_auth_has_credential_login_material(&live_auth) {
+        if let Some(obj) = live_auth.as_object() {
+            let has_stale_key = obj
+                .get("OPENAI_API_KEY")
+                .and_then(Value::as_str)
+                .map(|key| !key.trim().is_empty())
+                .unwrap_or(false);
+            if has_stale_key {
+                let mut cleaned = live_auth.clone();
+                if let Some(cleaned_obj) = cleaned.as_object_mut() {
+                    cleaned_obj.remove("OPENAI_API_KEY");
+                }
+                write_json_file(&auth_path, &cleaned)?;
+                return Ok(true);
+            }
+        }
+    }
+
+    Ok(false)
 }
 
 pub fn should_restore_codex_provider_token_for_backfill(

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -513,6 +513,13 @@ pub fn clear_stale_codex_live_auth_after_official_switch(
     // — but the OPENAI_API_KEY is still a third-party residue that must
     // not leak into the official endpoint.  Strip just that field,
     // preserving the OAuth tokens so the official login stays intact.
+    // Guard: when `auth_mode` is `"apikey"`, the OPENAI_API_KEY is the
+    // user's active official API-key credential, not a third-party
+    // residue — stripping it would strand the user on a 401 with no way
+    // to perform the selected API-key login. Only strip when a different
+    // auth mode (e.g. `"chatgpt"`) is active, which makes the key a
+    // leftover from a third-party switch that the OAuth login no longer
+    // needs.
     if codex_auth_has_credential_login_material(&live_auth) {
         if let Some(obj) = live_auth.as_object() {
             let has_stale_key = obj
@@ -520,7 +527,12 @@ pub fn clear_stale_codex_live_auth_after_official_switch(
                 .and_then(Value::as_str)
                 .map(|key| !key.trim().is_empty())
                 .unwrap_or(false);
-            if has_stale_key {
+            let auth_mode_is_apikey = obj
+                .get("auth_mode")
+                .and_then(Value::as_str)
+                .map(|mode| mode == "apikey")
+                .unwrap_or(false);
+            if has_stale_key && !auth_mode_is_apikey {
                 let mut cleaned = live_auth.clone();
                 if let Some(cleaned_obj) = cleaned.as_object_mut() {
                     cleaned_obj.remove("OPENAI_API_KEY");
@@ -2816,6 +2828,156 @@ experimental_bearer_token = "stale-table-key"
         assert!(!codex_live_auth_is_stale_third_party_residue(&json!({
             "OPENAI_API_KEY": ""
         })));
+    }
+
+    /// Redirect `get_codex_auth_path()` to a temp dir for tests that
+    /// exercise the file-writing cleanup path. `#[serial]` callers only.
+    struct TestCodexAuthHome {
+        _dir: tempfile::TempDir,
+        original_test_home: Option<String>,
+    }
+
+    impl TestCodexAuthHome {
+        fn new() -> Self {
+            let dir = tempfile::TempDir::new().expect("tempdir");
+            std::fs::create_dir_all(dir.path().join(".codex")).expect("create .codex");
+            let original_test_home = std::env::var("CC_SWITCH_TEST_HOME").ok();
+            std::env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+            Self {
+                _dir: dir,
+                original_test_home,
+            }
+        }
+    }
+
+    impl Drop for TestCodexAuthHome {
+        fn drop(&mut self) {
+            match &self.original_test_home {
+                Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+                None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+            }
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn clear_stale_auth_strips_third_party_key_when_chatgpt_oauth_coexists() {
+        // auth_mode "chatgpt" → OAuth is the active credential, the
+        // OPENAI_API_KEY is a third-party residue → strip it, keep tokens.
+        let _guard = TestCodexAuthHome::new();
+        let auth_path = get_codex_auth_path();
+        std::fs::create_dir_all(auth_path.parent().expect("parent exists"))
+            .expect("create .codex dir");
+        write_json_file(
+            &auth_path,
+            &json!({
+                "auth_mode": "chatgpt",
+                "OPENAI_API_KEY": "sk-third-party",
+                "tokens": { "access_token": "oauth-access", "id_token": "oauth-id" }
+            }),
+        )
+        .expect("seed live auth");
+
+        let cleaned =
+            clear_stale_codex_live_auth_after_official_switch(&json!({})).expect("clear succeeds");
+        assert!(cleaned, "third-party key should be stripped");
+
+        let after: Value = read_json_file(&auth_path).expect("read after");
+        assert!(
+            after.get("OPENAI_API_KEY").is_none(),
+            "stale third-party key must be removed"
+        );
+        assert_eq!(
+            after.get("auth_mode").and_then(Value::as_str),
+            Some("chatgpt"),
+            "OAuth auth_mode must be preserved"
+        );
+        assert!(
+            after.get("tokens").is_some(),
+            "OAuth tokens must be preserved"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn clear_stale_auth_preserves_active_apikey_when_oauth_tokens_coexist() {
+        // auth_mode "apikey" → the OPENAI_API_KEY is the user's active
+        // official API-key credential, not a third-party residue, even
+        // though stale OAuth tokens happen to coexist → must NOT strip.
+        let _guard = TestCodexAuthHome::new();
+        let auth_path = get_codex_auth_path();
+        std::fs::create_dir_all(auth_path.parent().expect("parent exists"))
+            .expect("create .codex dir");
+        write_json_file(
+            &auth_path,
+            &json!({
+                "auth_mode": "apikey",
+                "OPENAI_API_KEY": "sk-official-active",
+                "tokens": { "access_token": "stale-oauth", "id_token": "stale-id" }
+            }),
+        )
+        .expect("seed live auth");
+
+        let cleaned =
+            clear_stale_codex_live_auth_after_official_switch(&json!({})).expect("clear succeeds");
+        assert!(
+            !cleaned,
+            "active official API key must be preserved, not stripped"
+        );
+
+        let after: Value = read_json_file(&auth_path).expect("read after");
+        assert_eq!(
+            after.get("OPENAI_API_KEY").and_then(Value::as_str),
+            Some("sk-official-active"),
+            "active official API key must remain untouched"
+        );
+        assert_eq!(
+            after.get("auth_mode").and_then(Value::as_str),
+            Some("apikey"),
+            "auth_mode must be preserved"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn clear_stale_auth_deletes_file_for_pure_third_party_residue() {
+        // Case 1: no credential material, just a stale third-party key →
+        // delete the whole file so Codex shows its login screen.
+        let _guard = TestCodexAuthHome::new();
+        let auth_path = get_codex_auth_path();
+        std::fs::create_dir_all(auth_path.parent().expect("parent exists"))
+            .expect("create .codex dir");
+        write_json_file(
+            &auth_path,
+            &json!({ "auth_mode": "apikey", "OPENAI_API_KEY": "sk-third-party" }),
+        )
+        .expect("seed live auth");
+
+        let cleaned =
+            clear_stale_codex_live_auth_after_official_switch(&json!({})).expect("clear succeeds");
+        assert!(cleaned, "stale residue file should be deleted");
+        assert!(!auth_path.exists(), "auth.json should be gone");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn clear_stale_auth_noop_when_db_has_login_material() {
+        // A material-carrying official provider gets a full auth write;
+        // nothing stale can remain → early Ok(false), file untouched.
+        let _guard = TestCodexAuthHome::new();
+        let auth_path = get_codex_auth_path();
+        std::fs::create_dir_all(auth_path.parent().expect("parent exists"))
+            .expect("create .codex dir");
+        let seed = json!({ "auth_mode": "chatgpt", "OPENAI_API_KEY": "sk-third-party" });
+        write_json_file(&auth_path, &seed).expect("seed live auth");
+
+        let cleaned = clear_stale_codex_live_auth_after_official_switch(&json!({
+            "OPENAI_API_KEY": "sk-new-official"
+        }))
+        .expect("clear succeeds");
+        assert!(!cleaned, "material-carrying provider skips cleanup");
+        let after: Value = read_json_file(&auth_path).expect("read after");
+        assert_eq!(after, seed, "file must be untouched");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #6318

When routing is on and switching from a third-party provider (e.g. CSI GLM-5.2) to codex-official, the stale third-party `OPENAI_API_KEY` was not cleaned from `auth.json` because `codex_live_auth_is_stale_third_party_residue` treats OAuth-credential-bearing auth as non-stale. The stale key then caused 401 and forced ChatGPT re-login.

## Changes

**`codex_config.rs`** — `clear_stale_codex_live_auth_after_official_switch`:
- Case 1 (existing): no OAuth credentials, only stale key → delete file
- Case 2 (new): OAuth credentials + non-empty `OPENAI_API_KEY` coexist → strip just the `OPENAI_API_KEY` field, preserve OAuth tokens

## Test plan

- All 81 codex_config tests pass
- `stale_third_party_residue_detection` covers Case 1