### PR TITLE
Feature: Add Claude Desktop 3P configuration support on Linux

### DIFF
--- a/docs/user-manual/en/2-providers/2.6-claude-desktop.md
+++ b/docs/user-manual/en/2-providers/2.6-claude-desktop.md
@@ -260,7 +260,7 @@ For a native Claude Desktop installation, CC Switch uses `$XDG_CONFIG_HOME` (or 
 ~/.config/Claude-3p/configLibrary/00000000-0000-4000-8000-000000157210.json
 ```
 
-When CC Switch itself is installed as a Flatpak, it deliberately uses the host `~/.config` paths above rather than Flatpak's private `XDG_CONFIG_HOME`. The bundled Flatpak currently grants home-directory access; stricter custom Flatpak builds must grant read/write access to `xdg-config/Claude` and `xdg-config/Claude-3p`.
+When CC Switch itself is installed as a Flatpak, it deliberately uses the host `~/.config` paths above rather than Flatpak's private `XDG_CONFIG_HOME`. This is a deliberate design boundary: CC Switch does not offer a configuration-directory override or attempt to follow a custom host `XDG_CONFIG_HOME`, because Flatpak replaces that value inside the sandbox and the original value cannot be determined reliably. Use the native CC Switch package if Claude Desktop uses a custom XDG configuration directory. The bundled Flatpak currently grants home-directory access; stricter custom Flatpak builds must grant read/write access to `xdg-config/Claude` and `xdg-config/Claude-3p`.
 
 These files are maintained automatically by CC Switch. Manual edits are not recommended. If configuration becomes inconsistent, enabling the current provider again usually repairs it.
 

--- a/docs/user-manual/en/2-providers/2.6-claude-desktop.md
+++ b/docs/user-manual/en/2-providers/2.6-claude-desktop.md
@@ -249,6 +249,19 @@ CC Switch writes Claude Desktop 3P configuration files.
 %LOCALAPPDATA%\Claude-3p\configLibrary\00000000-0000-4000-8000-000000157210.json
 ```
 
+### Linux
+
+For a native Claude Desktop installation, CC Switch uses `$XDG_CONFIG_HOME` (or `~/.config` when it is unset):
+
+```text
+~/.config/Claude/claude_desktop_config.json
+~/.config/Claude-3p/claude_desktop_config.json
+~/.config/Claude-3p/configLibrary/_meta.json
+~/.config/Claude-3p/configLibrary/00000000-0000-4000-8000-000000157210.json
+```
+
+When CC Switch itself is installed as a Flatpak, it deliberately uses the host `~/.config` paths above rather than Flatpak's private `XDG_CONFIG_HOME`. The bundled Flatpak currently grants home-directory access; stricter custom Flatpak builds must grant read/write access to `xdg-config/Claude` and `xdg-config/Claude-3p`.
+
 These files are maintained automatically by CC Switch. Manual edits are not recommended. If configuration becomes inconsistent, enabling the current provider again usually repairs it.
 
 ## Status Messages
@@ -257,7 +270,7 @@ The Claude Desktop panel may show "Claude Desktop configuration needs attention"
 
 | Message | How to handle |
 |---------|---------------|
-| Current platform is not supported | Only macOS / Windows currently support writing 3P configuration |
+| Current platform is not supported | Use CC Switch on macOS, Windows, or Linux |
 | Profile contains model names outside the Sonnet / Opus / Haiku role families | Switch to the current provider again, or edit the provider to use model mapping |
 | Model mapping is enabled but no valid route exists | Edit the provider and add at least one model mapping |
 | Local routing token has not been generated | Switch to the provider again; CC Switch will write a new local token |

--- a/docs/user-manual/ja/2-providers/2.6-claude-desktop.md
+++ b/docs/user-manual/ja/2-providers/2.6-claude-desktop.md
@@ -249,6 +249,19 @@ CC Switch は Claude Desktop の 3P 設定ディレクトリに書き込みま�
 %LOCALAPPDATA%\Claude-3p\configLibrary\00000000-0000-4000-8000-000000157210.json
 ```
 
+### Linux
+
+ネイティブ版 Claude Desktop では `$XDG_CONFIG_HOME` を使用し、未設定時は `~/.config` を使用します。
+
+```text
+~/.config/Claude/claude_desktop_config.json
+~/.config/Claude-3p/claude_desktop_config.json
+~/.config/Claude-3p/configLibrary/_meta.json
+~/.config/Claude-3p/configLibrary/00000000-0000-4000-8000-000000157210.json
+```
+
+CC Switch 自体を Flatpak でインストールした場合も、Flatpak 固有の `XDG_CONFIG_HOME` ではなく、上記のホスト側 `~/.config` を使用します。同梱 Flatpak は現在 Home ディレクトリへのアクセスを許可しています。より厳格な独自 Flatpak ビルドでは、`xdg-config/Claude` と `xdg-config/Claude-3p` への読み書き権限が必要です。
+
 これらのファイルは CC Switch が自動管理します。手動編集はおすすめしません。設定の不整合が起きた場合は、現在のプロバイダーを再度有効化すると通常は修復できます。
 
 ## ステータス表示と対処
@@ -257,7 +270,7 @@ Claude Desktop パネル上部に「Claude Desktop 設定の確認が必要で�
 
 | 表示 | 対処方法 |
 |------|----------|
-| 現在のプラットフォームは未対応 | 3P 設定の書き込みは現在 macOS / Windows のみ対応 |
+| 現在のプラットフォームは未対応 | macOS / Windows / Linux で CC Switch を使用してください |
 | profile に Sonnet / Opus / Haiku の役割ファミリー以外のモデル名がある | 現在のプロバイダーへ再度切り替える、またはモデルマッピングを使うよう編集する |
 | モデルマッピングが有効だが有効なルートがない | プロバイダーを編集し、少なくとも 1 件のモデルマッピングを追加する |
 | ローカルルーティング token が未生成 | そのプロバイダーへ再度切り替えると、CC Switch が新しい token を書き込みます |

--- a/docs/user-manual/ja/2-providers/2.6-claude-desktop.md
+++ b/docs/user-manual/ja/2-providers/2.6-claude-desktop.md
@@ -260,7 +260,7 @@ CC Switch は Claude Desktop の 3P 設定ディレクトリに書き込みま�
 ~/.config/Claude-3p/configLibrary/00000000-0000-4000-8000-000000157210.json
 ```
 
-CC Switch 自体を Flatpak でインストールした場合も、Flatpak 固有の `XDG_CONFIG_HOME` ではなく、上記のホスト側 `~/.config` を使用します。同梱 Flatpak は現在 Home ディレクトリへのアクセスを許可しています。より厳格な独自 Flatpak ビルドでは、`xdg-config/Claude` と `xdg-config/Claude-3p` への読み書き権限が必要です。
+CC Switch 自体を Flatpak でインストールした場合も、Flatpak 固有の `XDG_CONFIG_HOME` ではなく、上記のホスト側 `~/.config` を使用します。これは意図的な設計上の境界です。Flatpak はサンドボックス内でこの変数を置き換えるため、元のホスト値を確実に取得できません。そのため CC Switch は設定ディレクトリの上書き項目を提供せず、ホスト側で独自設定された `XDG_CONFIG_HOME` を追従しません。Claude Desktop が独自の XDG 設定ディレクトリを使用する場合は、ネイティブ版 CC Switch を使用してください。同梱 Flatpak は現在 Home ディレクトリへのアクセスを許可しています。より厳格な独自 Flatpak ビルドでは、`xdg-config/Claude` と `xdg-config/Claude-3p` への読み書き権限が必要です。
 
 これらのファイルは CC Switch が自動管理します。手動編集はおすすめしません。設定の不整合が起きた場合は、現在のプロバイダーを再度有効化すると通常は修復できます。
 

--- a/docs/user-manual/zh/2-providers/2.6-claude-desktop.md
+++ b/docs/user-manual/zh/2-providers/2.6-claude-desktop.md
@@ -260,7 +260,7 @@ CC Switch 会写入 Claude Desktop 的 3P 配置目录。
 ~/.config/Claude-3p/configLibrary/00000000-0000-4000-8000-000000157210.json
 ```
 
-当 CC Switch 本身通过 Flatpak 安装时，会刻意使用上面的宿主机 `~/.config` 路径，不会误用 Flatpak 私有的 `XDG_CONFIG_HOME`。随附的 Flatpak 当前已授予整个 Home 目录访问权；更严格的自定义 Flatpak 构建必须对 `xdg-config/Claude` 和 `xdg-config/Claude-3p` 授予读写权限。
+当 CC Switch 本身通过 Flatpak 安装时，会刻意使用上面的宿主机 `~/.config` 路径，不会误用 Flatpak 私有的 `XDG_CONFIG_HOME`。这是有意的设计边界：CC Switch 不提供配置目录覆盖项，也不会尝试跟随宿主机自定义的 `XDG_CONFIG_HOME`，因为 Flatpak 会在沙箱内替换该变量，无法可靠地获知其原始值。如果 Claude Desktop 使用自定义 XDG 配置目录，请使用原生 CC Switch 软件包。随附的 Flatpak 当前已授予整个 Home 目录访问权；更严格的自定义 Flatpak 构建必须对 `xdg-config/Claude` 和 `xdg-config/Claude-3p` 授予读写权限。
 
 配置文件由 CC Switch 自动维护，不建议手动编辑。出现配置不一致时，重新启用当前供应商通常可以修复。
 

--- a/docs/user-manual/zh/2-providers/2.6-claude-desktop.md
+++ b/docs/user-manual/zh/2-providers/2.6-claude-desktop.md
@@ -249,6 +249,19 @@ CC Switch 会写入 Claude Desktop 的 3P 配置目录。
 %LOCALAPPDATA%\Claude-3p\configLibrary\00000000-0000-4000-8000-000000157210.json
 ```
 
+### Linux
+
+原生安装的 Claude Desktop 使用 `$XDG_CONFIG_HOME`；未设置时使用 `~/.config`：
+
+```text
+~/.config/Claude/claude_desktop_config.json
+~/.config/Claude-3p/claude_desktop_config.json
+~/.config/Claude-3p/configLibrary/_meta.json
+~/.config/Claude-3p/configLibrary/00000000-0000-4000-8000-000000157210.json
+```
+
+当 CC Switch 本身通过 Flatpak 安装时，会刻意使用上面的宿主机 `~/.config` 路径，不会误用 Flatpak 私有的 `XDG_CONFIG_HOME`。随附的 Flatpak 当前已授予整个 Home 目录访问权；更严格的自定义 Flatpak 构建必须对 `xdg-config/Claude` 和 `xdg-config/Claude-3p` 授予读写权限。
+
 配置文件由 CC Switch 自动维护，不建议手动编辑。出现配置不一致时，重新启用当前供应商通常可以修复。
 
 ## 状态提示与处理
@@ -257,7 +270,7 @@ Claude Desktop 面板顶部可能出现「Claude Desktop 配置需要检查」�
 
 | 提示                                 | 处理方式                                         |
 | ------------------------------------ | ------------------------------------------------ |
-| 当前平台暂不支持                     | 目前仅 macOS / Windows 支持写入 3P 配置          |
+| 当前平台暂不支持                     | 请在 macOS、Windows 或 Linux 上使用 CC Switch    |
 | profile 中存在非 Sonnet / Opus / Haiku 角色模型名 | 重新切换当前供应商，或编辑供应商改用模型映射 |
 | 启用了模型映射但没有有效路由         | 编辑供应商，至少添加一条模型映射                 |
 | 本地路由 token 尚未生成              | 重新切换该供应商，CC Switch 会写入新的本地 token |

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -1239,8 +1239,14 @@ fn current_platform_paths() -> Result<ClaudeDesktopPaths, AppError> {
 }
 
 /// Flatpak keeps an app's XDG_CONFIG_HOME inside its sandbox. Claude Desktop
-/// installed natively still stores its profile in the host's ~/.config, which
-/// must be exposed through the Flatpak filesystem permissions.
+/// installed natively uses the host's ~/.config by default, which must be
+/// exposed through the Flatpak filesystem permissions.
+///
+/// This is intentionally the host *default* configuration directory. We do
+/// not expose a directory override or attempt to recover a host-custom
+/// XDG_CONFIG_HOME: Flatpak replaces that variable with its private path, so
+/// its original host value is not available reliably from the sandbox. Users
+/// with a custom host XDG_CONFIG_HOME should run the native CC Switch package.
 #[cfg(target_os = "linux")]
 fn linux_config_dir() -> PathBuf {
     let xdg_config_home = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from);

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -1253,7 +1253,7 @@ fn linux_config_dir() -> PathBuf {
     linux_config_dir_from_home(&get_home_dir(), xdg_config_home.as_deref(), is_flatpak())
 }
 
-#[cfg(any(target_os = "linux", test))]
+#[cfg(target_os = "linux")]
 fn linux_config_dir_from_home(
     home: &Path,
     xdg_config_home: Option<&Path>,
@@ -1385,6 +1385,7 @@ mod tests {
         )
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn linux_config_dir_uses_absolute_xdg_config_home_outside_flatpak() {
         let home = Path::new("/home/tester");
@@ -1396,6 +1397,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn linux_config_dir_falls_back_for_missing_or_relative_xdg_config_home() {
         let home = Path::new("/home/tester");
@@ -1410,6 +1412,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn linux_config_dir_uses_host_config_when_cc_switch_runs_in_flatpak() {
         let home = Path::new("/home/tester");

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -3,7 +3,7 @@ use serde_json::{json, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-#[cfg(any(target_os = "macos", windows))]
+#[cfg(any(target_os = "macos", windows, target_os = "linux"))]
 use crate::config::get_home_dir;
 use crate::config::{atomic_write, delete_file, read_json_file, write_json_file};
 use crate::database::Database;
@@ -14,9 +14,9 @@ use crate::provider::{ClaudeDesktopMode, Provider};
 pub const PROFILE_ID: &str = "00000000-0000-4000-8000-000000157210";
 pub const PROFILE_NAME: &str = "CC Switch";
 
-#[cfg(any(target_os = "macos", windows, test))]
+#[cfg(any(target_os = "macos", windows, target_os = "linux", test))]
 const CONFIG_FILE: &str = "claude_desktop_config.json";
-#[cfg(any(target_os = "macos", windows, test))]
+#[cfg(any(target_os = "macos", windows, target_os = "linux", test))]
 const CONFIG_LIBRARY_DIR: &str = "configLibrary";
 const GATEWAY_TOKEN_SETTING_KEY: &str = "claude_desktop_gateway_token";
 const CLAUDE_DESKTOP_PROXY_PREFIX: &str = "/claude-desktop";
@@ -1211,7 +1211,7 @@ fn meta_has_profile_entry(path: &Path) -> bool {
 }
 
 fn is_supported_platform() -> bool {
-    cfg!(any(target_os = "macos", windows))
+    cfg!(any(target_os = "macos", windows, target_os = "linux"))
 }
 
 #[allow(clippy::needless_return)]
@@ -1227,10 +1227,50 @@ fn current_platform_paths() -> Result<ClaudeDesktopPaths, AppError> {
         return Ok(windows_paths_from_local_app_data(&local_app_data));
     }
 
-    #[cfg(not(any(target_os = "macos", windows)))]
+    #[cfg(target_os = "linux")]
+    {
+        return Ok(linux_paths_from_config_dir(&linux_config_dir()));
+    }
+
+    #[cfg(not(any(target_os = "macos", windows, target_os = "linux")))]
     {
         Err(unsupported_platform_error())
     }
+}
+
+/// Flatpak keeps an app's XDG_CONFIG_HOME inside its sandbox. Claude Desktop
+/// installed natively still stores its profile in the host's ~/.config, which
+/// must be exposed through the Flatpak filesystem permissions.
+#[cfg(target_os = "linux")]
+fn linux_config_dir() -> PathBuf {
+    let xdg_config_home = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from);
+    linux_config_dir_from_home(&get_home_dir(), xdg_config_home.as_deref(), is_flatpak())
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn linux_config_dir_from_home(
+    home: &Path,
+    xdg_config_home: Option<&Path>,
+    running_in_flatpak: bool,
+) -> PathBuf {
+    if running_in_flatpak {
+        return home.join(".config");
+    }
+
+    xdg_config_home
+        .filter(|path| path.is_absolute())
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| home.join(".config"))
+}
+
+#[cfg(target_os = "linux")]
+fn is_flatpak() -> bool {
+    Path::new("/.flatpak-info").is_file()
+}
+
+#[cfg(target_os = "linux")]
+fn linux_paths_from_config_dir(config_dir: &Path) -> ClaudeDesktopPaths {
+    paths_from_dirs(config_dir.join("Claude"), config_dir.join("Claude-3p"))
 }
 
 #[cfg(target_os = "macos")]
@@ -1281,7 +1321,7 @@ fn pick_windows_claude_dir(local_app_data: &Path, threep: bool) -> Option<PathBu
     candidates.into_iter().next()
 }
 
-#[cfg(any(target_os = "macos", windows, test))]
+#[cfg(any(target_os = "macos", windows, target_os = "linux", test))]
 fn paths_from_dirs(normal_dir: PathBuf, threep_dir: PathBuf) -> ClaudeDesktopPaths {
     let config_library_path = threep_dir.join(CONFIG_LIBRARY_DIR);
     let profile_path = config_library_path.join(format!("{PROFILE_ID}.json"));
@@ -1311,12 +1351,12 @@ fn proxy_origin_from_parts(listen_address: &str, listen_port: u16) -> String {
     format!("http://{}:{}", connect_host_for_url, listen_port)
 }
 
-#[cfg(not(any(target_os = "macos", windows)))]
+#[cfg(not(any(target_os = "macos", windows, target_os = "linux")))]
 fn unsupported_platform_error() -> AppError {
     AppError::localized(
         "claude_desktop.unsupported_platform",
-        "当前平台暂不支持 Claude Desktop 3P 配置。第一阶段仅支持 macOS 和 Windows。",
-        "Claude Desktop 3P configuration is not supported on this platform yet. Phase 1 only supports macOS and Windows.",
+        "当前平台暂不支持 Claude Desktop 3P 配置。支持的平台：macOS、Windows 和 Linux。",
+        "Claude Desktop 3P configuration is not supported on this platform yet. Supported platforms: macOS, Windows, and Linux.",
     )
 }
 
@@ -1337,6 +1377,42 @@ mod tests {
                 .join("Application Support")
                 .join("Claude-3p"),
         )
+    }
+
+    #[test]
+    fn linux_config_dir_uses_absolute_xdg_config_home_outside_flatpak() {
+        let home = Path::new("/home/tester");
+        let xdg = Path::new("/mnt/config");
+
+        assert_eq!(
+            linux_config_dir_from_home(home, Some(xdg), false),
+            PathBuf::from("/mnt/config")
+        );
+    }
+
+    #[test]
+    fn linux_config_dir_falls_back_for_missing_or_relative_xdg_config_home() {
+        let home = Path::new("/home/tester");
+
+        assert_eq!(
+            linux_config_dir_from_home(home, None, false),
+            PathBuf::from("/home/tester/.config")
+        );
+        assert_eq!(
+            linux_config_dir_from_home(home, Some(Path::new("relative/config")), false),
+            PathBuf::from("/home/tester/.config")
+        );
+    }
+
+    #[test]
+    fn linux_config_dir_uses_host_config_when_cc_switch_runs_in_flatpak() {
+        let home = Path::new("/home/tester");
+        let private_xdg = Path::new("/home/tester/.var/app/com.ccswitch.desktop/config");
+
+        assert_eq!(
+            linux_config_dir_from_home(home, Some(private_xdg), true),
+            PathBuf::from("/home/tester/.config")
+        );
     }
 
     fn test_db() -> Database {


### PR DESCRIPTION
## Summary / 概述

- Add Claude Desktop 3P configuration support on Linux.
- Use `$XDG_CONFIG_HOME` for native Linux installations, falling back to `~/.config` when it is unset or relative.
- When CC Switch runs as a Flatpak, use the host default `~/.config` directory instead of Flatpak's private `XDG_CONFIG_HOME`.
- Add unit tests covering native Linux and Flatpak path resolution.
- Update the English, Chinese, and Japanese user manuals with Linux paths, Flatpak permissions, and the custom XDG directory limitation.
- Preserve the existing macOS and Windows behavior.

---

- 为 Linux 增加 Claude Desktop 3P 配置支持
- 原生 Linux 安装优先使用 `$XDG_CONFIG_HOME`；未设置或值为相对路径时回退到 `~/.config`
- CC Switch 运行在 Flatpak 中时，使用宿主机默认的 `~/.config`，避免写入 Flatpak 私有的 `XDG_CONFIG_HOME`
- 增加原生 Linux 与 Flatpak 路径解析的单元测试
- 更新英文、中文和日文用户手册，说明 Linux 配置路径、Flatpak 权限以及自定义 XDG 配置目录的限制
- 保持现有 macOS 和 Windows 行为不变

## Related Issue / 关联 Issue

#4855 

## Screenshots / 截图

<img width="2560" height="1539" alt="微信图片_20260812194719_2_2" src="https://github.com/user-attachments/assets/2d46e3f6-d8f9-4665-880b-1135dcd591ec" />


不涉及 UI 变更

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未修改 TypeScript）
- [x] `pnpm format:check` passes / 通过代码格式检查（未运行）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（已同步更新英文、中文和日文文档）
