### PR TITLE
fix(grok): deduplicate npm launcher and native canonical installation on Windows

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2024,6 +2024,8 @@ fn enumerate_tool_installations(tool: &str) -> Vec<ToolInstallation> {
     #[cfg(not(target_os = "windows"))]
     use std::process::Command;
 
+    #[cfg(target_os = "windows")]
+    let home = dirs::home_dir().unwrap_or_default();
     let search_paths = build_tool_search_paths(tool);
     let current_path = std::env::var_os("PATH")
         .map(|value| value.to_string_lossy().into_owned())
@@ -2098,6 +2100,11 @@ fn enumerate_tool_installations(tool: &str) -> Vec<ToolInstallation> {
         }
     }
 
+    #[cfg(target_os = "windows")]
+    if tool == "grok" {
+        installs = dedupe_grok_npm_canonical_installations(&home, installs);
+    }
+
     // PATH 默认那处排最前，UI 一眼看到"命令行默认用的是哪处"。
     installs.sort_by_key(|i| std::cmp::Reverse(i.is_path_default));
     installs
@@ -2160,6 +2167,85 @@ fn is_grok_native_install(bin_path: &str, real_target: &str) -> bool {
         let normalized = path.replace('\\', "/").to_ascii_lowercase();
         normalized.contains("/.grok/bin/") || normalized.contains("/.grok/downloads/grok-")
     })
