### PR TITLE
fix(provider): finish model dropdown follow-ups

### DIFF
--- a/src/components/profiles/ProfileSwitcher.tsx
+++ b/src/components/profiles/ProfileSwitcher.tsx
@@ -130,7 +130,7 @@ export function ProfileSwitcher({ activeApp }: ProfileSwitcherProps) {
           sideOffset={6}
           className="z-[100] w-64 p-0"
         >
-          <Command>
+          <Command label={t("profiles.searchPlaceholder")}>
             <CommandInput placeholder={t("profiles.searchPlaceholder")} />
             <CommandList>
               <CommandEmpty>{t("profiles.empty")}</CommandEmpty>

--- a/src/components/providers/forms/HermesFormFields.tsx
+++ b/src/components/providers/forms/HermesFormFields.tsx
@@ -31,15 +31,7 @@ import {
   ChevronRight,
   Loader2,
 } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { ApiKeySection } from "./shared";
+import { ApiKeySection, ModelDropdown } from "./shared";
 import {
   fetchModelsForConfig,
   showFetchModelsError,
@@ -191,24 +183,6 @@ export function HermesFormFields({
     modelKeysRef.current.length = models.length;
   }
   const modelKeys = modelKeysRef.current;
-
-  // Group fetched models by vendor once — Radix DropdownMenuContent doesn't
-  // lazy-mount, so computing this in JSX would re-run per model row per render.
-  const groupedFetchedModels = useMemo(
-    () =>
-      Object.entries(
-        fetchedModels.reduce(
-          (acc, m) => {
-            const v = m.ownedBy || "Other";
-            if (!acc[v]) acc[v] = [];
-            acc[v].push(m);
-            return acc;
-          },
-          {} as Record<string, FetchedModel[]>,
-        ),
-      ).sort(([a], [b]) => a.localeCompare(b)),
-    [fetchedModels],
-  );
 
   const toggleModelAdvanced = (index: number) => {
     setExpandedModels((prev) => ({ ...prev, [index]: !prev[index] }));
@@ -422,42 +396,10 @@ export function HermesFormFields({
                         className="flex-1"
                       />
                       {fetchedModels.length > 0 && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="outline"
-                              size="icon"
-                              className="shrink-0"
-                            >
-                              <ChevronDown className="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent
-                            align="end"
-                            className="max-h-64 overflow-y-auto z-[200]"
-                          >
-                            {groupedFetchedModels.map(
-                              ([vendor, vModels], vi) => (
-                                <div key={vendor}>
-                                  {vi > 0 && <DropdownMenuSeparator />}
-                                  <DropdownMenuLabel>
-                                    {vendor}
-                                  </DropdownMenuLabel>
-                                  {vModels.map((m) => (
-                                    <DropdownMenuItem
-                                      key={m.id}
-                                      onSelect={() =>
-                                        handleModelChange(index, "id", m.id)
-                                      }
-                                    >
-                                      {m.id}
-                                    </DropdownMenuItem>
-                                  ))}
-                                </div>
-                              ),
-                            )}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                        <ModelDropdown
+                          models={fetchedModels}
+                          onSelect={(id) => handleModelChange(index, "id", id)}
+                        />
                       )}
                     </div>
                   </div>

--- a/src/components/providers/forms/OmoFormFields.tsx
+++ b/src/components/providers/forms/OmoFormFields.tsx
@@ -185,7 +185,11 @@ function ModelCombobox({
         collisionPadding={8}
         className="z-[1000] w-[var(--radix-popover-trigger-width)] p-0 border-border-default"
       >
-        <Command>
+        <Command
+          label={t("omo.searchModel", {
+            defaultValue: "Search model...",
+          })}
+        >
           <CommandInput
             placeholder={t("omo.searchModel", {
               defaultValue: "Search model...",

--- a/src/components/providers/forms/OpenClawFormFields.tsx
+++ b/src/components/providers/forms/OpenClawFormFields.tsx
@@ -25,16 +25,8 @@ import {
   ChevronRight,
   Loader2,
 } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Checkbox } from "@/components/ui/checkbox";
-import { ApiKeySection } from "./shared";
+import { ApiKeySection, ModelDropdown } from "./shared";
 import {
   fetchModelsForConfig,
   showFetchModelsError,
@@ -365,52 +357,10 @@ export function OpenClawFormFields({
                         className="flex-1"
                       />
                       {fetchedModels.length > 0 && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button
-                              variant="outline"
-                              size="icon"
-                              className="shrink-0"
-                            >
-                              <ChevronDown className="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent
-                            align="end"
-                            className="max-h-64 overflow-y-auto z-[200]"
-                          >
-                            {Object.entries(
-                              fetchedModels.reduce(
-                                (acc, m) => {
-                                  const v = m.ownedBy || "Other";
-                                  if (!acc[v]) acc[v] = [];
-                                  acc[v].push(m);
-                                  return acc;
-                                },
-                                {} as Record<string, FetchedModel[]>,
-                              ),
-                            )
-                              .sort(([a], [b]) => a.localeCompare(b))
-                              .map(([vendor, vModels], vi) => (
-                                <div key={vendor}>
-                                  {vi > 0 && <DropdownMenuSeparator />}
-                                  <DropdownMenuLabel>
-                                    {vendor}
-                                  </DropdownMenuLabel>
-                                  {vModels.map((m) => (
-                                    <DropdownMenuItem
-                                      key={m.id}
-                                      onSelect={() =>
-                                        handleModelChange(index, "id", m.id)
-                                      }
-                                    >
-                                      {m.id}
-                                    </DropdownMenuItem>
-                                  ))}
-                                </div>
-                              ))}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                        <ModelDropdown
+                          models={fetchedModels}
+                          onSelect={(id) => handleModelChange(index, "id", id)}
+                        />
                       )}
                     </div>
                   </div>

--- a/src/components/providers/forms/shared/ModelDropdown.tsx
+++ b/src/components/providers/forms/shared/ModelDropdown.tsx
@@ -56,7 +56,11 @@ export function ModelDropdown({
         collisionPadding={8}
         className="z-[200] w-72 p-0"
       >
-        <Command>
+        <Command
+          label={t("providerForm.searchModelPlaceholder", {
+            defaultValue: "Search models...",
+          })}
+        >
           <CommandInput
             placeholder={t("providerForm.searchModelPlaceholder", {
               defaultValue: "Search models...",

--- a/tests/components/ModelDropdown.test.tsx
+++ b/tests/components/ModelDropdown.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ModelDropdown } from "@/components/providers/forms/shared/ModelDropdown";
+
+describe("ModelDropdown", () => {
+  it("exposes a labelled search input and filters by vendor", async () => {
+    const onSelect = vi.fn();
+    Element.prototype.scrollIntoView = vi.fn();
+
+    render(
+      <ModelDropdown
+        models={[
+          { id: "gpt-5", ownedBy: "openai" },
+          { id: "claude-sonnet", ownedBy: "anthropic" },
+        ]}
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Select model" }));
+
+    const searchInput = screen.getByRole("combobox", {
+      name: "Search models...",
+    });
+    expect(searchInput).toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: "openai" } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "gpt-5" })).toBeVisible();
+      expect(
+        screen.queryByRole("option", { name: "claude-sonnet" }),
+      ).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("option", { name: "gpt-5" }));
+    expect(onSelect).toHaveBeenCalledWith("gpt-5");
+  });
+});


### PR DESCRIPTION
## Summary

- Reuse the shared searchable ModelDropdown in Hermes and OpenClaw, removing their duplicated vendor-grouped dropdown implementations.
- Give the cmdk search inputs explicit accessible labels in ModelDropdown, OmoFormFields, and ProfileSwitcher.
- Add a regression test covering vendor filtering and model selection.

This follows the two follow-up items noted after #6285.

## Testing

- pnpm typecheck
- pnpm test:unit (102 files, 709 tests)
- Prettier check on all changed files
- git diff --check