### PR TITLE
fix(codex): preserve desktop state across provider switches

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1618,8 +1618,53 @@ pub fn write_codex_provider_live_with_catalog(
     let prepared_config = config_text
         .map(|text| prepare_codex_config_text_with_model_catalog(settings, text, profile))
         .transpose()?;
+    let prepared_config = preserve_codex_desktop_live_state(prepared_config.as_deref())?;
 
     write_codex_live_for_provider(category, auth, prepared_config.as_deref())
+}
+
+/// Preserve Codex desktop-app preferences across provider-driven live writes.
+///
+/// `[desktop]` is owned by the running Codex/ChatGPT desktop app, not by a
+/// model provider. Provider snapshots can be stale (or omit newly introduced
+/// desktop keys entirely), so the current live table must replace the target
+/// snapshot's table immediately before every provider write. This also gives
+/// forward compatibility to desktop settings added by newer Codex releases.
+///
+/// If no live `config.toml` exists yet, the provider config is left unchanged:
+/// there is no live state to preserve on a first-time install/import.
+pub(crate) fn preserve_codex_desktop_live_state(
+    config_text: Option<&str>,
+) -> Result<Option<String>, AppError> {
+    let target_text = config_text.unwrap_or("");
+    let config_path = get_codex_config_path();
+    if !config_path.exists() {
+        return Ok(config_text.map(str::to_string));
+    }
+
+    let live_text = read_and_validate_codex_config_text()?;
+    let live_doc = live_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid live Codex config.toml: {e}")))?;
+    let mut target_doc = if target_text.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        target_text
+            .parse::<DocumentMut>()
+            .map_err(|e| AppError::Message(format!("Invalid target Codex config.toml: {e}")))?
+    };
+
+    let live_desktop = live_doc.get("desktop");
+    if config_text.is_none() && live_desktop.is_none() {
+        return Ok(None);
+    }
+
+    target_doc.as_table_mut().remove("desktop");
+    if let Some(desktop) = live_desktop {
+        target_doc["desktop"] = desktop.clone();
+    }
+
+    Ok(Some(target_doc.to_string()))
 }
 
 /// Extract a provider-scoped `experimental_bearer_token` from Codex `config.toml`.
@@ -2094,6 +2139,33 @@ pub fn strip_codex_mcp_servers_from_settings(settings: &mut Value) -> Result<(),
         }
     }
     if changed {
+        if let Some(obj) = settings.as_object_mut() {
+            obj.insert("config".to_string(), Value::String(doc.to_string()));
+        }
+    }
+    Ok(())
+}
+
+/// Remove desktop-app-owned state before persisting a Codex provider snapshot.
+///
+/// Provider activation restores `[desktop]` from the current live config, so
+/// keeping another copy in each provider would create stale, competing owners.
+pub(crate) fn strip_codex_desktop_from_settings(settings: &mut Value) -> Result<(), AppError> {
+    let Some(config_text) = settings
+        .get("config")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+    else {
+        return Ok(());
+    };
+    if !config_text.contains("desktop") {
+        return Ok(());
+    }
+
+    let mut doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+    if doc.as_table_mut().remove("desktop").is_some() {
         if let Some(obj) = settings.as_object_mut() {
             obj.insert("config".to_string(), Value::String(doc.to_string()));
         }
@@ -2604,6 +2676,29 @@ requires_openai_auth = true
             Some(original),
             "config text must be byte-identical when nothing is stripped"
         );
+    }
+
+    #[test]
+    fn strip_desktop_from_settings_removes_only_desktop_table() {
+        let mut settings = json!({
+            "auth": { "OPENAI_API_KEY": "sk-test" },
+            "config": r#"model = "gpt-5.5"
+
+[desktop]
+mac-menu-bar-enabled = false
+
+[features]
+js_repl = true
+"#,
+        });
+
+        strip_codex_desktop_from_settings(&mut settings).expect("strip desktop");
+        let config = settings["config"].as_str().expect("config text");
+        assert!(!config.contains("[desktop]"));
+        assert!(!config.contains("mac-menu-bar-enabled"));
+        assert!(config.contains("model = \"gpt-5.5\""));
+        assert!(config.contains("[features]"));
+        assert!(config.contains("js_repl = true"));
     }
 
     #[test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -864,6 +864,16 @@ fn restore_live_settings_for_provider_backfill(
         );
     }
 
