### PR TITLE
refactor(grokbuild): align provider form with Codex

### DIFF
--- a/src/components/providers/forms/GrokBuildProviderForm.tsx
+++ b/src/components/providers/forms/GrokBuildProviderForm.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/utils/providerConfigUtils";
 import {
   buildGrokBuildConfig,
+  GROK_BUILD_DEFAULT_API_BACKEND,
   parseGrokBuildConfig,
   updateGrokBuildConfig,
   validateGrokBuildConfig,
@@ -66,12 +67,6 @@ const grokPresetEntries: Array<{
     preset,
   })),
 ];
-
-export const grokApiBackendFromApiFormat = (format: CodexApiFormat): string => {
-  if (format === "openai_chat") return "chat_completions";
-  if (format === "anthropic") return "messages";
-  return "responses";
-};
 
 export function GrokBuildProviderForm({
   providerId,
@@ -109,7 +104,6 @@ export function GrokBuildProviderForm({
   );
   const [baseUrl, setBaseUrl] = useState(initialConfig.baseUrl);
   const [apiKey, setApiKey] = useState(initialConfig.apiKey);
-  const [apiBackend, setApiBackend] = useState(initialConfig.apiBackend);
   const [contextWindow, setContextWindow] = useState(
     String(initialConfig.contextWindow),
   );
@@ -222,9 +216,9 @@ export function GrokBuildProviderForm({
       baseUrl,
       name: form.getValues("name") || initialConfig.name,
       apiKey,
-      apiBackend,
       contextWindow: Number.parseInt(contextWindow, 10),
       ...overrides,
+      apiBackend: GROK_BUILD_DEFAULT_API_BACKEND,
     };
     setRawConfig((current) => updateGrokBuildConfig(current, next));
   };
@@ -269,8 +263,6 @@ export function GrokBuildProviderForm({
       "auth" in preset && typeof preset.auth?.OPENAI_API_KEY === "string"
         ? preset.auth.OPENAI_API_KEY
         : "";
-    const presetApiBackend = grokApiBackendFromApiFormat(presetApiFormat);
-
     form.setValue("name", presetName);
     form.setValue("websiteUrl", preset.websiteUrl ?? "");
     form.setValue("icon", preset.icon ?? "");
@@ -282,7 +274,6 @@ export function GrokBuildProviderForm({
     setApiKey(presetApiKey);
     setUpstreamModel(presetModel);
     setApiFormat(presetApiFormat);
-    setApiBackend(presetApiBackend);
     setPresetEndpoints(preset.endpointCandidates ?? []);
     setRawConfig(
       buildGrokBuildConfig({
@@ -291,7 +282,7 @@ export function GrokBuildProviderForm({
         baseUrl: presetBaseUrl,
         name: presetName,
         apiKey: presetApiKey,
-        apiBackend: presetApiBackend,
+        apiBackend: GROK_BUILD_DEFAULT_API_BACKEND,
         contextWindow: Number.parseInt(contextWindow, 10),
       }),
     );
@@ -305,7 +296,6 @@ export function GrokBuildProviderForm({
     setUpstreamModel(parsed.upstreamModel ?? parsed.model);
     setBaseUrl(parsed.baseUrl);
     setApiKey(parsed.apiKey);
-    setApiBackend(parsed.apiBackend);
     setContextWindow(String(parsed.contextWindow));
     if (parsed.name) form.setValue("name", parsed.name);
   };
@@ -360,7 +350,7 @@ export function GrokBuildProviderForm({
       baseUrl,
       name,
       apiKey,
-      apiBackend,
+      apiBackend: GROK_BUILD_DEFAULT_API_BACKEND,
       contextWindow: parsedContextWindow,
     });
     const configError = validateGrokBuildConfig(finalConfig);
@@ -451,62 +441,6 @@ export function GrokBuildProviderForm({
 
         {category !== "official" && (
           <>
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-              <FormItem>
-                <FormLabel htmlFor="grokbuild-profile">
-                  {t("grokBuild.profile", { defaultValue: "客户端模型档位" })}
-                </FormLabel>
-                <Input
-                  id="grokbuild-profile"
-                  value={profile}
-                  onChange={(event) => {
-                    const value = event.target.value;
-                    setProfile(value);
-                    syncStructuredConfig({ model: value });
-                  }}
-                  placeholder="grok-4.5"
-                  autoComplete="off"
-                />
-              </FormItem>
-
-              <FormItem>
-                <FormLabel htmlFor="grokbuild-api-backend">
-                  {t("grokBuild.apiBackend", { defaultValue: "API Backend" })}
-                </FormLabel>
-                <Input
-                  id="grokbuild-api-backend"
-                  value={apiBackend}
-                  onChange={(event) => {
-                    const value = event.target.value;
-                    setApiBackend(value);
-                    syncStructuredConfig({ apiBackend: value });
-                  }}
-                  placeholder="responses"
-                  autoComplete="off"
-                />
-              </FormItem>
-
-              <FormItem>
-                <FormLabel htmlFor="grokbuild-context-window">
-                  {t("grokBuild.contextWindow", { defaultValue: "上下文窗口" })}
-                </FormLabel>
-                <Input
-                  id="grokbuild-context-window"
-                  type="number"
-                  min={1}
-                  step={1}
-                  value={contextWindow}
-                  onChange={(event) => {
-                    const value = event.target.value;
-                    setContextWindow(value);
-                    syncStructuredConfig({
-                      contextWindow: Number.parseInt(value, 10),
-                    });
-                  }}
-                />
-              </FormItem>
-            </div>
-
             <CodexFormFields
               appId="grokbuild"
               providerId={providerId}
@@ -540,10 +474,7 @@ export function GrokBuildProviderForm({
               }}
               apiFormat={apiFormat}
               onApiFormatChange={(value) => {
-                const backend = grokApiBackendFromApiFormat(value);
                 setApiFormat(value);
-                setApiBackend(backend);
-                syncStructuredConfig({ apiBackend: backend });
               }}
               anthropicAuthField={anthropicAuthField}
               onAnthropicAuthFieldChange={setAnthropicAuthField}
@@ -563,6 +494,27 @@ export function GrokBuildProviderForm({
               localProxyBodyOverride={bodyOverride}
               onLocalProxyBodyOverrideChange={setBodyOverride}
             />
+
+            <FormItem>
+              <FormLabel htmlFor="grokbuild-context-window">
+                {t("grokBuild.contextWindow", { defaultValue: "上下文窗口" })}
+              </FormLabel>
+              <Input
+                id="grokbuild-context-window"
+                type="number"
+                min={1}
+                step={1}
+                inputMode="numeric"
+                value={contextWindow}
+                onChange={(event) => {
+                  const value = event.target.value;
+                  setContextWindow(value);
+                  syncStructuredConfig({
+                    contextWindow: Number.parseInt(value, 10),
+                  });
+                }}
+              />
+            </FormItem>
 
             <div className="space-y-2">
               <FormLabel htmlFor="grokbuild-config-toml">

--- a/tests/components/GrokBuildProviderForm.test.tsx
+++ b/tests/components/GrokBuildProviderForm.test.tsx
@@ -2,10 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { parse as parseToml } from "smol-toml";
 import { describe, expect, it, vi } from "vitest";
-import {
-  GrokBuildProviderForm,
-  grokApiBackendFromApiFormat,
-} from "@/components/providers/forms/GrokBuildProviderForm";
+import { GrokBuildProviderForm } from "@/components/providers/forms/GrokBuildProviderForm";
 
 vi.mock("@/components/JsonEditor", () => ({
   default: ({
@@ -92,37 +89,64 @@ describe("GrokBuildProviderForm", () => {
     });
   });
 
-  it("maps preset API formats into Grok api_backend", async () => {
-    // 预设列表已不含 Chat Completions 条目（国产官方直连被移除），
-    // chat/messages 映射分支由纯函数覆盖
-    expect(grokApiBackendFromApiFormat("openai_chat")).toBe("chat_completions");
-    expect(grokApiBackendFromApiFormat("anthropic")).toBe("messages");
-    expect(grokApiBackendFromApiFormat("openai_responses")).toBe("responses");
-
-    // 组件级接线用带显式 apiFormat 的 Responses 预设验证
-    const user = userEvent.setup();
-    const onSubmit = vi.fn();
-    render(
+  it("uses the Codex-style advanced section without redundant Grok fields", () => {
+    const { container } = render(
       <GrokBuildProviderForm
         submitLabel="Save"
-        onSubmit={onSubmit}
+        onSubmit={() => {}}
         onCancel={() => {}}
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: /APIKEY\.FUN/ }));
-    await user.type(screen.getByLabelText("API Key"), "secret-key");
+    expect(container.querySelector("#grokbuild-profile")).toBeNull();
+    expect(container.querySelector("#grokbuild-api-backend")).toBeNull();
+    expect(screen.getByText("高级选项")).toBeInTheDocument();
+    expect(container.querySelector("#grokbuild-context-window")).toHaveValue(
+      500000,
+    );
+    expect(screen.getByText("上游格式")).toBeInTheDocument();
+  });
+
+  it("keeps the Grok client on Responses when the upstream uses Chat", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const configToml = `[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "grok-4.5"
+base_url = "https://relay.example.com/v1"
+name = "Chat Relay"
+api_key = "secret-key"
+api_backend = "chat_completions"
+context_window = 500000
+`;
+    render(
+      <GrokBuildProviderForm
+        providerId="chat-relay"
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+        initialData={{
+          name: "Chat Relay",
+          category: "custom",
+          settingsConfig: { config: configToml },
+          meta: { apiFormat: "openai_chat" },
+        }}
+      />,
+    );
+
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     const submitted = onSubmit.mock.calls[0][0];
     const settings = JSON.parse(submitted.settingsConfig);
     const config = parseToml(settings.config) as any;
-    expect(submitted.meta.apiFormat).toBe("openai_responses");
+    expect(submitted.meta.apiFormat).toBe("openai_chat");
     const selected = config.model[config.models.default];
     expect(selected.api_backend).toBe("responses");
     expect(selected.model).toBe("grok-4.5");
-    expect(selected.base_url).toBe("https://api.apikey.fun/v1");
+    expect(selected.base_url).toBe("https://relay.example.com/v1");
   });
 
   it("renders localized validation feedback for malformed TOML", async () => {
@@ -178,9 +202,10 @@ context_window = 250000
       />,
     );
 
+    expect(container.querySelector("#grokbuild-profile")).toBeNull();
     expect(
-      container.querySelector<HTMLInputElement>("#grokbuild-profile")?.value,
-    ).toBe("existing-profile");
+      container.querySelector<HTMLInputElement>("#codexDefaultModel")?.value,
+    ).toBe("grok-upstream");
     expect(
       container.querySelector<HTMLInputElement>("#codexBaseUrl")?.value,
     ).toBe("https://existing.example.com/v1");


### PR DESCRIPTION
## Summary / 概述

- Align the Grok Build custom-provider form with the existing Codex advanced-options layout without modifying shared Codex form components.
- Remove the redundant client profile and API Backend inputs while retaining the context-window setting.
- Keep the Grok client config on the Responses backend, while preserving the selected upstream API format in provider metadata for routing conversion.
- Add regression coverage for the advanced section and non-Responses upstream formats.

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

N/A

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (N/A: no Rust code changed) / 通过 Clippy 检查（不适用：未修改 Rust 代码）
- [x] Updated i18n files (N/A: no new user-facing strings) / 已更新国际化文件（不适用：未新增用户可见文本）

## Tests / 测试

- `pnpm exec vitest run tests/components/GrokBuildProviderForm.test.tsx` (6 passed)
- `pnpm typecheck`
- `pnpm format:check`