### PR TITLE
fix(mcp): drop deleted MCP servers from the takeover live backup

### DIFF
--- a/src-tauri/src/mcp/codex.rs
+++ b/src-tauri/src/mcp/codex.rs
@@ -386,8 +386,9 @@ fn upsert_mcp_server_table(
 /// None 导致删除**静默失效**——界面提示已移除，条目却还在文件里，Codex 下次启动照样
 /// 加载。这比 panic 更隐蔽，因为用户往往正是发现某个 MCP 有问题才来关它的。
 ///
-/// 与写入分离成纯 doc 级函数，使守卫可脱离真实 `~/.codex/config.toml` 单测。
-fn remove_mcp_server_from_doc(doc: &mut toml_edit::DocumentMut, id: &str) {
+/// 与写入分离成纯 doc 级函数，使守卫可脱离真实 `~/.codex/config.toml` 单测，
+/// 也让代理接管备份里的同一张表复用同一套删除语义。
+pub(crate) fn remove_mcp_server_from_doc(doc: &mut toml_edit::DocumentMut, id: &str) {
     if let Some(item) = doc.get_mut("mcp_servers") {
         // `Item::None` 是 toml_edit 的占位形态，不是用户写下的值——对它告警是噪音。
         // 必须在取可变借用之前算出来。

--- a/src-tauri/src/mcp/grokbuild.rs
+++ b/src-tauri/src/mcp/grokbuild.rs
@@ -191,6 +191,14 @@ pub fn remove_server_from_grokbuild(id: &str) -> Result<(), AppError> {
             return Ok(());
         }
     };
+    remove_mcp_server_from_doc(&mut doc, id);
+    crate::config::write_text_file(&path, &doc.to_string())
+}
+
+/// 从 `[mcp_servers]` 中删除单个 MCP server。
+///
+/// 与写入分离成纯 doc 级函数，让代理接管备份里的同一张表复用同一套删除语义。
+pub(crate) fn remove_mcp_server_from_doc(doc: &mut toml_edit::DocumentMut, id: &str) {
     // 与写入侧对称使用 as_table_like_mut：inline table 形态下 as_table_mut 返回
     // None，删除会静默失效——界面显示已移除，Grok Build 下次启动仍会加载它。
     if let Some(item) = doc.get_mut("mcp_servers") {
@@ -207,7 +215,6 @@ pub fn remove_server_from_grokbuild(id: &str) -> Result<(), AppError> {
             None => {}
         }
     }
-    crate::config::write_text_file(&path, &doc.to_string())
 }
 
 #[cfg(test)]

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -38,3 +38,7 @@ pub use hermes::{import_from_hermes, remove_server_from_hermes, sync_single_serv
 pub use opencode::{
     import_from_opencode, remove_server_from_opencode, sync_single_server_to_opencode,
 };
+
+// 纯 doc 级删除：供代理接管备份复用同一套语义，见 ProxyService::remove_mcp_server_from_live_backup
+pub(crate) use codex::remove_mcp_server_from_doc as remove_mcp_server_from_codex_doc;
+pub(crate) use grokbuild::remove_mcp_server_from_doc as remove_mcp_server_from_grokbuild_doc;

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -158,6 +158,14 @@ impl McpService {
         // 从所有曾启用的应用中移除
         for app in server.apps.enabled_apps() {
             Self::remove_server_from_app(state, id, &app)?;
+            // 代理接管期间，接管前的整份 config.toml 快照存在 proxy_live_backup 里，
+            // 退出时原样写回。不同步摘掉这个条目，删除就会在退出后被撤销。
+            futures::executor::block_on(
+                state
+                    .proxy_service
+                    .remove_mcp_server_from_live_backup(&app, id),
+            )
+            .map_err(AppError::Message)?;
         }
         Ok(())
     }

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2637,6 +2637,12 @@ impl ProxyService {
         }
 
         let app_type_str = app_type.as_str();
+        // 快照的读-改-写走和热切换、接管开关同一把 per-app 锁。不加锁会和
+        // update_live_backup_from_provider_inner 交错：它先读快照，再用
+        // preserve_toml_mcp_servers_from_existing_config 把读到的 [mcp_servers] 带进新快照，
+        // 中间发生的删除因此被原样写回，条目又回到快照里。
+        let _guard = self.switch_locks.lock_for_app(app_type_str).await;
+
         let Some(backup) = self
             .db
             .get_live_backup(app_type_str)
@@ -2646,8 +2652,13 @@ impl ProxyService {
             return Ok(());
         };
 
-        let mut settings: Value = serde_json::from_str(&backup.original_config)
-            .map_err(|e| format!("解析 {app_type_str} Live 备份失败: {e}"))?;
+        // 快照解析失败一律告警跳过：调用方 delete_server 在此之前已经删掉库表行、改完 live
+        // 配置，这里再抛错只会让整条命令报失败，而重试时行已不在，直接返回 false。坏快照也
+        // 复活不了任何东西：restore_live_config_for_app_inner 同样解析失败，不会写回 live。
+        let Ok(mut settings) = serde_json::from_str::<Value>(&backup.original_config) else {
+            log::warn!("解析 {app_type_str} Live 备份失败，跳过快照清理");
+            return Ok(());
+        };
         let Some(config_text) = settings
             .get("config")
             .and_then(|value| value.as_str())
@@ -2659,7 +2670,7 @@ impl ProxyService {
             return Ok(());
         }
 
-        // 解析失败与 live 侧删除保持一致：告警跳过，不让一份坏快照挡住删除操作本身。
+        // 同上，也与 live 侧删除保持一致：坏快照不该挡住删除操作本身。
         let Ok(mut doc) = config_text.parse::<toml_edit::DocumentMut>() else {
             log::warn!("解析 {app_type_str} Live 备份中的 config.toml 失败，跳过快照清理");
             return Ok(());
@@ -4453,6 +4464,95 @@ wire_api = "responses"
             "got: {config}"
         );
         assert!(config.contains("default = \"grok-4.5\""), "got: {config}");
+    }
+
+    async fn codex_backup_config_text(db: &Database) -> String {
+        let backup = db
+            .get_live_backup("codex")
+            .await
+            .expect("read backup")
+            .expect("backup exists");
+        let value: Value = serde_json::from_str(&backup.original_config).expect("parse backup");
+        value["config"].as_str().expect("config text").to_string()
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn live_backup_mcp_removal_waits_for_the_app_switch_lock() {
+        use tokio::time::{sleep, Duration};
+
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        let db = Arc::new(Database::memory().expect("init db"));
+        db.save_live_backup(
+            "codex",
+            &serde_json::to_string(&json!({
+                "auth": {},
+                "config": "[mcp_servers.context7]\ntype = \"stdio\"\ncommand = \"npx\"\n"
+            }))
+            .expect("serialize backup"),
+        )
+        .await
+        .expect("save backup");
+
+        let service = ProxyService::new(db.clone());
+        let guard = service.lock_switch_for_test("codex").await;
+
+        let service_for_removal = service.clone();
+        let removal = tokio::spawn(async move {
+            service_for_removal
+                .remove_mcp_server_from_live_backup(&AppType::Codex, "context7")
+                .await
+                .expect("remove from live backup")
+        });
+
+        sleep(Duration::from_millis(20)).await;
+        assert!(
+            codex_backup_config_text(&db).await.contains("context7"),
+            "removal must queue behind the per-app switch lock, otherwise a hot switch \
+             holding it writes back the snapshot it read before the delete"
+        );
+
+        drop(guard);
+        removal.await.expect("join removal");
+        assert!(!codex_backup_config_text(&db).await.contains("context7"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn delete_mcp_server_survives_a_live_backup_that_is_not_valid_json() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        let db = Arc::new(Database::memory().expect("init db"));
+
+        let apps = crate::app_config::McpApps {
+            codex: true,
+            ..Default::default()
+        };
+        db.save_mcp_server(&mcp_server_for_test("context7", apps))
+            .expect("seed mcp server");
+        db.save_live_backup("codex", "{ not json")
+            .await
+            .expect("save backup");
+
+        let state = crate::store::AppState::new(db.clone());
+        // 库表行和 live 配置在快照清理之前就已经改掉了，这里再报错等于命令失败但删除已生效，
+        // 而重试会因为行不在而返回 false，用户没有任何办法把它删干净。
+        assert!(
+            crate::services::mcp::McpService::delete_server(&state, "context7")
+                .expect("an unreadable snapshot must not fail the delete")
+        );
+        assert!(!db
+            .get_all_mcp_servers()
+            .expect("read servers")
+            .contains_key("context7"));
+
+        let backup = db
+            .get_live_backup("codex")
+            .await
+            .expect("read backup")
+            .expect("backup exists");
+        assert_eq!(backup.original_config, "{ not json");
     }
 
     #[test]

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2618,6 +2618,77 @@ impl ProxyService {
         self.switch_locks.lock_for_app(app_type).await
     }
 
+    /// 从指定应用的 Live 备份快照中删除一个 MCP 服务器条目。
+    ///
+    /// 接管时存进 `proxy_live_backup` 的是整份 config.toml 文本，退出时原样写回。
+    /// 快照之后被删除的服务器因此会在退出时复活。这里只摘掉那一个条目，快照其余
+    /// 部分（auth、base_url、model、`[projects]`、用户手写的其它 MCP 条目）保持不动：
+    /// 整行删除会让恢复退回 SSOT 重建，把只存在于 Live 的内容一并丢掉。
+    ///
+    /// 只有 Codex 与 Grok Build 的快照带 `[mcp_servers]`（Claude 快照是
+    /// settings.json，MCP 在 `~/.claude.json`；Gemini 快照是 .env），其余应用直接返回。
+    pub(crate) async fn remove_mcp_server_from_live_backup(
+        &self,
+        app_type: &AppType,
+        server_id: &str,
+    ) -> Result<(), String> {
+        if !matches!(app_type, AppType::Codex | AppType::GrokBuild) {
+            return Ok(());
+        }
+
+        let app_type_str = app_type.as_str();
+        let Some(backup) = self
+            .db
+            .get_live_backup(app_type_str)
+            .await
+            .map_err(|e| format!("读取 {app_type_str} Live 备份失败: {e}"))?
+        else {
+            return Ok(());
+        };
+
+        let mut settings: Value = serde_json::from_str(&backup.original_config)
+            .map_err(|e| format!("解析 {app_type_str} Live 备份失败: {e}"))?;
+        let Some(config_text) = settings
+            .get("config")
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+        else {
+            return Ok(());
+        };
+        if !config_text.contains("mcp") {
+            return Ok(());
+        }
+
+        // 解析失败与 live 侧删除保持一致：告警跳过，不让一份坏快照挡住删除操作本身。
+        let Ok(mut doc) = config_text.parse::<toml_edit::DocumentMut>() else {
+            log::warn!("解析 {app_type_str} Live 备份中的 config.toml 失败，跳过快照清理");
+            return Ok(());
+        };
+
+        match app_type {
+            AppType::Codex => crate::mcp::remove_mcp_server_from_codex_doc(&mut doc, server_id),
+            _ => crate::mcp::remove_mcp_server_from_grokbuild_doc(&mut doc, server_id),
+        }
+
+        let new_config_text = doc.to_string();
+        if new_config_text == config_text {
+            return Ok(());
+        }
+
+        if let Some(obj) = settings.as_object_mut() {
+            obj.insert("config".to_string(), json!(new_config_text));
+        }
+        let json_str = serde_json::to_string(&settings)
+            .map_err(|e| format!("序列化 {app_type_str} Live 备份失败: {e}"))?;
+        self.db
+            .save_live_backup(app_type_str, &json_str)
+            .await
+            .map_err(|e| format!("写入 {app_type_str} Live 备份失败: {e}"))?;
+        log::info!("已从 {app_type_str} Live 备份中移除 MCP 服务器 '{server_id}'");
+
+        Ok(())
+    }
+
     fn preserve_toml_mcp_servers_from_existing_config(
         target_settings: &mut Value,
         existing_config: &Value,
@@ -4274,6 +4345,114 @@ wire_api = "responses"
             .expect("backup exists");
         let value: Value = serde_json::from_str(&backup.original_config).expect("parse backup");
         assert_eq!(value["auth"]["OPENAI_API_KEY"], "sk-real");
+    }
+
+    fn mcp_server_for_test(
+        id: &str,
+        apps: crate::app_config::McpApps,
+    ) -> crate::app_config::McpServer {
+        crate::app_config::McpServer {
+            id: id.to_string(),
+            name: id.to_string(),
+            server: json!({ "type": "stdio", "command": "npx" }),
+            apps,
+            description: None,
+            homepage: None,
+            docs: None,
+            tags: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_delete_mcp_server_drops_it_from_live_backup() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        let db = Arc::new(Database::memory().expect("init db"));
+
+        let apps = crate::app_config::McpApps {
+            codex: true,
+            ..Default::default()
+        };
+        db.save_mcp_server(&mcp_server_for_test("context7", apps))
+            .expect("seed mcp server");
+        db.save_live_backup(
+            "codex",
+            &serde_json::to_string(&json!({
+                "auth": { "OPENAI_API_KEY": "sk-real" },
+                "config": "model = \"gpt-5.4\"\n\n[mcp_servers.context7]\ntype = \"stdio\"\ncommand = \"npx\"\n\n[mcp_servers.handwritten]\ntype = \"stdio\"\ncommand = \"local\"\n"
+            }))
+            .expect("serialize backup"),
+        )
+        .await
+        .expect("save backup");
+
+        let state = crate::store::AppState::new(db.clone());
+        crate::services::mcp::McpService::delete_server(&state, "context7").expect("delete server");
+
+        let backup = db
+            .get_live_backup("codex")
+            .await
+            .expect("read backup")
+            .expect("backup exists");
+        let value: Value = serde_json::from_str(&backup.original_config).expect("parse backup");
+        let config = value["config"].as_str().expect("config text");
+        assert!(
+            !config.contains("context7"),
+            "deleted server must not survive in the snapshot, got: {config}"
+        );
+        // 快照里未被删除的内容必须原样保留：手写条目 cc-switch 从未导入，
+        // 库表里没有它的记录，恢复时丢掉它就是删掉用户自己写的配置。
+        assert!(
+            config.contains("[mcp_servers.handwritten]"),
+            "got: {config}"
+        );
+        assert!(config.contains("model = \"gpt-5.4\""), "got: {config}");
+        assert_eq!(value["auth"]["OPENAI_API_KEY"], "sk-real");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn grokbuild_delete_mcp_server_drops_it_from_live_backup() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        let db = Arc::new(Database::memory().expect("init db"));
+
+        let apps = crate::app_config::McpApps {
+            grokbuild: true,
+            ..Default::default()
+        };
+        db.save_mcp_server(&mcp_server_for_test("context7", apps))
+            .expect("seed mcp server");
+        db.save_live_backup(
+            "grokbuild",
+            &serde_json::to_string(&json!({
+                "config": "[models]\ndefault = \"grok-4.5\"\n\n[mcp_servers.context7]\ncommand = \"npx\"\n\n[mcp_servers.handwritten]\ncommand = \"local\"\n"
+            }))
+            .expect("serialize backup"),
+        )
+        .await
+        .expect("save backup");
+
+        let state = crate::store::AppState::new(db.clone());
+        crate::services::mcp::McpService::delete_server(&state, "context7").expect("delete server");
+
+        let backup = db
+            .get_live_backup("grokbuild")
+            .await
+            .expect("read backup")
+            .expect("backup exists");
+        let value: Value = serde_json::from_str(&backup.original_config).expect("parse backup");
+        let config = value["config"].as_str().expect("config text");
+        assert!(
+            !config.contains("context7"),
+            "deleted server must not survive in the snapshot, got: {config}"
+        );
+        assert!(
+            config.contains("[mcp_servers.handwritten]"),
+            "got: {config}"
+        );
+        assert!(config.contains("default = \"grok-4.5\""), "got: {config}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

`delete_server` clears the `mcp_servers` row and each app's live config, but not the takeover snapshot in `proxy_live_backup`. That snapshot is the whole `config.toml` text, written back verbatim on exit, so the deleted server returns and "import existing" puts it back in the database.

This removes only that entry, for Codex and Grok Build, the two apps whose snapshot is a `config.toml`, reusing the doc-level delete the live path already uses. Dropping the whole backup row would take `auth`, `base_url`, `model` and `[projects]` with it and push restore onto the SSOT rebuild. A snapshot written before this fix still restores once; one import-and-delete clears it.

#6270 is complementary: it reprojects servers the database still has.

## Related Issue / 关联 Issue

Fixes #6377

## Screenshots / 截图

N/A, backend only.

## Tests / 测试

New `codex_delete_mcp_server_drops_it_from_live_backup` and `grokbuild_delete_mcp_server_drops_it_from_live_backup`; both fail on main and check that a hand-written entry and `auth` survive.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 (not applicable; no user-facing text changed)
