### PR TITLE
fix(security): restrict ~/.cc-switch dir and backup db file permissions

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,10 +1,60 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::fs;
+use std::fs::Permissions;
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 
 use crate::error::AppError;
+
+/// 限制文件权限为「仅所有者可读写」（Unix: 0600；Windows: 无操作）。
+///
+/// Windows 没有 POSIX 权限位，`set_mode` 行为不可预测，因此仅在 Unix 平台生效；
+/// 同时避免 `set_permissions` 与 Windows ACL 机制冲突。
+pub fn restrict_file_mode(path: &Path) -> Result<(), AppError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(mut perms) = fs::metadata(path)?.permissions() {
+            perms.set_mode(0o600);
+            fs::set_permissions(path, perms).map_err(|e| AppError::io(path, e))?;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path; // Windows 忽略
+    }
+    Ok(())
+}
+
+/// 限制目录权限为「仅所有者可读写执行」（Unix: 0700；Windows: 无操作）。
+///
+/// 与 [`restrict_file_mode`] 配套：`.cc-switch/` 内所有数据（数据库、token、OAuth 凭据）
+/// 都依赖目录级的访问控制，目录 0755/0777 会让其他用户能列出文件名。
+pub fn restrict_dir_mode(path: &Path) -> Result<(), AppError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(mut perms) = fs::metadata(path)?.permissions() {
+            perms.set_mode(0o700);
+            fs::set_permissions(path, perms).map_err(|e| AppError::io(path, e))?;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path; // Windows 忽略
+    }
+    Ok(())
+}
+
+/// 确保 `.cc-switch/` 配置目录存在，并在 Unix 上收紧目录权限为 0700
+pub fn ensure_config_dir(dir: &Path) -> Result<(), AppError> {
+    fs::create_dir_all(dir).map_err(|e| AppError::io(dir, e))?;
+    if let Err(e) = restrict_dir_mode(dir) {
+        log::warn!("restrict dir mode failed for {}: {}", dir.display(), e);
+    }
+    Ok(())
+}
 
 /// 获取用户主目录，带回退和日志
 ///
@@ -471,12 +521,55 @@ pub fn atomic_write(path: &Path, data: &[u8]) -> Result<(), AppError> {
             });
         }
     }
+
+    // Unix 平台：原子写入完成后收紧文件权限为 0600（config.json 等敏感文件）
+    if cfg!(unix) {
+        if let Err(e) = restrict_file_mode(path) {
+            log::warn!("restrict file mode failed for {}: {}", path.display(), e);
+        }
+    }
+
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn restrict_dir_mode_sets_0700_on_unix() {
+        let dir = std::env::temp_dir().join(format!(
+            "cc-switch-dir-mode-test-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        restrict_dir_mode(&dir).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "dir mode should be 0700, got {:o}", mode);
+        }
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn ensure_config_dir_sets_0700_on_unix() {
+        let dir = std::env::temp_dir().join(format!(
+            "cc-switch-ensure-dir-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        ensure_config_dir(&dir).unwrap();
+        assert!(dir.exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "dir mode should be 0700, got {:o}", mode);
+        }
+        fs::remove_dir_all(&dir).ok();
+    }
 
     fn assert_atomic_write_replaces_existing_file(dir: &Path) {
         let path = dir.join("atomic-write-contract.json");

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -383,6 +383,8 @@ impl Database {
             .ok_or_else(|| AppError::Config("无效的数据库路径".to_string()))?
             .join("backups");
 
+        crate::config::ensure_config_dir(&backup_dir)?;
+
         fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
 
         let base_id = format!("db_backup_{}", Local::now().format("%Y%m%d_%H%M%S"));
@@ -405,6 +407,9 @@ impl Database {
                 .step(-1)
                 .map_err(|e| AppError::Database(e.to_string()))?;
         }
+
+        // 备份数据库含全部 token/凭据，收紧为 0600，防其他用户读取
+        crate::config::restrict_file_mode(&backup_path)?;
 
         Self::cleanup_db_backups(&backup_dir)?;
         Ok(Some(backup_path))

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -101,12 +101,17 @@ impl Database {
         let db_path = get_app_config_dir().join("cc-switch.db");
         let db_exists = db_path.exists();
 
-        // 确保父目录存在
+        // 确保父目录存在，并将 `.cc-switch/` 目录权限收紧为 0700
         if let Some(parent) = db_path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+            crate::config::ensure_config_dir(parent)?;
         }
 
         let conn = Connection::open(&db_path).map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Unix 平台：新创建的 SQLite 文件收紧为 0600（含 WAL/SHM 文件）
+        if cfg!(unix) && !db_exists {
+            let _ = crate::config::restrict_file_mode(&db_path);
+        }
 
         // 启用外键约束
         conn.execute("PRAGMA foreign_keys = ON;", [])


### PR DESCRIPTION
## Summary

Closes #3265.

`~/.cc-switch/` 目录和备份数据库文件此前沿用系统 umask 默认权限（目录 0755、文件 0644），同机其他用户可读取其中的 token / OAuth 凭据。

本 PR 在 Unix 平台收紧权限：

| 目标 | 修改前 | 修改后 |
|---|---|---|
| `~/.cc-switch/` 目录 | 0755（umask 默认） | **0700** |
| `~/.cc-switch/backups/` 目录 | 0755 | **0700** |
| 备份 `.db` 文件 | 0644 | **0600** |

## Changes

- `config.rs`：新增 `restrict_dir_mode()`（0700）与 `ensure_config_dir()`（确保目录存在 + 收紧 0700）；`atomic_write` 已有 0600 收紧逻辑，本次未改动
- `database/mod.rs`：数据库初始化时改用 `ensure_config_dir()`
- `database/backup.rs`：`backup_database_file()` 创建备份目录时收紧 0700，生成的备份 `.db` 收紧 0600
- 单元测试：`restrict_dir_mode_sets_0700_on_unix`、`ensure_config_dir_sets_0700_on_unix`（Windows 上 cfg 跳过）

## Notes

- 仅 Unix（macOS/Linux）生效；Windows 使用 ACL，`#[cfg(not(unix))]` 下为无操作，与仓库现有 `restrict_file_mode` 行为一致
- 已存在目录/文件也会被收紧（幂等），现有用户升级后自动获得保护