### PR TITLE
feat(provider): add EveryAPI presets for Claude Code and Codex

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -1475,4 +1475,22 @@ export const providerPresets: ProviderPreset[] = [
     icon: "jiekou",
     iconColor: "#000000",
   },
+  {
+    name: "EveryAPI",
+    websiteUrl: "https://everyapi.ai",
+    apiKeyUrl: "https://app.everyapi.ai/keys",
+    settingsConfig: {
+      env: {
+        // 裸 origin，不带 /v1：Anthropic 客户端会自行追加版本路径
+        ANTHROPIC_BASE_URL: "https://api.everyapi.ai",
+        ANTHROPIC_AUTH_TOKEN: "",
+      },
+    },
+    category: "aggregator",
+    // 第二项为中国大陆加速边缘节点，指向同一网关
+    endpointCandidates: [
+      "https://api.everyapi.ai",
+      "https://api-cn.everyapi.ai",
+    ],
+  },
 ];

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1719,4 +1719,17 @@ base_url = "https://cc-api.pipellm.ai/v1"`,
     icon: "jiekou",
     iconColor: "#000000",
   },
+  {
+    name: "EveryAPI",
+    websiteUrl: "https://everyapi.ai",
+    apiKeyUrl: "https://app.everyapi.ai/keys",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig("EveryAPI", "https://api.everyapi.ai/v1"),
+    // 第二项为中国大陆加速边缘节点，指向同一网关
+    endpointCandidates: [
+      "https://api.everyapi.ai/v1",
+      "https://api-cn.everyapi.ai/v1",
+    ],
+    category: "aggregator",
+  },
 ];

--- a/src/config/everyapiProviderPresets.test.ts
+++ b/src/config/everyapiProviderPresets.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { providerPresets } from "./claudeProviderPresets";
+import { codexProviderPresets } from "./codexProviderPresets";
+
+const gatewayOrigin = "https://api.everyapi.ai";
+const cnGatewayOrigin = "https://api-cn.everyapi.ai";
+const openAiBaseUrl = `${gatewayOrigin}/v1`;
+const cnOpenAiBaseUrl = `${cnGatewayOrigin}/v1`;
+const brandDetails = {
+  websiteUrl: "https://everyapi.ai",
+  apiKeyUrl: "https://app.everyapi.ai/keys",
+  category: "aggregator",
+};
+
+const allEveryApiPresetGroups = [
+  ["Claude Code", providerPresets],
+  ["Codex", codexProviderPresets],
+] as const;
+
+function findEveryApiEntry<T extends { name: string }>(entries: readonly T[]) {
+  return entries.find((entry) => entry.name === "EveryAPI");
+}
+
+describe("EveryAPI provider presets", () => {
+  it.each(allEveryApiPresetGroups)(
+    "%s registers exactly one EveryAPI preset",
+    (_surface, entries) => {
+      expect(entries.filter((entry) => entry.name === "EveryAPI")).toHaveLength(
+        1,
+      );
+    },
+  );
+
+  it("configures Claude Code with the bare gateway origin", () => {
+    const preset = findEveryApiEntry(providerPresets)!;
+    expect(preset).toMatchObject({
+      ...brandDetails,
+      settingsConfig: {
+        env: {
+          ANTHROPIC_BASE_URL: gatewayOrigin,
+          ANTHROPIC_AUTH_TOKEN: "",
+        },
+      },
+      endpointCandidates: [gatewayOrigin, cnGatewayOrigin],
+    });
+  });
+
+  it("keeps the Claude base URL free of a version suffix", () => {
+    // The Anthropic client appends its own /v1; baking one into the base URL
+    // produces /v1/v1/messages, which the gateway rejects.
+    const preset = findEveryApiEntry(providerPresets)!;
+    const env = (preset.settingsConfig as { env: Record<string, string> }).env;
+    expect(env.ANTHROPIC_BASE_URL).not.toMatch(/\/v1\/?$/);
+    for (const candidate of preset.endpointCandidates ?? []) {
+      expect(candidate).not.toMatch(/\/v1\/?$/);
+    }
+  });
+
+  it("forwards Claude model names instead of pinning one model", () => {
+    // The gateway routes whatever Claude model the client asks for, so the
+    // preset must not override the model the user (or Claude Code) selected.
+    const preset = findEveryApiEntry(providerPresets)!;
+    const env = (preset.settingsConfig as { env: Record<string, string> }).env;
+    expect(Object.keys(env).sort()).toEqual([
+      "ANTHROPIC_AUTH_TOKEN",
+      "ANTHROPIC_BASE_URL",
+    ]);
+  });
+
+  it("configures Codex against the OpenAI-compatible base", () => {
+    const preset = findEveryApiEntry(codexProviderPresets)!;
+    expect(preset).toMatchObject({
+      ...brandDetails,
+      auth: { OPENAI_API_KEY: "" },
+      endpointCandidates: [openAiBaseUrl, cnOpenAiBaseUrl],
+    });
+    expect(preset.config).toContain(`base_url = "${openAiBaseUrl}"`);
+    expect(preset.config).toContain('name = "EveryAPI"');
+    expect(preset.config).toContain('wire_api = "responses"');
+  });
+
+  it("points both surfaces at the same gateway host", () => {
+    const claudePreset = findEveryApiEntry(providerPresets)!;
+    const codexPreset = findEveryApiEntry(codexProviderPresets)!;
+    const claudeEnv = (
+      claudePreset.settingsConfig as { env: Record<string, string> }
+    ).env;
+    expect(codexPreset.config).toContain(
+      `base_url = "${claudeEnv.ANTHROPIC_BASE_URL}/v1"`,
+    );
+  });
+});


### PR DESCRIPTION
Refs #6397

Adds a built-in preset for [EveryAPI](https://everyapi.ai), an AI API gateway that serves the Anthropic Messages API and the OpenAI Responses API from one host, so a single key backs both Claude Code and Codex.

## Changes

| File | Change |
| --- | --- |
| `src/config/claudeProviderPresets.ts` | EveryAPI entry appended after JieKou AI |
| `src/config/codexProviderPresets.ts` | EveryAPI entry appended after JieKou AI |
| `src/config/everyapiProviderPresets.test.ts` | New — 7 tests, following the `ppioProviderPresets.test.ts` / `jiekouProviderPresets.test.ts` pattern |

## Two decisions worth reviewing

**The Claude base URL is the bare origin, not `/v1`.** The Anthropic client appends its own version path, so `https://api.everyapi.ai/v1` would produce `/v1/v1/messages` and get rejected. The Codex entry does use `/v1`, because that surface requires it — the asymmetry is intentional and is pinned by a test so a future edit cannot quietly "fix" it into a broken state.

**No `ANTHROPIC_MODEL` override.** The gateway routes whatever Claude model the client requests rather than remapping every request onto one model, so pinning a model here would take capability away from the user. A test asserts the env block stays exactly `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN`.

Both surfaces list the mainland-China accelerated edge (`api-cn.everyapi.ai`) as a second `endpointCandidates` entry; it fronts the same gateway.

## Deliberately out of scope

- **No `isPartner` / `partnerPromotionKey`.** There is no commercial arrangement with CC Switch; claiming one would be false.
- **No icon.** The brand SVG is not in the compact inline form `src/icons/extracted/index.ts` uses. Rather than ship an oversized asset I followed the existing DMXAPI / BaiLing / TheRouter precedent of omitting the field. Glad to supply an optimized mark if you want one.
- **No OpenCode / OpenClaw / Hermes / Claude Desktop entries.** Those presets carry per-model context-window and cost metadata, and I did not want to submit numbers I could not verify.

## Verification

Run locally on this branch:

```
pnpm typecheck        tsc --noEmit, clean
pnpm format:check     All matched files use Prettier code style!
pnpm test:unit        Test Files 109 passed (109) / Tests 745 passed (745)
```

The 7 new tests cover: exactly one preset registered per surface, the Claude env block and endpoint candidates, the no-version-suffix invariant, the no-model-override invariant, the Codex TOML (`base_url`, `name`, `wire_api = "responses"`), and that both surfaces resolve to the same gateway host.

Endpoints were checked against production before writing the config:

```
https://everyapi.ai                 200
https://app.everyapi.ai/keys        200
https://api.everyapi.ai             200
https://api-cn.everyapi.ai          200

POST https://api.everyapi.ai/v1/messages    401 invalid_access_token   (route exists, auth-gated, not 404)
POST https://api.everyapi.ai/v1/responses   401 invalid_access_token   (route exists, auth-gated, not 404)
```

`pnpm lint` from CONTRIBUTING.md could not be run — `package.json` has no `lint` script. Noted in the issue.

## Disclosure

I maintain EveryAPI. This proposes our own service, so please weigh it accordingly; I have kept the entry to plain configuration facts with no promotional flags.
