### PR TITLE
fix(proxy): route Grok Build wire APIs

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1149,6 +1149,13 @@ impl RequestForwarder {
             && super::providers::should_convert_codex_responses_to_chat(provider, endpoint);
         let codex_responses_to_anthropic = matches!(app_type, AppType::Codex | AppType::GrokBuild)
             && super::providers::should_convert_codex_responses_to_anthropic(provider, endpoint);
+        let endpoint_path = endpoint
+            .split_once('?')
+            .map_or(endpoint, |(path, _query)| path);
+        let grokbuild_direct_chat =
+            matches!(app_type, AppType::GrokBuild) && endpoint_path == "/chat/completions";
+        let grokbuild_direct_messages =
+            matches!(app_type, AppType::GrokBuild) && endpoint_path == "/v1/messages";
         let codex_official_auth_passthrough = matches!(app_type, AppType::Codex)
             && super::providers::is_codex_official_provider(provider);
 
@@ -1384,16 +1391,17 @@ impl RequestForwarder {
             )
         };
 
-        let codex_chat_base_is_full_endpoint =
-            codex_responses_to_chat && base_url_is_full_endpoint(&base_url, "/chat/completions");
+        let chat_base_is_full_endpoint = (codex_responses_to_chat || grokbuild_direct_chat)
+            && base_url_is_full_endpoint(&base_url, "/chat/completions");
 
-        // Defensive fallback mirroring `codex_chat_base_is_full_endpoint`: if a user pastes
+        // Defensive fallback mirroring `chat_base_is_full_endpoint`: if a user pastes
         // a base URL already ending in the Anthropic `/v1/messages` endpoint but leaves the
         // "full URL" switch off, treat it as a full endpoint so we don't double-append
         // `/v1/messages` (→ `.../v1/messages/v1/messages`, a non-retryable 400). Matches the
         // exact endpoint suffix, so prefixed gateways like `.../api/v1/messages` are covered.