+    // `[desktop]` belongs to the live Codex/ChatGPT app, not to a provider.
+    // Keeping it in provider snapshots creates stale competing copies that can
+    // reset UI preferences when switching in the opposite direction.
+    if let Err(err) = crate::codex_config::strip_codex_desktop_from_settings(&mut settings) {
+        log::warn!(
+            "Failed to strip desktop state while backfilling '{}': {err}",
+            provider.id
+        );
+    }
+
     // MCP 服务器归 DB mcp_servers 表所有，live 里的 [mcp_servers] 是同步投影；
     // 回填时剥掉，否则已删除的服务器会随供应商快照复活（逐条 reconcile 清不掉孤儿）。
     if let Err(err) = crate::codex_config::strip_codex_mcp_servers_from_settings(&mut settings) {

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -1366,6 +1366,9 @@ experimental_bearer_token = "sk-live-secret"
 model_catalog_json = "cc-switch-model-catalog.json"
 web_search = "disabled"
 
+[desktop]
+mac-menu-bar-enabled = false
+
 [model_providers.azure]
 name = "Azure OpenAI"
 base_url = "https://azure.example/v1"
@@ -1427,6 +1430,10 @@ command = "legacy-cmd"
             !extracted.contains("web_search"),
             "should strip the cc-switch web_search disabled sentinel, got: {extracted}"
         );
