### PR TITLE
fix(claude): keep provider terminal on active proxy takeover

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -3349,13 +3349,68 @@ pub async fn open_provider_terminal(
 
     // 从提供商配置中提取环境变量
     let config = &provider.settings_config;
-    let env_vars = extract_env_vars_from_config(config, &app_type);
+    let mut env_vars = extract_env_vars_from_config(config, &app_type);
+    apply_claude_takeover_proxy_to_terminal_env(
+        state.inner(),
+        &app_type,
+        &providerId,
+        &mut env_vars,
+    )
+    .await?;
 
     // 根据平台启动终端，传入提供商ID用于生成唯一的配置文件名
     launch_terminal_with_env(env_vars, &providerId, launch_cwd.as_deref())
         .map_err(|e| format!("启动终端失败: {e}"))?;
 
     Ok(true)
+}
+
+/// When Claude Live is routed through the local proxy, the provider-specific
+/// terminal must use the same local endpoint. Otherwise the temporary
+/// `--settings` file bypasses proxy takeover and sends Claude requests to the
+/// upstream provider directly.
+async fn apply_claude_takeover_proxy_to_terminal_env(
+    state: &crate::store::AppState,
+    app_type: &AppType,
+    provider_id: &str,
+    env_vars: &mut Vec<(String, String)>,
+) -> Result<(), String> {
+    if !matches!(app_type, AppType::Claude) {
+        return Ok(());
+    }
+
+    let takeover = state.proxy_service.get_takeover_status().await?;
+    if !takeover.claude {
+        return Ok(());
+    }
+
+    let current_provider_id = crate::settings::get_effective_current_provider(&state.db, app_type)
+        .map_err(|e| format!("获取 Claude 当前供应商失败: {e}"))?;
+    if current_provider_id.as_deref() != Some(provider_id) {
+        return Ok(());
+    }
+
+    let status = state.proxy_service.get_status().await?;
+    if !status.running || status.port == 0 {
+        return Ok(());
+    }
+
+    let host = match status.address.as_str() {
+        "" | "0.0.0.0" | "::" => "127.0.0.1".to_string(),
+        value if value.contains(':') && !value.starts_with('[') => format!("[{value}]"),
+        value => value.to_string(),
+    };
+    let proxy_url = format!("http://{host}:{}", status.port);
+    replace_env_value(env_vars, "ANTHROPIC_BASE_URL", proxy_url);
+    Ok(())
+}
+
+fn replace_env_value(env_vars: &mut Vec<(String, String)>, key: &str, value: String) {
+    if let Some((_, existing_value)) = env_vars.iter_mut().find(|(name, _)| name == key) {
+        *existing_value = value;
+    } else {
+        env_vars.push((key.to_string(), value));
+    }
 }
 
 /// 从提供商配置中提取环境变量
@@ -6392,6 +6447,47 @@ mod tests {
         assert_eq!(
             command,
             "pushd \"\\\\server\\share\\100%%^&^(test^)\" || exit /b 1\r\n"
+        );
+    }
+
+    #[test]
+    fn replace_env_value_updates_existing_base_url() {
+        let mut env_vars = vec![
+            ("ANTHROPIC_BASE_URL".to_string(), "https://upstream.test".to_string()),
+            ("ANTHROPIC_MODEL".to_string(), "model-a".to_string()),
+        ];
+
+        replace_env_value(
+            &mut env_vars,
+            "ANTHROPIC_BASE_URL",
+            "http://127.0.0.1:15721".to_string(),
+        );
+
+        assert_eq!(
+            env_vars,
+            vec![
+                ("ANTHROPIC_BASE_URL".to_string(), "http://127.0.0.1:15721".to_string()),
+                ("ANTHROPIC_MODEL".to_string(), "model-a".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn replace_env_value_adds_missing_base_url() {
+        let mut env_vars = vec![("ANTHROPIC_MODEL".to_string(), "model-a".to_string())];
+
+        replace_env_value(
+            &mut env_vars,
+            "ANTHROPIC_BASE_URL",
+            "http://127.0.0.1:15721".to_string(),
+        );
+
+        assert_eq!(
+            env_vars,
+            vec![
+                ("ANTHROPIC_MODEL".to_string(), "model-a".to_string()),
+                ("ANTHROPIC_BASE_URL".to_string(), "http://127.0.0.1:15721".to_string()),
+            ]
         );
     }
 }

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -6453,7 +6453,10 @@ mod tests {
     #[test]
     fn replace_env_value_updates_existing_base_url() {
         let mut env_vars = vec![
-            ("ANTHROPIC_BASE_URL".to_string(), "https://upstream.test".to_string()),
+            (
+                "ANTHROPIC_BASE_URL".to_string(),
+                "https://upstream.test".to_string(),
+            ),
             ("ANTHROPIC_MODEL".to_string(), "model-a".to_string()),
         ];
 
@@ -6466,7 +6469,10 @@ mod tests {
         assert_eq!(
             env_vars,
             vec![
-                ("ANTHROPIC_BASE_URL".to_string(), "http://127.0.0.1:15721".to_string()),
+                (
+                    "ANTHROPIC_BASE_URL".to_string(),
+                    "http://127.0.0.1:15721".to_string()
+                ),
                 ("ANTHROPIC_MODEL".to_string(), "model-a".to_string()),
             ]
         );
@@ -6486,7 +6492,10 @@ mod tests {
             env_vars,
             vec![
                 ("ANTHROPIC_MODEL".to_string(), "model-a".to_string()),
-                ("ANTHROPIC_BASE_URL".to_string(), "http://127.0.0.1:15721".to_string()),
+                (
+                    "ANTHROPIC_BASE_URL".to_string(),
+                    "http://127.0.0.1:15721".to_string()
+                ),
             ]
         );
     }


### PR DESCRIPTION
## Summary / 概述

When Claude proxy takeover is active, provider-specific **Open Terminal** currently builds a temporary `--settings` file from the provider's upstream URL. That bypasses CC Switch and breaks providers whose Claude Code support depends on Anthropic Messages -> OpenAI Chat/Responses conversion.

This change makes the Claude terminal launcher replace `ANTHROPIC_BASE_URL` with the running local proxy URL only when:

- Claude takeover is active;
- the selected provider is the current Claude provider; and
- the local proxy is running.

Other apps, non-current providers, and direct-mode launches keep their existing behavior. IPv4 wildcard, IPv6 wildcard, and IPv6 listener addresses are normalized into a client-usable URL.

Verified on Windows 11 with CC Switch 3.19.2, Claude Code 2.1.231, OpenCode Go, and `gpt-5.6-luna`:

- Before: provider terminal bypassed CC Switch and the direct `/v1/messages` request failed.
- After: the exact `claude --settings <temporary-file>` launch reached CC Switch, was converted to `/v1/responses`, returned `OK`, and recorded HTTP 200 with upstream model `gpt-5.6-luna`.

Added unit coverage for replacing an existing base URL and adding a missing one.

## Related Issue / 关联 Issue

Fixes #6237

## Screenshots / 截图

Not applicable; this is a backend terminal-launch routing fix.

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes (no frontend changes)
- [ ] `pnpm format:check` passes (no frontend changes)
- [ ] `cargo clippy` passes (Rust toolchain is unavailable on the test machine; CI requested)
- [x] Updated i18n files if user-facing text changed (no user-facing text changed)
- [x] Manual end-to-end verification passed for both normal Claude launch and provider-specific `--settings` launch
