### PR TITLE
fix: refresh MiniMax M3 pricing and modalities

### DIFF
--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -2208,7 +2208,7 @@ impl Database {
                 "0.06",
                 "0.375",
             ),
-            ("minimax-m3", "MiniMax M3", "0.30", "1.20", "0.06", "0"),
+            ("minimax-m3", "MiniMax M3", "0.60", "2.40", "0.12", "0"),
             // GLM (智谱)
             ("glm-4.7", "GLM-4.7", "0.6", "2.2", "0.11", "0"),
             ("glm-4.6", "GLM-4.6", "0.6", "2.2", "0.11", "0"),
@@ -2560,16 +2560,17 @@ impl Database {
                 "0.14",
                 "0",
             ),
+            // Refresh untouched rows that still use the previous built-in MiniMax M3 rates.
             (
                 "minimax-m3",
                 "MiniMax M3",
-                "0.30",
-                "1.20",
-                "0.06",
-                "0",
                 "0.60",
                 "2.40",
                 "0.12",
+                "0",
+                "0.30",
+                "1.20",
+                "0.06",
                 "0",
             ),
             // 2026-07-12 GPT-5.6 家族 cache write=1.25× 输入价（OpenAI 5.6 起的新规），

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -892,6 +892,42 @@ fn model_pricing_seed_repairs_known_outdated_builtin_prices() {
 }
 
 #[test]
+fn minimax_m3_pricing_repairs_previous_builtin_but_preserves_custom_prices() {
+    const PREVIOUS_BUILTIN: &str = "UPDATE model_pricing SET input_cost_per_million = '0.30', output_cost_per_million = '1.20', cache_read_cost_per_million = '0.06' WHERE model_id = 'minimax-m3'";
+    const CUSTOM: &str = "UPDATE model_pricing SET input_cost_per_million = '9', output_cost_per_million = '2.40', cache_read_cost_per_million = '0.12' WHERE model_id = 'minimax-m3'";
+
+    fn price(conn: &Connection) -> String {
+        conn.query_row(
+            "SELECT input_cost_per_million || '/' || output_cost_per_million || '/' ||
+                    cache_read_cost_per_million || '/' || cache_creation_cost_per_million
+             FROM model_pricing WHERE model_id = 'minimax-m3'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("query MiniMax M3 price")
+    }
+
+    let db = Database::memory().expect("create memory db");
+    {
+        let conn = db.conn.lock().expect("lock conn");
+        assert_eq!(price(&conn), "0.60/2.40/0.12/0");
+        conn.execute(PREVIOUS_BUILTIN, [])
+            .expect("restore previous MiniMax M3 price");
+    }
+    db.ensure_model_pricing_seeded()
+        .expect("repair previous price");
+    {
+        let conn = db.conn.lock().expect("lock conn");
+        assert_eq!(price(&conn), "0.60/2.40/0.12/0");
+        conn.execute(CUSTOM, []).expect("set custom price");
+    }
+    db.ensure_model_pricing_seeded()
+        .expect("preserve custom price");
+    let conn = db.conn.lock().expect("lock conn");
+    assert_eq!(price(&conn), "9/2.40/0.12/0");
+}
+
+#[test]
 fn ensure_incremental_auto_vacuum_rebuilds_existing_file_db() {
     let temp = NamedTempFile::new().expect("create temp db file");
     let path = temp.path().to_path_buf();

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1248,14 +1248,14 @@ requires_openai_auth = true`,
     // MiniMax 官方 API 参考已列 /v1/responses 为正式端点（CN/intl 双区，POST /v1/responses），原生 Responses，无需路由接管转换
     apiFormat: "openai_responses",
     // 官方 Codex catalog（platform.minimaxi.com/docs/token-plan/codex-cli）：
-    // shell_command 编辑、并行工具、文本+图像，不声明 freeform apply_patch
+    // shell_command editing, parallel tools, text/image/video input, and no freeform apply_patch.
     modelCatalog: modelCatalog([
       {
         model: "MiniMax-M3",
         displayName: "MiniMax-M3",
         contextWindow: 1000000,
         supportsParallelToolCalls: true,
-        inputModalities: ["text", "image"],
+        inputModalities: ["text", "image", "video"],
         baseInstructions:
           "You are Codex, a coding agent based on MiniMax-M3. You and the user share the same workspace and collaborate to achieve the user's goals.",
       },
@@ -1283,14 +1283,14 @@ requires_openai_auth = true`,
     // MiniMax 官方 API 参考已列 /v1/responses 为正式端点（CN/intl 双区，POST /v1/responses），原生 Responses，无需路由接管转换
     apiFormat: "openai_responses",
     // 官方 Codex catalog（platform.minimax.io/docs/token-plan/codex）：
-    // shell_command 编辑、并行工具、文本+图像，不声明 freeform apply_patch
+    // shell_command editing, parallel tools, text/image/video input, and no freeform apply_patch.
     modelCatalog: modelCatalog([
       {
         model: "MiniMax-M3",
         displayName: "MiniMax-M3",
         contextWindow: 1000000,
         supportsParallelToolCalls: true,
-        inputModalities: ["text", "image"],
+        inputModalities: ["text", "image", "video"],
         baseInstructions:
           "You are Codex, a coding agent based on MiniMax-M3. You and the user share the same workspace and collaborate to achieve the user's goals.",
       },

--- a/tests/config/codexChatProviderPresets.test.ts
+++ b/tests/config/codexChatProviderPresets.test.ts
@@ -219,4 +219,17 @@ describe("Codex Chat provider presets", () => {
       expect(preset?.codexChatReasoning).toBeUndefined();
     }
   });
+
+  it("advertises MiniMax M3 video input for both regional presets", () => {
+    for (const name of ["MiniMax", "MiniMax en"]) {
+      const preset = codexProviderPresets.find((item) => item.name === name);
+
+      expect(preset?.modelCatalog).toHaveLength(1);
+      expect(preset?.modelCatalog?.[0]?.inputModalities).toEqual([
+        "text",
+        "image",
+        "video",
+      ]);
+    }
+  });
 });


### PR DESCRIPTION
Reason: parameter-refresh | 2026-08-11 | refresh MiniMax-M3 pricing and input modalities: built-in rates remain 0.30/1.20/0.06 and the catalog omits video input

## Summary

- Update MiniMax M3 built-in token rates to 0.60/2.40/0.12 per million tokens.
- Repair untouched rows that still contain the previous built-in rates while preserving customized pricing.
- Advertise text, image, and video input in both regional MiniMax M3 catalogs.

## Testing

- cargo test minimax_m3_pricing_repairs_previous_builtin_but_preserves_custom_prices --lib
- pnpm vitest run tests/config/codexChatProviderPresets.test.ts
- pnpm typecheck
- pnpm format:check
- cargo clippy --lib -- -D warnings
- rustfmt --check --edition 2021 src-tauri/src/database/schema.rs src-tauri/src/database/tests.rs
