### PR TITLE
fix(linux-codex): disable OAuth requirement for custom providers

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1745,6 +1745,33 @@ fn remove_codex_experimental_bearer_token(config_text: &str) -> Result<String, A
     remove_codex_experimental_bearer_token_if(config_text, |_| true)
 }
 
+fn disable_codex_openai_auth_for_third_party(config_text: &str) -> Result<String, AppError> {
+    if config_text.trim().is_empty() {
+        return Ok(config_text.to_string());
+    }
+
+    let mut doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+
+    let Some(provider_id) = active_codex_model_provider_id(&doc) else {
+        return Ok(config_text.to_string());
+    };
+    if !is_custom_codex_model_provider_id(&provider_id) {
+        return Ok(config_text.to_string());
+    }
+
+    if let Some(provider_table) = doc
+        .get_mut("model_providers")
+        .and_then(|item| item.as_table_mut())
+        .and_then(|providers| providers.get_mut(provider_id.as_str()))
+        .and_then(|item| item.as_table_mut())
+    {
+        provider_table["requires_openai_auth"] = toml_edit::value(false);
+    }
+    Ok(doc.to_string())
+}
+
 /// Read the current Codex live settings as a `{ auth, config }` object.
 ///
 /// Missing `auth.json` collapses to `{}` so a config-only third-party install
@@ -2132,6 +2159,11 @@ pub fn write_codex_live_for_provider(
         write_codex_live_atomic(auth, config_text)
     } else {
         let live_config = prepare_codex_provider_live_config(auth, config_text.unwrap_or(""))?;
+        let live_config = if category == Some("official") {
+            live_config
+        } else {
+            disable_codex_openai_auth_for_third_party(&live_config)?
+        };
         write_codex_live_config_atomic(Some(&live_config))
     }
 }
@@ -2374,6 +2406,36 @@ mod tests {
             CodexCatalogToolProfile::from_api_format(None),
             CodexCatalogToolProfile::ProxyChat
         );
+    }
+
+    #[test]
+    fn third_party_provider_disables_openai_auth_requirement() {
+        let input = r#"model_provider = "custom"
+
+[model_providers.custom]
+base_url = "https://example.invalid/v1"
+requires_openai_auth = true
+"#;
+
+        let output = disable_codex_openai_auth_for_third_party(input).expect("rewrite config");
+        let doc: toml::Value = toml::from_str(&output).expect("parse output");
+
+        assert_eq!(
+            doc["model_providers"]["custom"]["requires_openai_auth"].as_bool(),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn official_provider_keeps_openai_auth_requirement() {
+        let input = r#"model_provider = "openai"
+
+[model_providers.openai]
+requires_openai_auth = true
+"#;
+
+        let output = disable_codex_openai_auth_for_third_party(input).expect("rewrite config");
+        assert_eq!(output, input);
     }
 
     #[test]

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -485,7 +485,8 @@ requires_openai_auth = true
             .and_then(|v| v.get("aihubmix"))
             .and_then(|v| v.get("requires_openai_auth"))
             .and_then(|v| v.as_bool()),
-        Some(true)
+        Some(false),
+        "third-party providers must use the configured API key instead of OpenAI OAuth"
     );
 
     ProviderService::switch(&state, AppType::Codex, "plain-provider")


### PR DESCRIPTION
## Summary / 概述

Fixes the Linux Codex custom-provider flow that can open the OpenAI sign-in screen after CC Switch applies an OpenAI-compatible third-party provider.

When the active `model_provider` is a custom provider, CC Switch now writes:

```toml
requires_openai_auth = false
```

This keeps Codex on provider-specific API-key authentication instead of triggering OpenAI account authentication.

Official OpenAI providers are intentionally unchanged.

## Root cause / 根因

Codex treats `requires_openai_auth = true` as an instruction to use OpenAI authentication; in that mode it ignores a provider-specific `env_key`.

Previously, a custom provider configuration could retain `requires_openai_auth = true` after the live config was written. On Linux this caused Codex to show the OpenAI login/account screen rather than use the configured third-party endpoint and API key.

## Changes / 改动

- Added `disable_codex_openai_auth_for_third_party`.
- Detects the active `model_provider`.
- Changes `requires_openai_auth` to `false` only when the active provider is custom.
- Preserves the existing behavior for the official `openai` provider.
- Does not alter empty configs or configs without an active provider table.

## Regression coverage / 回归覆盖

Added unit tests for:

1. A custom provider with `requires_openai_auth = true` is rewritten to `false`.
2. The official `openai` provider keeps its original authentication setting.

## Reproduction / 复现步骤

1. On Linux, configure a custom Codex provider with an OpenAI-compatible `base_url` and a provider API key.
2. Apply the provider through CC Switch.
3. Start Codex.
4. Before this fix, Codex can open the OpenAI account sign-in flow.
5. With this fix, CC Switch writes the custom provider config with `requires_openai_auth = false`, allowing the configured provider key to be used.

If an already-running Codex process still has the old configuration in memory, restart Linux/WSL once and launch CC Switch/Codex again.

## Validation / 验证

- `pnpm tauri build --bundles deb`
  - Environment: Ubuntu 24.04, amd64
  - Result: passed
- Debian package generated successfully:
  - `cc-switch_3.19.2_amd64.deb`
  - SHA256: `95d12f7628e20f71fbbf413173e69c23e9cee8157bd08c5f80003bc2ab744b50`

## References / 参考资料

- OpenAI Codex Authentication documentation: `requires_openai_auth = true` enables OpenAI authentication and ignores `env_key`; provider-specific API-key authentication uses `env_key`.
  - https://developers.openai.com/codex/auth
- OpenAI Codex Configuration Reference.
  - https://developers.openai.com/codex/config-reference

## Checklist / 检查清单

- [x] Focused change: only `src-tauri/src/codex_config.rs`
- [x] Unit coverage added for custom and official providers
- [x] Linux amd64 Debian bundle built successfully
- [x] No user-facing text changed; no i18n update needed