-        let codex_anthropic_base_is_full_endpoint =
-            codex_responses_to_anthropic && base_url_is_full_endpoint(&base_url, "/v1/messages");
+        let anthropic_base_is_full_endpoint = (codex_responses_to_anthropic
+            || grokbuild_direct_messages)
+            && base_url_is_full_endpoint(&base_url, "/v1/messages");
 
         let url = if matches!(resolved_claude_api_format.as_deref(), Some("gemini_native")) {
             super::gemini_url::resolve_gemini_native_url(
@@ -1401,10 +1409,7 @@ impl RequestForwarder {
                 &effective_endpoint,
                 is_full_url,
             )
-        } else if is_full_url
-            || codex_chat_base_is_full_endpoint
-            || codex_anthropic_base_is_full_endpoint
-        {
+        } else if is_full_url || chat_base_is_full_endpoint || anthropic_base_is_full_endpoint {
             append_query_to_full_url(&base_url, passthrough_query.as_deref())
         } else {
             adapter.build_url(&base_url, &effective_endpoint)
@@ -1872,11 +1877,18 @@ impl RequestForwarder {
             .ok()
             .and_then(|u| u.authority().map(|a| a.to_string()));
 
-        let should_send_anthropic_headers = adapter.name() == "Claude"
-            && matches!(resolved_claude_api_format.as_deref(), Some("anthropic"));
+        let should_send_anthropic_headers = grokbuild_direct_messages
+            || (adapter.name() == "Claude"
+                && matches!(resolved_claude_api_format.as_deref(), Some("anthropic")));
 
-        // 预计算 anthropic-beta 值（仅 Claude）
-        let anthropic_beta_value = if should_send_anthropic_headers {
+        // Native Grok Build Messages preserves the client's beta list as-is.
+        // Claude paths keep their existing Claude Code beta behavior.
+        let anthropic_beta_value = if grokbuild_direct_messages {
+            headers
+                .get("anthropic-beta")
+                .and_then(|beta| beta.to_str().ok())
+                .map(ToString::to_string)
+        } else if should_send_anthropic_headers {
             const CLAUDE_CODE_BETA: &str = "claude-code-20250219";
             Some(if let Some(beta) = headers.get("anthropic-beta") {
                 if let Ok(beta_str) = beta.to_str() {
@@ -3193,15 +3205,22 @@ fn merge_query_params(base_query: Option<&str>, extra_param: Option<&str>) -> Op
 }
 
 fn append_query_to_full_url(base_url: &str, query: Option<&str>) -> String {
-    match query {
+    let (base, fragment) = base_url
+        .split_once('#')
+        .map_or((base_url, None), |(base, fragment)| (base, Some(fragment)));
+    let url = match query {
         Some(query) if !query.is_empty() => {
-            if base_url.contains('?') {
-                format!("{base_url}&{query}")
+            if base.contains('?') {
+                format!("{base}&{query}")
             } else {
-                format!("{base_url}?{query}")
+                format!("{base}?{query}")
             }
         }
-        _ => base_url.to_string(),
+        _ => base.to_string(),
+    };
+    match fragment {
+        Some(fragment) => format!("{url}#{fragment}"),
+        None => url,
     }
 }
 
@@ -4218,6 +4237,17 @@ mod tests {
         assert_eq!(
             append_query_to_full_url("https://host.example/v1/messages", Some("x=1")),
             "https://host.example/v1/messages?x=1"
+        );
+        assert_eq!(
+            append_query_to_full_url("https://host.example/v1/messages#frag", Some("x=1")),
+            "https://host.example/v1/messages?x=1#frag"
+        );
+        assert_eq!(
+            append_query_to_full_url(
+                "https://host.example/v1/messages?beta=true#frag",
+                Some("x=1")
+            ),
+            "https://host.example/v1/messages?beta=true&x=1#frag"
         );
         // A base URL that already carries its own query is preserved verbatim (no double
         // `/v1/messages`, query kept).

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -126,6 +126,21 @@ pub async fn handle_messages(
     handle_messages_for_app(state, request, AppType::Claude, "Claude", "claude", None).await
 }
 
+pub async fn handle_grokbuild_messages(
+    State(state): State<ProxyState>,
+    request: axum::extract::Request,
+) -> Result<axum::response::Response, ProxyError> {
+    handle_messages_for_app(
+        state,
+        request,
+        AppType::GrokBuild,
+        "Grok Build",
+        "grokbuild",
+        Some("/grokbuild"),
+    )
+    .await
+}
+
 pub async fn handle_claude_desktop_messages(
     State(state): State<ProxyState>,
     request: axum::extract::Request,
@@ -704,6 +719,30 @@ pub async fn handle_chat_completions(
     State(state): State<ProxyState>,
     request: axum::extract::Request,
 ) -> Result<axum::response::Response, ProxyError> {
+    handle_chat_completions_for_app(state, request, AppType::Codex, "Codex", "codex").await
+}
+
+pub async fn handle_grokbuild_chat_completions(
+    State(state): State<ProxyState>,
+    request: axum::extract::Request,
+) -> Result<axum::response::Response, ProxyError> {
+    handle_chat_completions_for_app(
+        state,
+        request,
+        AppType::GrokBuild,
+        "Grok Build",
+        "grokbuild",
+    )
+    .await
+}
+
+async fn handle_chat_completions_for_app(
+    state: ProxyState,
+    request: axum::extract::Request,
+    app_type: AppType,
+    tag: &'static str,
+    app_type_str: &'static str,
+) -> Result<axum::response::Response, ProxyError> {
     let (parts, req_body) = request.into_parts();
     let method = parts.method.clone();
     let uri = parts.uri;
@@ -719,7 +758,7 @@ pub async fn handle_chat_completions(
         .map_err(|e| ProxyError::Internal(format!("Failed to parse request body: {e}")))?;
 
     let mut ctx =
-        RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
+        RequestContext::new(&state, &body, &headers, app_type.clone(), tag, app_type_str).await?;
     let endpoint = endpoint_with_query(&uri, "/chat/completions");
 
     let is_stream = body
@@ -730,7 +769,7 @@ pub async fn handle_chat_completions(
     let forwarder = ctx.create_forwarder(&state);
     let mut result = match forwarder
         .forward_with_retry(
-            &AppType::Codex,
+            &app_type,
             method,
             &endpoint,
             body,

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -327,11 +327,18 @@ impl ProxyServer {
             .route("/v1/responses", post(handlers::handle_responses))
             .route("/v1/v1/responses", post(handlers::handle_responses))
             .route("/codex/v1/responses", post(handlers::handle_responses))
-            // Grok Build uses the Responses protocol but has an independent
-            // provider namespace and failover queue.
+            // Grok Build has an independent provider namespace and failover queue.
+            .route(
+                "/grokbuild/v1/chat/completions",
+                post(handlers::handle_grokbuild_chat_completions),
+            )
             .route(
                 "/grokbuild/v1/responses",
                 post(handlers::handle_grokbuild_responses),
+            )
+            .route(
+                "/grokbuild/v1/messages",
+                post(handlers::handle_grokbuild_messages),
             )
             // OpenAI Responses Compact API (Codex CLI 远程压缩，透传)
             .route(
@@ -401,5 +408,139 @@ impl ProxyServer {
             .provider_router
             .reset_provider_breaker(provider_id, app_type)
             .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{Provider, ProviderMeta};
+    use axum::{body::Body, http::Request};
+    use serde_json::json;
+    use tokio::sync::mpsc;
+    use tower::Service;
+
+    #[tokio::test]
+    async fn grokbuild_routes_use_grokbuild_provider_and_preserve_protocol() {
+        let (capture_tx, mut capture_rx) = mpsc::unbounded_channel();
+        let upstream = Router::new().fallback(axum::routing::any(
+            move |request: axum::extract::Request| {
+                let capture_tx = capture_tx.clone();
+                async move {
+                    let path = request
+                        .uri()
+                        .path_and_query()
+                        .expect("upstream path")
+                        .as_str()
+                        .to_string();
+                    capture_tx
+                        .send((path, request.headers().clone()))
+                        .expect("capture request");
+                    axum::http::StatusCode::BAD_REQUEST
+                }
+            },
+        ));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind upstream");
+        let upstream_origin = format!("http://{}", listener.local_addr().expect("upstream addr"));
+        let upstream_task = tokio::spawn(async move {
+            axum::serve(listener, upstream)
+                .await
+                .expect("serve upstream");
+        });
+
+        let db = Arc::new(Database::memory().expect("in-memory database"));
+        let mut provider = Provider::with_id(
+            "grok-only".to_string(),
+            "Grok only".to_string(),
+            json!({
+                "base_url": upstream_origin.clone(),
+                "api_key": "grok-upstream-secret",
+            }),
+            None,
+        );
+        provider.in_failover_queue = true;
+        db.save_provider("grokbuild", &provider)
+            .expect("save GrokBuild provider");
+        let mut proxy_config = db
+            .get_proxy_config_for_app("grokbuild")
+            .await
+            .expect("GrokBuild proxy config");
+        proxy_config.auto_failover_enabled = true;
+        proxy_config.max_retries = 0;
+        db.update_proxy_config_for_app(proxy_config)
+            .await
+            .expect("enable GrokBuild failover queue");
+
+        let server = ProxyServer::new(ProxyConfig::default(), db.clone(), None);
+        let router = server.build_router();
+
+        for (route, api_format, expected_path) in [
+            (
+                "/grokbuild/v1/chat/completions?trace=chat",
+                "openai_chat",
+                "/v1/chat/completions?trace=chat",
+            ),
+            (
+                "/grokbuild/v1/messages?trace=messages",
+                "anthropic",
+                "/v1/messages?trace=messages",
+            ),
+        ] {
+            let is_messages = api_format == "anthropic";
+            provider.meta = Some(ProviderMeta {
+                api_format: Some(api_format.to_string()),
+                api_key_field: is_messages.then(|| "ANTHROPIC_API_KEY".to_string()),
+                ..Default::default()
+            });
+            provider.settings_config["base_url"] = json!(format!(
+                "{upstream_origin}{}",
+                expected_path.split('?').next().expect("endpoint path")
+            ));
+            db.save_provider("grokbuild", &provider)
+                .expect("update GrokBuild provider");
+
+            let mut request = Request::post(route)
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer client-secret");
+            if is_messages {
+                request = request
+                    .header("anthropic-version", "2024-01-01")
+                    .header("anthropic-beta", "test-beta");
+            }
+            let request = request
+                .body(Body::from(r#"{"model":"grok-4.5"}"#))
+                .expect("request");
+            router.clone().call(request).await.expect("route response");
+
+            let (path, headers) = capture_rx.try_recv().expect("GrokBuild upstream request");
+            assert_eq!(path, expected_path);
+            let (auth_header, auth_value) = if is_messages {
+                ("x-api-key", "grok-upstream-secret")
+            } else {
+                ("authorization", "Bearer grok-upstream-secret")
+            };
+            assert_eq!(
+                headers
+                    .get(auth_header)
+                    .and_then(|value| value.to_str().ok()),
+                Some(auth_value)
+            );
+            assert_eq!(
+                headers
+                    .get("anthropic-version")
+                    .and_then(|value| value.to_str().ok()),
+                is_messages.then_some("2024-01-01")
+            );
+            assert_eq!(
+                headers
+                    .get("anthropic-beta")
+                    .and_then(|value| value.to_str().ok()),
+                is_messages.then_some("test-beta")
+            );
+        }
+
+        upstream_task.abort();
     }
 }


### PR DESCRIPTION
## Summary

- Route Grok Build Chat Completions and Messages through its own provider namespace.
- Preserve Anthropic headers and full-endpoint query handling.

## Testing

- `cargo test --lib`
- `cargo clippy --lib --all-features -- -D warnings`

Fixes #5678