+        assert!(
+            !extracted.contains("[desktop]") && !extracted.contains("mac-menu-bar-enabled"),
+            "desktop app state must not enter provider common config, got: {extracted}"
+        );
         // 真正可共享的键保留
         assert!(
             extracted.contains("disable_response_storage = true"),
@@ -1444,6 +1451,145 @@ command = "legacy-cmd"
             extracted.contains("web_search = \"enabled\""),
             "a user-set web_search value is a shareable preference, got: {extracted}"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn codex_provider_switch_preserves_desktop_live_state_in_both_directions() {
+        with_test_home(|state, _| {
+            crate::settings::reload_settings().expect("reload test settings");
+
+            let mut third_party = Provider::with_id(
+                "third-party".into(),
+                "Third Party".into(),
+                json!({
+                    "auth": { "OPENAI_API_KEY": "sk-third-party" },
+                    "config": r#"model_provider = "custom"
+
+[desktop]
+mac-menu-bar-enabled = true
+
+[model_providers.custom]
+name = "Third Party"
+base_url = "https://third-party.example/v1"
+wire_api = "responses"
+"#
+                }),
+                None,
+            );
+            third_party.category = Some("custom".into());
+
+            let mut official = Provider::with_id(
+                "codex-official".into(),
+                "OpenAI Official".into(),
+                json!({
+                    "auth": {},
+                    "config": r#"model_provider = "openai"
+
+[desktop]
+mac-menu-bar-enabled = true
+"#
+                }),
+                None,
+            );
+            official.category = Some("official".into());
+
+            state
+                .db
+                .save_provider(AppType::Codex.as_str(), &third_party)
+                .expect("save third-party provider");
+            state
+                .db
+                .save_provider(AppType::Codex.as_str(), &official)
+                .expect("save official provider");
+            state
+                .db
+                .set_current_provider(AppType::Codex.as_str(), &third_party.id)
+                .expect("set current third-party provider");
+            crate::settings::set_current_provider(&AppType::Codex, Some(&third_party.id))
+                .expect("set local current provider");
+
+            let config_path = crate::codex_config::get_codex_config_path();
+            fs::create_dir_all(config_path.parent().expect("config parent"))
+                .expect("create codex config dir");
+            fs::write(
+                &config_path,
+                r#"model_provider = "custom"
+
+[desktop]
+mac-menu-bar-enabled = false
+conversationDetailMode = "STEPS_COMMANDS"
+
+[model_providers.custom]
+name = "Third Party"
+base_url = "https://third-party.example/v1"
+wire_api = "responses"
+"#,
+            )
+            .expect("seed live codex config");
+
+            ProviderService::switch(state, AppType::Codex, &official.id)
+                .expect("switch third-party to official");
+            let official_live = fs::read_to_string(&config_path).expect("read official live");
+            let official_doc: toml::Value =
+                toml::from_str(&official_live).expect("parse official live");
+            assert_eq!(
+                official_doc
+                    .get("desktop")
+                    .and_then(|desktop| desktop.get("mac-menu-bar-enabled"))
+                    .and_then(|value| value.as_bool()),
+                Some(false),
+                "third-party -> official must preserve the explicit false desktop preference"
+            );
+            assert_eq!(
+                official_doc
+                    .get("desktop")
+                    .and_then(|desktop| desktop.get("conversationDetailMode"))
+                    .and_then(|value| value.as_str()),
+                Some("STEPS_COMMANDS"),
+                "unknown/new desktop keys must be preserved structurally"
+            );
+
+            let stored_third_party = state
+                .db
+                .get_provider_by_id(&third_party.id, AppType::Codex.as_str())
+                .expect("read stored third-party provider")
+                .expect("stored third-party provider exists");
+            assert!(
+                !stored_third_party.settings_config["config"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("[desktop]"),
+                "backfill must not persist live desktop state into provider snapshots"
+            );
+
+            ProviderService::switch(state, AppType::Codex, &third_party.id)
+                .expect("switch official to third-party");
+            let third_party_live = fs::read_to_string(&config_path).expect("read third-party live");
+            let third_party_doc: toml::Value =
+                toml::from_str(&third_party_live).expect("parse third-party live");
+            assert_eq!(
+                third_party_doc
+                    .get("desktop")
+                    .and_then(|desktop| desktop.get("mac-menu-bar-enabled"))
+                    .and_then(|value| value.as_bool()),
+                Some(false),
+                "official -> third-party must preserve the same live desktop preference"
+            );
+
+            let stored_official = state
+                .db
+                .get_provider_by_id(&official.id, AppType::Codex.as_str())
+                .expect("read stored official provider")
+                .expect("stored official provider exists");
+            assert!(
+                !stored_official.settings_config["config"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains("[desktop]"),
+                "official backfill must also keep desktop state out of provider snapshots"
+            );
+        });
     }
 
     #[tokio::test]
@@ -3686,6 +3832,10 @@ impl ProviderService {
 
         // Remove entire model_providers table (provider-specific configuration)
         root.remove("model_providers");
+
+        // Desktop UI preferences are live app state, not shared provider
+        // configuration. They are preserved centrally at provider-write time.
+        root.remove("desktop");
 
         // MCP 服务器归 DB mcp_servers 表所有：进了共享片段会绕过按应用的
         // 启用状态被合并进所有勾选通用配置的供应商，且在通用配置编辑框里

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2881,6 +2881,11 @@ impl ProxyService {
                             auth, config_str,
                         )
                         .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
+                        let live_config = crate::codex_config::preserve_codex_desktop_live_state(
+                            Some(&live_config),
+                        )
+                        .map_err(|e| format!("写入 Codex 配置失败: {e}"))?
+                        .expect("a supplied Codex config remains present after preservation");
                         crate::codex_config::write_codex_live_config_atomic(Some(&live_config))
                             .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
                         return Ok(());
@@ -2945,6 +2950,10 @@ impl ProxyService {
                 )
                 .map_err(|e| format!("写入 Codex 配置失败: {e}"))?
             };
+            let live_config =
+                crate::codex_config::preserve_codex_desktop_live_state(Some(&live_config))
+                    .map_err(|e| format!("写入 Codex 配置失败: {e}"))?
+                    .expect("a supplied Codex config remains present after preservation");
             crate::codex_config::write_codex_live_config_atomic(Some(&live_config))
                 .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
             return Ok(());
@@ -2988,6 +2997,9 @@ impl ProxyService {
             })
             .transpose()
             .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
+        let prepared_cfg =
+            crate::codex_config::preserve_codex_desktop_live_state(prepared_cfg.as_deref())
+                .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
 
         match (auth, prepared_cfg.as_deref()) {
             (Some(auth), Some(cfg)) => {
@@ -4136,13 +4148,30 @@ wire_api = "responses"
                 "access_token": "oauth-access"
             }
         });
-        crate::codex_config::write_codex_live_atomic(&oauth_auth, Some("model = \"gpt-5.4\"\n"))
-            .expect("seed official live config");
+        crate::codex_config::write_codex_live_atomic(
+            &oauth_auth,
+            Some(
+                r#"model = "gpt-5.4"
+
+[desktop]
+mac-menu-bar-enabled = false
+conversationDetailMode = "expanded"
+"#,
+            ),
+        )
+        .expect("seed official live config");
 
         let mut official = Provider::with_id(
             "codex-official".to_string(),
             "OpenAI Official".to_string(),
-            json!({ "auth": {}, "config": "model = \"gpt-5.4\"\n" }),
+            json!({
+                "auth": {},
+                "config": r#"model = "gpt-5.4"
+
+[desktop]
+mac-menu-bar-enabled = true
+"#
+            }),
             None,
         );
         official.category = Some("official".to_string());
@@ -4160,6 +4189,9 @@ wire_api = "responses"
 name = "RightCode"
 base_url = "https://rightcode.example/v1"
 wire_api = "responses"
+
+[desktop]
+mac-menu-bar-enabled = true
 "#
             }),
             None,
