### PR TITLE
fix(deeplink): accept Claude Desktop providers

### DIFF
--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -81,10 +81,17 @@ fn parse_provider_deeplink(
     // Validate app type
     if !matches!(
         app.as_str(),
-        "claude" | "codex" | "gemini" | "grokbuild" | "opencode" | "openclaw" | "hermes"
+        "claude"
+            | "claude-desktop"
+            | "codex"
+            | "gemini"
+            | "grokbuild"
+            | "opencode"
+            | "openclaw"
+            | "hermes"
     ) {
         return Err(AppError::InvalidInput(format!(
-            "Invalid app type: must be 'claude', 'codex', 'gemini', 'grokbuild', 'opencode', 'openclaw', or 'hermes', got '{app}'"
+            "Invalid app type: must be 'claude', 'claude-desktop', 'codex', 'gemini', 'grokbuild', 'opencode', 'openclaw', or 'hermes', got '{app}'"
         )));
     }
 

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -79,6 +79,22 @@ fn test_parse_valid_claude_deeplink() {
 }
 
 #[test]
+fn test_parse_valid_claude_desktop_deeplink() {
+    use super::provider::build_provider_from_request;
+
+    let url = "ccswitch://v1/import?resource=provider&app=claude-desktop&name=Test%20Provider&endpoint=https%3A%2F%2Fapi.example.com&apiKey=sk-test-123";
+    let request = parse_deeplink_url(url).unwrap();
+
+    assert_eq!(request.app.as_deref(), Some("claude-desktop"));
+
+    let provider = build_provider_from_request(&AppType::ClaudeDesktop, &request).unwrap();
+    assert!(matches!(
+        provider.meta.and_then(|meta| meta.claude_desktop_mode),
+        Some(crate::provider::ClaudeDesktopMode::Direct)
+    ));
+}
+
+#[test]
 fn test_parse_deeplink_with_notes() {
     let url = "ccswitch://v1/import?resource=provider&app=codex&name=Codex&homepage=https%3A%2F%2Fcodex.com&endpoint=https%3A%2F%2Fapi.codex.com&apiKey=key123&notes=Test%20notes";
 


### PR DESCRIPTION
## Summary / 概述

Accept `app=claude-desktop` for provider deeplinks so requests can reach the Claude Desktop support already present in `AppType` and the provider builder.

The regression test parses a provider URI and verifies the resulting provider uses `ClaudeDesktopMode::Direct`. Prompt, MCP, Skill, proxy, UI, and release behavior are unchanged.

## Related Issue / 关联 Issue

Fixes #6368

## Screenshots / 截图

Not applicable; this is a provider deeplink parser fix with no UI change.

## Verification / 验证

- Added `test_parse_valid_claude_desktop_deeplink` for parser and existing Desktop builder behavior.
- Repository CI will run Rust formatting, Clippy, and tests on Linux, Windows, and macOS.
- Local Rust/Tauri verification was not run because this workstation does not have the required Rust 1.85+ toolchain; no local-pass claim is made.

## Checklist / 检查清单

- [ ] `cargo fmt --check` passes in CI
- [ ] `cargo clippy` passes in CI
- [ ] `cargo test` passes in CI
- [x] No frontend or user-facing text changed; TypeScript formatting/typecheck and i18n updates are not applicable
