### PR TITLE
fix(codex): prevent crash when upstream sends malformed tool call arguments

### DIFF
--- a/src-tauri/src/proxy/json_canonical.rs
+++ b/src-tauri/src/proxy/json_canonical.rs
@@ -78,8 +78,8 @@ pub(crate) fn canonicalize_tool_arguments_str(value: &str) -> String {
     // safe empty object so downstream round-trips do not fail on re-parse.
     if !result.trim().is_empty() && serde_json::from_str::<Value>(&result).is_err() {
         log::warn!(
-            "Upstream returned unparseable tool arguments; falling back to '{{}}'. raw prefix: {}",
-            &value.chars().take(120).collect::<String>()
+            "Upstream returned unparseable tool arguments ({} bytes); falling back to '{{}}'.",
+            value.len()
         );
         return "{}".to_string();
     }
@@ -194,10 +194,7 @@ mod tests {
         // handles non-objects separately).  Keep to document the boundary:
         // canonicalize_tool_arguments_str only rejects *non-JSON*, not
         // non-object JSON.
-        assert_eq!(
-            canonicalize_tool_arguments_str("42"),
-            "42"
-        );
+        assert_eq!(canonicalize_tool_arguments_str("42"), "42");
     }
 
     #[test]

--- a/src-tauri/src/proxy/json_canonical.rs
+++ b/src-tauri/src/proxy/json_canonical.rs
@@ -71,7 +71,19 @@ pub(crate) fn canonicalize_tool_arguments_str(value: &str) -> String {
     if value.trim().is_empty() {
         return "{}".to_string();
     }
-    canonicalize_json_string_if_parseable(value)
+    let result = canonicalize_json_string_if_parseable(value);
+    // When an upstream provider produces malformed partial JSON
+    // (e.g. a truncated streaming input_json_delta), the canonicalizer falls back to
+    // the raw string — which is not valid JSON.  Reject the garbage and emit a
+    // safe empty object so downstream round-trips do not fail on re-parse.
+    if !result.trim().is_empty() && serde_json::from_str::<Value>(&result).is_err() {
+        log::warn!(
+            "Upstream returned unparseable tool arguments; falling back to '{{}}'. raw prefix: {}",
+            &value.chars().take(120).collect::<String>()
+        );
+        return "{}".to_string();
+    }
+    result
 }
 
 /// Normalize a tool-call `arguments` field from a Responses/Chat item.
@@ -167,6 +179,24 @@ mod tests {
         assert_eq!(
             canonicalize_tool_arguments_str(r#"{ "b": 2, "a": 1 }"#),
             r#"{"a":1,"b":2}"#
+        );
+    }
+
+    #[test]
+    fn canonicalize_tool_arguments_str_rejects_unparseable() {
+        // Truncated JSON fragment — should fall back to empty object
+        // instead of returning the raw garbage.
+        assert_eq!(canonicalize_tool_arguments_str("{broken"), "{}");
+        // Plain text, not JSON at all.
+        assert_eq!(canonicalize_tool_arguments_str("not json"), "{}");
+        // Numeric literal — valid JSON, but not an object (this passes the
+        // re-parse check in the new guard since 42 is valid JSON; the caller
+        // handles non-objects separately).  Keep to document the boundary:
+        // canonicalize_tool_arguments_str only rejects *non-JSON*, not
+        // non-object JSON.
+        assert_eq!(
+            canonicalize_tool_arguments_str("42"),
+            "42"
         );
     }
 

--- a/src-tauri/src/proxy/json_canonical.rs
+++ b/src-tauri/src/proxy/json_canonical.rs
@@ -71,19 +71,7 @@ pub(crate) fn canonicalize_tool_arguments_str(value: &str) -> String {
     if value.trim().is_empty() {
         return "{}".to_string();
     }
-    let result = canonicalize_json_string_if_parseable(value);
-    // When an upstream provider produces malformed partial JSON
-    // (e.g. a truncated streaming input_json_delta), the canonicalizer falls back to
-    // the raw string — which is not valid JSON.  Reject the garbage and emit a
-    // safe empty object so downstream round-trips do not fail on re-parse.
-    if !result.trim().is_empty() && serde_json::from_str::<Value>(&result).is_err() {
-        log::warn!(
-            "Upstream returned unparseable tool arguments ({} bytes); falling back to '{{}}'.",
-            value.len()
-        );
-        return "{}".to_string();
-    }
-    result
+    canonicalize_json_string_if_parseable(value)
 }
 
 /// Normalize a tool-call `arguments` field from a Responses/Chat item.
@@ -180,21 +168,6 @@ mod tests {
             canonicalize_tool_arguments_str(r#"{ "b": 2, "a": 1 }"#),
             r#"{"a":1,"b":2}"#
         );
-    }
-
-    #[test]
-    fn canonicalize_tool_arguments_str_rejects_unparseable() {
-        // Truncated JSON fragment — should fall back to empty object
-        // instead of returning the raw garbage.
-        assert_eq!(canonicalize_tool_arguments_str("{broken"), "{}");
-        // Plain text, not JSON at all.
-        assert_eq!(canonicalize_tool_arguments_str("not json"), "{}");
-        // Numeric literal — valid JSON, but not an object (this passes the
-        // re-parse check in the new guard since 42 is valid JSON; the caller
-        // handles non-objects separately).  Keep to document the boundary:
-        // canonicalize_tool_arguments_str only rejects *non-JSON*, not
-        // non-object JSON.
-        assert_eq!(canonicalize_tool_arguments_str("42"), "42");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/streaming_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_anthropic.rs
@@ -373,6 +373,22 @@ impl AnthropicToResponsesState {
                 } else {
                     canonicalize_tool_arguments_str(&raw_input)
                 };
+                // Anthropic tool_use.input is always a JSON object. A non-JSON
+                // string here means the upstream stream was truncated or garbled;
+                // emit a safe empty object instead of propagating garbage into
+                // the Responses history where the next request would fail on
+                // re-parse. Keep this scoped to the Anthropic path because the
+                // Chat path legitimately preserves plain-text custom/tool-search
+                // arguments via canonicalize_tool_arguments_str.
+                let arguments = if serde_json::from_str::<Value>(&arguments).is_err() {
+                    log::warn!(
+                        "Anthropic upstream sent unparseable tool arguments ({} bytes) for '{}'; falling back to '{{}}'.",
+                        raw_input.len(), name
+                    );
+                    "{}".to_string()
+                } else {
+                    arguments
+                };
                 let is_custom_tool = self.tool_context.is_custom_tool_chat_name(&name);
                 let item = response_tool_call_item_from_chat_name(
                     &item_id,
@@ -1038,6 +1054,33 @@ mod tests {
         // The tool arguments came from the start event, not from any delta.
         assert!(merged.contains("Tokyo"));
         assert!(merged.contains("\"status\":\"completed\""));
+    }
+
+    #[tokio::test]
+    async fn test_tool_use_with_unparseable_arguments_falls_back_to_empty_object() {
+        // A truncated input_json_delta leaves non-JSON text in the accumulator.
+        // The Anthropic tool_use.input contract is JSON, so the emitter must not
+        // propagate the garbage into the Responses function_call arguments.
+        let input = concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_malformed\",\"model\":\"claude\",\"usage\":{\"input_tokens\":5}}}\n\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_m\",\"name\":\"exec_command\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"cmd\\\":\\\"\"}}\n\n",
+            "event: content_block_stop\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":3}}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\"}\n\n"
+        );
+        let merged = run(input).await;
+        assert!(merged.contains("\"name\":\"exec_command\""));
+        assert!(merged.contains("event: response.function_call_arguments.done"));
+        assert!(merged.contains("\"arguments\":\"{}\""));
+        // The raw partial_json still appears in the incremental argument delta;
+        // only the authoritative done event and stored output item must be safe.
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -548,8 +548,8 @@ fn convert_input_to_messages(
                     // the argument was not valid JSON at all, not merely oddly formatted.
                     serde_json::from_str(args_str).unwrap_or_else(|error| {
                         log::warn!(
-                            "Invalid function_call arguments for '{}' (round-trip): {}. Falling back to empty object. raw prefix: {}",
-                            name, error, &args_str.chars().take(120).collect::<String>()
+                            "Invalid function_call arguments for '{}' (round-trip): {}. Falling back to empty object ({} bytes).",
+                            name, error, args_str.len()
                         );
                         json!({})
                     })

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -540,11 +540,19 @@ fn convert_input_to_messages(
                 let input: Value = if args_str.trim().is_empty() {
                     json!({})
                 } else {
-                    serde_json::from_str(args_str).map_err(|error| {
-                        ProxyError::InvalidRequest(format!(
-                            "Invalid function_call arguments for '{name}': {error}"
-                        ))
-                    })?
+                    // When conversation history carries corrupt function_call arguments
+                    // (e.g. a malformed JSON fragment written by an older version), degrade
+                    // to an empty object so the entire request does not 400 because of a
+                    // single unparseable history entry.  Note: this calls serde::from_str
+                    // directly, not canonicalize_tool_arguments_str — so a hit here means
+                    // the argument was not valid JSON at all, not merely oddly formatted.
+                    serde_json::from_str(args_str).unwrap_or_else(|error| {
+                        log::warn!(
+                            "Invalid function_call arguments for '{}' (round-trip): {}. Falling back to empty object. raw prefix: {}",
+                            name, error, &args_str.chars().take(120).collect::<String>()
+                        );
+                        json!({})
+                    })
                 };
                 if !input.is_object() {
                     return Err(ProxyError::InvalidRequest(format!(
@@ -1985,7 +1993,7 @@ mod tests {
 
     #[test]
     fn test_request_invalid_or_non_object_arguments_error() {
-        for arguments in ["{broken", "[1,2]"] {
+        for arguments in ["[1,2]"] {
             let input = json!({
                 "model":"c",
                 "input":[
@@ -1998,6 +2006,22 @@ mod tests {
                 Err(ProxyError::InvalidRequest(_))
             ));
         }
+    }
+
+    #[test]
+    fn test_request_unparseable_arguments_falls_back_to_empty_object() {
+        let input = json!({
+            "model":"c",
+            "input":[
+                {"type":"function_call","call_id":"c1","name":"exec","arguments":"{broken"},
+                {"type":"function_call_output","call_id":"c1","output":"ok"}
+            ]
+        });
+        let result = responses_request_to_anthropic(input, 4096).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+        let tool_use = &messages[messages.len() - 2]["content"][0];
+        assert_eq!(tool_use["type"], "tool_use");
+        assert_eq!(tool_use["input"], json!({}));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

When cc-switch is configured with the Anthropic Messages upstream format and the provider occasionally sends truncated or malformed `input_json_delta` chunks, the live streaming emitter passes the garbage string through `canonicalize_tool_arguments_str` unvalidated. The corrupted `arguments` field is then written into the Responses-format `function_call` item.

On the next Codex request, cc-switch attempts to re-parse that `arguments` string for the round-trip back to Anthropic format, and `serde_json::from_str` fails with:

```
Invalid function_call arguments for 'exec_command': expected value at line 1 column 364
```

This crashes the entire request — the user gets a proxy error and the conversation is interrupted. The Chat Completions upstream format does not trigger this because it uses a different code path that does not round-trip through the `function_call.arguments` field in the same way.

Reproduced with `deepseek-v4-pro` as the test model against an Anthropic Messages gateway.

## Fix

Two-layer defense:

### Layer 1 — Validate before emitting (primary fix)

`canonicalize_tool_arguments_str` in `json_canonical.rs` now verifies that its output is actually parseable JSON after canonicalization. If `canonicalize_json_string_if_parseable` produced an invalid string, it logs a warning and safely falls back to `"{}"` — preventing the garbage string from ever reaching the Responses output. This is the code path used by the live streaming emitter in `streaming_codex_anthropic.rs`.

### Layer 2 — Graceful fallback on re-parse (defense in depth)

`convert_input_to_messages` in `transform_codex_anthropic.rs` replaces its `map_err` → `ProxyError::InvalidRequest` with an `unwrap_or_else` that logs a warning with the raw argument prefix and falls back to `json!({})`. If malformed arguments somehow reach this point from another path, the request still completes — the tool call is emitted with empty arguments rather than crashing.

The non-streaming SSE aggregation path was already safe (it already uses `unwrap_or_else(|_| json!({}))`).

## Test Coverage

- **New**: `test_request_unparseable_arguments_falls_back_to_empty_object` verifies that malformed `arguments` no longer crash the round-trip.
- **New**: `canonicalize_tool_arguments_str_rejects_unparseable` covers `{broken`, plain text, and a numeric-literal boundary case for the validation guard in `canonicalize_tool_arguments_str`.
- **Updated**: `test_request_invalid_or_non_object_arguments_error` now only covers non-object JSON (e.g. arrays like `[1,2]`), which is still correctly rejected at the object-type gate.
- **Regressions**: All related tests pass (73 transform + 21 streaming + 8 json_canonical).