@@ -4189,6 +4221,8 @@ wire_api = "responses"
         ));
         assert!(official_live.contains("requires_openai_auth = true"));
         assert!(!official_live.contains(PROXY_TOKEN_PLACEHOLDER));
+        assert!(official_live.contains("mac-menu-bar-enabled = false"));
+        assert!(official_live.contains("conversationDetailMode = \"expanded\""));
 
         service
             .hot_switch_provider("codex", "rightcode")
@@ -4206,6 +4240,8 @@ wire_api = "responses"
         assert!(!crate::codex_config::codex_config_has_official_proxy_route(
             &third_party_live
         ));
+        assert!(third_party_live.contains("mac-menu-bar-enabled = false"));
+        assert!(third_party_live.contains("conversationDetailMode = \"expanded\""));
 
         service
             .hot_switch_provider("codex", "codex-official")
@@ -4222,12 +4258,18 @@ wire_api = "responses"
             &official_live
         ));
         assert!(!official_live.contains(PROXY_TOKEN_PLACEHOLDER));
+        assert!(official_live.contains("mac-menu-bar-enabled = false"));
+        assert!(official_live.contains("conversationDetailMode = \"expanded\""));
 
         service
             .set_takeover_for_app("codex", false)
             .await
             .expect("disable takeover");
         assert_eq!(read_auth(), oauth_auth);
+        let restored_live = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
+            .expect("read restored config");
+        assert!(restored_live.contains("mac-menu-bar-enabled = false"));
+        assert!(restored_live.contains("conversationDetailMode = \"expanded\""));
     }
 
     #[test]


### PR DESCRIPTION
Closes #6400.

## Summary

- treat Codex `[desktop]` as provider-independent live application state
- preserve the complete live `[desktop]` table before ordinary, proxy takeover, hot-switch, failover, and restore writes
- strip `[desktop]` from provider backfill snapshots and Common Config extraction to remove competing owners
- preserve unknown future desktop keys, not only `mac-menu-bar-enabled`

## Regression coverage

- third-party -> official -> third-party ordinary switching
- official -> third-party -> official proxy hot switching and takeover restore
- stale provider values cannot override the live value
- outgoing provider snapshots do not persist `[desktop]`

## Validation

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml`