### PR TITLE
feat(codex): add official account profiles

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -168,6 +168,12 @@ const CODEX_RESERVED_MODEL_PROVIDER_IDS: &[&str] = &[
 
 /// 获取 Codex 配置目录路径
 pub fn get_codex_config_dir() -> PathBuf {
+    if let Some(active) = std::env::var_os("CODEX_HOME") {
+        if !active.is_empty() {
+            return PathBuf::from(active);
+        }
+    }
+
     if let Some(custom) = crate::settings::get_codex_override_dir() {
         return custom;
     }
@@ -266,6 +272,7 @@ pub fn write_codex_live_atomic(
         return Err(e);
     }
 
+    crate::codex_profile::mirror_active_config_to_shared()?;
     Ok(())
 }
 
@@ -328,7 +335,8 @@ pub fn write_codex_live_config_atomic(config_text_opt: Option<&str>) -> Result<(
         toml::from_str::<toml::Table>(&cfg_text).map_err(|e| AppError::toml(&config_path, e))?;
     }
 
-    write_text_file(&config_path, &cfg_text)
+    write_text_file(&config_path, &cfg_text)?;
+    crate::codex_profile::mirror_active_config_to_shared()
 }
 
 pub fn extract_codex_auth_api_key(auth: &Value) -> Option<String> {

--- a/src-tauri/src/codex_profile.rs
+++ b/src-tauri/src/codex_profile.rs
@@ -32,12 +32,6 @@ pub fn account_profile_dir(account_id: &str) -> PathBuf {
     managed_profiles_dir().join(format!("account-{:x}", digest))
 }
 
-pub fn active_codex_dir_for_account(account_id: Option<&str>) -> PathBuf {
-    account_id
-        .map(account_profile_dir)
-        .unwrap_or_else(shared_codex_dir)
-}
-
 /// Prepare an account profile. `auth.json` and `config.toml` are intentionally
 /// excluded from links: auth is private, while config is copied on activation
 /// because Codex/CC Switch replace it atomically (which would sever a symlink).
@@ -77,7 +71,7 @@ pub fn prepare_account_profile(account_id: &str) -> Result<PathBuf, AppError> {
 
     let shared_config = shared.join("config.toml");
     let profile_config = profile.join("config.toml");
-    if shared_config.is_file() {
+    if shared_config.is_file() && !profile_config.exists() {
         fs::copy(&shared_config, &profile_config).map_err(|e| AppError::io(&profile_config, e))?;
     }
 
@@ -131,6 +125,22 @@ pub fn read_account_auth(account_id: &str) -> Result<Option<serde_json::Value>, 
         return Ok(None);
     }
     crate::config::read_json_file(&path).map(Some)
+}
+
+pub fn remove_account_profile(account_id: &str) -> Result<(), AppError> {
+    let profile = account_profile_dir(account_id);
+    if profile.exists() {
+        fs::remove_dir_all(&profile).map_err(|e| AppError::io(&profile, e))?;
+    }
+    Ok(())
+}
+
+pub fn remove_all_account_profiles() -> Result<(), AppError> {
+    let profiles = managed_profiles_dir();
+    if profiles.exists() {
+        fs::remove_dir_all(&profiles).map_err(|e| AppError::io(&profiles, e))?;
+    }
+    Ok(())
 }
 
 #[cfg(unix)]

--- a/src-tauri/src/codex_profile.rs
+++ b/src-tauri/src/codex_profile.rs
@@ -1,0 +1,280 @@
+//! Managed Codex account profiles.
+//!
+//! `CODEX_HOME` is account-specific so every official ChatGPT account owns a
+//! separate `auth.json`. Everything else continues to live in the user's normal
+//! Codex directory and is projected into the account profile.
+
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::config::{atomic_write, get_app_config_dir, get_home_dir};
+use crate::error::AppError;
+
+const CODEX_HOME_ENV: &str = "CODEX_HOME";
+const CODEX_SQLITE_HOME_ENV: &str = "CODEX_SQLITE_HOME";
+const PROFILE_DIR_NAME: &str = "codex-profiles";
+const ENV_FILE_NAME: &str = "codex-env.sh";
+const SHELL_SOURCE_MARKER: &str = "# CC Switch managed Codex profile";
+
+/// The canonical, shared Codex directory. This deliberately ignores
+/// `CODEX_HOME`, which may already point at an account profile.
+pub fn shared_codex_dir() -> PathBuf {
+    crate::settings::get_codex_override_dir().unwrap_or_else(|| get_home_dir().join(".codex"))
+}
+
+pub fn managed_profiles_dir() -> PathBuf {
+    get_app_config_dir().join(PROFILE_DIR_NAME)
+}
+
+pub fn account_profile_dir(account_id: &str) -> PathBuf {
+    let digest = Sha256::digest(account_id.as_bytes());
+    managed_profiles_dir().join(format!("account-{:x}", digest))
+}
+
+pub fn active_codex_dir_for_account(account_id: Option<&str>) -> PathBuf {
+    account_id
+        .map(account_profile_dir)
+        .unwrap_or_else(shared_codex_dir)
+}
+
+/// Prepare an account profile. `auth.json` and `config.toml` are intentionally
+/// excluded from links: auth is private, while config is copied on activation
+/// because Codex/CC Switch replace it atomically (which would sever a symlink).
+pub fn prepare_account_profile(account_id: &str) -> Result<PathBuf, AppError> {
+    let shared = shared_codex_dir();
+    let profile = account_profile_dir(account_id);
+    fs::create_dir_all(&shared).map_err(|e| AppError::io(&shared, e))?;
+    fs::create_dir_all(&profile).map_err(|e| AppError::io(&profile, e))?;
+
+    for required in ["sessions", "archived_sessions", "skills"] {
+        let path = shared.join(required);
+        fs::create_dir_all(&path).map_err(|e| AppError::io(&path, e))?;
+    }
+    for required in ["history.jsonl", "session_index.jsonl"] {
+        let path = shared.join(required);
+        if !path.exists() {
+            atomic_write(&path, b"")?;
+        }
+        ensure_shared_link(&path, &profile.join(required))?;
+    }
+
+    for entry in fs::read_dir(&shared).map_err(|e| AppError::io(&shared, e))? {
+        let entry = entry.map_err(|e| AppError::io(&shared, e))?;
+        let name = entry.file_name();
+        if name == "auth.json"
+            || name == "config.toml"
+            || name == "accounts"
+            || name == "mcp-oauth-locks"
+            || !entry.path().is_dir()
+        {
+            continue;
+        }
+        let source = entry.path();
+        let target = profile.join(&name);
+        ensure_shared_link(&source, &target)?;
+    }
+
+    let shared_config = shared.join("config.toml");
+    let profile_config = profile.join("config.toml");
+    if shared_config.is_file() {
+        fs::copy(&shared_config, &profile_config).map_err(|e| AppError::io(&profile_config, e))?;
+    }
+
+    Ok(profile)
+}
+
+pub fn activate(account_id: Option<&str>) -> Result<PathBuf, AppError> {
+    let shared = shared_codex_dir();
+    fs::create_dir_all(&shared).map_err(|e| AppError::io(&shared, e))?;
+    mirror_active_config_to_shared()?;
+    let active = match account_id {
+        Some(account_id) => prepare_account_profile(account_id)?,
+        None => shared.clone(),
+    };
+
+    persist_user_environment(&active, &shared)?;
+    // SAFETY: CC Switch owns these two process variables and serializes Codex
+    // provider switches. Child Codex processes inherit the newly active profile.
+    std::env::set_var(CODEX_HOME_ENV, &active);
+    std::env::set_var(CODEX_SQLITE_HOME_ENV, &shared);
+    Ok(active)
+}
+
+/// Keep `config.toml` shared without relying on a file symlink that Codex's
+/// atomic replace would sever. This is called before changing profiles and
+/// after every CC Switch live write.
+pub fn mirror_active_config_to_shared() -> Result<(), AppError> {
+    let Some(active) = std::env::var_os(CODEX_HOME_ENV).map(PathBuf::from) else {
+        return Ok(());
+    };
+    let shared = shared_codex_dir();
+    if active == shared || !active.starts_with(managed_profiles_dir()) {
+        return Ok(());
+    }
+    let source = active.join("config.toml");
+    if source.is_file() {
+        let target = shared.join("config.toml");
+        fs::copy(&source, &target).map_err(|e| AppError::io(&target, e))?;
+    }
+    Ok(())
+}
+
+pub fn write_account_auth(account_id: &str, auth: &serde_json::Value) -> Result<(), AppError> {
+    let profile = prepare_account_profile(account_id)?;
+    crate::config::write_private_json_file(&profile.join("auth.json"), auth)
+}
+
+pub fn read_account_auth(account_id: &str) -> Result<Option<serde_json::Value>, AppError> {
+    let path = account_profile_dir(account_id).join("auth.json");
+    if !path.is_file() {
+        return Ok(None);
+    }
+    crate::config::read_json_file(&path).map(Some)
+}
+
+#[cfg(unix)]
+fn ensure_shared_link(source: &Path, target: &Path) -> Result<(), AppError> {
+    use std::os::unix::fs::symlink;
+    if target.exists() || target.symlink_metadata().is_ok() {
+        return Ok(());
+    }
+    symlink(source, target).map_err(|e| AppError::io(target, e))
+}
+
+#[cfg(windows)]
+fn ensure_shared_link(source: &Path, target: &Path) -> Result<(), AppError> {
+    if target.exists() || target.symlink_metadata().is_ok() {
+        return Ok(());
+    }
+    if source.is_dir() {
+        let status = std::process::Command::new("cmd")
+            .args(["/C", "mklink", "/J"])
+            .arg(target)
+            .arg(source)
+            .status()
+            .map_err(|e| AppError::io(target, e))?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(AppError::Message(format!(
+                "Failed to create Codex shared directory junction: {}",
+                target.display()
+            )))
+        }
+    } else {
+        fs::hard_link(source, target).map_err(|e| AppError::io(target, e))
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn persist_user_environment(active: &Path, shared: &Path) -> Result<(), AppError> {
+    let env_file = get_app_config_dir().join(ENV_FILE_NAME);
+    let contents = render_posix_env_file(active, shared);
+    atomic_write(&env_file, contents.as_bytes())?;
+
+    let shell = std::env::var("SHELL").unwrap_or_default();
+    let rc_path = if shell.ends_with("/zsh") {
+        get_home_dir().join(".zshrc")
+    } else if shell.ends_with("/bash") {
+        get_home_dir().join(".bashrc")
+    } else {
+        get_home_dir().join(".profile")
+    };
+    ensure_shell_sources_env_file(&rc_path, &env_file)
+}
+
+#[cfg(target_os = "windows")]
+fn persist_user_environment(active: &Path, shared: &Path) -> Result<(), AppError> {
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
+    let (environment, _) = RegKey::predef(HKEY_CURRENT_USER)
+        .create_subkey("Environment")
+        .map_err(|e| AppError::Message(format!("Failed to open HKCU\\Environment: {e}")))?;
+    environment
+        .set_value(CODEX_HOME_ENV, &active.to_string_lossy().as_ref())
+        .map_err(|e| AppError::Message(format!("Failed to persist CODEX_HOME: {e}")))?;
+    environment
+        .set_value(CODEX_SQLITE_HOME_ENV, &shared.to_string_lossy().as_ref())
+        .map_err(|e| AppError::Message(format!("Failed to persist CODEX_SQLITE_HOME: {e}")))?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn render_posix_env_file(active: &Path, shared: &Path) -> String {
+    format!(
+        "{SHELL_SOURCE_MARKER}\nexport {CODEX_HOME_ENV}={}\nexport {CODEX_SQLITE_HOME_ENV}={}\n",
+        shell_quote(&active.to_string_lossy()),
+        shell_quote(&shared.to_string_lossy())
+    )
+}
+
+#[cfg(not(target_os = "windows"))]
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn ensure_shell_sources_env_file(rc_path: &Path, env_file: &Path) -> Result<(), AppError> {
+    let source_line = format!(
+        ". {} {SHELL_SOURCE_MARKER}",
+        shell_quote(&env_file.to_string_lossy())
+    );
+    let current = match fs::read_to_string(rc_path) {
+        Ok(value) => value,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(AppError::io(rc_path, error)),
+    };
+    if current
+        .lines()
+        .any(|line| line.contains(SHELL_SOURCE_MARKER))
+    {
+        return Ok(());
+    }
+    let mut next = current;
+    if !next.is_empty() && !next.ends_with('\n') {
+        next.push('\n');
+    }
+    next.push_str(&source_line);
+    next.push('\n');
+    atomic_write(rc_path, next.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn account_profile_names_are_stable_and_path_safe() {
+        let a = account_profile_dir("acct/with:unsafe chars");
+        let b = account_profile_dir("acct/with:unsafe chars");
+        assert_eq!(a, b);
+        let name = a.file_name().unwrap().to_string_lossy();
+        assert!(name.starts_with("account-"));
+        assert!(name.chars().all(|ch| ch.is_ascii_hexdigit() || ch == '-'));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn posix_env_file_quotes_paths() {
+        let rendered = render_posix_env_file(
+            Path::new("/tmp/profile with ' quote"),
+            Path::new("/tmp/shared"),
+        );
+        assert!(rendered.contains("export CODEX_HOME='/tmp/profile with '\\'' quote'"));
+        assert!(rendered.contains("export CODEX_SQLITE_HOME='/tmp/shared'"));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn shell_source_line_is_idempotent() {
+        let temp = tempfile::tempdir().unwrap();
+        let rc = temp.path().join(".zshrc");
+        let env_file = temp.path().join("codex-env.sh");
+        ensure_shell_sources_env_file(&rc, &env_file).unwrap();
+        ensure_shell_sources_env_file(&rc, &env_file).unwrap();
+        let text = fs::read_to_string(rc).unwrap();
+        assert_eq!(text.matches(SHELL_SOURCE_MARKER).count(), 1);
+    }
+}

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -2,6 +2,7 @@ use indexmap::IndexMap;
 use tauri::{Emitter, Manager, State};
 
 use crate::app_config::AppType;
+use crate::commands::codex_oauth::CodexOAuthState;
 use crate::commands::copilot::CopilotAuthState;
 use crate::commands::xai_oauth::XaiOAuthState;
 use crate::error::AppError;
@@ -36,27 +37,45 @@ pub fn get_current_provider(state: State<'_, AppState>, app: String) -> Result<S
 }
 
 #[tauri::command]
-pub fn add_provider(
-    state: State<'_, AppState>,
+pub async fn add_provider(
+    app_handle: tauri::AppHandle,
     app: String,
     provider: Provider,
     #[allow(non_snake_case)] addToLive: Option<bool>,
 ) -> Result<bool, String> {
     let app_type = AppType::from_str(&app).map_err(|e| e.to_string())?;
-    ProviderService::add(state.inner(), app_type, provider, addToLive.unwrap_or(true))
-        .map_err(|e| e.to_string())
+    materialize_codex_official_profile_auth(&app_handle, &app_type, &provider).await?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app_handle
+            .try_state::<AppState>()
+            .ok_or_else(|| "应用状态不可用".to_string())?;
+        ProviderService::add(state.inner(), app_type, provider, addToLive.unwrap_or(true))
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("供应商创建任务执行失败: {e}"))?
 }
 
 #[tauri::command]
-pub fn update_provider(
-    state: State<'_, AppState>,
+pub async fn update_provider(
+    app_handle: tauri::AppHandle,
     app: String,
     provider: Provider,
     #[allow(non_snake_case)] originalId: Option<String>,
 ) -> Result<bool, String> {
     let app_type = AppType::from_str(&app).map_err(|e| e.to_string())?;
-    ProviderService::update(state.inner(), app_type, originalId.as_deref(), provider)
-        .map_err(|e| e.to_string())
+    materialize_codex_official_profile_auth(&app_handle, &app_type, &provider).await?;
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let state = app_handle
+            .try_state::<AppState>()
+            .ok_or_else(|| "应用状态不可用".to_string())?;
+        ProviderService::update(state.inner(), app_type, originalId.as_deref(), provider)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("供应商更新任务执行失败: {e}"))?
 }
 
 #[tauri::command]
@@ -107,6 +126,21 @@ pub async fn switch_provider(
     id: String,
 ) -> Result<SwitchResult, String> {
     let app_type = AppType::from_str(&app).map_err(|e| e.to_string())?;
+    let provider = if matches!(app_type, AppType::Codex) {
+        let state = app_handle
+            .try_state::<AppState>()
+            .ok_or_else(|| "应用状态不可用".to_string())?;
+        state
+            .db
+            .get_provider_by_id(&id, app_type.as_str())
+            .map_err(|e| e.to_string())?
+    } else {
+        None
+    };
+    if let Some(provider) = provider.as_ref() {
+        materialize_codex_official_profile_auth(&app_handle, &app_type, provider).await?;
+    }
+
     tauri::async_runtime::spawn_blocking(move || {
         let state = app_handle
             .try_state::<AppState>()
@@ -115,6 +149,33 @@ pub async fn switch_provider(
     })
     .await
     .map_err(|e| format!("供应商切换任务执行失败: {e}"))?
+}
+
+async fn materialize_codex_official_profile_auth(
+    app_handle: &tauri::AppHandle,
+    app_type: &AppType,
+    provider: &Provider,
+) -> Result<(), String> {
+    if !matches!(app_type, AppType::Codex) || provider.category.as_deref() != Some("official") {
+        return Ok(());
+    }
+    let Some(account_id) = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
+    else {
+        return Ok(());
+    };
+
+    let oauth_state = app_handle.state::<CodexOAuthState>();
+    let auth = oauth_state
+        .0
+        .read()
+        .await
+        .get_codex_auth_for_account(&account_id)
+        .await
+        .map_err(|e| e.to_string())?;
+    crate::codex_profile::write_account_auth(&account_id, &auth).map_err(|e| e.to_string())
 }
 
 fn import_default_config_internal(state: &AppState, app_type: AppType) -> Result<bool, AppError> {

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -317,9 +317,13 @@ pub fn write_json_file<T: Serialize>(path: &Path, data: &T) -> Result<(), AppErr
 
 /// Write JSON containing credentials with owner-only Unix permissions.
 pub fn write_private_json_file<T: Serialize>(path: &Path, data: &T) -> Result<(), AppError> {
-    let value = serde_json::to_value(data).map_err(|e| AppError::JsonSerialize { source: e })?;
-    let json = serde_json::to_string_pretty(&sort_json_keys(&value))
-        .map_err(|e| AppError::JsonSerialize { source: e })?;
+    #[cfg(unix)]
+    let json = serde_json::to_value(data)
+        .map_err(|e| AppError::JsonSerialize { source: e })
+        .and_then(|value| {
+            serde_json::to_string_pretty(&sort_json_keys(&value))
+                .map_err(|e| AppError::JsonSerialize { source: e })
+        })?;
 
     #[cfg(unix)]
     {
@@ -359,7 +363,7 @@ pub fn write_private_json_file<T: Serialize>(path: &Path, data: &T) -> Result<()
         }
         fs::set_permissions(path, fs::Permissions::from_mode(0o600))
             .map_err(|e| AppError::io(path, e))?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(unix))]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -315,6 +315,57 @@ pub fn write_json_file<T: Serialize>(path: &Path, data: &T) -> Result<(), AppErr
     write_json_file_with_contents(path, data).map(|_| ())
 }
 
+/// Write JSON containing credentials with owner-only Unix permissions.
+pub fn write_private_json_file<T: Serialize>(path: &Path, data: &T) -> Result<(), AppError> {
+    let value = serde_json::to_value(data).map_err(|e| AppError::JsonSerialize { source: e })?;
+    let json = serde_json::to_string_pretty(&sort_json_keys(&value))
+        .map_err(|e| AppError::JsonSerialize { source: e })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let parent = path
+            .parent()
+            .ok_or_else(|| AppError::Config("无效的路径".to_string()))?;
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| AppError::Config("无效的路径".to_string()))?
+            .to_string_lossy();
+        let tmp = parent.join(format!(
+            ".{file_name}.tmp.{}.{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&tmp)
+            .map_err(|e| AppError::io(&tmp, e))?;
+        if let Err(e) = file.write_all(json.as_bytes()).and_then(|_| file.flush()) {
+            drop(file);
+            let _ = fs::remove_file(&tmp);
+            return Err(AppError::io(&tmp, e));
+        }
+        drop(file);
+        if let Err(e) = fs::rename(&tmp, path) {
+            let _ = fs::remove_file(&tmp);
+            return Err(AppError::io(path, e));
+        }
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+            .map_err(|e| AppError::io(path, e))?;
+        return Ok(());
+    }
+
+    #[cfg(not(unix))]
+    write_json_file(path, data)
+}
+
 /// 原子写入文本文件（用于 TOML/纯文本）
 pub fn write_text_file(path: &Path, data: &str) -> Result<(), AppError> {
     if let Some(parent) = path.parent() {
@@ -503,6 +554,28 @@ mod tests {
     fn atomic_write_replaces_existing_file() {
         let dir = tempfile::tempdir().unwrap();
         assert_atomic_write_replaces_existing_file(dir.path());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_json_file_has_owner_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.json");
+        std::fs::write(&path, b"old credentials").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_private_json_file(&path, &serde_json::json!({ "refresh_token": "secret" })).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(
+            read_json_file::<Value>(&path).unwrap()["refresh_token"],
+            "secret"
+        );
     }
 
     #[cfg(windows)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod claude_mcp;
 mod claude_plugin;
 mod codex_config;
 mod codex_history_migration;
+mod codex_profile;
 mod codex_state_db;
 mod commands;
 mod config;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -620,6 +620,11 @@ pub fn run() {
             // 设置 AppHandle 用于代理故障转移时的 UI 更新
             app_state.proxy_service.set_app_handle(app.handle().clone());
 
+            if let Err(err) = crate::services::provider::restore_active_codex_profile(&app_state)
+            {
+                log::warn!("Failed to restore active Codex profile at startup: {err}");
+            }
+
             // ============================================================
             // 按表独立判断的导入逻辑（各类数据独立检查，互不影响）
             // ============================================================

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -187,6 +187,9 @@ struct CodexAccountData {
     pub email: Option<String>,
     /// Refresh Token（持久化）
     pub refresh_token: String,
+    /// Official Codex `auth.json` also needs the OIDC identity token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id_token: Option<String>,
     /// 认证时间戳（秒）
     pub authenticated_at: i64,
 }
@@ -415,7 +418,7 @@ impl CodexOAuthManager {
         }
 
         let account = self
-            .add_account_internal(account_id, refresh_token, email)
+            .add_account_internal(account_id, refresh_token, tokens.id_token, email)
             .await?;
 
         Ok(Some(account))
@@ -498,6 +501,46 @@ impl CodexOAuthManager {
         &self,
         account_id: &str,
     ) -> Result<String, CodexOAuthError> {
+        // Codex CLI may have rotated the same account's refresh token while
+        // using its profile. Pull that canonical value back before deciding to
+        // refresh in the OAuth center, preventing stale-token reuse.
+        let mut profile_exists = false;
+        let mut profile_changed_manager = false;
+        if let Ok(Some(profile_auth)) = crate::codex_profile::read_account_auth(account_id) {
+            profile_exists = true;
+            let profile_tokens = profile_auth
+                .get("tokens")
+                .and_then(serde_json::Value::as_object);
+            let profile_refresh = profile_tokens
+                .and_then(|tokens| tokens.get("refresh_token"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+            let profile_id = profile_tokens
+                .and_then(|tokens| tokens.get("id_token"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+            if profile_refresh.is_some() || profile_id.is_some() {
+                let mut accounts = self.accounts.write().await;
+                if let Some(account) = accounts.get_mut(account_id) {
+                    if let Some(refresh) = profile_refresh {
+                        if account.refresh_token != refresh {
+                            account.refresh_token = refresh;
+                            profile_changed_manager = true;
+                        }
+                    }
+                    if let Some(id_token) = profile_id {
+                        if account.id_token.as_deref() != Some(id_token.as_str()) {
+                            account.id_token = Some(id_token);
+                            profile_changed_manager = true;
+                        }
+                    }
+                }
+            }
+        }
+        if profile_changed_manager {
+            self.save_to_disk().await?;
+        }
+
         // 先检查缓存
         {
             let tokens = self.access_tokens.read().await;
@@ -533,16 +576,27 @@ impl CodexOAuthManager {
 
         let new_tokens = self.refresh_with_token(&refresh_token).await?;
 
-        // 如果服务端返回了新的 refresh_token，更新存储
-        if let Some(new_refresh) = new_tokens.refresh_token.clone() {
-            if new_refresh != refresh_token {
-                let mut accounts = self.accounts.write().await;
-                if let Some(account) = accounts.get_mut(account_id) {
-                    account.refresh_token = new_refresh;
+        // Keep every credential needed to project an official Codex auth.json.
+        let mut account_changed = false;
+        {
+            let mut accounts = self.accounts.write().await;
+            if let Some(account) = accounts.get_mut(account_id) {
+                if let Some(new_refresh) = new_tokens.refresh_token.clone() {
+                    if new_refresh != account.refresh_token {
+                        account.refresh_token = new_refresh;
+                        account_changed = true;
+                    }
                 }
-                drop(accounts);
-                self.save_to_disk().await?;
+                if let Some(id_token) = new_tokens.id_token.clone() {
+                    if account.id_token.as_deref() != Some(id_token.as_str()) {
+                        account.id_token = Some(id_token);
+                        account_changed = true;
+                    }
+                }
             }
+        }
+        if account_changed {
+            self.save_to_disk().await?;
         }
 
         let access_token = new_tokens.access_token.clone();
@@ -559,7 +613,78 @@ impl CodexOAuthManager {
             );
         }
 
+        // If this account already has an official profile, immediately project
+        // manager-side token rotation back to it. This keeps one effective
+        // refresh-token lineage even when quota/proxy traffic triggered refresh.
+        if profile_exists {
+            let account = self
+                .accounts
+                .read()
+                .await
+                .get(account_id)
+                .cloned()
+                .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
+            if let Some(id_token) = account.id_token {
+                let auth = serde_json::json!({
+                    "OPENAI_API_KEY": serde_json::Value::Null,
+                    "auth_mode": "chatgpt",
+                    "last_refresh": chrono::Utc::now().to_rfc3339(),
+                    "tokens": {
+                        "access_token": access_token.clone(),
+                        "account_id": account.account_id,
+                        "id_token": id_token,
+                        "refresh_token": account.refresh_token,
+                    }
+                });
+                crate::codex_profile::write_account_auth(account_id, &auth)
+                    .map_err(|e| CodexOAuthError::IoError(e.to_string()))?;
+            }
+        }
+
         Ok(access_token)
+    }
+
+    /// Build the official Codex CLI auth.json for one managed account.
+    /// Legacy OAuth-center records did not retain `id_token`; those are
+    /// refreshed once so the projected profile always has a complete bundle.
+    pub async fn get_codex_auth_for_account(
+        &self,
+        account_id: &str,
+    ) -> Result<serde_json::Value, CodexOAuthError> {
+        let needs_identity_refresh = {
+            let accounts = self.accounts.read().await;
+            accounts
+                .get(account_id)
+                .map(|account| account.id_token.is_none())
+                .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?
+        };
+        if needs_identity_refresh {
+            self.access_tokens.write().await.remove(account_id);
+        }
+
+        let access_token = self.get_valid_token_for_account(account_id).await?;
+        let account = self
+            .accounts
+            .read()
+            .await
+            .get(account_id)
+            .cloned()
+            .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
+        let id_token = account.id_token.ok_or_else(|| {
+            CodexOAuthError::TokenFetchFailed("刷新响应缺少 id_token".to_string())
+        })?;
+
+        Ok(serde_json::json!({
+            "OPENAI_API_KEY": serde_json::Value::Null,
+            "auth_mode": "chatgpt",
+            "last_refresh": chrono::Utc::now().to_rfc3339(),
+            "tokens": {
+                "access_token": access_token,
+                "account_id": account.account_id,
+                "id_token": id_token,
+                "refresh_token": account.refresh_token,
+            }
+        }))
     }
 
     /// 获取默认账号的有效 token
@@ -695,6 +820,7 @@ impl CodexOAuthManager {
         &self,
         account_id: String,
         refresh_token: String,
+        id_token: Option<String>,
         email: Option<String>,
     ) -> Result<GitHubAccount, CodexOAuthError> {
         let now = chrono::Utc::now().timestamp();
@@ -703,6 +829,7 @@ impl CodexOAuthManager {
             account_id: account_id.clone(),
             email,
             refresh_token,
+            id_token,
             authenticated_at: now,
         };
 
@@ -1084,6 +1211,7 @@ mod tests {
                 .add_account_internal(
                     "acc-123".to_string(),
                     "rt-secret".to_string(),
+                    Some("id-secret".to_string()),
                     Some("user@example.com".to_string()),
                 )
                 .await
@@ -1106,6 +1234,7 @@ mod tests {
             .add_account_internal(
                 "acc-123".to_string(),
                 "rt".to_string(),
+                Some("id-a".to_string()),
                 Some("a@example.com".to_string()),
             )
             .await
@@ -1114,6 +1243,7 @@ mod tests {
             .add_account_internal(
                 "acc-456".to_string(),
                 "rt2".to_string(),
+                Some("id-b".to_string()),
                 Some("b@example.com".to_string()),
             )
             .await

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -738,6 +738,8 @@ impl CodexOAuthManager {
         }
 
         self.save_to_disk().await?;
+        crate::codex_profile::remove_account_profile(account_id)
+            .map_err(|err| CodexOAuthError::IoError(err.to_string()))?;
         Ok(())
     }
 
@@ -785,6 +787,8 @@ impl CodexOAuthManager {
         if self.storage_path.exists() {
             std::fs::remove_file(&self.storage_path)?;
         }
+        crate::codex_profile::remove_all_account_profiles()
+            .map_err(|err| CodexOAuthError::IoError(err.to_string()))?;
 
         Ok(())
     }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -64,6 +64,19 @@ fn activate_codex_profile_for_provider(provider: &Provider) -> Result<(), AppErr
     Ok(())
 }
 
+pub fn restore_active_codex_profile(state: &AppState) -> Result<(), AppError> {
+    let current_id = ProviderService::current(state, AppType::Codex)?;
+    if current_id.is_empty() {
+        return Ok(());
+    }
+
+    let providers = state.db.get_all_providers(AppType::Codex.as_str())?;
+    if let Some(provider) = providers.get(&current_id) {
+        activate_codex_profile_for_provider(provider)?;
+    }
+    Ok(())
+}
+
 /// 统一会话开关变更后，立即按新开关状态重写当前官方 Codex 供应商的
 /// live 配置，使开关即时生效（无需等下一次切换）。
 /// 当前供应商非官方（或不存在）时为 no-op：注入只作用于官方配置，

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -51,6 +51,19 @@ pub fn official_provider_supports_proxy_takeover(app_type: &AppType, provider: &
         && crate::proxy::providers::is_codex_official_provider(provider)
 }
 
+fn activate_codex_profile_for_provider(provider: &Provider) -> Result<(), AppError> {
+    let account_id = if provider.category.as_deref() == Some("official") {
+        provider
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
+    } else {
+        None
+    };
+    crate::codex_profile::activate(account_id.as_deref())?;
+    Ok(())
+}
+
 /// 统一会话开关变更后，立即按新开关状态重写当前官方 Codex 供应商的
 /// live 配置，使开关即时生效（无需等下一次切换）。
 /// 当前供应商非官方（或不存在）时为 no-op：注入只作用于官方配置，
@@ -2588,6 +2601,9 @@ impl ProviderService {
         let current = state.db.get_current_provider(app_type.as_str())?;
         if current.is_none() {
             // No current provider, set as current and sync
+            if matches!(app_type, AppType::Codex) {
+                activate_codex_profile_for_provider(&provider)?;
+            }
             state
                 .db
                 .set_current_provider(app_type.as_str(), &provider.id)?;
@@ -2755,6 +2771,10 @@ impl ProviderService {
         let is_current = effective_current.as_deref() == Some(provider.id.as_str());
 
         if is_current {
+            if matches!(app_type, AppType::Codex) {
+                activate_codex_profile_for_provider(&provider)?;
+            }
+
             // 如果 Claude 代理接管处于激活状态，并且代理服务正在运行：
             // - 不直接走普通 Live 写入逻辑
             // - 改为更新 Live 备份，并在 Claude 下同步代理安全的 Live 配置
@@ -3038,6 +3058,10 @@ impl ProviderService {
                 id
             );
 
+            if matches!(app_type, AppType::Codex) {
+                activate_codex_profile_for_provider(_provider)?;
+            }
+
             futures::executor::block_on(
                 state
                     .proxy_service
@@ -3131,6 +3155,12 @@ impl ProviderService {
                     }
                 }
             }
+        }
+
+        // Backfill must read the outgoing profile first. Only after that is
+        // complete may CODEX_HOME move to the target account profile.
+        if matches!(app_type, AppType::Codex) {
+            activate_codex_profile_for_provider(provider)?;
         }
 
         // Additive mode apps skip setting is_current (no such concept)

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -28,6 +28,7 @@ import {
 import EndpointSpeedTest from "./EndpointSpeedTest";
 import { ApiKeySection, EndpointField, ModelDropdown } from "./shared";
 import { XaiOAuthSection } from "./XaiOAuthSection";
+import { CodexOAuthSection } from "./CodexOAuthSection";
 import {
   fetchModelsForConfig,
   fetchXaiOauthModels,
@@ -54,6 +55,9 @@ interface EndpointCandidate {
 interface CodexFormFieldsProps {
   appId?: AppId;
   providerId?: string;
+  isOfficialProfile?: boolean;
+  selectedCodexAccountId?: string | null;
+  onCodexAccountSelect?: (accountId: string | null) => void;
   // xAI OAuth 托管预设（Grok 订阅）：隐藏 API Key / 端点输入，挂账号选择区块
   isXaiOauthPreset?: boolean;
   isXaiOauthAuthenticated?: boolean;
@@ -166,6 +170,9 @@ function catalogRowsMatchModels(
 export function CodexFormFields({
   appId = "codex",
   providerId,
+  isOfficialProfile,
+  selectedCodexAccountId,
+  onCodexAccountSelect,
   isXaiOauthPreset,
   isXaiOauthAuthenticated,
   selectedXaiAccountId,
@@ -501,6 +508,15 @@ export function CodexFormFields({
 
   return (
     <>
+      {isOfficialProfile && (
+        <CodexOAuthSection
+          selectedAccountId={selectedCodexAccountId}
+          onAccountSelect={onCodexAccountSelect}
+          showAccountQuota
+          allowDefaultAccount={false}
+        />
+      )}
+
       {/* xAI OAuth 认证（Grok 订阅托管账号） */}
       {isXaiOauthPreset && (
         <XaiOAuthSection
@@ -510,7 +526,7 @@ export function CodexFormFields({
       )}
 
       {/* Codex API Key 输入框（托管 OAuth 预设无需 Key） */}
-      {!isXaiOauthPreset && (
+      {!isXaiOauthPreset && !isOfficialProfile && (
         <ApiKeySection
           id="codexApiKey"
           label="API Key"

--- a/src/components/providers/forms/CodexOAuthSection.tsx
+++ b/src/components/providers/forms/CodexOAuthSection.tsx
@@ -34,6 +34,8 @@ interface CodexOAuthSectionProps {
   selectedAccountId?: string | null;
   /** 账号选择回调 */
   onAccountSelect?: (accountId: string | null) => void;
+  /** 是否允许不绑定具体账号、运行时使用 OAuth 中心默认账号 */
+  allowDefaultAccount?: boolean;
   /** 是否开启 Codex FAST mode */
   fastModeEnabled?: boolean;
   /** FAST mode 切换回调 */
@@ -51,6 +53,7 @@ export const CodexOAuthSection: React.FC<CodexOAuthSectionProps> = ({
   showAccountQuota = false,
   selectedAccountId,
   onAccountSelect,
+  allowDefaultAccount = true,
   fastModeEnabled = false,
   onFastModeChange,
 }) => {
@@ -121,7 +124,9 @@ export const CodexOAuthSection: React.FC<CodexOAuthSectionProps> = ({
             {t("codexOauth.selectAccount", "选择账号")}
           </Label>
           <Select
-            value={selectedAccountId || "none"}
+            value={
+              selectedAccountId || (allowDefaultAccount ? "none" : undefined)
+            }
             onValueChange={handleAccountSelect}
           >
             <SelectTrigger>
@@ -133,11 +138,13 @@ export const CodexOAuthSection: React.FC<CodexOAuthSectionProps> = ({
               />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="none">
-                <span className="text-muted-foreground">
-                  {t("codexOauth.useDefaultAccount", "使用默认账号")}
-                </span>
-              </SelectItem>
+              {allowDefaultAccount && (
+                <SelectItem value="none">
+                  <span className="text-muted-foreground">
+                    {t("codexOauth.useDefaultAccount", "使用默认账号")}
+                  </span>
+                </SelectItem>
+              )}
               {accounts.map((account) => (
                 <SelectItem key={account.id} value={account.id}>
                   <div className="flex items-center gap-2">

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -522,6 +522,7 @@ function ProviderFormFull({
   const {
     isAuthenticated: isCodexOauthAuthenticated,
     accounts: codexOauthAccounts,
+    defaultAccountId: defaultCodexAccountId,
   } = useCodexOauth();
 
   const {
@@ -544,6 +545,17 @@ function ProviderFormFull({
   const [codexFastMode, setCodexFastMode] = useState<boolean>(
     () => initialData?.meta?.codexFastMode ?? false,
   );
+
+  useEffect(() => {
+    if (
+      appId === "codex" &&
+      category === "official" &&
+      !selectedCodexAccountId &&
+      defaultCodexAccountId
+    ) {
+      setSelectedCodexAccountId(defaultCodexAccountId);
+    }
+  }, [appId, category, defaultCodexAccountId, selectedCodexAccountId]);
   const [codexChatReasoning, setCodexChatReasoning] =
     useState<CodexChatReasoning>(
       () => initialData?.meta?.codexChatReasoning ?? {},
@@ -1170,6 +1182,7 @@ function ProviderFormFull({
     const isCodexOauthProvider =
       presetProviderType === "codex_oauth" ||
       initialData?.meta?.providerType === "codex_oauth";
+    const isCodexOfficialProfile = appId === "codex" && category === "official";
     const isXaiOauthProvider =
       presetProviderType === "xai_oauth" ||
       initialData?.meta?.providerType === "xai_oauth";
@@ -1181,7 +1194,10 @@ function ProviderFormFull({
       );
       return;
     }
-    if (isCodexOauthProvider && !isCodexOauthAuthenticated) {
+    if (
+      (isCodexOauthProvider || isCodexOfficialProfile) &&
+      !isCodexOauthAuthenticated
+    ) {
       toast.error(
         t("codexOauth.loginRequired", {
           defaultValue: "请先登录 ChatGPT 账号",
@@ -1218,12 +1234,20 @@ function ProviderFormFull({
       return;
     }
     if (
-      isCodexOauthProvider &&
+      (isCodexOauthProvider || isCodexOfficialProfile) &&
       !selectedAccountIsUsable(selectedCodexAccountId, codexOauthAccounts)
     ) {
       toast.error(
         t("managedAuth.selectedAccountUnavailable", {
           defaultValue: "已绑定账号不存在，请重新选择账号",
+        }),
+      );
+      return;
+    }
+    if (isCodexOfficialProfile && !selectedCodexAccountId) {
+      toast.error(
+        t("codexOauth.selectAccountPlaceholder", {
+          defaultValue: "请选择一个 ChatGPT 账号",
         }),
       );
       return;
@@ -1563,7 +1587,7 @@ function ProviderFormFull({
             authProvider: "github_copilot",
             accountId: selectedGitHubAccountId ?? undefined,
           }
-        : isCodexOauthProvider
+        : isCodexOauthProvider || (appId === "codex" && category === "official")
           ? {
               source: "managed_account",
               authProvider: "codex_oauth",
@@ -2279,6 +2303,9 @@ function ProviderFormFull({
           {appId === "codex" && (
             <CodexFormFields
               providerId={providerId}
+              isOfficialProfile={category === "official"}
+              selectedCodexAccountId={selectedCodexAccountId}
+              onCodexAccountSelect={setSelectedCodexAccountId}
               isXaiOauthPreset={
                 presetProviderType === "xai_oauth" ||
                 initialData?.meta?.providerType === "xai_oauth"


### PR DESCRIPTION
## What changed

- add account-specific Codex profiles for official ChatGPT accounts
- bind official Codex providers to managed OAuth accounts and materialize complete `auth.json` credentials
- keep shared Codex configuration, sessions, history, and SQLite state available across account profiles
- synchronize rotated refresh and identity tokens between the OAuth manager and active profiles
- enforce owner-only permissions when writing credential JSON on Unix

## Why

Official Codex providers previously shared one live Codex home and credential file, so switching managed ChatGPT accounts could reuse or overwrite another account's authentication state. Separate profiles isolate credentials while preserving the user's shared Codex data and configuration.

## Impact

Users can bind an official Codex provider to a specific managed ChatGPT account and switch providers without mixing account credentials.

## Validation

- repository tests verified by the author in a Docker container
- `pnpm typecheck`
- `pnpm format:check`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
