### PR TITLE
fix(provider): open terminal directly without directory picker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -824,14 +824,7 @@ function App() {
 
   const handleOpenTerminal = async (provider: Provider) => {
     try {
-      const selectedDir = await settingsApi.pickDirectory();
-      if (!selectedDir) {
-        return;
-      }
-
-      await providersApi.openTerminal(provider.id, activeApp, {
-        cwd: selectedDir,
-      });
+      await providersApi.openTerminal(provider.id, activeApp);
       toast.success(
         t("provider.terminalOpened", {
           defaultValue: "终端已打开",


### PR DESCRIPTION
## Summary / 概述

Fixes #6352

点击 Provider 卡片上的「打开终端」按钮时，会先弹出系统的「选择文件夹」对话框，选完目录才打开终端。本 PR 移除了这个强制的文件夹选择步骤：点击按钮直接打开终端（默认工作目录）。

The "Open Terminal" button on a provider card always popped a system folder-picker dialog first and only opened the terminal after a folder was chosen. This PR removes that forced picker step: clicking the button now opens the terminal immediately in its default working directory.

## Changes / 改动

- `src/App.tsx`: `handleOpenTerminal` no longer calls `settingsApi.pickDirectory()` / passes `cwd`. It calls `providersApi.openTerminal(provider.id, activeApp)` directly.
- 后端契约不变：`open_provider_terminal` 的 `cwd` 参数本就是可选的（`Option`），不传时在默认目录启动。
- 不涉及用户可见文本，无需更新 i18n。

## Local Verification / 本地验证

已在本地完整跑通：

- `pnpm tauri build` 打包独立 exe（release）✅
- 运行打包后的 exe，点击「打开终端」按钮 ✅
  - 不再弹出「选择文件夹」对话框
  - 直接打开终端窗口，自动运行 `claude --settings <临时配置>` 加载当前 provider 配置
- `pnpm typecheck` ✅
- `pnpm format:check` ✅
- `pnpm test:unit` — 100 files / 695 tests passed ✅
- 后端无改动，`cargo clippy` N/A

## Checklist / 检查清单

- [x] I have read and understood my code. / 我已阅读并理解我的代码
- [x] I have tested this locally. / 我已在本地验证（实际运行打包后的应用点击按钮）
- [x] Small and focused PR. / 小而聚焦（+1/-8）
- [x] Related issue opened first. / 已先开 Issue #6352