+}
+
+#[cfg(target_os = "windows")]
+fn is_grok_npm_global_launcher(path: &Path) -> bool {
+    let is_grok_cmd = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem.eq_ignore_ascii_case("grok"))
+        && path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("cmd"));
+    if !is_grok_cmd {
+        return false;
+    }
+
+    let Some(prefix) = path.parent() else {
+        return false;
+    };
+    prefix
+        .join("node_modules")
+        .join("@xai-official")
+        .join("grok")
+        .is_dir()
+}
+
+/// Grok's npm package installs its native payload into the canonical
+/// `~/.grok/bin` directory. The npm launcher and that payload are therefore
+/// one installation even though they live in different directories.
+#[cfg(target_os = "windows")]
+fn dedupe_grok_npm_canonical_installations(
+    home: &Path,
+    installs: Vec<ToolInstallation>,
+) -> Vec<ToolInstallation> {
+    let canonical_native = home.join(".grok").join("bin").join("grok.exe");
+    let Ok(canonical_native) = std::fs::canonicalize(canonical_native) else {
+        return installs;
+    };
+
+    let Some(native_index) = installs
+        .iter()
+        .position(|install| install.runnable && install.real == canonical_native)
+    else {
+        return installs;
+    };
+    let native_version = installs[native_index].version.as_ref();
+
+    let mut related = vec![native_index];
+    for (index, install) in installs.iter().enumerate() {
+        if index == native_index
+            || !install.runnable
+            || install.version.as_ref() != native_version
+            || !is_grok_npm_global_launcher(Path::new(&install.path))
+        {
+            continue;
+        }
+        related.push(index);
+    }
+    if related.len() < 2 {
+        return installs;
+    }
+
+    let representative = related
+        .iter()
+        .copied()
+        .max_by_key(|index| (installs[*index].is_path_default, installs[*index].runnable))
+        .expect("related Grok installations should not be empty");
+
+    installs
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, install)| {
+            if index == representative || !related.contains(&index) {
+                Some(install)
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// 含空格才用 POSIX 单引号包一层,否则保持裸路径——命令展示更干净。
@@ -6177,6 +6263,84 @@ mod tests {
         let preferred = windows_runnable_sibling_for_extensionless_tool(&extensionless);
 
         assert_eq!(preferred.as_deref(), Some(cmd.as_path()));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn grok_npm_launcher_and_canonical_binary_are_one_installation() {
+        let root = tempfile::tempdir().expect("temp dir should be created");
+        let home = root.path().join("home");
+        let native_bin = home.join(".grok").join("bin").join("grok.exe");
+        std::fs::create_dir_all(native_bin.parent().unwrap())
+            .expect("native Grok directory should be created");
+        std::fs::write(&native_bin, "native binary fixture")
+            .expect("native Grok fixture should be created");
+
+        let npm_prefix = root.path().join("nodejs").join("npm-global");
+        let npm_package = npm_prefix
+            .join("node_modules")
+            .join("@xai-official")
+            .join("grok");
+        std::fs::create_dir_all(&npm_package).expect("npm package fixture should be created");
+        let npm_launcher = npm_prefix.join("grok.cmd");
+        std::fs::create_dir_all(&npm_prefix).expect("npm prefix should be created");
+        std::fs::write(&npm_launcher, "@echo off\r\n").expect("npm launcher should be created");
+
+        let native_real =
+            std::fs::canonicalize(&native_bin).expect("native fixture should resolve");
+        let npm_real = std::fs::canonicalize(&npm_launcher).expect("npm fixture should resolve");
+        let installs = vec![
+            ToolInstallation {
+                path: npm_launcher.to_string_lossy().into_owned(),
+                version: Some("0.2.106".to_string()),
+                runnable: true,
+                error: None,
+                source: "system".to_string(),
+                is_path_default: true,
+                real: npm_real.clone(),
+            },
+            ToolInstallation {
+                path: native_bin.to_string_lossy().into_owned(),
+                version: Some("0.2.106".to_string()),
+                runnable: true,
+                error: None,
+                source: "system".to_string(),
+                is_path_default: false,
+                real: native_real.clone(),
+            },
+        ];
+
+        let deduped = dedupe_grok_npm_canonical_installations(&home, installs);
+
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].path, npm_launcher.to_string_lossy());
+        assert!(deduped[0].is_path_default);
+
+        let different_versions = vec![
+            ToolInstallation {
+                path: npm_launcher.to_string_lossy().into_owned(),
+                version: Some("0.2.107".to_string()),
+                runnable: true,
+                error: None,
+                source: "system".to_string(),
+                is_path_default: true,
+                real: npm_real,
+            },
+            ToolInstallation {
+                path: native_bin.to_string_lossy().into_owned(),
+                version: Some("0.2.106".to_string()),
+                runnable: true,
+                error: None,
+                source: "system".to_string(),
+                is_path_default: false,
+                real: native_real,
+            },
+        ];
+
+        assert_eq!(
+            dedupe_grok_npm_canonical_installations(&home, different_versions).len(),
+            2
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -510,7 +510,11 @@ fn npm_install_command_for(tool: &str) -> Option<&'static str> {
         "claude" => Some("npm i -g @anthropic-ai/claude-code@latest"),
         "codex" => Some("npm i -g @openai/codex@latest"),
         "gemini" => Some("npm i -g @google/gemini-cli@latest"),
-        "grok" => Some("npm i -g @xai-official/grok@latest"),
+        // grok 特例：xAI 从未更新 `latest` dist-tag（长期停在 0.1.4，仅 darwin/arm64），
+        // `@latest` 会让 Windows/Linux 直接 EBADPLATFORM。显式钉在支持 win32/x64 的 1.x 线，
+        // 与 npm_package_spec / fetch_npm_max_version 保持一致；若 xAI 修好 dist-tag，
+        // ^1.0.1 也会自动跟进 1.x 内更新。
+        "grok" => Some("npm i -g @xai-official/grok@^1.0.1"),
         "opencode" => Some("npm i -g opencode-ai@latest"),
         "openclaw" => Some("npm i -g openclaw@latest"),
         _ => None,
@@ -795,7 +799,15 @@ async fn get_single_tool_version_impl(
         }
         "codex" => fetch_npm_latest_for_tool(&client, "@openai/codex", tool, local).await,
         "gemini" => fetch_npm_latest_for_tool(&client, "@google/gemini-cli", tool, local).await,
-        "grok" => fetch_npm_latest_for_tool(&client, "@xai-official/grok", tool, local).await,
+        // grok 的 `latest` dist-tag 长期停在 0.1.4（仅 darwin/arm64），dist-tags
+        // 探测会误报远古版本；改用 versions 数组取最高稳定版，失败时退回 dist-tags。
+        "grok" => {
+            if let Some(v) = fetch_npm_max_version(&client, "@xai-official/grok").await {
+                Some(v)
+            } else {
+                fetch_npm_latest_for_tool(&client, "@xai-official/grok", tool, local).await
+            }
+        }
         "opencode" => {
             if let Some(version) =
                 fetch_npm_latest_for_tool(&client, "opencode-ai", tool, local).await
@@ -936,6 +948,24 @@ async fn fetch_npm_dist_tags(
     let resp = client.get(&url).send().await.ok()?;
     let json = resp.json::<serde_json::Value>().await.ok()?;
     json.get("dist-tags")?.as_object().cloned()
+}
+
+/// 拉取 npm 包 versions 数组里最高的**稳定**版本（忽略预发布）。
+///
+/// grok 专用：xAI 从未更新 `latest` dist-tag（停在 0.1.4，仅 darwin/arm64），
+/// dist-tags 探测会误导 UI 显示远古版本；versions 数组不受 dist-tag 影响。
+/// 其他工具仍走 `fetch_npm_latest_for_tool` 的 dist-tags 逻辑（作者有意发布的
+/// "latest" 就是他们想展示的版本）。
+async fn fetch_npm_max_version(client: &reqwest::Client, package: &str) -> Option<String> {
+    let url = format!("https://registry.npmjs.org/{package}");
+    let resp = client.get(&url).send().await.ok()?;
+    let json = resp.json::<serde_json::Value>().await.ok()?;
+    let versions = json.get("versions")?.as_object()?;
+    versions
+        .keys()
+        .filter(|v| !v.contains('-'))
+        .max_by(|a, b| compare_semver(a, b).unwrap_or(std::cmp::Ordering::Equal))
+        .map(|v| v.to_string())
 }
 
 /// 查询某 npm 工具要展示的"最新版本":取 `latest`,并在本地版本领先时按工具的
@@ -2124,6 +2154,21 @@ fn npm_package_for(tool: &str) -> Option<&'static str> {
     }
 }
 
+/// npm 包安装 spec（包名 + 版本约束）。除 grok 外一律 `@latest`。
+///
+/// grok 特例：xAI 从未更新过 `latest` dist-tag，长期停在 0.1.4（仅 darwin/arm64，
+/// 见 npm_install_command_for 注释），`@latest` 在 Windows/Linux 上必然 EBADPLATFORM。
+/// 显式钉在支持 win32/x64 的最高稳定线 1.x；该线内更新可被 `^` 自动跟进。
+fn npm_package_spec(tool: &str) -> Option<String> {
+    npm_package_for(tool).map(|pkg| {
+        if pkg == "@xai-official/grok" {
+            format!("{pkg}@^1.0.1")
+        } else {
+            format!("{pkg}@latest")
+        }
+    })
+}
+
 /// 取路径的父目录(纯字符串截断,不碰 fs):`/a/b/npm` → `/a/b`、`C:\a\b\npm.cmd`
 /// → `C:\a\b`、混合分隔符 `C:\a/b\npm` → `C:\a/b`。无父目录返回空串。
 ///
@@ -2417,6 +2462,16 @@ fn anchored_official_update_command(tool: &str, bin_path: &str) -> Option<String
 /// nvm/homebrew 下的 node+npm 均不可见 → grok 内部 spawn 得到 ENOENT，只向用户抛出
 /// 费解的 `Error: No such file or directory (os error 2)`（实测复现）。
 ///
+/// **2026-08 新增的第三个失败模式：`latest` dist-tag 事故**。xAI 在 0.1.4 之后
+/// 发布的所有版本（0.2.x/1.0.x）都**没有更新 npm `latest` dist-tag**——它至今仍指向
+/// 0.1.4（仅 darwin/arm64）。于是 `grok update` 内部的 `npm view ... version` 查到
+/// 0.1.4、再 `npm i -g @xai-official/grok@0.1.4`，Windows/Linux 上直接 EBADPLATFORM。
+/// 本函数保留官方 installer fallback 正是解法：官方 install 会覆写
+/// `~/.grok/config.toml` 的 `installer = "internal"`，此后 `grok update` 改走
+/// node-free 直连下载，彻底绕开 npm dist-tag。ccs 侧其它 npm 命令一律显式钉
+/// `^1.0.1`（见 `npm_install_command_for` / `npm_package_spec`），版本探测走
+/// `fetch_npm_max_version`（versions 数组），均不再读 `latest` tag。
+///
 /// **这是上游换了机制**：0.2.111 及更早版本自更新是直接下载二进制到 `~/.grok/downloads/`
 /// （彼时 `is_grok_native_install` 假设的 "native = 不碰 npm" 成立），0.2.112 起改走上述 npm
 /// 管道（落点随之从 `downloads/` 变为 `bin/`）。**副作用**：npm 全局包那一处安装是
@@ -2553,16 +2608,16 @@ fn package_manager_anchored_command_from_paths(
         let brew = sibling_bin(bin_path, "brew")?;
         return Some(format!("{} upgrade {formula}", quote_path_if_spaced(&brew)));
     }
-    let pkg = npm_package_for(tool)?;
+    let spec = npm_package_spec(tool)?;
     match infer_install_source(Path::new(bin_path)) {
         "volta" => {
             let volta = sibling_bin(bin_path, "volta")?;
-            return Some(format!("{} install {pkg}", quote_path_if_spaced(&volta)));
+            return Some(format!("{} install {spec}", quote_path_if_spaced(&volta)));
         }
         "bun" => {
             let bun = sibling_bin(bin_path, "bun")?;
             return Some(format!(
-                "{} add -g {pkg}@latest",
+                "{} add -g {spec}",
                 quote_path_if_spaced(&bun)
             ));
         }
@@ -2572,7 +2627,7 @@ fn package_manager_anchored_command_from_paths(
         // self-update，上层会直接锚到 CLI 自身；否则返回 None 走静态兜底。
         _ => return None,
     }
-    anchored_npm_command(bin_path, &format!("i -g {pkg}@latest"))
+    anchored_npm_command(bin_path, &format!("i -g {spec}"))
 }
 
 /// 给定工具、原始 bin 路径（命令行命中的入口）、canonicalize 后的真身路径，
@@ -2637,20 +2692,20 @@ fn anchored_command_from_paths(tool: &str, bin_path: &str, real_target: &str) ->
 
 #[cfg(target_os = "windows")]
 fn package_manager_anchored_command_from_paths(tool: &str, bin_path: &str) -> Option<String> {
-    let pkg = npm_package_for(tool)?;
+    let spec = npm_package_spec(tool)?;
 
     match infer_install_source(Path::new(bin_path)) {
         "volta" => {
             let volta = sibling_bin_with_ext(bin_path, "volta", &["exe", "cmd"])?;
             Some(format!(
-                "{} install {pkg}",
+                "{} install {spec}",
                 win_quote_path_for_batch(&volta)
             ))
         }
         "pnpm" => {
             let pnpm = sibling_bin_with_ext(bin_path, "pnpm", &["cmd", "exe"])?;
             Some(format!(
-                "{} add -g {pkg}@latest",
+                "{} add -g {spec}",
                 win_quote_path_for_batch(&pnpm)
             ))
         }
@@ -2659,7 +2714,7 @@ fn package_manager_anchored_command_from_paths(tool: &str, bin_path: &str) -> Op
         _ => {
             let npm = sibling_bin_with_ext(bin_path, "npm", &["cmd", "exe"])?;
             Some(format!(
-                "{} i -g {pkg}@latest",
+                "{} i -g {spec}",
                 win_quote_path_for_batch(&npm)
             ))
         }
@@ -4528,7 +4583,7 @@ mod tests {
         assert_eq!(npm_package_for("grok"), Some("@xai-official/grok"));
         assert_eq!(
             npm_install_command_for("grok"),
-            Some("npm i -g @xai-official/grok@latest")
+            Some("npm i -g @xai-official/grok@^1.0.1")
         );
         assert_eq!(official_update_args("grok"), Some("update"));
 
@@ -4536,7 +4591,7 @@ mod tests {
             assert_eq!(
                 tool_action_shell_command_for_shell("grok", action, LifecycleCommandShell::Posix)
                     .as_deref(),
-                Some("npm i -g @xai-official/grok@latest")
+                Some("npm i -g @xai-official/grok@^1.0.1")
             );
         }
 
@@ -4549,7 +4604,7 @@ mod tests {
                 LifecycleCommandShell::WindowsBatch,
             )
             .as_deref(),
-            Some("npm i -g @xai-official/grok@latest")
+            Some("npm i -g @xai-official/grok@^1.0.1")
         );
     }
 
@@ -4802,7 +4857,7 @@ mod tests {
             let cmd = anchored_command_from_paths("grok", &bin_path, &bin_path);
             let npm_full = format!("{}\\npm.cmd", sub.to_string_lossy());
             let expected = format!(
-                "{} i -g @xai-official/grok@latest",
+                "{} i -g @xai-official/grok@^1.0.1",
                 expect_quoted_path(&npm_full)
             );
             assert_eq!(cmd.as_deref(), Some(expected.as_str()));
@@ -4838,7 +4893,7 @@ mod tests {
                 "native installer first: {install}"
             );
             assert!(
-                install.ends_with("|| call npm i -g @xai-official/grok@latest"),
+                install.ends_with("|| call npm i -g @xai-official/grok@^1.0.1"),
                 "npm fallback should remain available: {install}"
             );
             let expected_encoded = powershell_encoded_command(GROK_INSTALL_WINDOWS_SCRIPT);
@@ -5175,7 +5230,7 @@ mod tests {
             assert!(
                 grok.starts_with(
                     "bash -c 'tmp=$(mktemp) && curl -fsSL https://x.ai/cli/install.sh "
-                ) && grok.contains(" || npm i -g @xai-official/grok@latest"),
+                ) && grok.contains(" || npm i -g @xai-official/grok@^1.0.1"),
                 "WSL grok install should prefer native POSIX installer with npm fallback: {grok}"
             );
             assert!(!grok.contains("| bash"));
@@ -5392,7 +5447,7 @@ mod tests {
             assert_eq!(
                 cmd.as_deref(),
                 Some(
-                    "PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @xai-official/grok@latest"
+                    "PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @xai-official/grok@^1.0.1"
                 )
             );
         }
@@ -5939,7 +5994,7 @@ mod tests {
                 "should include official installer URL: {cmd}"
             );
             assert!(
-                cmd.contains("@xai-official/grok@latest"),
+                cmd.contains("@xai-official/grok@^1.0.1"),
                 "should keep npm package as fallback: {cmd}"
             );
             let parts: Vec<&str> = cmd.split("||").collect();
@@ -5976,7 +6031,7 @@ mod tests {
             assert!(!static_fallback_command("gemini").contains("gemini update"));
             assert_eq!(
                 static_fallback_command("grok"),
-                "npm i -g @xai-official/grok@latest"
+                "npm i -g @xai-official/grok@^1.0.1"
             );
             assert!(!static_fallback_command("grok").contains("grok update"));
             assert_eq!(


### PR DESCRIPTION
## Problem

Grok's npm package installs its native binary into `~/.grok/bin/grok.exe` while the npm launcher script (`grok.cmd`) lives in a separate npm prefix directory. The `enumerate_tool_installations` function treated them as two independent installations of the same version, causing false conflict warnings in the upgrade UI.

## Solution

Added `dedupe_grok_npm_canonical_installations` which merges npm launcher + native binary into one entry (keeping the one with `is_path_default`), triggered only for `tool == "grok"` on Windows.

## Verification

- Targeted test: `grok_npm_launcher_and_canonical_binary_are_one_installation` — passes
- Same-version launcher + native → deduped to 1 entry
- Different-version launcher + native → kept as 2 entries (no false merge)