### PR TITLE
fix(responses): map Anthropic web_search server tool to Responses built-in web_search

### DIFF
--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -360,6 +360,14 @@ pub fn anthropic_to_responses(
             .iter()
             .filter(|t| t.get("type").and_then(|v| v.as_str()) != Some("BatchTool"))
             .map(|t| {
+                // Anthropic server-side web_search tool (e.g. type
+                // "web_search_20250305" / "web_search_20260209" /
+                // "web_search_20260318"). Responses gateways like DeepSeek
+                // declare it as {"type":"web_search"} and execute the search
+                // server-side; a function-style definition is not accepted.
+                if is_anthropic_web_search_tool(t) {
+                    return json!({"type": "web_search"});
+                }
                 json!({
                     "type": "function",
                     "name": t.get("name").and_then(|n| n.as_str()).unwrap_or(""),
@@ -446,6 +454,20 @@ pub fn anthropic_to_responses(
     Ok(result)
 }
 
+/// Detect Anthropic's server-side `web_search` tool declaration. The Messages
+/// API exposes it as a versioned tool type (`web_search_20250305`,
+/// `web_search_20260209`, `web_search_20260318`, ...) with `name: "web_search"`.
+/// A user-defined function tool named "web_search" (type `custom`/missing) must
+/// NOT be treated as the server tool, so the versioned `type` prefix is the
+/// authoritative signal; the bare `name` fallback only catches the unversioned
+/// `{"type":"web_search"}` form some gateways emit.
+fn is_anthropic_web_search_tool(tool: &Value) -> bool {
+    matches!(
+        tool.get("type").and_then(Value::as_str),
+        Some(t) if t.starts_with("web_search_") || t == "web_search"
+    )
+}
+
 fn map_tool_choice_to_responses(tool_choice: &Value) -> Value {
     match tool_choice {
         Value::String(_) => tool_choice.clone(),
@@ -454,13 +476,21 @@ fn map_tool_choice_to_responses(tool_choice: &Value) -> Value {
             Some("any") => json!("required"),
             Some("auto") => json!("auto"),
             Some("none") => json!("none"),
-            // Anthropic forced tool -> Responses function tool selector
+            // Anthropic forced tool -> Responses tool selector
             Some("tool") => {
                 let name = obj.get("name").and_then(|n| n.as_str()).unwrap_or("");
-                json!({
-                    "type": "function",
-                    "name": name
-                })
+                // Anthropic server-side web_search tool. DeepSeek and other
+                // Responses gateways only accept {"type":"web_search"} here;
+                // a function-style selector is rejected with a 400 while
+                // thinking is enabled.
+                if name == "web_search" {
+                    json!({"type": "web_search"})
+                } else {
+                    json!({
+                        "type": "function",
+                        "name": name
+                    })
+                }
             }
             _ => tool_choice.clone(),
         },
@@ -1180,6 +1210,124 @@ mod tests {
             "model": "gpt-4o",
             "max_tokens": 1024,
             "messages": [{"role": "user", "content": "Weather?"}],
+            "tool_choice": {"type": "tool", "name": "get_weather"}
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["tool_choice"]["type"], "function");
+        assert_eq!(result["tool_choice"]["name"], "get_weather");
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_web_search_tool_preserved() {
+        // Anthropic server-side web_search must map to Responses' built-in
+        // web_search tool, not a function definition.
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Search the web"}],
+            "tools": [{
+                "type": "web_search_20260318",
+                "name": "web_search"
+            }]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["tools"][0], json!({"type": "web_search"}));
+        assert!(result["tools"][0].get("name").is_none());
+        assert!(result["tools"][0].get("parameters").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_web_search_older_version_preserved() {
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Search the web"}],
+            "tools": [{
+                "type": "web_search_20250305",
+                "name": "web_search"
+            }]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["tools"][0], json!({"type": "web_search"}));
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_mixed_web_search_and_function_tools() {
+        // A request mixing the server tool with a normal function tool must
+        // keep both: web_search stays a server tool, the function stays a
+        // function.
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Do both"}],
+            "tools": [
+                {"type": "web_search_20260209", "name": "web_search"},
+                {
+                    "name": "get_weather",
+                    "description": "Get weather info",
+                    "input_schema": {"type": "object", "properties": {"location": {"type": "string"}}}
+                }
+            ]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["tools"].as_array().unwrap().len(), 2);
+        assert_eq!(result["tools"][0], json!({"type": "web_search"}));
+        assert_eq!(result["tools"][1]["type"], "function");
+        assert_eq!(result["tools"][1]["name"], "get_weather");
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_user_function_named_web_search_not_mapped() {
+        // A user-defined function tool that happens to be named "web_search"
+        // (type custom/missing, with an input_schema) is NOT the server tool and
+        // must stay a function definition.
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Use my tool"}],
+            "tools": [{
+                "name": "web_search",
+                "description": "custom wrapper",
+                "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}}
+            }]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["tools"][0]["type"], "function");
+        assert_eq!(result["tools"][0]["name"], "web_search");
+        assert!(result["tools"][0].get("parameters").is_some());
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_web_search_tool_choice_preserved() {
+        // Forced web_search tool_choice must map to Responses' built-in
+        // web_search selector, NOT a function-style selector. DeepSeek rejects
+        // the latter with a 400 when thinking is enabled.
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Search the web"}],
+            "tools": [{"type": "web_search_20260318", "name": "web_search"}],
+            "tool_choice": {"type": "tool", "name": "web_search"}
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["tool_choice"], json!({"type": "web_search"}));
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_regular_tool_choice_unaffected() {
+        // A forced tool_choice for a normal function must still map to the
+        // function selector.
+        let input = json!({
+            "model": "gpt-4o",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Weather?"}],
+            "tools": [{"name": "get_weather", "input_schema": {"type": "object"}}],
             "tool_choice": {"type": "tool", "name": "get_weather"}
         });
 

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -385,7 +385,7 @@ pub fn anthropic_to_responses(
     }
 
     if let Some(v) = body.get("tool_choice") {
-        result["tool_choice"] = map_tool_choice_to_responses(v);
+        result["tool_choice"] = map_tool_choice_to_responses(v, body.get("tools"));
     }
 
     // Inject prompt_cache_key for improved cache routing on OpenAI-compatible endpoints
@@ -468,7 +468,15 @@ fn is_anthropic_web_search_tool(tool: &Value) -> bool {
     )
 }
 
-fn map_tool_choice_to_responses(tool_choice: &Value) -> Value {
+/// Map an Anthropic forced/auto tool_choice to the Responses equivalent.
+///
+/// `tools` is the original Anthropic request's `tools` array (if any). For a
+/// forced `{"type":"tool","name":...}` choice, the selector follows the matching
+/// tool declaration: a server-side web_search tool maps to Responses' built-in
+/// `{"type":"web_search"}`, while a user-defined function (even one named
+/// "web_search") keeps a `function` selector so the declaration and the choice
+/// stay consistent.
+fn map_tool_choice_to_responses(tool_choice: &Value, tools: Option<&Value>) -> Value {
     match tool_choice {
         Value::String(_) => tool_choice.clone(),
         Value::Object(obj) => match obj.get("type").and_then(|t| t.as_str()) {
@@ -479,11 +487,19 @@ fn map_tool_choice_to_responses(tool_choice: &Value) -> Value {
             // Anthropic forced tool -> Responses tool selector
             Some("tool") => {
                 let name = obj.get("name").and_then(|n| n.as_str()).unwrap_or("");
-                // Anthropic server-side web_search tool. DeepSeek and other
-                // Responses gateways only accept {"type":"web_search"} here;
-                // a function-style selector is rejected with a 400 while
-                // thinking is enabled.
-                if name == "web_search" {
+                // Only map to Responses' built-in web_search when the forced
+                // tool's declaration in `tools` is Anthropic's server-side
+                // web_search tool. DeepSeek and other Responses gateways
+                // reject a function-style selector for it with a 400 while
+                // thinking is enabled; conversely, a user-defined function
+                // named "web_search" must keep its function selector.
+                let is_server_web_search = tools.and_then(|t| t.as_array()).is_some_and(|arr| {
+                    arr.iter().any(|t| {
+                        t.get("name").and_then(Value::as_str) == Some(name)
+                            && is_anthropic_web_search_tool(t)
+                    })
+                });
+                if is_server_web_search {
                     json!({"type": "web_search"})
                 } else {
                     json!({
@@ -1334,6 +1350,33 @@ mod tests {
         let result = anthropic_to_responses(input, None, false, false).unwrap();
         assert_eq!(result["tool_choice"]["type"], "function");
         assert_eq!(result["tool_choice"]["name"], "get_weather");
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_forced_choice_for_custom_web_search_function_keeps_function_selector(
+    ) {
+        // A user-defined function named "web_search" (type custom/missing) that
+        // is forced via tool_choice must keep a function selector, matching its
+        // function declaration. Only Anthropic's server-side web_search tool
+        // (versioned type) maps to {"type":"web_search"}.
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Use my tool"}],
+            "tools": [{
+                "name": "web_search",
+                "description": "custom wrapper",
+                "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}}
+            }],
+            "tool_choice": {"type": "tool", "name": "web_search"}
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["tools"][0]["type"], "function");
+        assert_eq!(
+            result["tool_choice"],
+            json!({"type": "function", "name": "web_search"})
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 问题

Claude Code 内置 WebSearch(Anthropic 服务端 `web_search` server tool)经 CC Switch 的 **Responses 路由**(`apiFormat: responses`)转发到 DeepSeek(OpenCode Go)时,100% 返回 400:

```
invalid_request_error: Thinking mode does not support this tool_choice
```

普通对话、普通 function tool 均正常,仅 WebSearch 失败。openai_chat 协议路径同样失败(历史报错 `function "web_search" not found`)。

## 根因

`transform_responses.rs` 将 Anthropic 请求翻译为 Responses 格式时,有两处把 web_search server tool 当作普通 function tool 处理:

1. **tools 数组**(`anthropic_to_responses`):`{"type":"web_search_20260318","name":"web_search"}` 被硬转成 `{"type":"function",...}`,丢失了 server tool 语义。
2. **tool_choice**(`map_tool_choice_to_responses`):Claude Code 对 WebSearch 强制发送 `{"type":"tool","name":"web_search"}`,被转成 `{"type":"function","name":"web_search"}`。DeepSeek 的 Responses API 只接受 `{"type":"web_search"}` 或 `auto`,收到 function 风格的选择器时在 thinking 模式下直接 400(已用上游 token 穷举 9 种 tool_choice 实测验证)。

DeepSeek 官方文档确认 Responses API 原生支持服务端 web_search(tools 表:`web_search` — "executed on the server side"),所以这是纯转换层 bug。

## 修改

`src-tauri/src/proxy/providers/transform_responses.rs`:

- 新增 `is_anthropic_web_search_tool` 辅助函数,识别版本化的 Anthropic server tool type(`web_search_*`)。仅匹配 versioned type,不匹配用户自定义的 `type: custom` function 工具(即使也叫 "web_search")。
- tools 数组转换:web_search server tool → `{"type":"web_search"}`;普通 function 工具保持 `{"type":"function",...}` 不变。
- `map_tool_choice_to_responses`:改为接收原始 `tools` 数组,只有当强制 tool_choice 指向的声明确实是 Anthropic 服务端 web_search(versioned type)时才 → `{"type":"web_search"}`;自定义函数(含同名 "web_search")保持 function selector(Codex review 建议,避免 function 声明与 web_search 选择器错配)。

**响应侧无需改动**:DeepSeek 的 web_search 是服务端循环模式,搜索结果由上游消费,响应只有整合后的 message;`web_search_call` 在流式/非流式转换中本就静默忽略,`stop_reason` 正确映射为 `end_turn`。

## 测试

新增 7 个单元测试:
- web_search 新/旧版本工具类型保留为 `{"type":"web_search"}`
- 混合 web_search + function 工具时两者都保留
- 用户自定义名为 "web_search" 的 function 工具不被误判(声明与 tool_choice 均保持 function)
- web_search 强制 tool_choice → `{"type":"web_search"}`
- 普通 function 的强制 tool_choice 不受影响

## 验证

- `cargo test --lib proxy::providers::transform_responses` 全部通过(83 个)
- `cargo fmt` 通过
- `cargo clippy -- -D warnings` 通过

Closes #6367
