### PR TITLE
fix(lib): reset skip_taskbar before window.show() across entry points

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -256,6 +256,10 @@ fn handle_deeplink_url(
 
             if focus_main_window {
                 if let Some(window) = app.get_webview_window("main") {
+                    #[cfg(target_os = "windows")]
+                    {
+                        let _ = window.set_skip_taskbar(false);
+                    }
                     let _ = window.unminimize();
                     let _ = window.show();
                     let _ = window.set_focus();
@@ -357,6 +361,13 @@ pub fn run() {
 
             // Show and focus window regardless
             if let Some(window) = app.get_webview_window("main") {
+                // 防御性重置 Windows 的 skip_taskbar：single_instance 触发时，
+                // 原进程可能因 silent_startup / 关闭到托盘等处于 skip_taskbar(true) 状态，
+                // 仅 show() 不会重置该状态，会导致窗口可见但不在任务栏、最小化后消失。
+                #[cfg(target_os = "windows")]
+                {
+                    let _ = window.set_skip_taskbar(false);
+                }
                 let _ = window.unminimize();
                 let _ = window.show();
                 let _ = window.set_focus();
@@ -545,6 +556,10 @@ pub fn run() {
                     });
                     // 主窗口默认 visible:false，恢复界面必须强制显示
                     if let Some(window) = app.get_webview_window("main") {
+                        #[cfg(target_os = "windows")]
+                        {
+                            let _ = window.set_skip_taskbar(false);
+                        }
                         let _ = window.show();
                         let _ = window.set_focus();
                     }
@@ -1788,6 +1803,10 @@ pub fn run() {
 
                             // 确保主窗口可见
                             if let Some(window) = app_handle.get_webview_window("main") {
+                                #[cfg(target_os = "windows")]
+                                {
+                                    let _ = window.set_skip_taskbar(false);
+                                }
                                 let _ = window.unminimize();
                                 let _ = window.show();
                                 let _ = window.set_focus();


### PR DESCRIPTION

## Summary / 概述

修复 Windows 上 CC Switch 主窗口最小化后从任务栏消失的 bug。多个 `window.show()` 调用点没有在 `show()` 前重置 `skip_taskbar` 状态，导致窗口可见但不在任务栏、点击最小化按钮后窗口彻底消失。

This PR fixes a Windows bug where the main window disappears from the taskbar after clicking minimize. Several `window.show()` call sites do not reset `skip_taskbar` before showing, causing the window to be visible but not in the taskbar — clicking minimize then makes the window disappear entirely.

## Problem

**复现步骤 / Steps to reproduce:**
1. 在 CC Switch 设置中启用"开机自启"和"静默启动"
2. 重启 Windows（应用通过 autostart 启动，窗口隐藏，skip_taskbar=true）
3. 从**开始菜单/桌面快捷方式**点击 CC Switch（触发 single_instance handler 唤起已运行实例）
4. 窗口出现，但**任务栏里没有 CC Switch 图标**
5. 点击最小化按钮 → 窗口**完全消失**（既不在任务栏也找不到）

预期：最小化后窗口应该正常显示在任务栏
实际：窗口可见但不在任务栏，最小化后消失


## Root Cause / 根因分析

代码不对称：`tray.rs::handle_tray_menu_event` 中的 `show_main` 处理器在 `window.show()` 前调用了 `set_skip_taskbar(false)` 重置状态，但**其他 4 处** `window.show()` 调用点（**包括用户实际触发的 single_instance handler**）都没有做这个重置。

`window.show()` 本身不会重置 `skip_taskbar`，所以当原进程处于 `skip_taskbar(true)` 状态时，调 `show()` 后窗口会显示但仍在任务栏之外。

## Fix / 修复

在 4 个 `window.show()` 调用点之前增加防御性的 `set_skip_taskbar(false)` 调用（`#[cfg(target_os = "windows")]`），与 `tray.rs:show_main` 的模式对齐：

| 入口 | 文件位置 | 触发场景 |
|---|---|---|
| `single_instance` handler | lib.rs:360-361 | 快捷方式/开始菜单唤起已运行实例（**用户报告的场景**）|
| `handle_deeplink_url` | lib.rs:256 | `ccswitch://` URL 唤起 |
| DB 恢复流程 | lib.rs:556 | 数据库版本不匹配时 |
| `RunEvent::Opened` | lib.rs:1803 | 系统接收到 deep-link URL |

未修改任何 `set_skip_taskbar(true)` 调用——只在 `show()` 之前补上对称的重置。

## Testing / 测试

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib catalog_json`：7/7 通过
- [x] 手动测试（Win10 22H2，autostart + silent_startup + 从开始菜单启动场景）：最小化按钮恢复正常工作


## Checklist / 检查清单

- [x] `cargo fmt --check` passes / 通过代码格式检查
- [x] `cargo clippy` passes / 通过 Clippy 检查
- [x] `cargo test` passes / 通过单元测试