### PR TITLE
fix(usage): keep multi-year trend tooltip and dots on the same point (#6302)

### DIFF
--- a/src/components/usage/UsageTrendChart.tsx
+++ b/src/components/usage/UsageTrendChart.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AreaChart,
@@ -29,6 +30,102 @@ interface UsageTrendChartProps {
   refreshIntervalMs: number;
 }
 
+export interface UsageTrendStatLike {
+  date: string;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCacheCreationTokens: number;
+  totalCacheReadTokens: number;
+  totalCost: string | number;
+}
+
+export interface UsageTrendChartPoint {
+  /** Unique category key for Recharts — must not collide across years. */
+  xKey: string;
+  rawDate: string;
+  /** Short tick label shown on the X axis. */
+  label: string;
+  /** Fuller label used by the tooltip. */
+  tooltipLabel: string;
+  hour: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  cost: number | null;
+}
+
+/** Build chart rows from backend trend stats. Exported for unit tests. */
+export function buildUsageTrendChartData(
+  trends: UsageTrendStatLike[] | undefined,
+  options: {
+    isHourly: boolean;
+    dateLocale: string;
+    /** Inclusive range endpoints (unix seconds). Used to decide year labels. */
+    startDate: number;
+    endDate: number;
+  },
+): UsageTrendChartPoint[] {
+  const { isHourly, dateLocale, startDate, endDate } = options;
+  const startYear = new Date(startDate * 1000).getFullYear();
+  const endYear = new Date(endDate * 1000).getFullYear();
+  const spansMultipleYears = startYear !== endYear;
+
+  return (
+    trends?.map((stat) => {
+      const pointDate = new Date(stat.date);
+      const cost = parseFiniteNumber(stat.totalCost);
+      // Prefer a stable unique key from the source timestamp / date string.
+      // Falling back to ISO keeps categories unique even if the backend
+      // returns sparse points that share the same local MM/DD across years.
+      const xKey = stat.date;
+      const tooltipLabel = isHourly
+        ? pointDate.toLocaleString(dateLocale, {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+          })
+        : pointDate.toLocaleDateString(dateLocale, {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+          });
+      const label = isHourly
+        ? pointDate.toLocaleString(dateLocale, {
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+          })
+        : spansMultipleYears
+          ? pointDate.toLocaleDateString(dateLocale, {
+              year: "2-digit",
+              month: "2-digit",
+              day: "2-digit",
+            })
+          : pointDate.toLocaleDateString(dateLocale, {
+              month: "2-digit",
+              day: "2-digit",
+            });
+
+      return {
+        xKey,
+        rawDate: stat.date,
+        label,
+        tooltipLabel,
+        hour: pointDate.getHours(),
+        inputTokens: stat.totalInputTokens,
+        outputTokens: stat.totalOutputTokens,
+        cacheCreationTokens: stat.totalCacheCreationTokens,
+        cacheReadTokens: stat.totalCacheReadTokens,
+        cost: cost ?? null,
+      };
+    }) || []
+  );
+}
+
 export function UsageTrendChart({
   range,
   rangeLabel,
@@ -47,6 +144,22 @@ export function UsageTrendChart({
     },
   );
 
+  const durationSeconds = Math.max(endDate - startDate, 0);
+  const isHourly = durationSeconds <= 24 * 60 * 60;
+  const language = i18n.resolvedLanguage || i18n.language || "en";
+  const dateLocale = getLocaleFromLanguage(language);
+
+  const chartData = useMemo(
+    () =>
+      buildUsageTrendChartData(trends, {
+        isHourly,
+        dateLocale,
+        startDate,
+        endDate,
+      }),
+    [trends, isHourly, dateLocale, startDate, endDate],
+  );
+
   if (isLoading) {
     return (
       <div className="flex h-[350px] items-center justify-center rounded-xl bg-card/40 border border-border/50">
@@ -55,43 +168,13 @@ export function UsageTrendChart({
     );
   }
 
-  const durationSeconds = Math.max(endDate - startDate, 0);
-  const isHourly = durationSeconds <= 24 * 60 * 60;
-  const language = i18n.resolvedLanguage || i18n.language || "en";
-  const dateLocale = getLocaleFromLanguage(language);
-  const chartData =
-    trends?.map((stat) => {
-      const pointDate = new Date(stat.date);
-      const cost = parseFiniteNumber(stat.totalCost);
-      return {
-        rawDate: stat.date,
-        label: isHourly
-          ? pointDate.toLocaleString(dateLocale, {
-              month: "2-digit",
-              day: "2-digit",
-              hour: "2-digit",
-              minute: "2-digit",
-            })
-          : pointDate.toLocaleDateString(dateLocale, {
-              month: "2-digit",
-              day: "2-digit",
-            }),
-        hour: pointDate.getHours(),
-        inputTokens: stat.totalInputTokens,
-        outputTokens: stat.totalOutputTokens,
-        cacheCreationTokens: stat.totalCacheCreationTokens,
-        cacheReadTokens: stat.totalCacheReadTokens,
-        cost: cost ?? null,
-      };
-    }) || [];
-
-  const displayData = chartData;
-
-  const CustomTooltip = ({ active, payload, label }: any) => {
+  const CustomTooltip = ({ active, payload }: any) => {
     if (active && payload && payload.length) {
+      const point = payload[0]?.payload as UsageTrendChartPoint | undefined;
+      const heading = point?.tooltipLabel ?? point?.label ?? "";
       return (
         <div className="rounded-lg border bg-background/95 p-3 shadow-lg backdrop-blur-md">
-          <p className="mb-2 font-medium">{label}</p>
+          <p className="mb-2 font-medium">{heading}</p>
           {payload.map((entry: any, index: number) => (
             <div
               key={index}
@@ -128,7 +211,7 @@ export function UsageTrendChart({
       <div className="h-[350px] w-full">
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart
-            data={displayData}
+            data={chartData}
             margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
           >
             <defs>
@@ -162,11 +245,13 @@ export function UsageTrendChart({
               opacity={0.4}
             />
             <XAxis
-              dataKey="label"
+              dataKey="xKey"
               axisLine={false}
               tickLine={false}
               tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
               dy={10}
+              tickFormatter={(_, index) => chartData[index]?.label ?? ""}
+              allowDuplicatedCategory={false}
             />
             <YAxis
               yAxisId="tokens"

--- a/src/components/usage/UsageTrendChart.tsx
+++ b/src/components/usage/UsageTrendChart.tsx
@@ -126,6 +126,15 @@ export function buildUsageTrendChartData(
   );
 }
 
+/** Resolve a tick label by the unique category key (not by filtered tick index). */
+export function formatUsageTrendTickLabel(
+  xKey: string,
+  chartData: UsageTrendChartPoint[],
+): string {
+  const point = chartData.find((row) => row.xKey === xKey);
+  return point?.label ?? xKey;
+}
+
 export function UsageTrendChart({
   range,
   rangeLabel,
@@ -250,7 +259,9 @@ export function UsageTrendChart({
               tickLine={false}
               tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
               dy={10}
-              tickFormatter={(_, index) => chartData[index]?.label ?? ""}
+              tickFormatter={(value) =>
+                formatUsageTrendTickLabel(String(value), chartData)
+              }
               allowDuplicatedCategory={false}
             />
             <YAxis

--- a/tests/components/UsageTrendChart.test.ts
+++ b/tests/components/UsageTrendChart.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildUsageTrendChartData } from "@/components/usage/UsageTrendChart";
+import {
+  buildUsageTrendChartData,
+  formatUsageTrendTickLabel,
+} from "@/components/usage/UsageTrendChart";
 
 const day = (isoDate: string) =>
   ({
@@ -66,5 +69,49 @@ describe("buildUsageTrendChartData (#6302)", () => {
     // en-US 2-digit month/day — should not need a year prefix inside one year.
     expect(points[0].label).not.toMatch(/2026/);
     expect(points[0].tooltipLabel).toMatch(/2026/);
+  });
+});
+
+describe("formatUsageTrendTickLabel", () => {
+  it("resolves labels by xKey even when the tick index is thinned", () => {
+    const startDate = Math.floor(Date.parse("2025-01-01T00:00:00Z") / 1000);
+    const endDate = Math.floor(Date.parse("2026-08-10T00:00:00Z") / 1000);
+    const points = buildUsageTrendChartData(
+      [
+        {
+          date: "2025-01-01T12:00:00.000Z",
+          totalInputTokens: 1,
+          totalOutputTokens: 1,
+          totalCacheCreationTokens: 0,
+          totalCacheReadTokens: 0,
+          totalCost: "0",
+        },
+        {
+          date: "2025-04-27T12:00:00.000Z",
+          totalInputTokens: 1,
+          totalOutputTokens: 1,
+          totalCacheCreationTokens: 0,
+          totalCacheReadTokens: 0,
+          totalCost: "0",
+        },
+        {
+          date: "2026-04-27T12:00:00.000Z",
+          totalInputTokens: 1,
+          totalOutputTokens: 1,
+          totalCacheCreationTokens: 0,
+          totalCacheReadTokens: 0,
+          totalCost: "0",
+        },
+      ],
+      { isHourly: false, dateLocale: "en-US", startDate, endDate },
+    );
+
+    // Simulate Recharts passing a later category as the only visible tick
+    // (filtered index 0 would wrongly map to the first chart row).
+    const last = points[2];
+    expect(formatUsageTrendTickLabel(last.xKey, points)).toBe(last.label);
+    expect(formatUsageTrendTickLabel(last.xKey, points)).not.toBe(
+      points[0].label,
+    );
   });
 });

--- a/tests/components/UsageTrendChart.test.ts
+++ b/tests/components/UsageTrendChart.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { buildUsageTrendChartData } from "@/components/usage/UsageTrendChart";
+
+const day = (isoDate: string) =>
+  ({
+    date: `${isoDate}T12:00:00.000Z`,
+    totalInputTokens: 100,
+    totalOutputTokens: 50,
+    totalCacheCreationTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCost: "0.01",
+  }) as const;
+
+describe("buildUsageTrendChartData (#6302)", () => {
+  it("keeps unique x-axis keys when the same MM/DD appears in multiple years", () => {
+    // 2025-04-27 and 2026-04-27 share the same MM/DD tick text in single-year
+    // formatting. Using that text as the Recharts category key made activeDots
+    // jump to the earlier year's point while the tooltip followed the cursor.
+    const startDate = Math.floor(Date.parse("2025-01-01T00:00:00Z") / 1000);
+    const endDate = Math.floor(Date.parse("2026-08-10T00:00:00Z") / 1000);
+
+    const points = buildUsageTrendChartData(
+      [day("2025-04-27"), day("2026-04-27")],
+      {
+        isHourly: false,
+        dateLocale: "en-US",
+        startDate,
+        endDate,
+      },
+    );
+
+    expect(points).toHaveLength(2);
+    expect(points[0].xKey).not.toBe(points[1].xKey);
+    expect(points[0].xKey).toContain("2025-04-27");
+    expect(points[1].xKey).toContain("2026-04-27");
+    // Tooltip always carries a year so the user can tell which April it is.
+    expect(points[0].tooltipLabel).toMatch(/2025/);
+    expect(points[1].tooltipLabel).toMatch(/2026/);
+  });
+
+  it("includes a year in the axis tick when the selected range spans years", () => {
+    const startDate = Math.floor(Date.parse("2025-01-01T00:00:00Z") / 1000);
+    const endDate = Math.floor(Date.parse("2026-08-10T00:00:00Z") / 1000);
+
+    const points = buildUsageTrendChartData([day("2026-04-27")], {
+      isHourly: false,
+      dateLocale: "en-US",
+      startDate,
+      endDate,
+    });
+
+    expect(points[0].label).toMatch(/26|2026/);
+  });
+
+  it("keeps short MM/DD ticks for single-year ranges", () => {
+    const startDate = Math.floor(Date.parse("2026-01-01T00:00:00Z") / 1000);
+    const endDate = Math.floor(Date.parse("2026-08-10T00:00:00Z") / 1000);
+
+    const points = buildUsageTrendChartData([day("2026-04-27")], {
+      isHourly: false,
+      dateLocale: "en-US",
+      startDate,
+      endDate,
+    });
+
+    // en-US 2-digit month/day — should not need a year prefix inside one year.
+    expect(points[0].label).not.toMatch(/2026/);
+    expect(points[0].tooltipLabel).toMatch(/2026/);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix usage trend chart hover mismatch when the selected range spans multiple years and shares the same `MM/DD` labels.
- Use the raw timestamp/date string as the Recharts category key so active dots, the cursor line, and the tooltip all refer to the same point.
- Show a year in axis ticks and tooltip headings for multi-year ranges; keep short `MM/DD` ticks inside a single year.
- Add unit tests for the multi-year collision case.

Fixes #6302

## Root cause
`UsageTrendChart` set `XAxis dataKey="label"` where `label` is a localized `MM/DD` string. Over a range like `2025-01-01`–`2026-08-10`, `04/27` exists in both years, so Recharts treated them as one category and hover highlight jumped to the first match.

## Test plan
- [x] `vitest` `tests/components/UsageTrendChart.test.ts`
- [x] Prettier check on touched files
- [ ] Manual: Settings → Usage Statistics → custom range spanning two years (e.g. 2025-01-01 – 2026-08-10); hover a later-year point and confirm tooltip + active dots + vertical cursor align