### PR TITLE
feat(provider): add DeepSeek Harness support

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -34,6 +34,7 @@ impl McpApps {
             AppType::Hermes => self.hermes,
             AppType::Pi => false, // Pi core has no native MCP registry.
             AppType::ClaudeDesktop => false,
+            AppType::DeepSeekHarness => false,
         }
     }
 
@@ -47,8 +48,9 @@ impl McpApps {
             AppType::OpenCode => self.opencode = enabled,
             AppType::OpenClaw => {} // OpenClaw doesn't support MCP, ignore
             AppType::Hermes => self.hermes = enabled,
-            AppType::Pi => {}            // Pi core has no native MCP registry.
+            AppType::Pi => {}              // Pi core has no native MCP registry.
             AppType::ClaudeDesktop => {} // Claude Desktop 3P provider config doesn't support MCP here
+            AppType::DeepSeekHarness => {} // DeepSeek Harness MCP switching is not managed
         }
     }
 
@@ -119,6 +121,7 @@ impl SkillApps {
             AppType::Pi => self.pi,
             AppType::OpenClaw => false, // OpenClaw doesn't support Skills
             AppType::ClaudeDesktop => false,
+            AppType::DeepSeekHarness => false,
         }
     }
 
@@ -134,6 +137,7 @@ impl SkillApps {
             AppType::Pi => self.pi = enabled,
             AppType::OpenClaw => {} // OpenClaw doesn't support Skills, ignore
             AppType::ClaudeDesktop => {} // Claude Desktop 3P profiles don't use CC Switch skill sync
+            AppType::DeepSeekHarness => {} // DeepSeek Harness skill sync is not managed
         }
     }
 
@@ -392,6 +396,8 @@ pub enum AppType {
     OpenClaw,
     Hermes,
     Pi,
+    #[serde(rename = "deepseek-harness", alias = "deepseek_harness", alias = "dsh")]
+    DeepSeekHarness,
 }
 
 impl AppType {
@@ -406,6 +412,7 @@ impl AppType {
             AppType::OpenClaw => "openclaw",
             AppType::Hermes => "hermes",
             AppType::Pi => "pi",
+            AppType::DeepSeekHarness => "deepseek-harness",
         }
     }
 
@@ -440,6 +447,7 @@ impl AppType {
             AppType::OpenClaw,
             AppType::Hermes,
             AppType::Pi,
+            AppType::DeepSeekHarness,
         ]
         .into_iter()
     }
@@ -460,10 +468,11 @@ impl FromStr for AppType {
             "openclaw" => Ok(AppType::OpenClaw),
             "hermes" => Ok(AppType::Hermes),
             "pi" => Ok(AppType::Pi),
+            "deepseek-harness" | "deepseek_harness" | "dsh" => Ok(AppType::DeepSeekHarness),
             other => Err(AppError::localized(
                 "unsupported_app",
-                format!("不支持的应用标识: '{other}'。可选值: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, pi。"),
-                format!("Unsupported app id: '{other}'. Allowed: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, pi."),
+                format!("不支持的应用标识: '{other}'。可选值: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, pi, deepseek-harness。"),
+                format!("Unsupported app id: '{other}'. Allowed: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, pi, deepseek-harness."),
             )),
         }
     }
@@ -504,6 +513,7 @@ impl CommonConfigSnippets {
             AppType::OpenClaw => self.openclaw.as_ref(),
             AppType::Hermes => self.hermes.as_ref(),
             AppType::Pi => None,
+            AppType::DeepSeekHarness => None,
         }
     }
 
@@ -519,6 +529,7 @@ impl CommonConfigSnippets {
             AppType::OpenClaw => self.openclaw = snippet,
             AppType::Hermes => self.hermes = snippet,
             AppType::Pi => {}
+            AppType::DeepSeekHarness => {}
         }
     }
 }
@@ -563,6 +574,7 @@ impl Default for MultiAppConfig {
         apps.insert("opencode".to_string(), ProviderManager::default());
         apps.insert("openclaw".to_string(), ProviderManager::default());
         apps.insert("hermes".to_string(), ProviderManager::default());
+        apps.insert("deepseek-harness".to_string(), ProviderManager::default());
 
         Self {
             version: 2,
@@ -845,6 +857,7 @@ impl MultiAppConfig {
             // Pi was added after prompts moved to SQLite. Keeping it out of
             // this legacy config avoids a second, unused prompt state.
             AppType::Pi => return Ok(false),
+            AppType::DeepSeekHarness => return Ok(false),
         };
 
         prompts.insert(id, prompt);
@@ -889,6 +902,7 @@ impl MultiAppConfig {
                 AppType::OpenClaw => continue, // OpenClaw MCP is still in development, skip
                 AppType::Hermes => continue,   // Hermes didn't exist in v3.6.x, skip
                 AppType::Pi => continue,       // Pi didn't exist in v3.6.x, skip
+                AppType::DeepSeekHarness => continue, // DeepSeek Harness has no MCP support
             };
 
             for (id, entry) in old_servers {

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -146,6 +146,15 @@ pub async fn get_config_status(
                 path,
             })
         }
+        AppType::DeepSeekHarness => {
+            let dir = crate::dsh_config::get_dsh_dir();
+            let exists = crate::dsh_config::get_dsh_settings_path().exists()
+                || crate::dsh_config::get_dsh_credentials_path().exists();
+            Ok(ConfigStatus {
+                exists,
+                path: dir.to_string_lossy().to_string(),
+            })
+        }
     }
 }
 
@@ -168,6 +177,7 @@ pub async fn get_config_dir(app: String) -> Result<String, String> {
         AppType::OpenClaw => crate::openclaw_config::get_openclaw_dir(),
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
         AppType::Pi => crate::pi_config::get_pi_agent_dir().map_err(|e| e.to_string())?,
+        AppType::DeepSeekHarness => crate::dsh_config::get_dsh_dir(),
     };
 
     Ok(dir.to_string_lossy().to_string())
@@ -187,6 +197,7 @@ pub async fn open_config_folder(handle: AppHandle, app: String) -> Result<bool, 
         AppType::OpenClaw => crate::openclaw_config::get_openclaw_dir(),
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
         AppType::Pi => crate::pi_config::get_pi_agent_dir().map_err(|e| e.to_string())?,
+        AppType::DeepSeekHarness => crate::dsh_config::get_dsh_dir(),
     };
 
     if !config_dir.exists() {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -48,6 +48,20 @@ fn merge_settings_for_save(
     // 开关）后、前端 query 缓存刷新前的一次全量保存会把旧 marker 重放回来，
     // 重新开启时被"复活"的标记挡住而漏迁。
     incoming.local_migrations = existing.local_migrations.clone();
+
+    // current_provider_* 同样是后端事务维护的设备级指针。前端保存的是一份
+    // 可能早于最近一次 provider switch 的全量设置快照；若接收其中的 current，
+    // 普通设置保存就会把刚提交的切换静默回滚。所有 current 指针都必须以
+    // 当前后端状态为准，切换只能通过 provider service 提交。
+    incoming.current_provider_claude = existing.current_provider_claude.clone();
+    incoming.current_provider_claude_desktop = existing.current_provider_claude_desktop.clone();
+    incoming.current_provider_codex = existing.current_provider_codex.clone();
+    incoming.current_provider_gemini = existing.current_provider_gemini.clone();
+    incoming.current_provider_grokbuild = existing.current_provider_grokbuild.clone();
+    incoming.current_provider_opencode = existing.current_provider_opencode.clone();
+    incoming.current_provider_openclaw = existing.current_provider_openclaw.clone();
+    incoming.current_provider_hermes = existing.current_provider_hermes.clone();
+    incoming.current_provider_deepseek_harness = existing.current_provider_deepseek_harness.clone();
     incoming
 }
 
@@ -63,12 +77,30 @@ pub async fn save_settings(
     state: tauri::State<'_, crate::store::AppState>,
     settings: crate::settings::AppSettings,
 ) -> Result<bool, String> {
-    let existing = crate::settings::get_settings();
-    let merged = merge_settings_for_save(settings, &existing);
-    let unify_codex_changed =
-        merged.unify_codex_session_history != existing.unify_codex_session_history;
-    let unify_codex_enabled = merged.unify_codex_session_history;
-    crate::settings::update_settings(merged).map_err(|e| e.to_string())?;
+    // The Harness config root and its device-local current pointer participate
+    // in provider transactions. Serialize settings saves with those operations
+    // so one transaction cannot read from one root and write to another.
+    let _deepseek_harness_settings_guard = futures::executor::block_on(
+        state
+            .inner()
+            .proxy_service
+            .lock_switch_for_app(crate::app_config::AppType::DeepSeekHarness.as_str()),
+    );
+
+    // Merge and persist under one settings write lock. In particular, a
+    // provider switch that committed immediately before this save cannot be
+    // replaced by an older frontend snapshot between get_settings and write.
+    let (existing, unify_codex_changed, unify_codex_enabled) =
+        crate::settings::update_settings_atomically(|existing| {
+            let merged = merge_settings_for_save(settings, existing);
+            let result = (
+                existing.clone(),
+                merged.unify_codex_session_history != existing.unify_codex_session_history,
+                merged.unify_codex_session_history,
+            );
+            (merged, result)
+        })
+        .map_err(|e| e.to_string())?;
 
     // 统一会话开关变更时立即重写当前官方 Codex 供应商的 live 配置，
     // 不必等下一次切换才生效。
@@ -82,7 +114,13 @@ pub async fn save_settings(
             crate::services::provider::reapply_current_codex_official_live(state.inner())
         {
             log::warn!("统一 Codex 会话历史开关变更后重写 live 配置失败，回滚设置: {err}");
-            if let Err(rollback_err) = crate::settings::update_settings(existing) {
+            // Roll back user-owned settings against the latest locked state.
+            // Backend-owned current pointers and migration markers may have
+            // advanced while Codex Live was being rewritten and must not be
+            // replaced by the pre-save snapshot.
+            if let Err(rollback_err) = crate::settings::update_settings_atomically(|current| {
+                (merge_settings_for_save(existing.clone(), current), ())
+            }) {
                 log::error!("回滚统一会话开关设置失败: {rollback_err}");
             }
             return Err(format!(
@@ -617,6 +655,101 @@ mod tests {
         let merged = merge_settings_for_save(incoming, &existing);
 
         assert!(merged.local_migrations.is_none());
+    }
+
+    #[test]
+    fn save_settings_should_preserve_all_backend_owned_current_provider_pointers() {
+        let existing = AppSettings {
+            current_provider_claude: Some("claude-new".to_string()),
+            current_provider_claude_desktop: Some("desktop-new".to_string()),
+            current_provider_codex: Some("codex-new".to_string()),
+            current_provider_gemini: Some("gemini-new".to_string()),
+            current_provider_grokbuild: Some("grok-new".to_string()),
+            current_provider_opencode: Some("opencode-new".to_string()),
+            current_provider_openclaw: Some("openclaw-new".to_string()),
+            current_provider_hermes: Some("hermes-new".to_string()),
+            current_provider_deepseek_harness: Some("harness-new".to_string()),
+            ..AppSettings::default()
+        };
+        let incoming = AppSettings {
+            current_provider_claude: Some("claude-stale".to_string()),
+            current_provider_claude_desktop: None,
+            current_provider_codex: Some("codex-stale".to_string()),
+            current_provider_gemini: None,
+            current_provider_grokbuild: Some("grok-stale".to_string()),
+            current_provider_opencode: None,
+            current_provider_openclaw: Some("openclaw-stale".to_string()),
+            current_provider_hermes: None,
+            current_provider_deepseek_harness: Some("harness-stale".to_string()),
+            ..AppSettings::default()
+        };
+
+        let merged = merge_settings_for_save(incoming, &existing);
+
+        assert_eq!(
+            merged.current_provider_claude,
+            existing.current_provider_claude
+        );
+        assert_eq!(
+            merged.current_provider_claude_desktop,
+            existing.current_provider_claude_desktop
+        );
+        assert_eq!(
+            merged.current_provider_codex,
+            existing.current_provider_codex
+        );
+        assert_eq!(
+            merged.current_provider_gemini,
+            existing.current_provider_gemini
+        );
+        assert_eq!(
+            merged.current_provider_grokbuild,
+            existing.current_provider_grokbuild
+        );
+        assert_eq!(
+            merged.current_provider_opencode,
+            existing.current_provider_opencode
+        );
+        assert_eq!(
+            merged.current_provider_openclaw,
+            existing.current_provider_openclaw
+        );
+        assert_eq!(
+            merged.current_provider_hermes,
+            existing.current_provider_hermes
+        );
+        assert_eq!(
+            merged.current_provider_deepseek_harness,
+            existing.current_provider_deepseek_harness
+        );
+    }
+
+    #[test]
+    fn failed_save_rollback_preserves_backend_current_that_advanced_after_commit() {
+        let before_save = AppSettings {
+            language: Some("en".to_string()),
+            current_provider_codex: Some("codex-before".to_string()),
+            current_provider_deepseek_harness: Some("harness-before".to_string()),
+            ..AppSettings::default()
+        };
+        let current_at_rollback = AppSettings {
+            language: Some("ja".to_string()),
+            current_provider_codex: Some("codex-after".to_string()),
+            current_provider_deepseek_harness: Some("harness-after".to_string()),
+            ..AppSettings::default()
+        };
+
+        let rolled_back = merge_settings_for_save(before_save, &current_at_rollback);
+
+        assert_eq!(rolled_back.language.as_deref(), Some("en"));
+        assert_eq!(
+            rolled_back.current_provider_codex.as_deref(),
+            Some("codex-after")
+        );
+        assert_eq!(
+            rolled_back.current_provider_deepseek_harness.as_deref(),
+            Some("harness-after")
+        );
     }
 }
 

--- a/src-tauri/src/database/dao/mcp.rs
+++ b/src-tauri/src/database/dao/mcp.rs
@@ -91,7 +91,9 @@ impl Database {
             AppType::OpenCode => Some("enabled_opencode"),
             AppType::Hermes => Some("enabled_hermes"),
             // These applications intentionally have no MCP flag in the SSOT.
-            AppType::ClaudeDesktop | AppType::OpenClaw | AppType::Pi => None,
+            AppType::ClaudeDesktop | AppType::OpenClaw | AppType::Pi | AppType::DeepSeekHarness => {
+                None
+            }
         };
 
         if let Some(column) = column {

--- a/src-tauri/src/database/dao/providers.rs
+++ b/src-tauri/src/database/dao/providers.rs
@@ -277,6 +277,27 @@ impl Database {
         Ok(())
     }
 
+    /// Update only the presentation order for an existing provider.
+    ///
+    /// Re-saving a caller's full provider snapshot here can overwrite a newer
+    /// settings/backfill transaction, or even recreate a concurrently deleted
+    /// row. A narrow UPDATE makes ordering independent from provider contents.
+    pub fn update_provider_sort_index(
+        &self,
+        app_type: &str,
+        id: &str,
+        sort_index: usize,
+    ) -> Result<bool, AppError> {
+        let conn = lock_conn!(self.conn);
+        let changed = conn
+            .execute(
+                "UPDATE providers SET sort_index = ?1 WHERE id = ?2 AND app_type = ?3",
+                params![sort_index, id, app_type],
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(changed > 0)
+    }
+
     /// Replace a provider row under a new ID without exposing an intermediate
     /// duplicate or missing row. Existing endpoint and health references move
     /// with the provider, while its current-state bit is preserved.
@@ -803,6 +824,55 @@ impl Database {
         self.save_provider(app_type_str, &provider)?;
 
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod provider_sort_index_tests {
+    use crate::app_config::AppType;
+    use crate::database::Database;
+    use crate::provider::Provider;
+
+    #[test]
+    fn sort_index_update_does_not_replace_provider_contents_or_recreate_deleted_rows() {
+        let db = Database::memory().expect("memory db");
+        let app = AppType::DeepSeekHarness;
+        let mut provider = Provider::with_id(
+            "harness-sort".to_string(),
+            "Before".to_string(),
+            serde_json::json!({ "defaultModel": "deepseek-v4-flash" }),
+            None,
+        );
+        provider.sort_index = Some(0);
+        db.save_provider(app.as_str(), &provider)
+            .expect("seed provider");
+
+        let mut updated = provider.clone();
+        updated.name = "After".to_string();
+        updated.settings_config = serde_json::json!({ "defaultModel": "deepseek-v4-pro" });
+        db.save_provider(app.as_str(), &updated)
+            .expect("commit newer provider contents");
+
+        assert!(db
+            .update_provider_sort_index(app.as_str(), &provider.id, 7)
+            .expect("update sort index"));
+        let stored = db
+            .get_provider_by_id(&provider.id, app.as_str())
+            .expect("read provider")
+            .expect("provider exists");
+        assert_eq!(stored.name, "After");
+        assert_eq!(stored.settings_config, updated.settings_config);
+        assert_eq!(stored.sort_index, Some(7));
+
+        db.delete_provider(app.as_str(), &provider.id)
+            .expect("delete provider");
+        assert!(!db
+            .update_provider_sort_index(app.as_str(), &provider.id, 8)
+            .expect("missing-row update is a no-op"));
+        assert!(db
+            .get_provider_by_id(&provider.id, app.as_str())
+            .expect("read deleted provider")
+            .is_none());
     }
 }
 

--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -81,7 +81,16 @@ fn parse_provider_deeplink(
     // Validate app type
     if !matches!(
         app.as_str(),
-        "claude" | "codex" | "gemini" | "grokbuild" | "opencode" | "openclaw" | "hermes"
+        "claude"
+            | "codex"
+            | "gemini"
+            | "grokbuild"
+            | "opencode"
+            | "openclaw"
+            | "hermes"
+            | "deepseek-harness"
+            | "deepseek_harness"
+            | "dsh"
     ) {
         return Err(AppError::InvalidInput(format!(
             "Invalid provider app type: '{app}'"

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -181,21 +181,44 @@ pub(crate) fn build_provider_from_request(
             ));
         }
         AppType::DeepSeekHarness => {
-            let mut config = serde_json::Map::new();
+            // Keep the complete native Harness profile carried by the inline
+            // config. The URL-facing connection fields below are then applied
+            // on top so their documented precedence remains unchanged.
+            let mut config = extract_deepseek_harness_inline_config(request)?;
+            // Deep links are untrusted input and must not choose a credential
+            // reference. A link-controlled ref could name an environment
+            // variable inherited by a later Harness process; because inherited
+            // env wins over `.credentials.yaml`, that process could send an
+            // unrelated secret to the link-controlled endpoint. Bind every
+            // imported key to a fresh ref that the link cannot predict or
+            // shadow accidentally. Credential-free links keep Harness' native
+            // default and may not smuggle a ref through inline config.
+            config.remove("apiKeyEnv");
             if let Some(api_key) = request.api_key.as_deref() {
                 config.insert("apiKey".to_string(), serde_json::json!(api_key));
+                config.insert(
+                    "apiKeyEnv".to_string(),
+                    serde_json::json!(format!(
+                        "CC_SWITCH_DSH_IMPORT_{}",
+                        uuid::Uuid::new_v4()
+                            .simple()
+                            .to_string()
+                            .to_ascii_uppercase()
+                    )),
+                );
             }
             let endpoint = get_primary_endpoint(request);
             if !endpoint.is_empty() {
                 config.insert("baseURL".to_string(), serde_json::json!(endpoint));
             }
-            config.insert(
-                "defaultModel".to_string(),
-                serde_json::json!(request
-                    .model
-                    .clone()
-                    .unwrap_or_else(|| "deepseek-v4-flash".to_string())),
-            );
+            if let Some(model) = request.model.as_deref() {
+                config.insert("defaultModel".to_string(), serde_json::json!(model));
+            } else if !config.contains_key("defaultModel") {
+                config.insert(
+                    "defaultModel".to_string(),
+                    serde_json::json!("deepseek-v4-flash"),
+                );
+            }
             serde_json::Value::Object(config)
         }
     };
@@ -633,6 +656,58 @@ fn build_hermes_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
 // Config Merge Logic
 // =============================================================================
 
+/// Decode an inline config into a JSON value using the same format rules for
+/// both field extraction and provider construction. Keeping this in one place
+/// prevents a valid TOML payload from being merged successfully and then
+/// losing its non-connection fields during construction.
+fn parse_inline_config_value(
+    request: &DeepLinkImportRequest,
+) -> Result<Option<serde_json::Value>, AppError> {
+    let config_content = if let Some(config_b64) = &request.config {
+        let decoded = decode_base64_param("config", config_b64)?;
+        String::from_utf8(decoded)
+            .map_err(|e| AppError::InvalidInput(format!("Invalid UTF-8 in config: {e}")))?
+    } else if request.config_url.is_some() {
+        // Fetch remote config (TODO: implement remote fetching in next phase)
+        return Err(AppError::InvalidInput(
+            "Remote config URL is not yet supported. Use inline config instead.".to_string(),
+        ));
+    } else {
+        return Ok(None);
+    };
+
+    let format = request.config_format.as_deref().unwrap_or("json");
+    let config_value = match format {
+        "json" => serde_json::from_str(&config_content)
+            .map_err(|e| AppError::InvalidInput(format!("Invalid JSON config: {e}")))?,
+        "toml" => {
+            let toml_value: toml::Value = toml::from_str(&config_content)
+                .map_err(|e| AppError::InvalidInput(format!("Invalid TOML config: {e}")))?;
+            serde_json::to_value(toml_value)
+                .map_err(|e| AppError::Message(format!("Failed to convert TOML to JSON: {e}")))?
+        }
+        _ => {
+            return Err(AppError::InvalidInput(format!(
+                "Unsupported config format: {format}"
+            )))
+        }
+    };
+
+    Ok(Some(config_value))
+}
+
+fn extract_deepseek_harness_inline_config(
+    request: &DeepLinkImportRequest,
+) -> Result<serde_json::Map<String, serde_json::Value>, AppError> {
+    match parse_inline_config_value(request)? {
+        Some(serde_json::Value::Object(config)) => Ok(config),
+        Some(_) => Err(AppError::InvalidInput(
+            "DeepSeek Harness config must be a JSON object".to_string(),
+        )),
+        None => Ok(serde_json::Map::new()),
+    }
+}
+
 /// Parse and merge configuration from Base64 encoded config or remote URL
 ///
 /// Priority: URL params > inline config > remote config
@@ -644,39 +719,8 @@ pub fn parse_and_merge_config(
         return Ok(request.clone());
     }
 
-    // Step 1: Get config content
-    let config_content = if let Some(config_b64) = &request.config {
-        // Decode Base64 inline config
-        let decoded = decode_base64_param("config", config_b64)?;
-        String::from_utf8(decoded)
-            .map_err(|e| AppError::InvalidInput(format!("Invalid UTF-8 in config: {e}")))?
-    } else if let Some(_config_url) = &request.config_url {
-        // Fetch remote config (TODO: implement remote fetching in next phase)
-        return Err(AppError::InvalidInput(
-            "Remote config URL is not yet supported. Use inline config instead.".to_string(),
-        ));
-    } else {
-        return Ok(request.clone());
-    };
-
-    // Step 2: Parse config based on format
-    let format = request.config_format.as_deref().unwrap_or("json");
-    let config_value: serde_json::Value = match format {
-        "json" => serde_json::from_str(&config_content)
-            .map_err(|e| AppError::InvalidInput(format!("Invalid JSON config: {e}")))?,
-        "toml" => {
-            let toml_value: toml::Value = toml::from_str(&config_content)
-                .map_err(|e| AppError::InvalidInput(format!("Invalid TOML config: {e}")))?;
-            // Convert TOML to JSON for uniform processing
-            serde_json::to_value(toml_value)
-                .map_err(|e| AppError::Message(format!("Failed to convert TOML to JSON: {e}")))?
-        }
-        _ => {
-            return Err(AppError::InvalidInput(format!(
-                "Unsupported config format: {format}"
-            )))
-        }
-    };
+    let config_value = parse_inline_config_value(request)?
+        .ok_or_else(|| AppError::InvalidInput("Missing inline provider config".to_string()))?;
 
     // Step 3: Extract values from config based on app type and merge with URL params
     let mut merged = request.clone();

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -41,31 +41,53 @@ pub fn import_provider_from_deeplink(
         .clone()
         .ok_or_else(|| AppError::InvalidInput("Missing 'app' field for provider".to_string()))?;
 
-    let api_key = merged_request.api_key.as_ref().ok_or_else(|| {
-        AppError::InvalidInput("API key is required (either in URL or config file)".to_string())
-    })?;
+    // Parse the app before validating connection fields: Harness can reuse its
+    // native credential store and bundled endpoint when a deep link omits them.
+    let app_type = AppType::from_str(&app_str)
+        .map_err(|_| AppError::InvalidInput(format!("Invalid app type: {app_str}")))?;
+    let uses_native_connection_defaults = matches!(app_type, AppType::DeepSeekHarness);
+    let declares_endpoint = merged_request
+        .endpoint
+        .as_deref()
+        .is_some_and(|value| value.split(',').any(|endpoint| !endpoint.trim().is_empty()));
 
-    if api_key.is_empty() {
-        return Err(AppError::InvalidInput(
-            "API key cannot be empty".to_string(),
-        ));
+    match merged_request.api_key.as_ref() {
+        Some(api_key) if api_key.is_empty() => {
+            return Err(AppError::InvalidInput(
+                "API key cannot be empty".to_string(),
+            ));
+        }
+        // A credential-free Harness link is safe only when it also keeps the
+        // native endpoint. Otherwise an imported endpoint could reuse and
+        // exfiltrate a credential from the Harness environment/store.
+        None if !uses_native_connection_defaults || declares_endpoint => {
+            return Err(AppError::InvalidInput(
+                "API key is required (either in URL or config file)".to_string(),
+            ));
+        }
+        _ => {}
     }
 
     // Get endpoint: supports comma-separated multiple URLs (first is primary)
-    let endpoint_str = merged_request.endpoint.as_ref().ok_or_else(|| {
-        AppError::InvalidInput("Endpoint is required (either in URL or config file)".to_string())
-    })?;
-
     // Parse endpoints: split by comma, first is primary
-    let all_endpoints: Vec<String> = endpoint_str
+    let all_endpoints: Vec<String> = merged_request
+        .endpoint
+        .as_deref()
+        .unwrap_or_default()
         .split(',')
         .map(|e| e.trim().to_string())
         .filter(|e| !e.is_empty())
         .collect();
 
-    let primary_endpoint = all_endpoints
-        .first()
-        .ok_or_else(|| AppError::InvalidInput("Endpoint cannot be empty".to_string()))?;
+    let primary_endpoint = all_endpoints.first();
+    if primary_endpoint.is_none() && !uses_native_connection_defaults {
+        let message = if merged_request.endpoint.is_some() {
+            "Endpoint cannot be empty"
+        } else {
+            "Endpoint is required (either in URL or config file)"
+        };
+        return Err(AppError::InvalidInput(message.to_string()));
+    }
 
     // Auto-infer homepage from endpoint if not provided
     if merged_request
@@ -73,27 +95,28 @@ pub fn import_provider_from_deeplink(
         .as_ref()
         .is_none_or(|s| s.is_empty())
     {
-        merged_request.homepage = infer_homepage_from_endpoint(primary_endpoint);
+        merged_request.homepage =
+            primary_endpoint.and_then(|endpoint| infer_homepage_from_endpoint(endpoint));
     }
 
-    let homepage = merged_request.homepage.as_ref().ok_or_else(|| {
-        AppError::InvalidInput("Homepage is required (either in URL or config file)".to_string())
-    })?;
+    if !uses_native_connection_defaults {
+        let homepage = merged_request.homepage.as_ref().ok_or_else(|| {
+            AppError::InvalidInput(
+                "Homepage is required (either in URL or config file)".to_string(),
+            )
+        })?;
 
-    if homepage.is_empty() {
-        return Err(AppError::InvalidInput(
-            "Homepage cannot be empty".to_string(),
-        ));
+        if homepage.is_empty() {
+            return Err(AppError::InvalidInput(
+                "Homepage cannot be empty".to_string(),
+            ));
+        }
     }
 
     let name = merged_request
         .name
         .clone()
         .ok_or_else(|| AppError::InvalidInput("Missing 'name' field for provider".to_string()))?;
-
-    // Parse app type
-    let app_type = AppType::from_str(&app_str)
-        .map_err(|_| AppError::InvalidInput(format!("Invalid app type: {app_str}")))?;
 
     // Build provider configuration based on app type
     let mut provider = build_provider_from_request(&app_type, &merged_request)?;

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -157,6 +157,24 @@ pub(crate) fn build_provider_from_request(
                 "Pi providers must be added from the Pi provider page".to_string(),
             ));
         }
+        AppType::DeepSeekHarness => {
+            let mut config = serde_json::Map::new();
+            if let Some(api_key) = request.api_key.as_deref() {
+                config.insert("apiKey".to_string(), serde_json::json!(api_key));
+            }
+            let endpoint = get_primary_endpoint(request);
+            if !endpoint.is_empty() {
+                config.insert("baseURL".to_string(), serde_json::json!(endpoint));
+            }
+            config.insert(
+                "defaultModel".to_string(),
+                serde_json::json!(request
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| "deepseek-v4-flash".to_string())),
+            );
+            serde_json::Value::Object(config)
+        }
     };
 
     // Build usage script configuration if provided
@@ -653,6 +671,30 @@ pub fn parse_and_merge_config(
         // Additive mode apps use JSON config directly; pass through as-is
         "openclaw" | "opencode" | "hermes" => {
             merge_additive_config(&mut merged, &config_value)?;
+        }
+        "deepseek-harness" | "deepseek_harness" | "dsh" => {
+            if merged.api_key.as_ref().is_none_or(|value| value.is_empty()) {
+                merged.api_key = config_value
+                    .get("apiKey")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+            }
+            if merged
+                .endpoint
+                .as_ref()
+                .is_none_or(|value| value.is_empty())
+            {
+                merged.endpoint = config_value
+                    .get("baseURL")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+            }
+            if merged.model.as_ref().is_none_or(|value| value.is_empty()) {
+                merged.model = config_value
+                    .get("defaultModel")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+            }
         }
         "" => {
             // No app specified, skip merging

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -127,6 +127,38 @@ fn test_parse_grokbuild_provider() {
 }
 
 #[test]
+fn test_parse_deepseek_harness_provider() {
+    use super::provider::build_provider_from_request;
+
+    let url = "ccswitch://v1/import?resource=provider&app=deepseek-harness&name=DeepSeek%20Relay&endpoint=https%3A%2F%2Fapi.example.com&apiKey=secret&model=private-model";
+    let request = parse_deeplink_url(url).unwrap();
+    let provider = build_provider_from_request(&AppType::DeepSeekHarness, &request).unwrap();
+
+    assert_eq!(provider.settings_config["apiKey"], "secret");
+    assert_eq!(
+        provider.settings_config["baseURL"],
+        "https://api.example.com"
+    );
+    assert_eq!(provider.settings_config["defaultModel"], "private-model");
+}
+
+#[test]
+fn test_parse_deepseek_harness_provider_omits_missing_optional_live_fields() {
+    use super::provider::build_provider_from_request;
+
+    let url = "ccswitch://v1/import?resource=provider&app=dsh&name=DeepSeek";
+    let request = parse_deeplink_url(url).unwrap();
+    let provider = build_provider_from_request(&AppType::DeepSeekHarness, &request).unwrap();
+
+    assert!(provider.settings_config.get("apiKey").is_none());
+    assert!(provider.settings_config.get("baseURL").is_none());
+    assert_eq!(
+        provider.settings_config["defaultModel"],
+        "deepseek-v4-flash"
+    );
+}
+
+#[test]
 fn test_parse_invalid_scheme() {
     let url = "https://v1/import?resource=provider&app=claude&name=Test";
 
@@ -650,6 +682,30 @@ context_window = 500000
     assert_eq!(merged.endpoint.as_deref(), Some("https://grok.example/v1"));
     assert_eq!(merged.model.as_deref(), Some("grok-upstream"));
     assert_eq!(merged.homepage.as_deref(), Some("https://grok.example"));
+}
+
+#[test]
+fn test_parse_and_merge_config_deepseek_harness() {
+    let config = serde_json::json!({
+        "apiKey": "sk-dsh",
+        "baseURL": "https://dsh.example",
+        "defaultModel": "deepseek-private"
+    })
+    .to_string();
+    let request = DeepLinkImportRequest {
+        version: "v1".to_string(),
+        resource: "provider".to_string(),
+        app: Some("deepseek-harness".to_string()),
+        name: Some("DeepSeek Harness".to_string()),
+        config: Some(BASE64_STANDARD.encode(config.as_bytes())),
+        config_format: Some("json".to_string()),
+        ..Default::default()
+    };
+
+    let merged = parse_and_merge_config(&request).unwrap();
+    assert_eq!(merged.api_key.as_deref(), Some("sk-dsh"));
+    assert_eq!(merged.endpoint.as_deref(), Some("https://dsh.example"));
+    assert_eq!(merged.model.as_deref(), Some("deepseek-private"));
 }
 
 #[test]

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -709,6 +709,109 @@ fn test_parse_and_merge_config_deepseek_harness() {
 }
 
 #[test]
+fn test_build_deepseek_harness_provider_preserves_native_config_with_url_overrides() {
+    use super::provider::build_provider_from_request;
+
+    let config = serde_json::json!({
+        "apiKey": "sk-from-config",
+        "baseURL": "https://config.example",
+        "defaultModel": "config-model",
+        "apiKeyEnv": "CUSTOM_DEEPSEEK_KEY",
+        "thinking": "enabled",
+        "reasoningEffort": "low",
+        "defaultReasoningEffort": "max",
+        "maxTokens": 16384,
+        "defaultContextWindow": 131072,
+        "models": [{
+            "id": "config-model",
+            "name": "Config model",
+            "contextWindow": 131072,
+            "maxTokens": 16384
+        }],
+        "retryPolicy": { "mode": "normal", "maxRetries": 4 },
+        "futureNativeField": { "enabled": true }
+    })
+    .to_string();
+    let request = DeepLinkImportRequest {
+        version: "v1".to_string(),
+        resource: "provider".to_string(),
+        app: Some("deepseek-harness".to_string()),
+        name: Some("DeepSeek Harness".to_string()),
+        api_key: Some("sk-from-url".to_string()),
+        endpoint: Some("https://url.example,https://fallback.example".to_string()),
+        model: Some("url-model".to_string()),
+        config: Some(BASE64_STANDARD.encode(config.as_bytes())),
+        config_format: Some("json".to_string()),
+        ..Default::default()
+    };
+
+    let merged = parse_and_merge_config(&request).expect("merge Harness config");
+    let provider = build_provider_from_request(&AppType::DeepSeekHarness, &merged)
+        .expect("build Harness provider");
+    let settings = provider.settings_config;
+
+    assert_eq!(settings["apiKey"], "sk-from-url");
+    assert_eq!(settings["baseURL"], "https://url.example");
+    assert_eq!(settings["defaultModel"], "url-model");
+    let credential_ref = settings["apiKeyEnv"]
+        .as_str()
+        .expect("generated credential ref");
+    assert!(credential_ref.starts_with("CC_SWITCH_DSH_IMPORT_"));
+    assert_ne!(credential_ref, "CUSTOM_DEEPSEEK_KEY");
+    assert_eq!(settings["thinking"], "enabled");
+    assert_eq!(settings["reasoningEffort"], "low");
+    assert_eq!(settings["defaultReasoningEffort"], "max");
+    assert_eq!(settings["maxTokens"], 16384);
+    assert_eq!(settings["defaultContextWindow"], 131072);
+    assert_eq!(
+        settings["retryPolicy"],
+        serde_json::json!({ "mode": "normal", "maxRetries": 4 })
+    );
+    assert_eq!(
+        settings["futureNativeField"],
+        serde_json::json!({ "enabled": true })
+    );
+    assert_eq!(
+        settings["models"],
+        serde_json::json!([{
+            "id": "config-model",
+            "name": "Config model",
+            "contextWindow": 131072,
+            "maxTokens": 16384
+        }])
+    );
+    crate::dsh_config::validate_settings_config(&settings)
+        .expect("preserved Harness config should pass the live writer schema");
+}
+
+#[test]
+fn test_build_deepseek_harness_provider_drops_untrusted_ref_without_key() {
+    use super::provider::build_provider_from_request;
+
+    let config = serde_json::json!({
+        "apiKeyEnv": "VICTIM_ENV_SECRET",
+        "defaultModel": "deepseek-v4-flash"
+    })
+    .to_string();
+    let request = DeepLinkImportRequest {
+        version: "v1".to_string(),
+        resource: "provider".to_string(),
+        app: Some("deepseek-harness".to_string()),
+        name: Some("DeepSeek Harness".to_string()),
+        config: Some(BASE64_STANDARD.encode(config.as_bytes())),
+        config_format: Some("json".to_string()),
+        ..Default::default()
+    };
+
+    let merged = parse_and_merge_config(&request).expect("merge Harness config");
+    let provider = build_provider_from_request(&AppType::DeepSeekHarness, &merged)
+        .expect("build Harness provider");
+
+    assert!(provider.settings_config.get("apiKeyEnv").is_none());
+    assert!(provider.settings_config.get("apiKey").is_none());
+}
+
+#[test]
 fn test_parse_and_merge_config_url_override() {
     let config_json = r#"{"env":{"ANTHROPIC_AUTH_TOKEN":"sk-old","ANTHROPIC_BASE_URL":"https://api.anthropic.com/v1"}}"#;
     let config_b64 = BASE64_STANDARD.encode(config_json.as_bytes());

--- a/src-tauri/src/dsh_config.rs
+++ b/src-tauri/src/dsh_config.rs
@@ -40,6 +40,8 @@ const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 pub struct DshWriteOutcome {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup_path: Option<String>,
+    #[serde(skip)]
+    pub(crate) rollback_token: Option<DshLiveStateSnapshot>,
 }
 
 #[derive(Debug)]
@@ -51,33 +53,90 @@ struct PreparedConfig {
     api_key_env: String,
 }
 
-#[derive(Debug)]
 enum CredentialAction {
     Keep,
     Set(String),
     Unset,
 }
 
-#[derive(Debug)]
+impl std::fmt::Debug for CredentialAction {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Keep => formatter.write_str("Keep"),
+            Self::Set(_) => formatter.write_str("Set([REDACTED])"),
+            Self::Unset => formatter.write_str("Unset"),
+        }
+    }
+}
+
 struct CredentialUpdate {
     path: PathBuf,
     previous: Option<Vec<u8>>,
     next: Vec<u8>,
 }
 
+#[derive(Clone, PartialEq, Eq)]
+struct DshFileTransition {
+    before: Option<Vec<u8>>,
+    committed: Option<Vec<u8>>,
+}
+
+/// Compare-and-restore token produced by the same locked read/modify/write
+/// operation that committed the live Harness files.
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct DshLiveStateSnapshot {
+    home: PathBuf,
+    settings: Option<DshFileTransition>,
+    credentials: Option<DshFileTransition>,
+}
+
+impl std::fmt::Debug for DshLiveStateSnapshot {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DshLiveStateSnapshot")
+            .field("home", &self.home)
+            .field("settings_changed", &self.settings.is_some())
+            .field("credentials_changed", &self.credentials.is_some())
+            .finish()
+    }
+}
+
 /// Cross-process writer lock compatible with DeepSeek Harness' `<file>.lock`
 /// protocol. Harness never removes a contender's lock, so neither do we.
 struct DshFileLock {
-    path: PathBuf,
+    path: Option<PathBuf>,
+}
+
+impl DshFileLock {
+    fn release(mut self) -> Result<(), AppError> {
+        let path = self
+            .path
+            .as_ref()
+            .expect("DeepSeek Harness writer lock must have a path");
+        match fs::remove_file(path) {
+            Ok(()) => {
+                self.path.take();
+                Ok(())
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                self.path.take();
+                Ok(())
+            }
+            Err(error) => Err(AppError::io(path, error)),
+        }
+    }
 }
 
 impl Drop for DshFileLock {
     fn drop(&mut self) {
-        if let Err(error) = fs::remove_file(&self.path) {
+        let Some(path) = self.path.as_ref() else {
+            return;
+        };
+        if let Err(error) = fs::remove_file(path) {
             if error.kind() != ErrorKind::NotFound {
                 log::warn!(
                     "Failed to release DeepSeek Harness writer lock {}: {error}",
-                    self.path.display()
+                    path.display()
                 );
             }
         }
@@ -110,7 +169,9 @@ fn acquire_file_lock(filename: &Path) -> Result<DshFileLock, AppError> {
                     let _ = fs::remove_file(&lock_path);
                     return Err(AppError::io(&lock_path, error));
                 }
-                return Ok(DshFileLock { path: lock_path });
+                return Ok(DshFileLock {
+                    path: Some(lock_path),
+                });
             }
             Err(error) if error.kind() == ErrorKind::AlreadyExists => {
                 if Instant::now() >= deadline {
@@ -123,6 +184,95 @@ fn acquire_file_lock(filename: &Path) -> Result<DshFileLock, AppError> {
                 delay = std::cmp::min(delay.saturating_mul(2), LOCK_RETRY_MAX);
             }
             Err(error) => return Err(AppError::io(&lock_path, error)),
+        }
+    }
+}
+
+fn combine_errors(context: &str, first: AppError, second: AppError) -> AppError {
+    AppError::Message(format!("{context}: {first}; additionally: {second}"))
+}
+
+fn release_file_locks(
+    credentials_lock: Option<DshFileLock>,
+    settings_lock: DshFileLock,
+) -> Result<(), AppError> {
+    let settings_result = settings_lock.release();
+    let credentials_result = credentials_lock
+        .map(DshFileLock::release)
+        .transpose()
+        .map(|_| ());
+    match (settings_result, credentials_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(first), Err(second)) => Err(combine_errors(
+            "Failed to release DeepSeek Harness writer locks",
+            first,
+            second,
+        )),
+    }
+}
+
+fn finish_locked<T>(
+    operation: Result<T, AppError>,
+    credentials_lock: Option<DshFileLock>,
+    settings_lock: DshFileLock,
+) -> Result<T, AppError> {
+    let release = release_file_locks(credentials_lock, settings_lock);
+    match (operation, release) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), Ok(())) => Err(error),
+        // Once the live files are committed, returning Err would discard a
+        // rollback token and falsely tell the caller that nothing changed.
+        // Keep the successful outcome; the stale lock itself makes later
+        // conforming writes fail visibly instead of permitting divergence.
+        (Ok(value), Err(error)) => {
+            log::warn!(
+                "DeepSeek Harness files committed, but an explicit writer lock release failed: {error}"
+            );
+            Ok(value)
+        }
+        (Err(first), Err(second)) => Err(combine_errors(
+            "DeepSeek Harness operation and lock release both failed",
+            first,
+            second,
+        )),
+    }
+}
+
+fn acquire_native_file_locks(
+    settings_path: &Path,
+    credentials_path: &Path,
+    include_credentials: bool,
+) -> Result<(Option<DshFileLock>, DshFileLock), AppError> {
+    if !include_credentials {
+        return Ok((None, acquire_file_lock(settings_path)?));
+    }
+
+    if credentials_path < settings_path {
+        let credentials_lock = acquire_file_lock(credentials_path)?;
+        match acquire_file_lock(settings_path) {
+            Ok(settings_lock) => Ok((Some(credentials_lock), settings_lock)),
+            Err(error) => match credentials_lock.release() {
+                Ok(()) => Err(error),
+                Err(release_error) => Err(combine_errors(
+                    "Failed to acquire DeepSeek Harness settings lock",
+                    error,
+                    release_error,
+                )),
+            },
+        }
+    } else {
+        let settings_lock = acquire_file_lock(settings_path)?;
+        match acquire_file_lock(credentials_path) {
+            Ok(credentials_lock) => Ok((Some(credentials_lock), settings_lock)),
+            Err(error) => match settings_lock.release() {
+                Ok(()) => Err(error),
+                Err(release_error) => Err(combine_errors(
+                    "Failed to acquire DeepSeek Harness credentials lock",
+                    error,
+                    release_error,
+                )),
+            },
         }
     }
 }
@@ -161,6 +311,82 @@ fn absolutize_dsh_home(path: &Path) -> PathBuf {
     }
 }
 
+#[cfg(windows)]
+fn is_wsl_unc_path(path: &Path) -> bool {
+    let normalized = path.to_string_lossy().replace('/', "\\");
+    let lower = normalized.to_ascii_lowercase();
+    let canonical = lower
+        .strip_prefix("\\\\?\\unc\\")
+        .map(|rest| format!("\\\\{rest}"))
+        .unwrap_or(lower);
+    canonical.starts_with("\\\\wsl$\\") || canonical.starts_with("\\\\wsl.localhost\\")
+}
+
+fn ensure_safe_live_write_path(home: &Path) -> Result<(), AppError> {
+    #[cfg(windows)]
+    {
+        if is_wsl_unc_path(home) {
+            return Err(AppError::InvalidInput(format!(
+                "Refusing to write DeepSeek Harness files through Windows WSL UNC path {}; configure and run CC Switch inside WSL so settings and credentials remain owner-only",
+                home.display()
+            )));
+        }
+        let mut resolved_ancestor = Some(home);
+        let resolves_into_wsl = loop {
+            let Some(candidate) = resolved_ancestor else {
+                break false;
+            };
+            match fs::canonicalize(candidate) {
+                Ok(resolved) => break is_wsl_unc_path(&resolved),
+                Err(error) if error.kind() == ErrorKind::NotFound => {
+                    resolved_ancestor = candidate.parent();
+                }
+                Err(error) => return Err(AppError::io(candidate, error)),
+            }
+        };
+        if resolves_into_wsl {
+            return Err(AppError::InvalidInput(format!(
+                "Refusing to write DeepSeek Harness files through Windows WSL UNC path {}; configure and run CC Switch inside WSL so settings and credentials remain owner-only",
+                home.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn read_optional_bytes(path: &Path) -> Result<Option<Vec<u8>>, AppError> {
+    match fs::read(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(AppError::io(path, error)),
+    }
+}
+
+fn read_optional_string(path: &Path) -> Result<Option<String>, AppError> {
+    match fs::read_to_string(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(AppError::io(path, error)),
+    }
+}
+
+fn read_optional_private_bytes(path: &Path) -> Result<Option<Vec<u8>>, AppError> {
+    use std::io::Read;
+
+    let mut file = match fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(AppError::io(path, error)),
+    };
+    let metadata = file.metadata().map_err(|error| AppError::io(path, error))?;
+    assert_owner_only_metadata(path, &metadata)?;
+
+    let mut contents = Vec::new();
+    file.read_to_end(&mut contents)
+        .map_err(|error| AppError::io(path, error))?;
+    Ok(Some(contents))
+}
+
 /// Resolve the configured Harness home used by CC Switch.
 pub fn get_dsh_dir() -> PathBuf {
     resolve_dsh_home(crate::settings::get_deepseek_harness_override_dir().as_deref())
@@ -174,6 +400,63 @@ pub fn get_dsh_credentials_path() -> PathBuf {
     get_dsh_dir().join(CREDENTIALS_FILENAME)
 }
 
+impl DshLiveStateSnapshot {
+    pub(crate) fn restore(&self) -> Result<(), AppError> {
+        ensure_safe_live_write_path(&self.home)?;
+        if self.settings.is_none() && self.credentials.is_none() {
+            return Ok(());
+        }
+        let _guard = dsh_write_lock().lock()?;
+        ensure_private_home(&self.home)?;
+
+        let settings_path = self.home.join(SETTINGS_FILENAME);
+        let credentials_path = self.home.join(CREDENTIALS_FILENAME);
+        let (credentials_lock, settings_lock) = acquire_native_file_locks(
+            &settings_path,
+            &credentials_path,
+            self.credentials.is_some(),
+        )?;
+        let operation = (|| {
+            // Compare every tracked file before restoring either one. This
+            // prevents a failed DB transaction from clobbering Harness edits
+            // that landed after CC Switch committed the live files.
+            if let Some(transition) = self.credentials.as_ref() {
+                verify_committed_file(&credentials_path, transition)?;
+            }
+            if let Some(transition) = self.settings.as_ref() {
+                verify_committed_file(&settings_path, transition)?;
+            }
+
+            // Restore the old settings generation first. Reintroducing an old
+            // credential while the newly selected endpoint/ref is still live
+            // could expose that secret to the wrong endpoint. If settings
+            // restoration fails, short-circuit and keep the committed
+            // credential state rather than creating that unsafe combination.
+            restore_settings_then_credentials(
+                || match self.settings.as_ref() {
+                    Some(transition) => restore_file_transition(&settings_path, transition, false),
+                    None => Ok(()),
+                },
+                || match self.credentials.as_ref() {
+                    Some(transition) => {
+                        restore_file_transition(&credentials_path, transition, true)
+                    }
+                    None => Ok(()),
+                },
+            )
+        })();
+        finish_locked(operation, credentials_lock, settings_lock)
+    }
+}
+
+fn restore_settings_then_credentials(
+    restore_settings: impl FnOnce() -> Result<(), AppError>,
+    restore_credentials: impl FnOnce() -> Result<(), AppError>,
+) -> Result<(), AppError> {
+    restore_settings()?;
+    restore_credentials()
+}
+
 /// Read the native DeepSeek profile currently represented by Harness user
 /// settings. Environment-only credentials are intentionally never returned.
 pub fn read_live_settings() -> Result<Option<JsonValue>, AppError> {
@@ -182,6 +465,12 @@ pub fn read_live_settings() -> Result<Option<JsonValue>, AppError> {
 
 /// Write a native DeepSeek profile and make it the default Harness selection.
 pub fn write_live_settings(settings_config: &JsonValue) -> Result<DshWriteOutcome, AppError> {
+    write_live_settings_transactional(settings_config)
+}
+
+pub(crate) fn write_live_settings_transactional(
+    settings_config: &JsonValue,
+) -> Result<DshWriteOutcome, AppError> {
     let backup_root = get_app_config_dir()
         .join("backups")
         .join("deepseek-harness");
@@ -193,11 +482,10 @@ pub fn write_live_settings(settings_config: &JsonValue) -> Result<DshWriteOutcom
 pub fn read_live_config_at(override_dir: Option<&Path>) -> Result<Option<JsonValue>, AppError> {
     let home = resolve_dsh_home(override_dir);
     let settings_path = home.join(SETTINGS_FILENAME);
-    if !settings_path.exists() {
+    let Some(raw) = read_optional_string(&settings_path)? else {
         return Ok(None);
-    }
+    };
 
-    let raw = fs::read_to_string(&settings_path).map_err(|e| AppError::io(&settings_path, e))?;
     let root = parse_settings_document(&raw, &settings_path)?;
     let llm_key = YamlValue::String(LLM_SECTION.to_string());
     let llm = root.get(&llm_key);
@@ -255,6 +543,13 @@ pub fn read_live_config_at(override_dir: Option<&Path>) -> Result<Option<JsonVal
         );
     }
 
+    validate_settings_config(&JsonValue::Object(object.clone())).map_err(|error| {
+        AppError::Config(format!(
+            "Invalid DeepSeek Harness provider settings in {}: {error}",
+            settings_path.display()
+        ))
+    })?;
+
     let api_key_env = object
         .get("apiKeyEnv")
         .and_then(JsonValue::as_str)
@@ -282,10 +577,9 @@ fn write_live_config_at(
 fn get_current_model_at(override_dir: Option<&Path>) -> Result<Option<String>, AppError> {
     let home = resolve_dsh_home(override_dir);
     let path = home.join(SETTINGS_FILENAME);
-    if !path.exists() {
+    let Some(raw) = read_optional_string(&path)? else {
         return Ok(None);
-    }
-    let raw = fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?;
+    };
     let root = parse_settings_document(&raw, &path)?;
     let Some(selection) = read_selection(&root, &path)? else {
         return Ok(None);
@@ -302,6 +596,8 @@ fn write_live_config_inner(
     backup_root: Option<&Path>,
 ) -> Result<DshWriteOutcome, AppError> {
     let prepared = prepare_config(settings_config)?;
+    reject_current_process_env_shadow(&prepared)?;
+    ensure_safe_live_write_path(home)?;
     let _guard = dsh_write_lock().lock()?;
 
     let path = home.join(SETTINGS_FILENAME);
@@ -310,94 +606,194 @@ fn write_live_config_inner(
     // A settings-only switch must not contend with Harness' credential store.
     // Set/Unset operations still acquire both native locks in stable path
     // order so separate CC Switch processes cannot deadlock each other.
-    let (_credentials_lock, _settings_lock): (Option<DshFileLock>, DshFileLock) =
-        match &prepared.credential_action {
-            CredentialAction::Keep => (None, acquire_file_lock(&path)?),
-            CredentialAction::Set(_) | CredentialAction::Unset if credentials_path < path => (
-                Some(acquire_file_lock(&credentials_path)?),
-                acquire_file_lock(&path)?,
-            ),
-            CredentialAction::Set(_) | CredentialAction::Unset => {
-                let settings_lock = acquire_file_lock(&path)?;
-                let credentials_lock = acquire_file_lock(&credentials_path)?;
-                (Some(credentials_lock), settings_lock)
+    let include_credentials = !matches!(prepared.credential_action, CredentialAction::Keep);
+    let (credentials_lock, settings_lock) =
+        acquire_native_file_locks(&path, &credentials_path, include_credentials)?;
+
+    let operation = (|| {
+        // The settings read is protected by its native writer lock. Credential
+        // reads below occur only for Set/Unset, while the credential lock is held.
+        let raw_bytes = read_optional_bytes(&path)?;
+        let raw = raw_bytes
+            .as_deref()
+            .map(|contents| {
+                std::str::from_utf8(contents)
+                    .map(str::to_owned)
+                    .map_err(|_| {
+                        AppError::Config(format!(
+                            "DeepSeek Harness settings at {} must be UTF-8",
+                            path.display()
+                        ))
+                    })
+            })
+            .transpose()?
+            .unwrap_or_default();
+        let root = parse_settings_document(&raw, &path)?;
+        let credential_update = match &prepared.credential_action {
+            CredentialAction::Keep => None,
+            CredentialAction::Set(api_key) => {
+                prepare_managed_credential(home, &prepared.api_key_env, Some(api_key))?
+            }
+            CredentialAction::Unset => {
+                prepare_managed_credential(home, &prepared.api_key_env, None)?
             }
         };
+        reject_unsafe_credential_generation(&prepared, &root, &path, credential_update.is_some())?;
 
-    // The settings read is protected by its native writer lock. Credential
-    // reads below occur only for Set/Unset, while the credential lock is held.
-    let raw = if path.exists() {
-        fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?
-    } else {
-        String::new()
-    };
-    let root = parse_settings_document(&raw, &path)?;
-
-    let llm_yaml = serde_yaml::to_value(&prepared.profile)
-        .map_err(|e| AppError::Config(format!("Failed to serialize DeepSeek profile: {e}")))?;
-    let mut selection = YamlMapping::new();
-    selection.insert(
-        YamlValue::String("provider".to_string()),
-        YamlValue::String(DSH_PROVIDER_ID.to_string()),
-    );
-    selection.insert(
-        YamlValue::String("model".to_string()),
-        YamlValue::String(prepared.default_model),
-    );
-    if let Some(effort) = prepared.default_reasoning_effort {
+        let llm_yaml = serde_yaml::to_value(&prepared.profile)
+            .map_err(|e| AppError::Config(format!("Failed to serialize DeepSeek profile: {e}")))?;
+        let mut selection = YamlMapping::new();
         selection.insert(
-            YamlValue::String("reasoningEffort".to_string()),
-            YamlValue::String(effort),
+            YamlValue::String("provider".to_string()),
+            YamlValue::String(DSH_PROVIDER_ID.to_string()),
         );
-    }
-
-    let with_llm = patch_top_level_mapping_section(&raw, &root, LLM_SECTION, &llm_yaml)?;
-    let next_root = parse_settings_document(&with_llm, &path)?;
-    let next = patch_top_level_mapping_section(
-        &with_llm,
-        &next_root,
-        DEFAULT_MODEL_SECTION,
-        &YamlValue::Mapping(selection),
-    )?;
-    parse_settings_document(&next, &path)?;
-
-    // Validate and render both documents before changing either one. The
-    // credential is committed first because it is reversible; a settings
-    // failure restores the exact previous credential bytes.
-    let credential_update = match &prepared.credential_action {
-        CredentialAction::Keep => None,
-        CredentialAction::Set(api_key) => {
-            prepare_managed_credential(home, &prepared.api_key_env, Some(api_key))?
+        selection.insert(
+            YamlValue::String("model".to_string()),
+            YamlValue::String(prepared.default_model.clone()),
+        );
+        if let Some(effort) = prepared.default_reasoning_effort.as_ref() {
+            selection.insert(
+                YamlValue::String("reasoningEffort".to_string()),
+                YamlValue::String(effort.clone()),
+            );
         }
-        CredentialAction::Unset => prepare_managed_credential(home, &prepared.api_key_env, None)?,
-    };
 
-    if next == raw && credential_update.is_none() {
-        return Ok(DshWriteOutcome::default());
-    }
+        let with_llm = patch_top_level_mapping_section(&raw, &root, LLM_SECTION, &llm_yaml)?;
+        let next_root = parse_settings_document(&with_llm, &path)?;
+        let next = patch_top_level_mapping_section(
+            &with_llm,
+            &next_root,
+            DEFAULT_MODEL_SECTION,
+            &YamlValue::Mapping(selection),
+        )?;
+        parse_settings_document(&next, &path)?;
 
-    let backup_path = match (backup_root, raw.is_empty()) {
-        (Some(root), false) => Some(create_settings_backup(root, &raw)?),
-        _ => None,
-    };
-    if let Some(update) = credential_update.as_ref() {
-        apply_credential_update(update)?;
-    }
-    if next != raw {
-        if let Err(error) = write_settings_atomic(&path, next.as_bytes()) {
-            if let Some(update) = credential_update.as_ref() {
-                if let Err(rollback_error) = rollback_credential_update(update) {
-                    return Err(AppError::Message(format!(
-                        "Failed to write DeepSeek Harness settings ({error}); credential rollback also failed ({rollback_error})"
-                    )));
+        if next == raw && credential_update.is_none() {
+            return Ok(DshWriteOutcome::default());
+        }
+
+        let backup_path = match (backup_root, raw.is_empty()) {
+            (Some(root), false) => Some(create_settings_backup(root, &raw)?),
+            _ => None,
+        };
+        if let Some(update) = credential_update.as_ref() {
+            apply_credential_update(update)?;
+        }
+        if next != raw {
+            if let Err(error) = write_settings_atomic(&path, next.as_bytes()) {
+                if let Some(update) = credential_update.as_ref() {
+                    if let Err(rollback_error) = rollback_credential_update(update) {
+                        return Err(AppError::Message(format!(
+                            "Failed to write DeepSeek Harness settings ({error}); credential rollback also failed ({rollback_error})"
+                        )));
+                    }
                 }
+                return Err(error);
             }
-            return Err(error);
         }
+        let settings_transition = (next != raw).then(|| DshFileTransition {
+            before: raw_bytes,
+            committed: Some(next.as_bytes().to_vec()),
+        });
+        let credentials_transition = credential_update.as_ref().map(|update| DshFileTransition {
+            before: update.previous.clone(),
+            committed: Some(update.next.clone()),
+        });
+        Ok(DshWriteOutcome {
+            backup_path: backup_path.map(|p| p.display().to_string()),
+            rollback_token: Some(DshLiveStateSnapshot {
+                home: home.to_path_buf(),
+                settings: settings_transition,
+                credentials: credentials_transition,
+            }),
+        })
+    })();
+
+    finish_locked(operation, credentials_lock, settings_lock)
+}
+
+fn reject_unsafe_credential_generation(
+    prepared: &PreparedConfig,
+    root: &YamlMapping,
+    settings_path: &Path,
+    credential_changes: bool,
+) -> Result<(), AppError> {
+    if !credential_changes || !matches!(prepared.credential_action, CredentialAction::Set(_)) {
+        return Ok(());
     }
-    Ok(DshWriteOutcome {
-        backup_path: backup_path.map(|p| p.display().to_string()),
-    })
+
+    let llm_key = YamlValue::String(LLM_SECTION.to_string());
+    let (current_endpoint, current_reference) = match root.get(&llm_key) {
+        None => (None, DEFAULT_API_KEY_ENV.to_string()),
+        Some(YamlValue::Mapping(mapping)) => {
+            let base_url_key = YamlValue::String("baseURL".to_string());
+            let endpoint = match mapping.get(&base_url_key) {
+                None | Some(YamlValue::Null) => None,
+                Some(YamlValue::String(value)) => Some(value.clone()),
+                Some(_) => {
+                    return Err(AppError::Config(format!(
+                        "DeepSeek Harness setting '{LLM_SECTION}.baseURL' must be a string in {}",
+                        settings_path.display()
+                    )))
+                }
+            };
+            let reference_key = YamlValue::String("apiKeyEnv".to_string());
+            let reference = match mapping.get(&reference_key) {
+                None | Some(YamlValue::Null) => DEFAULT_API_KEY_ENV.to_string(),
+                Some(YamlValue::String(value)) => value.clone(),
+                Some(_) => {
+                    return Err(AppError::Config(format!(
+                        "DeepSeek Harness setting '{LLM_SECTION}.apiKeyEnv' must be a string in {}",
+                        settings_path.display()
+                    )))
+                }
+            };
+            validate_credential_ref(&reference).map_err(|error| {
+                AppError::Config(format!(
+                    "Invalid DeepSeek Harness credential reference in {}: {error}",
+                    settings_path.display()
+                ))
+            })?;
+            (endpoint, reference)
+        }
+        Some(_) => {
+            return Err(AppError::Config(format!(
+                "DeepSeek Harness section '{LLM_SECTION}' must be a mapping in {}",
+                settings_path.display()
+            )))
+        }
+    };
+    let target_endpoint = prepared
+        .profile
+        .get("baseURL")
+        .and_then(JsonValue::as_str)
+        .map(ToOwned::to_owned);
+
+    if current_reference == prepared.api_key_env && current_endpoint != target_endpoint {
+        return Err(AppError::InvalidInput(format!(
+            "Refusing to change DeepSeek Harness baseURL and API key under the same credential reference '{}'; use a new apiKeyEnv so the new credential is installed before the endpoint is activated",
+            prepared.api_key_env
+        )));
+    }
+    Ok(())
+}
+
+/// Validate a persisted provider bundle without reading or writing Harness
+/// files. Provider transactions use this before committing non-current rows.
+pub(crate) fn validate_settings_config(settings_config: &JsonValue) -> Result<(), AppError> {
+    prepare_config(settings_config).map(|_| ())
+}
+
+fn reject_current_process_env_shadow(prepared: &PreparedConfig) -> Result<(), AppError> {
+    if !matches!(prepared.credential_action, CredentialAction::Keep)
+        && std::env::var_os(&prepared.api_key_env).is_some_and(|value| !value.is_empty())
+    {
+        return Err(AppError::InvalidInput(format!(
+            "DeepSeek Harness credential '{}' is supplied read-only by the launching environment; unset it before switching",
+            prepared.api_key_env
+        )));
+    }
+    Ok(())
 }
 
 fn prepare_config(settings_config: &JsonValue) -> Result<PreparedConfig, AppError> {
@@ -418,23 +814,28 @@ fn prepare_config(settings_config: &JsonValue) -> Result<PreparedConfig, AppErro
         "default reasoning effort",
     )?;
     if let Some(effort) = requested_default_reasoning_effort.as_deref() {
-        if !matches!(effort, "off" | "high" | "max") {
+        if !matches!(effort, "off" | "low" | "high" | "max") {
             return Err(AppError::InvalidInput(
-                "DeepSeek Harness default reasoning effort must be off, high, or max".to_string(),
+                "DeepSeek Harness default reasoning effort must be off, low, high, or max"
+                    .to_string(),
             ));
         }
     }
 
     let credential_action = match profile.remove("apiKey") {
         None | Some(JsonValue::Null) => CredentialAction::Keep,
-        Some(JsonValue::String(value)) if value.is_empty() => CredentialAction::Unset,
         Some(JsonValue::String(value)) => {
-            if value.chars().any(char::is_control) {
+            let value = value.trim_matches(is_ecmascript_whitespace);
+            if value.is_empty() {
+                CredentialAction::Unset
+            } else if !value.bytes().all(|byte| (0x21..=0x7e).contains(&byte)) {
                 return Err(AppError::InvalidInput(
-                    "DeepSeek Harness API key must not contain control characters".to_string(),
+                    "DeepSeek Harness API key must contain only printable ASCII characters without spaces"
+                        .to_string(),
                 ));
+            } else {
+                CredentialAction::Set(value.to_string())
             }
-            CredentialAction::Set(value)
         }
         Some(_) => {
             return Err(AppError::InvalidInput(
@@ -444,8 +845,8 @@ fn prepare_config(settings_config: &JsonValue) -> Result<PreparedConfig, AppErro
     };
 
     let api_key_env = match profile.get("apiKeyEnv") {
-        None => DEFAULT_API_KEY_ENV.to_string(),
-        Some(JsonValue::String(value)) => value.trim().to_string(),
+        None | Some(JsonValue::Null) => DEFAULT_API_KEY_ENV.to_string(),
+        Some(JsonValue::String(value)) => value.trim_matches(is_ecmascript_whitespace).to_string(),
         Some(_) => {
             return Err(AppError::InvalidInput(
                 "DeepSeek Harness apiKeyEnv must be a string".to_string(),
@@ -453,13 +854,6 @@ fn prepare_config(settings_config: &JsonValue) -> Result<PreparedConfig, AppErro
         }
     };
     validate_credential_ref(&api_key_env)?;
-    if !matches!(credential_action, CredentialAction::Keep)
-        && std::env::var_os(&api_key_env).is_some_and(|value| !value.is_empty())
-    {
-        return Err(AppError::InvalidInput(format!(
-            "DeepSeek Harness credential '{api_key_env}' is supplied read-only by the launching environment; unset it before switching"
-        )));
-    }
     if profile.contains_key("apiKeyEnv") {
         profile.insert(
             "apiKeyEnv".to_string(),
@@ -469,12 +863,14 @@ fn prepare_config(settings_config: &JsonValue) -> Result<PreparedConfig, AppErro
 
     let profile_reasoning_effort = match profile.get("reasoningEffort") {
         None | Some(JsonValue::Null) => None,
-        Some(JsonValue::String(value)) if matches!(value.as_str(), "off" | "high" | "max") => {
+        Some(JsonValue::String(value))
+            if matches!(value.as_str(), "off" | "low" | "high" | "max") =>
+        {
             Some(value.as_str())
         }
         Some(JsonValue::String(_)) => {
             return Err(AppError::InvalidInput(
-                "DeepSeek Harness reasoningEffort must be off, high, or max".to_string(),
+                "DeepSeek Harness reasoningEffort must be off, low, high, or max".to_string(),
             ))
         }
         Some(_) => {
@@ -512,6 +908,7 @@ fn prepare_config(settings_config: &JsonValue) -> Result<PreparedConfig, AppErro
         ));
     }
 
+    validate_optional_string(profile.get("baseURL"), "baseURL")?;
     validate_positive_integer(profile.get("maxTokens"), "maxTokens")?;
     validate_positive_integer(profile.get("defaultContextWindow"), "defaultContextWindow")?;
     if let Some(value) = profile.get("streamIdleTimeoutMs") {
@@ -532,6 +929,28 @@ fn prepare_config(settings_config: &JsonValue) -> Result<PreparedConfig, AppErro
         credential_action,
         api_key_env,
     })
+}
+
+fn is_ecmascript_whitespace(character: char) -> bool {
+    matches!(
+        character,
+        '\u{0009}'
+            | '\u{000A}'
+            | '\u{000B}'
+            | '\u{000C}'
+            | '\u{000D}'
+            | '\u{0020}'
+            | '\u{00A0}'
+            | '\u{1680}'
+            | '\u{2000}'
+            ..='\u{200A}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202F}'
+                | '\u{205F}'
+                | '\u{3000}'
+                | '\u{FEFF}'
+    )
 }
 
 fn required_private_string(
@@ -556,6 +975,15 @@ fn optional_private_string(
         None | Some(JsonValue::Null) => Ok(None),
         Some(JsonValue::String(value)) if value.trim().is_empty() => Ok(None),
         Some(JsonValue::String(value)) => Ok(Some(value.trim().to_string())),
+        Some(_) => Err(AppError::InvalidInput(format!(
+            "DeepSeek Harness {label} must be a string"
+        ))),
+    }
+}
+
+fn validate_optional_string(value: Option<&JsonValue>, label: &str) -> Result<(), AppError> {
+    match value {
+        None | Some(JsonValue::Null) | Some(JsonValue::String(_)) => Ok(()),
         Some(_) => Err(AppError::InvalidInput(format!(
             "DeepSeek Harness {label} must be a string"
         ))),
@@ -822,11 +1250,15 @@ fn yaml_to_json(value: &YamlValue, context: &str) -> Result<JsonValue, AppError>
 
 fn read_managed_credential(home: &Path, reference: &str) -> Result<Option<String>, AppError> {
     let path = home.join(CREDENTIALS_FILENAME);
-    if !path.exists() {
+    let Some(raw) = read_optional_private_bytes(&path)? else {
         return Ok(None);
-    }
-    assert_owner_only(&path)?;
-    let raw = fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?;
+    };
+    let raw = String::from_utf8(raw).map_err(|_| {
+        AppError::Config(format!(
+            "DeepSeek Harness credentials at {} must be UTF-8",
+            path.display()
+        ))
+    })?;
     let values = parse_credentials_document(&raw, &path)?;
     Ok(values
         .get(YamlValue::String(reference.to_string()))
@@ -841,12 +1273,7 @@ fn prepare_managed_credential(
 ) -> Result<Option<CredentialUpdate>, AppError> {
     validate_credential_ref(reference)?;
     let path = home.join(CREDENTIALS_FILENAME);
-    let previous = if path.exists() {
-        assert_owner_only(&path)?;
-        Some(fs::read(&path).map_err(|e| AppError::io(&path, e))?)
-    } else {
-        None
-    };
+    let previous = read_optional_private_bytes(&path)?;
     let raw = previous
         .as_deref()
         .map(|bytes| {
@@ -890,12 +1317,38 @@ fn apply_credential_update(update: &CredentialUpdate) -> Result<(), AppError> {
 fn rollback_credential_update(update: &CredentialUpdate) -> Result<(), AppError> {
     match update.previous.as_deref() {
         Some(previous) => write_private_atomic(&update.path, previous),
-        None => {
-            if update.path.exists() {
-                fs::remove_file(&update.path).map_err(|e| AppError::io(&update.path, e))?;
-            }
-            Ok(())
-        }
+        None => remove_file_if_present(&update.path),
+    }
+}
+
+fn remove_file_if_present(path: &Path) -> Result<(), AppError> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(AppError::io(path, error)),
+    }
+}
+
+fn verify_committed_file(path: &Path, transition: &DshFileTransition) -> Result<(), AppError> {
+    let current = read_optional_bytes(path)?;
+    if current != transition.committed {
+        return Err(AppError::Conflict(format!(
+            "DeepSeek Harness file {} changed after CC Switch wrote it; refusing to overwrite the newer contents during rollback",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn restore_file_transition(
+    path: &Path,
+    transition: &DshFileTransition,
+    private: bool,
+) -> Result<(), AppError> {
+    match transition.before.as_deref() {
+        Some(contents) if private => write_private_atomic(path, contents),
+        Some(contents) => write_settings_atomic(path, contents),
+        None => remove_file_if_present(path),
     }
 }
 
@@ -938,12 +1391,9 @@ fn parse_credentials_document(raw: &str, path: &Path) -> Result<YamlMapping, App
 }
 
 #[cfg(unix)]
-fn assert_owner_only(path: &Path) -> Result<(), AppError> {
+fn assert_owner_only_metadata(path: &Path, metadata: &fs::Metadata) -> Result<(), AppError> {
     use std::os::unix::fs::PermissionsExt;
-    let mode = fs::metadata(path)
-        .map_err(|e| AppError::io(path, e))?
-        .permissions()
-        .mode();
+    let mode = metadata.permissions().mode();
     if mode & 0o077 != 0 {
         return Err(AppError::Config(format!(
             "DeepSeek Harness credentials file {} must have mode 0600",
@@ -954,18 +1404,29 @@ fn assert_owner_only(path: &Path) -> Result<(), AppError> {
 }
 
 #[cfg(not(unix))]
-fn assert_owner_only(_path: &Path) -> Result<(), AppError> {
+fn assert_owner_only_metadata(_path: &Path, _metadata: &fs::Metadata) -> Result<(), AppError> {
     Ok(())
 }
 
+fn assert_owner_only(path: &Path) -> Result<(), AppError> {
+    let metadata = fs::metadata(path).map_err(|error| AppError::io(path, error))?;
+    assert_owner_only_metadata(path, &metadata)
+}
+
 fn ensure_private_home(home: &Path) -> Result<(), AppError> {
-    fs::create_dir_all(home).map_err(|e| AppError::io(home, e))?;
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(home, fs::Permissions::from_mode(0o700))
-            .map_err(|e| AppError::io(home, e))?;
+        use std::os::unix::fs::DirBuilderExt;
+
+        // `mode` applies only to directories this call creates. In
+        // particular, do not chmod a pre-existing directory or the target of
+        // a symlink supplied as DSH_HOME.
+        let mut builder = fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700);
+        builder.create(home).map_err(|e| AppError::io(home, e))?;
     }
+    #[cfg(not(unix))]
+    fs::create_dir_all(home).map_err(|e| AppError::io(home, e))?;
     Ok(())
 }
 
@@ -985,12 +1446,14 @@ fn write_private_atomic(path: &Path, contents: &[u8]) -> Result<(), AppError> {
 }
 
 /// Atomically replace a Harness-owned document without ever materializing its
-/// contents in a group/world-readable temporary file. On Windows the shared
-/// writer already uses `ReplaceFileW` (with its WSL-UNC fallback), so retain
-/// that replacement path; POSIX needs an explicit mode on the initial
-/// `create_new` because chmod-after-rename leaves a crash-persistent exposure
-/// window for credentials.
+/// contents in a group/world-readable temporary file. Windows WSL UNC paths
+/// are rejected because Windows replacement APIs cannot guarantee POSIX mode
+/// 0600 there. POSIX needs an explicit mode on the initial `create_new`
+/// because chmod-after-rename leaves a crash-persistent exposure window.
 fn write_owner_only_atomic(path: &Path, contents: &[u8]) -> Result<(), AppError> {
+    if let Some(home) = path.parent() {
+        ensure_safe_live_write_path(home)?;
+    }
     #[cfg(unix)]
     {
         use std::io::Write;
@@ -1401,9 +1864,15 @@ fn create_settings_backup(root: &Path, source: &str) -> Result<PathBuf, AppError
     let base = format!("settings_{}", Local::now().format("%Y%m%d_%H%M%S"));
     let mut path = root.join(format!("{base}.yaml"));
     let mut counter = 1;
-    while path.exists() {
-        path = root.join(format!("{base}_{counter}.yaml"));
-        counter += 1;
+    loop {
+        match fs::symlink_metadata(&path) {
+            Ok(_) => {
+                path = root.join(format!("{base}_{counter}.yaml"));
+                counter += 1;
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => break,
+            Err(error) => return Err(AppError::io(&path, error)),
+        }
     }
     write_owner_only_atomic(&path, source.as_bytes())?;
     cleanup_settings_backups(root)?;
@@ -1797,5 +2266,542 @@ mod tests {
         let credentials = fs::read_to_string(temp.path().join(CREDENTIALS_FILENAME)).unwrap();
         assert!(!credentials.contains("DEEPSEEK_API_KEY"));
         assert!(credentials.contains("OTHER_KEY: keep-me"));
+    }
+
+    #[test]
+    fn api_key_normalization_matches_harness_credential_rules() {
+        let padded = prepare_config(&json!({
+            "apiKey": "  sk-valid_ascii-123  ",
+            "defaultModel": "deepseek-v4-flash"
+        }))
+        .unwrap();
+        assert!(matches!(
+            padded.credential_action,
+            CredentialAction::Set(ref value) if value == "sk-valid_ascii-123"
+        ));
+        let debug = format!("{padded:?}");
+        assert!(debug.contains("Set([REDACTED])"));
+        assert!(!debug.contains("sk-valid_ascii-123"));
+
+        let bom_padded = prepare_config(&json!({
+            "apiKey": "\u{feff}sk-bom-trimmed\u{feff}",
+            "defaultModel": "deepseek-v4-flash"
+        }))
+        .unwrap();
+        assert!(matches!(
+            bom_padded.credential_action,
+            CredentialAction::Set(ref value) if value == "sk-bom-trimmed"
+        ));
+
+        let whitespace = prepare_config(&json!({
+            "apiKey": " \t\r\n ",
+            "defaultModel": "deepseek-v4-flash"
+        }))
+        .unwrap();
+        assert!(matches!(
+            whitespace.credential_action,
+            CredentialAction::Unset
+        ));
+
+        for invalid in ["sk embedded-space", "密钥", "sk\u{007f}", "\u{0085}"] {
+            let error = prepare_config(&json!({
+                "apiKey": invalid,
+                "defaultModel": "deepseek-v4-flash"
+            }))
+            .unwrap_err();
+            assert!(!error.to_string().contains(invalid));
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        assert!(write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "apiKey": "\u{0085}",
+                "defaultModel": "deepseek-v4-flash"
+            }),
+        )
+        .is_err());
+        assert_eq!(
+            read_optional_bytes(&temp.path().join(CREDENTIALS_FILENAME)).unwrap(),
+            None
+        );
+        assert_eq!(
+            read_optional_bytes(&temp.path().join(SETTINGS_FILENAME)).unwrap(),
+            None
+        );
+
+        let invalid_ref_home = tempfile::tempdir().unwrap();
+        assert!(write_live_config_at(
+            Some(invalid_ref_home.path()),
+            &json!({
+                "apiKey": "sk-valid",
+                "apiKeyEnv": "\u{0085}VICTIM_ENV",
+                "defaultModel": "deepseek-v4-flash"
+            }),
+        )
+        .is_err());
+        assert_eq!(
+            read_optional_bytes(&invalid_ref_home.path().join(CREDENTIALS_FILENAME)).unwrap(),
+            None
+        );
+        assert_eq!(
+            read_optional_bytes(&invalid_ref_home.path().join(SETTINGS_FILENAME)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn accepts_low_reasoning_effort_in_profile_and_default_selection() {
+        let temp = tempfile::tempdir().unwrap();
+        write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "defaultModel": "deepseek-v4-pro",
+                "reasoningEffort": "low",
+                "defaultReasoningEffort": "low"
+            }),
+        )
+        .unwrap();
+
+        let settings = fs::read_to_string(temp.path().join(SETTINGS_FILENAME)).unwrap();
+        assert_eq!(settings.matches("reasoningEffort: low").count(), 2);
+        let live = read_live_config_at(Some(temp.path())).unwrap().unwrap();
+        assert_eq!(live["reasoningEffort"], "low");
+        assert_eq!(live["defaultReasoningEffort"], "low");
+    }
+
+    #[test]
+    fn rejects_non_string_base_url_before_touching_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let input = json!({
+            "defaultModel": "deepseek-v4-flash",
+            "baseURL": ["https://api.example"]
+        });
+
+        assert!(validate_settings_config(&input).is_err());
+        assert!(write_live_config_at(Some(temp.path()), &input).is_err());
+        assert_eq!(
+            read_optional_bytes(&temp.path().join(SETTINGS_FILENAME)).unwrap(),
+            None
+        );
+        assert_eq!(
+            read_optional_bytes(&temp.path().join(CREDENTIALS_FILENAME)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn static_validation_ignores_runtime_env_shadow_but_live_write_rejects_it() {
+        let temp = tempfile::tempdir().unwrap();
+        let input = json!({
+            "apiKey": "managed-secret",
+            "apiKeyEnv": "TEST_STATIC_VALIDATION_ENV_SHADOW",
+            "defaultModel": "deepseek-v4-flash"
+        });
+        std::env::set_var("TEST_STATIC_VALIDATION_ENV_SHADOW", "inherited-secret");
+        let validation = validate_settings_config(&input);
+        let write = write_live_config_at(Some(temp.path()), &input);
+        std::env::remove_var("TEST_STATIC_VALIDATION_ENV_SHADOW");
+
+        assert!(validation.is_ok());
+        assert!(write.is_err());
+        assert_eq!(
+            read_optional_bytes(&temp.path().join(SETTINGS_FILENAME)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn optional_file_read_only_treats_not_found_as_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let missing = temp.path().join("missing");
+        assert_eq!(read_optional_string(&missing).unwrap(), None);
+
+        let directory = temp.path().join("not-a-file");
+        fs::create_dir(&directory).unwrap();
+        assert!(read_optional_string(&directory).is_err());
+        assert!(read_optional_bytes(&directory).is_err());
+    }
+
+    #[test]
+    fn rejects_endpoint_and_key_generation_change_under_same_reference() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join(SETTINGS_FILENAME);
+        let credentials_path = temp.path().join(CREDENTIALS_FILENAME);
+        let original_settings = concat!(
+            "llm-deepseek:\n",
+            "  apiKeyEnv: TEST_ATOMIC_SAME_REF\n",
+            "  baseURL: https://old.example\n",
+            "agent-default-model:\n",
+            "  provider: deepseek-official\n",
+            "  model: old-model\n",
+        );
+        let original_credentials = "TEST_ATOMIC_SAME_REF: old-secret\n";
+        fs::write(&settings_path, original_settings).unwrap();
+        write_private(&credentials_path, original_credentials);
+
+        let error = write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "apiKey": "new-secret",
+                "apiKeyEnv": "TEST_ATOMIC_SAME_REF",
+                "baseURL": "https://new.example",
+                "defaultModel": "new-model"
+            }),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("same credential reference"));
+        assert_eq!(
+            fs::read(&settings_path).unwrap(),
+            original_settings.as_bytes()
+        );
+        assert_eq!(
+            fs::read(&credentials_path).unwrap(),
+            original_credentials.as_bytes()
+        );
+    }
+
+    #[test]
+    fn switches_endpoint_and_key_generation_through_a_new_reference() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(SETTINGS_FILENAME),
+            concat!(
+                "llm-deepseek:\n",
+                "  apiKeyEnv: TEST_ATOMIC_OLD_REF\n",
+                "  baseURL: https://old.example\n",
+                "agent-default-model:\n",
+                "  provider: deepseek-official\n",
+                "  model: old-model\n",
+            ),
+        )
+        .unwrap();
+        write_private(
+            &temp.path().join(CREDENTIALS_FILENAME),
+            "TEST_ATOMIC_OLD_REF: old-secret\n",
+        );
+
+        let outcome = write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "apiKey": "new-secret",
+                "apiKeyEnv": "TEST_ATOMIC_NEW_REF",
+                "baseURL": "https://new.example",
+                "defaultModel": "new-model"
+            }),
+        )
+        .unwrap();
+
+        let settings = fs::read_to_string(temp.path().join(SETTINGS_FILENAME)).unwrap();
+        assert!(settings.contains("apiKeyEnv: TEST_ATOMIC_NEW_REF"));
+        assert!(settings.contains("baseURL: https://new.example"));
+        let credentials = fs::read_to_string(temp.path().join(CREDENTIALS_FILENAME)).unwrap();
+        assert!(credentials.contains("TEST_ATOMIC_OLD_REF: old-secret"));
+        assert!(credentials.contains("TEST_ATOMIC_NEW_REF: new-secret"));
+        assert!(outcome.rollback_token.is_some());
+        assert!(!format!("{outcome:?}").contains("new-secret"));
+    }
+
+    #[test]
+    fn allows_endpoint_change_when_same_reference_keeps_identical_key_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(SETTINGS_FILENAME),
+            concat!(
+                "llm-deepseek:\n",
+                "  apiKeyEnv: TEST_ATOMIC_STABLE_REF\n",
+                "  baseURL: https://old.example\n",
+                "agent-default-model:\n",
+                "  provider: deepseek-official\n",
+                "  model: old-model\n",
+            ),
+        )
+        .unwrap();
+        write_private(
+            &temp.path().join(CREDENTIALS_FILENAME),
+            "TEST_ATOMIC_STABLE_REF: stable-secret\n",
+        );
+
+        let outcome = write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "apiKey": "stable-secret",
+                "apiKeyEnv": "TEST_ATOMIC_STABLE_REF",
+                "baseURL": "https://new.example",
+                "defaultModel": "new-model"
+            }),
+        )
+        .unwrap();
+
+        assert!(fs::read_to_string(temp.path().join(SETTINGS_FILENAME))
+            .unwrap()
+            .contains("baseURL: https://new.example"));
+        assert!(outcome
+            .rollback_token
+            .as_ref()
+            .is_some_and(|token| token.credentials.is_none()));
+    }
+
+    #[test]
+    fn rollback_token_restores_exact_bytes_and_absence() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join(SETTINGS_FILENAME);
+        let credentials_path = temp.path().join(CREDENTIALS_FILENAME);
+        let original_settings = concat!(
+            "# exact settings bytes\n",
+            "llm-deepseek:\n",
+            "  apiKeyEnv: TEST_ROLLBACK_OLD_REF\n",
+            "  baseURL: https://old.example\n",
+            "agent-default-model:\n",
+            "  provider: deepseek-official\n",
+            "  model: old-model\n",
+        );
+        let original_credentials = concat!(
+            "# exact credential bytes\n",
+            "TEST_ROLLBACK_OLD_REF: old-secret\n",
+        );
+        fs::write(&settings_path, original_settings).unwrap();
+        write_private(&credentials_path, original_credentials);
+
+        let outcome = write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "apiKey": "new-secret",
+                "apiKeyEnv": "TEST_ROLLBACK_NEW_REF",
+                "baseURL": "https://new.example",
+                "defaultModel": "new-model"
+            }),
+        )
+        .unwrap();
+        let token = outcome.rollback_token.unwrap();
+        token.restore().unwrap();
+
+        assert_eq!(
+            fs::read(&settings_path).unwrap(),
+            original_settings.as_bytes()
+        );
+        assert_eq!(
+            fs::read(&credentials_path).unwrap(),
+            original_credentials.as_bytes()
+        );
+        assert!(matches!(token.restore(), Err(AppError::Conflict(_))));
+
+        let empty = tempfile::tempdir().unwrap();
+        let create_outcome = write_live_config_at(
+            Some(empty.path()),
+            &json!({ "defaultModel": "deepseek-v4-flash" }),
+        )
+        .unwrap();
+        create_outcome.rollback_token.unwrap().restore().unwrap();
+        assert_eq!(
+            read_optional_bytes(&empty.path().join(SETTINGS_FILENAME)).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn rollback_of_unset_restores_settings_before_target_credential() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join(SETTINGS_FILENAME);
+        let credentials_path = temp.path().join(CREDENTIALS_FILENAME);
+        let original_settings = concat!(
+            "llm-deepseek:\n",
+            "  apiKeyEnv: TEST_UNSET_OLD_REF\n",
+            "  baseURL: https://old.example\n",
+            "agent-default-model:\n",
+            "  provider: deepseek-official\n",
+            "  model: old-model\n",
+        );
+        let original_credentials = concat!(
+            "TEST_UNSET_OLD_REF: old-secret\n",
+            "TEST_UNSET_TARGET_REF: target-secret\n",
+        );
+        fs::write(&settings_path, original_settings).unwrap();
+        write_private(&credentials_path, original_credentials);
+
+        let outcome = write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "apiKey": "",
+                "apiKeyEnv": "TEST_UNSET_TARGET_REF",
+                "baseURL": "https://new.example",
+                "defaultModel": "new-model"
+            }),
+        )
+        .unwrap();
+        assert!(!fs::read_to_string(&credentials_path)
+            .unwrap()
+            .contains("TEST_UNSET_TARGET_REF"));
+
+        outcome.rollback_token.unwrap().restore().unwrap();
+        assert_eq!(
+            fs::read(&settings_path).unwrap(),
+            original_settings.as_bytes()
+        );
+        assert_eq!(
+            fs::read(&credentials_path).unwrap(),
+            original_credentials.as_bytes()
+        );
+    }
+
+    #[test]
+    fn safe_restore_order_short_circuits_before_credentials_on_settings_error() {
+        use std::cell::Cell;
+
+        let credential_restore_called = Cell::new(false);
+        let result = restore_settings_then_credentials(
+            || Err(AppError::Message("settings restore failed".to_string())),
+            || {
+                credential_restore_called.set(true);
+                Ok(())
+            },
+        );
+
+        assert!(result.is_err());
+        assert!(!credential_restore_called.get());
+    }
+
+    #[test]
+    fn rollback_token_preserves_newer_harness_edits_without_partial_restore() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings_path = temp.path().join(SETTINGS_FILENAME);
+        let credentials_path = temp.path().join(CREDENTIALS_FILENAME);
+        fs::write(
+            &settings_path,
+            concat!(
+                "llm-deepseek:\n",
+                "  apiKeyEnv: TEST_CAS_OLD_REF\n",
+                "  baseURL: https://old.example\n",
+                "agent-default-model:\n",
+                "  provider: deepseek-official\n",
+                "  model: old-model\n",
+            ),
+        )
+        .unwrap();
+        write_private(&credentials_path, "TEST_CAS_OLD_REF: old-secret\n");
+
+        let outcome = write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "apiKey": "new-secret",
+                "apiKeyEnv": "TEST_CAS_NEW_REF",
+                "baseURL": "https://new.example",
+                "defaultModel": "new-model"
+            }),
+        )
+        .unwrap();
+        let committed_credentials = fs::read(&credentials_path).unwrap();
+        let mut newer_settings = fs::read(&settings_path).unwrap();
+        newer_settings.extend_from_slice(b"# Harness changed this after CC Switch\n");
+        fs::write(&settings_path, &newer_settings).unwrap();
+
+        let error = outcome.rollback_token.unwrap().restore().unwrap_err();
+        assert!(matches!(error, AppError::Conflict(_)));
+        assert_eq!(fs::read(&settings_path).unwrap(), newer_settings);
+        assert_eq!(fs::read(&credentials_path).unwrap(), committed_credentials);
+    }
+
+    #[test]
+    fn explicit_lock_release_surfaces_removal_errors() {
+        let temp = tempfile::tempdir().unwrap();
+        let document = temp.path().join("document.yaml");
+        let lock = acquire_file_lock(&document).unwrap();
+        let lock_path = lock.path.as_ref().unwrap().clone();
+        fs::remove_file(&lock_path).unwrap();
+        fs::create_dir(&lock_path).unwrap();
+
+        assert!(lock.release().is_err());
+        fs::remove_dir(&lock_path).unwrap();
+    }
+
+    #[test]
+    fn committed_operation_keeps_rollback_outcome_when_lock_release_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let document = temp.path().join("document.yaml");
+        let lock = acquire_file_lock(&document).unwrap();
+        let lock_path = lock.path.as_ref().unwrap().clone();
+        fs::remove_file(&lock_path).unwrap();
+        fs::create_dir(&lock_path).unwrap();
+
+        assert_eq!(finish_locked(Ok(42), None, lock).unwrap(), 42);
+        fs::remove_dir(&lock_path).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_home_creation_does_not_chmod_existing_or_symlinked_directories() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let temp = tempfile::tempdir().unwrap();
+        let existing = temp.path().join("existing");
+        fs::create_dir(&existing).unwrap();
+        fs::set_permissions(&existing, fs::Permissions::from_mode(0o750)).unwrap();
+        ensure_private_home(&existing).unwrap();
+        assert_eq!(
+            fs::metadata(&existing).unwrap().permissions().mode() & 0o777,
+            0o750
+        );
+
+        let target = temp.path().join("target");
+        let linked = temp.path().join("linked");
+        fs::create_dir(&target).unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o750)).unwrap();
+        symlink(&target, &linked).unwrap();
+        ensure_private_home(&linked).unwrap();
+        assert_eq!(
+            fs::metadata(&target).unwrap().permissions().mode() & 0o777,
+            0o750
+        );
+
+        let created = temp.path().join("created");
+        ensure_private_home(&created).unwrap();
+        assert_eq!(
+            fs::metadata(&created).unwrap().permissions().mode() & 0o077,
+            0
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn credential_permissions_are_checked_before_secret_bytes_are_parsed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(CREDENTIALS_FILENAME);
+        fs::write(&path, [0xff, 0xfe, 0xfd]).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let read_error = read_managed_credential(temp.path(), DEFAULT_API_KEY_ENV).unwrap_err();
+        let prepare_error =
+            prepare_managed_credential(temp.path(), DEFAULT_API_KEY_ENV, Some("replacement"))
+                .err()
+                .expect("wide credential permissions must be rejected");
+        assert!(read_error.to_string().contains("mode 0600"));
+        assert!(prepare_error.to_string().contains("mode 0600"));
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(read_managed_credential(temp.path(), DEFAULT_API_KEY_ENV)
+            .unwrap_err()
+            .to_string()
+            .contains("UTF-8"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn keep_write_fails_closed_for_wsl_unc_before_filesystem_access() {
+        for home in [
+            Path::new(r"\\wsl$\DefinitelyMissing\home\user\.dsh"),
+            Path::new(r"\\wsl.localhost\DefinitelyMissing\home\user\.dsh"),
+            Path::new(r"\\?\UNC\wsl.localhost\DefinitelyMissing\home\user\.dsh"),
+        ] {
+            let error = write_live_config_inner(
+                home,
+                &json!({ "defaultModel": "deepseek-v4-flash" }),
+                None,
+            )
+            .unwrap_err();
+            assert!(error.to_string().contains("WSL UNC"));
+        }
     }
 }

--- a/src-tauri/src/dsh_config.rs
+++ b/src-tauri/src/dsh_config.rs
@@ -1,0 +1,1801 @@
+//! DeepSeek Harness native-provider configuration support.
+//!
+//! CC Switch owns only the `llm-deepseek` and `agent-default-model` sections
+//! in `$DSH_HOME/settings.yaml`. API keys remain references in that document;
+//! their values live in the Harness-managed `.credentials.yaml` store.
+
+#[cfg(not(unix))]
+use crate::config::atomic_write;
+use crate::config::{get_app_config_dir, get_home_dir};
+use crate::error::AppError;
+use crate::settings::effective_backup_retain_count;
+use chrono::Local;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
+use std::collections::HashSet;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+pub const DSH_PROVIDER_ID: &str = "deepseek-official";
+const DEFAULT_API_KEY_ENV: &str = "DEEPSEEK_API_KEY";
+const SETTINGS_FILENAME: &str = "settings.yaml";
+const CREDENTIALS_FILENAME: &str = ".credentials.yaml";
+const LLM_SECTION: &str = "llm-deepseek";
+const DEFAULT_MODEL_SECTION: &str = "agent-default-model";
+const DEFAULT_MODEL_ID: &str = "deepseek-v4-flash";
+const LOCK_RETRY_INITIAL: Duration = Duration::from_millis(20);
+const LOCK_RETRY_MAX: Duration = Duration::from_millis(200);
+const LOCK_TIMEOUT: Duration = Duration::from_secs(2);
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DshWriteOutcome {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backup_path: Option<String>,
+}
+
+#[derive(Debug)]
+struct PreparedConfig {
+    profile: JsonValue,
+    default_model: String,
+    default_reasoning_effort: Option<String>,
+    credential_action: CredentialAction,
+    api_key_env: String,
+}
+
+#[derive(Debug)]
+enum CredentialAction {
+    Keep,
+    Set(String),
+    Unset,
+}
+
+#[derive(Debug)]
+struct CredentialUpdate {
+    path: PathBuf,
+    previous: Option<Vec<u8>>,
+    next: Vec<u8>,
+}
+
+/// Cross-process writer lock compatible with DeepSeek Harness' `<file>.lock`
+/// protocol. Harness never removes a contender's lock, so neither do we.
+struct DshFileLock {
+    path: PathBuf,
+}
+
+impl Drop for DshFileLock {
+    fn drop(&mut self) {
+        if let Err(error) = fs::remove_file(&self.path) {
+            if error.kind() != ErrorKind::NotFound {
+                log::warn!(
+                    "Failed to release DeepSeek Harness writer lock {}: {error}",
+                    self.path.display()
+                );
+            }
+        }
+    }
+}
+
+fn dsh_write_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+fn acquire_file_lock(filename: &Path) -> Result<DshFileLock, AppError> {
+    let mut lock_name = filename.as_os_str().to_os_string();
+    lock_name.push(".lock");
+    let lock_path = PathBuf::from(lock_name);
+    let deadline = Instant::now() + LOCK_TIMEOUT;
+    let mut delay = LOCK_RETRY_INITIAL;
+    loop {
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        match options.open(&lock_path) {
+            Ok(mut file) => {
+                use std::io::Write;
+                if let Err(error) = writeln!(file, "{}", std::process::id()) {
+                    let _ = fs::remove_file(&lock_path);
+                    return Err(AppError::io(&lock_path, error));
+                }
+                return Ok(DshFileLock { path: lock_path });
+            }
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                if Instant::now() >= deadline {
+                    return Err(AppError::Config(format!(
+                        "Timed out waiting for DeepSeek Harness writer lock {}",
+                        lock_path.display()
+                    )));
+                }
+                thread::sleep(delay);
+                delay = std::cmp::min(delay.saturating_mul(2), LOCK_RETRY_MAX);
+            }
+            Err(error) => return Err(AppError::io(&lock_path, error)),
+        }
+    }
+}
+
+/// Resolve the Harness home with native precedence: explicit override,
+/// non-blank `DSH_HOME`, then `~/.dsh`.
+pub fn resolve_dsh_home(override_dir: Option<&Path>) -> PathBuf {
+    if let Some(path) = override_dir {
+        return absolutize_dsh_home(path);
+    }
+    if let Some(raw) = std::env::var_os("DSH_HOME") {
+        let value = raw.to_string_lossy();
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return absolutize_dsh_home(Path::new(trimmed));
+        }
+    }
+    get_home_dir().join(".dsh")
+}
+
+fn absolutize_dsh_home(path: &Path) -> PathBuf {
+    let raw = path.to_string_lossy();
+    let expanded = if raw == "~" {
+        get_home_dir()
+    } else if let Some(rest) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("~\\")) {
+        get_home_dir().join(rest)
+    } else {
+        path.to_path_buf()
+    };
+    if expanded.is_absolute() {
+        expanded
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|_| get_home_dir())
+            .join(expanded)
+    }
+}
+
+/// Resolve the configured Harness home used by CC Switch.
+pub fn get_dsh_dir() -> PathBuf {
+    resolve_dsh_home(crate::settings::get_deepseek_harness_override_dir().as_deref())
+}
+
+pub fn get_dsh_settings_path() -> PathBuf {
+    get_dsh_dir().join(SETTINGS_FILENAME)
+}
+
+pub fn get_dsh_credentials_path() -> PathBuf {
+    get_dsh_dir().join(CREDENTIALS_FILENAME)
+}
+
+/// Read the native DeepSeek profile currently represented by Harness user
+/// settings. Environment-only credentials are intentionally never returned.
+pub fn read_live_settings() -> Result<Option<JsonValue>, AppError> {
+    read_live_config_at(Some(&get_dsh_dir()))
+}
+
+/// Write a native DeepSeek profile and make it the default Harness selection.
+pub fn write_live_settings(settings_config: &JsonValue) -> Result<DshWriteOutcome, AppError> {
+    let backup_root = get_app_config_dir()
+        .join("backups")
+        .join("deepseek-harness");
+    write_live_config_inner(&get_dsh_dir(), settings_config, Some(&backup_root))
+}
+
+/// Explicit-home variant used by tests and callers that already resolved the
+/// Harness home. It does not create CC Switch backup artifacts.
+pub fn read_live_config_at(override_dir: Option<&Path>) -> Result<Option<JsonValue>, AppError> {
+    let home = resolve_dsh_home(override_dir);
+    let settings_path = home.join(SETTINGS_FILENAME);
+    if !settings_path.exists() {
+        return Ok(None);
+    }
+
+    let raw = fs::read_to_string(&settings_path).map_err(|e| AppError::io(&settings_path, e))?;
+    let root = parse_settings_document(&raw, &settings_path)?;
+    let llm_key = YamlValue::String(LLM_SECTION.to_string());
+    let llm = root.get(&llm_key);
+    let selection = read_selection(&root, &settings_path)?;
+
+    if let Some(selection) = selection.as_ref() {
+        // User settings are layered over Harness' bundled base config, so a
+        // missing provider still resolves to the official DeepSeek route.
+        if selection.provider.as_deref().unwrap_or(DSH_PROVIDER_ID) != DSH_PROVIDER_ID {
+            return Ok(None);
+        }
+    }
+
+    if llm.is_none() && selection.is_none() {
+        return Ok(None);
+    }
+
+    let mut profile = match llm {
+        Some(YamlValue::Mapping(_)) => yaml_to_json(llm.expect("checked Some"), LLM_SECTION)?,
+        Some(_) => {
+            return Err(AppError::Config(format!(
+                "DeepSeek Harness section '{LLM_SECTION}' must be a mapping in {}",
+                settings_path.display()
+            )))
+        }
+        None => JsonValue::Object(serde_json::Map::new()),
+    };
+    let object = profile.as_object_mut().ok_or_else(|| {
+        AppError::Config(format!(
+            "DeepSeek Harness section '{LLM_SECTION}' must be an object"
+        ))
+    })?;
+
+    if let Some(selection) = selection {
+        object.insert(
+            "defaultModel".to_string(),
+            JsonValue::String(
+                selection
+                    .model
+                    .unwrap_or_else(|| DEFAULT_MODEL_ID.to_string()),
+            ),
+        );
+        if let Some(effort) = selection.reasoning_effort {
+            object.insert(
+                "defaultReasoningEffort".to_string(),
+                JsonValue::String(effort),
+            );
+        }
+    } else {
+        // Harness supplies this selection from its bundled base config when
+        // the user settings file only overrides the DeepSeek provider.
+        object.insert(
+            "defaultModel".to_string(),
+            JsonValue::String(DEFAULT_MODEL_ID.to_string()),
+        );
+    }
+
+    let api_key_env = object
+        .get("apiKeyEnv")
+        .and_then(JsonValue::as_str)
+        .unwrap_or(DEFAULT_API_KEY_ENV);
+    validate_credential_ref(api_key_env)?;
+    if let Some(api_key) = read_managed_credential(&home, api_key_env)? {
+        object.insert("apiKey".to_string(), JsonValue::String(api_key));
+    }
+
+    Ok(Some(profile))
+}
+
+/// Explicit-home write variant. Unlike [`write_live_settings`], it does not
+/// create backups under the CC Switch data directory.
+#[cfg(test)]
+fn write_live_config_at(
+    override_dir: Option<&Path>,
+    settings_config: &JsonValue,
+) -> Result<DshWriteOutcome, AppError> {
+    let home = resolve_dsh_home(override_dir);
+    write_live_config_inner(&home, settings_config, None)
+}
+
+#[cfg(test)]
+fn get_current_model_at(override_dir: Option<&Path>) -> Result<Option<String>, AppError> {
+    let home = resolve_dsh_home(override_dir);
+    let path = home.join(SETTINGS_FILENAME);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?;
+    let root = parse_settings_document(&raw, &path)?;
+    let Some(selection) = read_selection(&root, &path)? else {
+        return Ok(None);
+    };
+    if selection.provider.as_deref() != Some(DSH_PROVIDER_ID) {
+        return Ok(None);
+    }
+    Ok(selection.model)
+}
+
+fn write_live_config_inner(
+    home: &Path,
+    settings_config: &JsonValue,
+    backup_root: Option<&Path>,
+) -> Result<DshWriteOutcome, AppError> {
+    let prepared = prepare_config(settings_config)?;
+    let _guard = dsh_write_lock().lock()?;
+
+    let path = home.join(SETTINGS_FILENAME);
+    let credentials_path = home.join(CREDENTIALS_FILENAME);
+    ensure_private_home(home)?;
+    // A settings-only switch must not contend with Harness' credential store.
+    // Set/Unset operations still acquire both native locks in stable path
+    // order so separate CC Switch processes cannot deadlock each other.
+    let (_credentials_lock, _settings_lock): (Option<DshFileLock>, DshFileLock) =
+        match &prepared.credential_action {
+            CredentialAction::Keep => (None, acquire_file_lock(&path)?),
+            CredentialAction::Set(_) | CredentialAction::Unset if credentials_path < path => (
+                Some(acquire_file_lock(&credentials_path)?),
+                acquire_file_lock(&path)?,
+            ),
+            CredentialAction::Set(_) | CredentialAction::Unset => {
+                let settings_lock = acquire_file_lock(&path)?;
+                let credentials_lock = acquire_file_lock(&credentials_path)?;
+                (Some(credentials_lock), settings_lock)
+            }
+        };
+
+    // The settings read is protected by its native writer lock. Credential
+    // reads below occur only for Set/Unset, while the credential lock is held.
+    let raw = if path.exists() {
+        fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?
+    } else {
+        String::new()
+    };
+    let root = parse_settings_document(&raw, &path)?;
+
+    let llm_yaml = serde_yaml::to_value(&prepared.profile)
+        .map_err(|e| AppError::Config(format!("Failed to serialize DeepSeek profile: {e}")))?;
+    let mut selection = YamlMapping::new();
+    selection.insert(
+        YamlValue::String("provider".to_string()),
+        YamlValue::String(DSH_PROVIDER_ID.to_string()),
+    );
+    selection.insert(
+        YamlValue::String("model".to_string()),
+        YamlValue::String(prepared.default_model),
+    );
+    if let Some(effort) = prepared.default_reasoning_effort {
+        selection.insert(
+            YamlValue::String("reasoningEffort".to_string()),
+            YamlValue::String(effort),
+        );
+    }
+
+    let with_llm = patch_top_level_mapping_section(&raw, &root, LLM_SECTION, &llm_yaml)?;
+    let next_root = parse_settings_document(&with_llm, &path)?;
+    let next = patch_top_level_mapping_section(
+        &with_llm,
+        &next_root,
+        DEFAULT_MODEL_SECTION,
+        &YamlValue::Mapping(selection),
+    )?;
+    parse_settings_document(&next, &path)?;
+
+    // Validate and render both documents before changing either one. The
+    // credential is committed first because it is reversible; a settings
+    // failure restores the exact previous credential bytes.
+    let credential_update = match &prepared.credential_action {
+        CredentialAction::Keep => None,
+        CredentialAction::Set(api_key) => {
+            prepare_managed_credential(home, &prepared.api_key_env, Some(api_key))?
+        }
+        CredentialAction::Unset => prepare_managed_credential(home, &prepared.api_key_env, None)?,
+    };
+
+    if next == raw && credential_update.is_none() {
+        return Ok(DshWriteOutcome::default());
+    }
+
+    let backup_path = match (backup_root, raw.is_empty()) {
+        (Some(root), false) => Some(create_settings_backup(root, &raw)?),
+        _ => None,
+    };
+    if let Some(update) = credential_update.as_ref() {
+        apply_credential_update(update)?;
+    }
+    if next != raw {
+        if let Err(error) = write_settings_atomic(&path, next.as_bytes()) {
+            if let Some(update) = credential_update.as_ref() {
+                if let Err(rollback_error) = rollback_credential_update(update) {
+                    return Err(AppError::Message(format!(
+                        "Failed to write DeepSeek Harness settings ({error}); credential rollback also failed ({rollback_error})"
+                    )));
+                }
+            }
+            return Err(error);
+        }
+    }
+    Ok(DshWriteOutcome {
+        backup_path: backup_path.map(|p| p.display().to_string()),
+    })
+}
+
+fn prepare_config(settings_config: &JsonValue) -> Result<PreparedConfig, AppError> {
+    let mut profile = settings_config.as_object().cloned().ok_or_else(|| {
+        AppError::InvalidInput("DeepSeek Harness provider config must be an object".to_string())
+    })?;
+
+    let default_model = required_private_string(&mut profile, "defaultModel", "model")?;
+    if default_model.chars().any(char::is_control) {
+        return Err(AppError::InvalidInput(
+            "DeepSeek Harness model must not contain control characters".to_string(),
+        ));
+    }
+
+    let requested_default_reasoning_effort = optional_private_string(
+        &mut profile,
+        "defaultReasoningEffort",
+        "default reasoning effort",
+    )?;
+    if let Some(effort) = requested_default_reasoning_effort.as_deref() {
+        if !matches!(effort, "off" | "high" | "max") {
+            return Err(AppError::InvalidInput(
+                "DeepSeek Harness default reasoning effort must be off, high, or max".to_string(),
+            ));
+        }
+    }
+
+    let credential_action = match profile.remove("apiKey") {
+        None | Some(JsonValue::Null) => CredentialAction::Keep,
+        Some(JsonValue::String(value)) if value.is_empty() => CredentialAction::Unset,
+        Some(JsonValue::String(value)) => {
+            if value.chars().any(char::is_control) {
+                return Err(AppError::InvalidInput(
+                    "DeepSeek Harness API key must not contain control characters".to_string(),
+                ));
+            }
+            CredentialAction::Set(value)
+        }
+        Some(_) => {
+            return Err(AppError::InvalidInput(
+                "DeepSeek Harness apiKey must be a string".to_string(),
+            ))
+        }
+    };
+
+    let api_key_env = match profile.get("apiKeyEnv") {
+        None => DEFAULT_API_KEY_ENV.to_string(),
+        Some(JsonValue::String(value)) => value.trim().to_string(),
+        Some(_) => {
+            return Err(AppError::InvalidInput(
+                "DeepSeek Harness apiKeyEnv must be a string".to_string(),
+            ))
+        }
+    };
+    validate_credential_ref(&api_key_env)?;
+    if !matches!(credential_action, CredentialAction::Keep)
+        && std::env::var_os(&api_key_env).is_some_and(|value| !value.is_empty())
+    {
+        return Err(AppError::InvalidInput(format!(
+            "DeepSeek Harness credential '{api_key_env}' is supplied read-only by the launching environment; unset it before switching"
+        )));
+    }
+    if profile.contains_key("apiKeyEnv") {
+        profile.insert(
+            "apiKeyEnv".to_string(),
+            JsonValue::String(api_key_env.clone()),
+        );
+    }
+
+    let profile_reasoning_effort = match profile.get("reasoningEffort") {
+        None | Some(JsonValue::Null) => None,
+        Some(JsonValue::String(value)) if matches!(value.as_str(), "off" | "high" | "max") => {
+            Some(value.as_str())
+        }
+        Some(JsonValue::String(_)) => {
+            return Err(AppError::InvalidInput(
+                "DeepSeek Harness reasoningEffort must be off, high, or max".to_string(),
+            ))
+        }
+        Some(_) => {
+            return Err(AppError::InvalidInput(
+                "DeepSeek Harness reasoningEffort must be a string".to_string(),
+            ))
+        }
+    };
+    let thinking_disabled = match profile.get("thinking") {
+        None | Some(JsonValue::Null) => false,
+        Some(JsonValue::String(value)) if value == "disabled" => true,
+        Some(JsonValue::String(value)) if value == "enabled" => false,
+        Some(JsonValue::String(_)) => {
+            return Err(AppError::InvalidInput(
+                "DeepSeek Harness thinking must be enabled or disabled".to_string(),
+            ))
+        }
+        Some(_) => {
+            return Err(AppError::InvalidInput(
+                "DeepSeek Harness thinking must be a string".to_string(),
+            ))
+        }
+    };
+    // The provider profile and the default-model selection are independent
+    // native settings. Keep an omitted selection effort omitted instead of
+    // copying `llm-deepseek.reasoningEffort` into `agent-default-model`.
+    let default_reasoning_effort =
+        requested_default_reasoning_effort.or_else(|| thinking_disabled.then(|| "off".to_string()));
+    if thinking_disabled
+        && (profile_reasoning_effort.is_some_and(|effort| effort != "off")
+            || default_reasoning_effort.as_deref() != Some("off"))
+    {
+        return Err(AppError::InvalidInput(
+            "DeepSeek Harness thinking=disabled requires reasoning effort off".to_string(),
+        ));
+    }
+
+    validate_positive_integer(profile.get("maxTokens"), "maxTokens")?;
+    validate_positive_integer(profile.get("defaultContextWindow"), "defaultContextWindow")?;
+    if let Some(value) = profile.get("streamIdleTimeoutMs") {
+        let timeout = value.as_f64().filter(|value| value.is_finite());
+        if timeout.is_none_or(|value| value <= 0.0 || value > i32::MAX as f64) {
+            return Err(AppError::InvalidInput(format!(
+                "DeepSeek Harness streamIdleTimeoutMs must be positive and no greater than {}",
+                i32::MAX
+            )));
+        }
+    }
+    validate_retry_policy(profile.get("retryPolicy"))?;
+    validate_models(profile.get("models"))?;
+    Ok(PreparedConfig {
+        profile: JsonValue::Object(profile),
+        default_model,
+        default_reasoning_effort,
+        credential_action,
+        api_key_env,
+    })
+}
+
+fn required_private_string(
+    object: &mut serde_json::Map<String, JsonValue>,
+    key: &str,
+    label: &str,
+) -> Result<String, AppError> {
+    match object.remove(key) {
+        Some(JsonValue::String(value)) if !value.trim().is_empty() => Ok(value.trim().to_string()),
+        _ => Err(AppError::InvalidInput(format!(
+            "DeepSeek Harness {label} is required"
+        ))),
+    }
+}
+
+fn optional_private_string(
+    object: &mut serde_json::Map<String, JsonValue>,
+    key: &str,
+    label: &str,
+) -> Result<Option<String>, AppError> {
+    match object.remove(key) {
+        None | Some(JsonValue::Null) => Ok(None),
+        Some(JsonValue::String(value)) if value.trim().is_empty() => Ok(None),
+        Some(JsonValue::String(value)) => Ok(Some(value.trim().to_string())),
+        Some(_) => Err(AppError::InvalidInput(format!(
+            "DeepSeek Harness {label} must be a string"
+        ))),
+    }
+}
+
+fn validate_models(models: Option<&JsonValue>) -> Result<(), AppError> {
+    let Some(models) = models else {
+        return Ok(());
+    };
+    let entries = models.as_array().ok_or_else(|| {
+        AppError::InvalidInput("DeepSeek Harness models must be an array".to_string())
+    })?;
+    let mut seen = HashSet::new();
+    for (index, entry) in entries.iter().enumerate() {
+        let object = entry.as_object().ok_or_else(|| {
+            AppError::InvalidInput(format!(
+                "DeepSeek Harness model at index {index} must be an object"
+            ))
+        })?;
+        let id = entry
+            .as_object()
+            .and_then(|item| item.get("id"))
+            .and_then(JsonValue::as_str)
+            .map(str::trim)
+            .filter(|id| !id.is_empty())
+            .ok_or_else(|| {
+                AppError::InvalidInput(format!(
+                    "DeepSeek Harness model at index {index} must have a non-empty id"
+                ))
+            })?;
+        if id.chars().any(char::is_control) {
+            return Err(AppError::InvalidInput(format!(
+                "DeepSeek Harness model '{id}' contains control characters"
+            )));
+        }
+        if !seen.insert(id.to_string()) {
+            return Err(AppError::InvalidInput(format!(
+                "DeepSeek Harness model id '{id}' is duplicated"
+            )));
+        }
+        for key in ["name", "description"] {
+            if let Some(value) = object.get(key) {
+                if !value.is_string() || key == "name" && value.as_str() == Some("") {
+                    return Err(AppError::InvalidInput(format!(
+                        "DeepSeek Harness model '{id}' {key} must be a{} string",
+                        if key == "name" { " non-empty" } else { "" }
+                    )));
+                }
+            }
+        }
+        for key in ["contextWindow", "maxTokens"] {
+            validate_positive_integer(object.get(key), &format!("model '{id}' {key}"))?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_positive_integer(value: Option<&JsonValue>, label: &str) -> Result<(), AppError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    if value
+        .as_u64()
+        .is_none_or(|number| number == 0 || number > MAX_SAFE_INTEGER)
+    {
+        return Err(AppError::InvalidInput(format!(
+            "DeepSeek Harness {label} must be a positive JavaScript-safe integer"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_retry_policy(value: Option<&JsonValue>) -> Result<(), AppError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let object = value.as_object().ok_or_else(|| {
+        AppError::InvalidInput("DeepSeek Harness retryPolicy must be an object".to_string())
+    })?;
+    let mode = object.get("mode").and_then(JsonValue::as_str);
+    let allowed: &[&str] = match mode {
+        Some("normal") => &["mode", "maxRetries", "retryableCodes", "backoff"],
+        Some("always") => &["mode", "backoff"],
+        _ => {
+            return Err(AppError::InvalidInput(
+                "DeepSeek Harness retryPolicy.mode must be normal or always".to_string(),
+            ))
+        }
+    };
+    if let Some(key) = object.keys().find(|key| !allowed.contains(&key.as_str())) {
+        return Err(AppError::InvalidInput(format!(
+            "DeepSeek Harness retryPolicy has unknown key '{key}'"
+        )));
+    }
+    if mode == Some("normal") {
+        if let Some(retries) = object.get("maxRetries") {
+            if retries
+                .as_u64()
+                .is_none_or(|retries| retries > MAX_SAFE_INTEGER)
+            {
+                return Err(AppError::InvalidInput(
+                    "DeepSeek Harness retryPolicy.maxRetries must be a non-negative JavaScript-safe integer".to_string(),
+                ));
+            }
+        }
+        if let Some(codes) = object.get("retryableCodes") {
+            let codes = codes
+                .as_array()
+                .filter(|codes| !codes.is_empty())
+                .ok_or_else(|| {
+                    AppError::InvalidInput(
+                        "DeepSeek Harness retryPolicy.retryableCodes must be a non-empty array"
+                            .to_string(),
+                    )
+                })?;
+            let mut seen = HashSet::new();
+            if codes.iter().any(|code| {
+                code.as_str()
+                    .filter(|code| !code.is_empty())
+                    .is_none_or(|code| !seen.insert(code))
+            }) {
+                return Err(AppError::InvalidInput(
+                    "DeepSeek Harness retryPolicy.retryableCodes must contain unique non-empty strings"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    if let Some(backoff) = object.get("backoff") {
+        let backoff = backoff.as_object().ok_or_else(|| {
+            AppError::InvalidInput(
+                "DeepSeek Harness retryPolicy.backoff must be an object".to_string(),
+            )
+        })?;
+        let allowed = ["initialDelayMs", "maxDelayMs", "jitterRatio"];
+        if let Some(key) = backoff.keys().find(|key| !allowed.contains(&key.as_str())) {
+            return Err(AppError::InvalidInput(format!(
+                "DeepSeek Harness retryPolicy.backoff has unknown key '{key}'"
+            )));
+        }
+        let initial = validate_timer(backoff.get("initialDelayMs"), "initialDelayMs")?;
+        let maximum = validate_timer(backoff.get("maxDelayMs"), "maxDelayMs")?;
+        if initial
+            .zip(maximum)
+            .is_some_and(|(initial, maximum)| initial > maximum)
+        {
+            return Err(AppError::InvalidInput(
+                "DeepSeek Harness retryPolicy initialDelayMs must not exceed maxDelayMs"
+                    .to_string(),
+            ));
+        }
+        if let Some(jitter) = backoff.get("jitterRatio") {
+            if jitter
+                .as_f64()
+                .filter(|value| value.is_finite())
+                .is_none_or(|value| !(0.0..=1.0).contains(&value))
+            {
+                return Err(AppError::InvalidInput(
+                    "DeepSeek Harness retryPolicy jitterRatio must be between 0 and 1".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_timer(value: Option<&JsonValue>, label: &str) -> Result<Option<f64>, AppError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let value = value.as_f64().filter(|value| value.is_finite());
+    if value.is_none_or(|value| value <= 0.0 || value > i32::MAX as f64) {
+        return Err(AppError::InvalidInput(format!(
+            "DeepSeek Harness retryPolicy {label} must be positive and no greater than {}",
+            i32::MAX
+        )));
+    }
+    Ok(value)
+}
+
+fn validate_credential_ref(value: &str) -> Result<(), AppError> {
+    let mut chars = value.chars();
+    let valid_first = chars
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic());
+    if !valid_first || !chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric()) {
+        return Err(AppError::InvalidInput(format!(
+            "DeepSeek Harness credential reference '{value}' must be a POSIX identifier"
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct DshSelection {
+    provider: Option<String>,
+    model: Option<String>,
+    reasoning_effort: Option<String>,
+}
+
+fn read_selection(root: &YamlMapping, path: &Path) -> Result<Option<DshSelection>, AppError> {
+    let selection_key = YamlValue::String(DEFAULT_MODEL_SECTION.to_string());
+    let Some(value) = root.get(&selection_key) else {
+        return Ok(None);
+    };
+    let mapping = value.as_mapping().ok_or_else(|| {
+        AppError::Config(format!(
+            "DeepSeek Harness section '{DEFAULT_MODEL_SECTION}' must be a mapping in {}",
+            path.display()
+        ))
+    })?;
+    Ok(Some(DshSelection {
+        provider: optional_yaml_string(mapping, "provider", path)?,
+        model: optional_yaml_string(mapping, "model", path)?,
+        reasoning_effort: optional_yaml_string(mapping, "reasoningEffort", path)?,
+    }))
+}
+
+fn optional_yaml_string(
+    mapping: &YamlMapping,
+    key: &str,
+    path: &Path,
+) -> Result<Option<String>, AppError> {
+    let yaml_key = YamlValue::String(key.to_string());
+    match mapping.get(&yaml_key) {
+        None | Some(YamlValue::Null) => Ok(None),
+        Some(YamlValue::String(value)) if !value.trim().is_empty() => {
+            Ok(Some(value.trim().to_string()))
+        }
+        Some(YamlValue::String(_)) => Ok(None),
+        Some(_) => Err(AppError::Config(format!(
+            "DeepSeek Harness setting '{DEFAULT_MODEL_SECTION}.{key}' must be a string in {}",
+            path.display()
+        ))),
+    }
+}
+
+fn parse_settings_document(raw: &str, path: &Path) -> Result<YamlMapping, AppError> {
+    if raw.trim().is_empty() {
+        return Ok(YamlMapping::new());
+    }
+    let parsed: YamlValue = serde_yaml::from_str(raw).map_err(|_| {
+        AppError::Config(format!(
+            "Invalid DeepSeek Harness YAML document at {}",
+            path.display()
+        ))
+    })?;
+    parsed.as_mapping().cloned().ok_or_else(|| {
+        AppError::Config(format!(
+            "DeepSeek Harness settings at {} must be a mapping",
+            path.display()
+        ))
+    })
+}
+
+fn yaml_to_json(value: &YamlValue, context: &str) -> Result<JsonValue, AppError> {
+    serde_json::to_value(value).map_err(|e| {
+        AppError::Config(format!(
+            "Failed to convert DeepSeek Harness {context} to JSON: {e}"
+        ))
+    })
+}
+
+fn read_managed_credential(home: &Path, reference: &str) -> Result<Option<String>, AppError> {
+    let path = home.join(CREDENTIALS_FILENAME);
+    if !path.exists() {
+        return Ok(None);
+    }
+    assert_owner_only(&path)?;
+    let raw = fs::read_to_string(&path).map_err(|e| AppError::io(&path, e))?;
+    let values = parse_credentials_document(&raw, &path)?;
+    Ok(values
+        .get(YamlValue::String(reference.to_string()))
+        .and_then(YamlValue::as_str)
+        .map(ToOwned::to_owned))
+}
+
+fn prepare_managed_credential(
+    home: &Path,
+    reference: &str,
+    value: Option<&str>,
+) -> Result<Option<CredentialUpdate>, AppError> {
+    validate_credential_ref(reference)?;
+    let path = home.join(CREDENTIALS_FILENAME);
+    let previous = if path.exists() {
+        assert_owner_only(&path)?;
+        Some(fs::read(&path).map_err(|e| AppError::io(&path, e))?)
+    } else {
+        None
+    };
+    let raw = previous
+        .as_deref()
+        .map(|bytes| {
+            std::str::from_utf8(bytes).map(str::to_owned).map_err(|_| {
+                AppError::Config(format!(
+                    "DeepSeek Harness credentials at {} must be UTF-8",
+                    path.display()
+                ))
+            })
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let parsed = parse_credentials_document(&raw, &path)?;
+    let existing = parsed
+        .get(YamlValue::String(reference.to_string()))
+        .and_then(YamlValue::as_str);
+    if existing == value {
+        return Ok(None);
+    }
+    let next = match value {
+        Some(value) => replace_yaml_section(
+            &raw,
+            &parsed,
+            reference,
+            &YamlValue::String(value.to_string()),
+        )?,
+        None => remove_yaml_section(&raw, &parsed, reference)?,
+    };
+    parse_credentials_document(&next, &path)?;
+    Ok(Some(CredentialUpdate {
+        path,
+        previous,
+        next: next.into_bytes(),
+    }))
+}
+
+fn apply_credential_update(update: &CredentialUpdate) -> Result<(), AppError> {
+    write_private_atomic(&update.path, &update.next)
+}
+
+fn rollback_credential_update(update: &CredentialUpdate) -> Result<(), AppError> {
+    match update.previous.as_deref() {
+        Some(previous) => write_private_atomic(&update.path, previous),
+        None => {
+            if update.path.exists() {
+                fs::remove_file(&update.path).map_err(|e| AppError::io(&update.path, e))?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn parse_credentials_document(raw: &str, path: &Path) -> Result<YamlMapping, AppError> {
+    if raw.trim().is_empty() {
+        return Ok(YamlMapping::new());
+    }
+    let parsed: YamlValue = serde_yaml::from_str(raw).map_err(|_| {
+        // Parser diagnostics can quote the source line, which is a secret.
+        AppError::Config(format!(
+            "Invalid DeepSeek Harness credentials document at {}",
+            path.display()
+        ))
+    })?;
+    let mapping = parsed.as_mapping().cloned().ok_or_else(|| {
+        AppError::Config(format!(
+            "DeepSeek Harness credentials at {} must be a string mapping",
+            path.display()
+        ))
+    })?;
+    for (key, value) in &mapping {
+        let Some(key) = key.as_str() else {
+            return Err(AppError::Config(format!(
+                "DeepSeek Harness credentials at {} contain a non-string reference",
+                path.display()
+            )));
+        };
+        validate_credential_ref(key)?;
+        match value {
+            YamlValue::String(value) if !value.is_empty() => {}
+            _ => {
+                return Err(AppError::Config(format!(
+                    "DeepSeek Harness credential '{key}' at {} must be a non-empty string",
+                    path.display()
+                )))
+            }
+        }
+    }
+    Ok(mapping)
+}
+
+#[cfg(unix)]
+fn assert_owner_only(path: &Path) -> Result<(), AppError> {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = fs::metadata(path)
+        .map_err(|e| AppError::io(path, e))?
+        .permissions()
+        .mode();
+    if mode & 0o077 != 0 {
+        return Err(AppError::Config(format!(
+            "DeepSeek Harness credentials file {} must have mode 0600",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn assert_owner_only(_path: &Path) -> Result<(), AppError> {
+    Ok(())
+}
+
+fn ensure_private_home(home: &Path) -> Result<(), AppError> {
+    fs::create_dir_all(home).map_err(|e| AppError::io(home, e))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(home, fs::Permissions::from_mode(0o700))
+            .map_err(|e| AppError::io(home, e))?;
+    }
+    Ok(())
+}
+
+fn write_settings_atomic(path: &Path, contents: &[u8]) -> Result<(), AppError> {
+    if let Some(home) = path.parent() {
+        ensure_private_home(home)?;
+    }
+    write_owner_only_atomic(path, contents)
+}
+
+fn write_private_atomic(path: &Path, contents: &[u8]) -> Result<(), AppError> {
+    if let Some(home) = path.parent() {
+        ensure_private_home(home)?;
+    }
+    write_owner_only_atomic(path, contents)?;
+    assert_owner_only(path)
+}
+
+/// Atomically replace a Harness-owned document without ever materializing its
+/// contents in a group/world-readable temporary file. On Windows the shared
+/// writer already uses `ReplaceFileW` (with its WSL-UNC fallback), so retain
+/// that replacement path; POSIX needs an explicit mode on the initial
+/// `create_new` because chmod-after-rename leaves a crash-persistent exposure
+/// window for credentials.
+fn write_owner_only_atomic(path: &Path, contents: &[u8]) -> Result<(), AppError> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+
+        let parent = path.parent().ok_or_else(|| {
+            AppError::Config("DeepSeek Harness document path has no parent".to_string())
+        })?;
+        let file_name = path.file_name().ok_or_else(|| {
+            AppError::Config("DeepSeek Harness document path has no filename".to_string())
+        })?;
+        static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+
+        let mut last_collision = None;
+        let (temporary, mut file) = (|| {
+            for _ in 0..16 {
+                let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+                let mut temporary_name = file_name.to_os_string();
+                temporary_name.push(format!(".tmp.{}.{timestamp}.{counter}", std::process::id()));
+                let candidate = parent.join(temporary_name);
+                match fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .mode(0o600)
+                    .open(&candidate)
+                {
+                    Ok(file) => return Ok((candidate, file)),
+                    Err(source) if source.kind() == ErrorKind::AlreadyExists => {
+                        last_collision = Some((candidate, source));
+                    }
+                    Err(source) => return Err(AppError::io(&candidate, source)),
+                }
+            }
+
+            let (candidate, source) =
+                last_collision.expect("owner-only temporary filename loop must run");
+            Err(AppError::io(&candidate, source))
+        })()?;
+
+        if let Err(source) = file.write_all(contents).and_then(|_| file.flush()) {
+            drop(file);
+            let _ = fs::remove_file(&temporary);
+            return Err(AppError::io(&temporary, source));
+        }
+        drop(file);
+        if let Err(source) = fs::rename(&temporary, path) {
+            let _ = fs::remove_file(&temporary);
+            return Err(AppError::IoContext {
+                context: format!(
+                    "Failed to atomically replace DeepSeek Harness document: {} -> {}",
+                    temporary.display(),
+                    path.display()
+                ),
+                source,
+            });
+        }
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    atomic_write(path, contents)
+}
+
+fn is_top_level_key_line(line: &str) -> bool {
+    if line.is_empty() || matches!(line.as_bytes()[0], b' ' | b'\t' | b'#' | b'-') {
+        return false;
+    }
+    line.find(':').is_some_and(|position| {
+        let after = &line[position + 1..];
+        after.is_empty() || after.starts_with([' ', '\t', '\r', '\n'])
+    })
+}
+
+fn line_has_key(line: &str, key: &str) -> bool {
+    if !is_top_level_key_line(line) {
+        return false;
+    }
+    let before = line[..line.find(':').expect("checked colon")].trim_end();
+    before == key || before == format!("'{key}'") || before == format!("\"{key}\"")
+}
+
+fn find_yaml_section_range(raw: &str, key: &str) -> Option<(usize, usize)> {
+    let mut start = None;
+    let mut offset = 0;
+    for line in raw.split_inclusive('\n') {
+        if start.is_none() && line_has_key(line, key) {
+            start = Some(offset);
+        } else if let Some(section_start) = start {
+            if is_top_level_key_line(line) {
+                return Some((
+                    section_start,
+                    trailing_comment_start(raw, section_start, offset),
+                ));
+            }
+        }
+        offset += line.len();
+    }
+    start.map(|section_start| {
+        (
+            section_start,
+            trailing_comment_start(raw, section_start, raw.len()),
+        )
+    })
+}
+
+fn trailing_comment_start(raw: &str, start: usize, boundary: usize) -> usize {
+    let mut offset = start;
+    let mut last_content_end = start;
+    for line in raw[start..boundary].split_inclusive('\n') {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() && !trimmed.starts_with('#') {
+            last_content_end = offset + line.len();
+        }
+        offset += line.len();
+    }
+    last_content_end
+}
+
+fn serialize_yaml_section(key: &str, value: &YamlValue) -> Result<String, AppError> {
+    let mut section = YamlMapping::new();
+    section.insert(YamlValue::String(key.to_string()), value.clone());
+    serde_yaml::to_string(&YamlValue::Mapping(section)).map_err(|e| {
+        AppError::Config(format!(
+            "Failed to serialize DeepSeek Harness YAML section '{key}': {e}"
+        ))
+    })
+}
+
+/// Patch direct children of an existing top-level mapping without rebuilding
+/// the whole section. Existing child text is retained byte-for-byte when its
+/// semantic value is unchanged; changed leaves/subtrees replace only their
+/// own child block, new children append, and removed children are deleted.
+/// This keeps comments, quoting, key order, and formatting for every untouched
+/// setting. A missing section still uses the canonical serializer.
+fn patch_top_level_mapping_section(
+    raw: &str,
+    parsed: &YamlMapping,
+    section_key: &str,
+    value: &YamlValue,
+) -> Result<String, AppError> {
+    let target = value.as_mapping().ok_or_else(|| {
+        AppError::Config(format!(
+            "DeepSeek Harness YAML section '{section_key}' must be a mapping"
+        ))
+    })?;
+    let Some((section_start, section_end)) = find_yaml_section_range(raw, section_key) else {
+        return replace_yaml_section(raw, parsed, section_key, value);
+    };
+    let existing = parsed
+        .get(YamlValue::String(section_key.to_string()))
+        .and_then(YamlValue::as_mapping)
+        .ok_or_else(|| {
+            AppError::Config(format!(
+                "DeepSeek Harness YAML section '{section_key}' must be a mapping"
+            ))
+        })?;
+
+    let section = &raw[section_start..section_end];
+    let children = find_mapping_child_ranges(section, section_key)?;
+    let existing_keys = existing
+        .keys()
+        .map(|key| {
+            key.as_str().ok_or_else(|| {
+                AppError::Config(format!(
+                    "DeepSeek Harness YAML section '{section_key}' contains a non-string key"
+                ))
+            })
+        })
+        .collect::<Result<HashSet<_>, _>>()?;
+    let located_keys = children
+        .iter()
+        .map(|child| child.key.as_str())
+        .collect::<HashSet<_>>();
+    if existing_keys != located_keys {
+        return Err(AppError::Config(format!(
+            "DeepSeek Harness YAML section '{section_key}' uses unsupported child-key formatting"
+        )));
+    }
+    let mut rendered = section.to_string();
+
+    // Work backwards so byte ranges remain valid. Only direct string keys are
+    // supported by Harness' settings schemas; fail closed for exotic YAML.
+    for child in children.iter().rev() {
+        let yaml_key = YamlValue::String(child.key.clone());
+        match target.get(&yaml_key) {
+            Some(next_value) if existing.get(&yaml_key) == Some(next_value) => {}
+            Some(next_value) => {
+                let replacement = serialize_yaml_child(&child.key, next_value, child.indent)?;
+                rendered.replace_range(child.key_start..child.end, &replacement);
+            }
+            None => rendered.replace_range(child.start..child.end, ""),
+        }
+    }
+
+    let child_indent = children.first().map_or(2, |child| child.indent);
+    let mut additions = String::new();
+    for (key, next_value) in target {
+        let key = key.as_str().ok_or_else(|| {
+            AppError::Config(format!(
+                "DeepSeek Harness YAML section '{section_key}' contains a non-string key"
+            ))
+        })?;
+        if !located_keys.contains(key) {
+            additions.push_str(&serialize_yaml_child(key, next_value, child_indent)?);
+        }
+    }
+    if !additions.is_empty() {
+        if !rendered.ends_with('\n') {
+            rendered.push('\n');
+        }
+        rendered.push_str(&additions);
+    }
+
+    let mut result = String::with_capacity(raw.len() + rendered.len());
+    result.push_str(&raw[..section_start]);
+    result.push_str(&rendered);
+    result.push_str(&raw[section_end..]);
+    Ok(result)
+}
+
+#[derive(Debug)]
+struct YamlChildRange {
+    key: String,
+    indent: usize,
+    key_start: usize,
+    start: usize,
+    end: usize,
+}
+
+fn find_mapping_child_ranges(
+    section: &str,
+    section_key: &str,
+) -> Result<Vec<YamlChildRange>, AppError> {
+    let first_line_end = section.find('\n').map_or(section.len(), |index| index + 1);
+    let header = &section[..first_line_end];
+    let header_colon = header.find(':').ok_or_else(|| {
+        AppError::Config(format!(
+            "DeepSeek Harness YAML section '{section_key}' has no mapping delimiter"
+        ))
+    })?;
+    if !header[header_colon + 1..].trim().is_empty() {
+        return Err(AppError::Config(format!(
+            "DeepSeek Harness YAML section '{section_key}' uses unsupported inline formatting"
+        )));
+    }
+    let body = &section[first_line_end..];
+    let indent = body
+        .split_inclusive('\n')
+        .find_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                return None;
+            }
+            let leading = line.len() - line.trim_start_matches([' ', '\t']).len();
+            (leading > 0).then_some(leading)
+        })
+        .unwrap_or(2);
+
+    let mut starts = Vec::<(String, usize, usize)>::new();
+    let mut pending_comment_start = None;
+    let mut offset = first_line_end;
+    for line in body.split_inclusive('\n') {
+        let trimmed = line.trim();
+        if let Some(key) = mapping_key_at_indent(line, indent) {
+            let key_start = offset;
+            let owned_start = pending_comment_start.unwrap_or(offset);
+            starts.push((key, owned_start, key_start));
+            pending_comment_start = None;
+        } else if trimmed.is_empty() {
+            pending_comment_start = None;
+        } else if trimmed.starts_with('#') {
+            pending_comment_start.get_or_insert(offset);
+        } else {
+            pending_comment_start = None;
+        }
+        offset += line.len();
+    }
+
+    let mut ranges = Vec::with_capacity(starts.len());
+    for (index, (key, start, key_start)) in starts.iter().enumerate() {
+        if ranges
+            .iter()
+            .any(|range: &YamlChildRange| range.key == *key)
+        {
+            return Err(AppError::Config(format!(
+                "DeepSeek Harness YAML section '{section_key}' contains duplicate key '{key}'"
+            )));
+        }
+        let boundary = starts
+            .get(index + 1)
+            .map_or(section.len(), |(_, start, _)| *start);
+        ranges.push(YamlChildRange {
+            key: key.clone(),
+            indent,
+            key_start: *key_start,
+            start: *start,
+            end: trailing_comment_start(section, *start, boundary),
+        });
+    }
+    Ok(ranges)
+}
+
+fn mapping_key_at_indent(line: &str, indent: usize) -> Option<String> {
+    let without_newline = line.trim_end_matches(['\r', '\n']);
+    let leading = without_newline.len() - without_newline.trim_start_matches([' ', '\t']).len();
+    if leading != indent {
+        return None;
+    }
+    let content = &without_newline[leading..];
+    if content.is_empty() || content.starts_with(['#', '-']) {
+        return None;
+    }
+    let colon = content.find(':')?;
+    let after = &content[colon + 1..];
+    if !after.is_empty() && !after.starts_with([' ', '\t']) {
+        return None;
+    }
+    let raw_key = content[..colon].trim_end();
+    if raw_key.is_empty() {
+        return None;
+    }
+    if let Some(quoted) = raw_key
+        .strip_prefix('\'')
+        .and_then(|key| key.strip_suffix('\''))
+    {
+        return Some(quoted.replace("''", "'"));
+    }
+    if let Some(quoted) = raw_key
+        .strip_prefix('"')
+        .and_then(|key| key.strip_suffix('"'))
+    {
+        return serde_yaml::from_str::<String>(raw_key)
+            .ok()
+            .or_else(|| Some(quoted.to_string()));
+    }
+    Some(raw_key.to_string())
+}
+
+fn serialize_yaml_child(key: &str, value: &YamlValue, indent: usize) -> Result<String, AppError> {
+    let serialized = serialize_yaml_section(key, value)?;
+    let padding = " ".repeat(indent);
+    let mut output = String::with_capacity(serialized.len() + indent * 2);
+    for line in serialized.split_inclusive('\n') {
+        output.push_str(&padding);
+        output.push_str(line);
+    }
+    if !output.ends_with('\n') {
+        output.push('\n');
+    }
+    Ok(output)
+}
+
+fn replace_yaml_section(
+    raw: &str,
+    parsed: &YamlMapping,
+    key: &str,
+    value: &YamlValue,
+) -> Result<String, AppError> {
+    let serialized = serialize_yaml_section(key, value)?;
+    if let Some((start, end)) = find_yaml_section_range(raw, key) {
+        let mut result = String::with_capacity(raw.len() + serialized.len());
+        result.push_str(&raw[..start]);
+        result.push_str(&serialized);
+        result.push_str(&raw[end..]);
+        return Ok(result);
+    }
+
+    if parsed.contains_key(YamlValue::String(key.to_string())) {
+        return Err(AppError::Config(format!(
+            "DeepSeek Harness YAML key '{key}' uses unsupported formatting; edit it to a plain or quoted top-level key before switching"
+        )));
+    }
+    let mut result = raw.to_string();
+    if !result.is_empty() && !result.ends_with('\n') {
+        result.push('\n');
+    }
+    result.push_str(&serialized);
+    if !result.ends_with('\n') {
+        result.push('\n');
+    }
+    Ok(result)
+}
+
+fn remove_yaml_section(raw: &str, parsed: &YamlMapping, key: &str) -> Result<String, AppError> {
+    if let Some((start, end)) = find_yaml_section_range(raw, key) {
+        let mut result = String::with_capacity(raw.len() - (end - start));
+        result.push_str(&raw[..start]);
+        result.push_str(&raw[end..]);
+        return Ok(result);
+    }
+    if parsed.contains_key(YamlValue::String(key.to_string())) {
+        return Err(AppError::Config(format!(
+            "DeepSeek Harness YAML key '{key}' uses unsupported formatting; edit it to a plain or quoted top-level key before switching"
+        )));
+    }
+    Ok(raw.to_string())
+}
+
+fn create_settings_backup(root: &Path, source: &str) -> Result<PathBuf, AppError> {
+    // Backups contain the entire settings document, including namespaces CC
+    // Switch does not own and which may carry personal values. Give them the
+    // same owner-only creation contract as the native document.
+    ensure_private_home(root)?;
+    let base = format!("settings_{}", Local::now().format("%Y%m%d_%H%M%S"));
+    let mut path = root.join(format!("{base}.yaml"));
+    let mut counter = 1;
+    while path.exists() {
+        path = root.join(format!("{base}_{counter}.yaml"));
+        counter += 1;
+    }
+    write_owner_only_atomic(&path, source.as_bytes())?;
+    cleanup_settings_backups(root)?;
+    Ok(path)
+}
+
+fn cleanup_settings_backups(root: &Path) -> Result<(), AppError> {
+    let retain = effective_backup_retain_count();
+    let mut entries = fs::read_dir(root)
+        .map_err(|e| AppError::io(root, e))?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "yaml"))
+        .collect::<Vec<_>>();
+    if entries.len() <= retain {
+        return Ok(());
+    }
+    entries.sort_by_key(|entry| entry.metadata().and_then(|meta| meta.modified()).ok());
+    let remove_count = entries.len() - retain;
+    for entry in entries.into_iter().take(remove_count) {
+        if let Err(error) = fs::remove_file(entry.path()) {
+            log::warn!(
+                "Failed to remove old DeepSeek Harness backup {}: {error}",
+                entry.path().display()
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn write_private(path: &Path, contents: &str) {
+        fs::write(path, contents).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_documents_are_owner_only_from_initial_atomic_create() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "apiKey": "secret-value",
+                "defaultModel": "deepseek-v4-flash"
+            }),
+        )
+        .unwrap();
+
+        for filename in [SETTINGS_FILENAME, CREDENTIALS_FILENAME] {
+            let path = temp.path().join(filename);
+            assert_eq!(
+                fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o600,
+                "{filename} must be created owner-only"
+            );
+        }
+    }
+
+    #[test]
+    fn writes_native_sections_credentials_and_preserves_unrelated_text() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(SETTINGS_FILENAME),
+            "# header\ntelemetry:\n  enabled: false\n\n# keep this comment\nother: value\n",
+        )
+        .unwrap();
+        write_private(
+            &temp.path().join(CREDENTIALS_FILENAME),
+            "# managed store\nOTHER_KEY: keep-me\n",
+        );
+
+        write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "apiKey": "secret-value",
+                "defaultModel": "deepseek-v4-pro",
+                "defaultReasoningEffort": "max",
+                "apiKeyEnv": "TEAM_DEEPSEEK_KEY",
+                "baseURL": "https://gateway.example",
+                "futureField": { "enabled": true }
+            }),
+        )
+        .unwrap();
+
+        let settings = fs::read_to_string(temp.path().join(SETTINGS_FILENAME)).unwrap();
+        assert!(settings.contains("# header"));
+        assert!(settings.contains("# keep this comment"));
+        assert!(settings.contains("telemetry:"));
+        assert!(settings.contains("futureField:"));
+        assert!(!settings.contains("apiKey:"));
+        assert!(!settings.contains("defaultModel:"));
+        assert!(settings.contains("provider: deepseek-official"));
+        assert!(settings.contains("model: deepseek-v4-pro"));
+        assert!(settings.contains("reasoningEffort: max"));
+
+        let credentials = fs::read_to_string(temp.path().join(CREDENTIALS_FILENAME)).unwrap();
+        assert!(credentials.contains("# managed store"));
+        assert!(credentials.contains("OTHER_KEY: keep-me"));
+        let parsed =
+            parse_credentials_document(&credentials, &temp.path().join(CREDENTIALS_FILENAME))
+                .unwrap();
+        assert_eq!(
+            parsed
+                .get(YamlValue::String("TEAM_DEEPSEEK_KEY".to_string()))
+                .and_then(YamlValue::as_str),
+            Some("secret-value")
+        );
+    }
+
+    #[test]
+    fn reads_snapshot_without_exposing_environment_only_secret() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(SETTINGS_FILENAME),
+            "llm-deepseek:\n  apiKeyEnv: TEST_ENV_ONLY_KEY\n  baseURL: https://api.example\nagent-default-model:\n  provider: deepseek-official\n  model: model-a\n",
+        )
+        .unwrap();
+        std::env::set_var("TEST_ENV_ONLY_KEY", "must-not-leak");
+        let snapshot = read_live_config_at(Some(temp.path())).unwrap().unwrap();
+        std::env::remove_var("TEST_ENV_ONLY_KEY");
+
+        assert_eq!(snapshot["defaultModel"], "model-a");
+        assert_eq!(snapshot["baseURL"], "https://api.example");
+        assert!(snapshot.get("apiKey").is_none());
+    }
+
+    #[test]
+    fn reads_provider_only_override_with_bundled_default_model() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(SETTINGS_FILENAME),
+            "llm-deepseek:\n  baseURL: https://api.example\nagent-default-model:\n  provider: deepseek-official\n",
+        )
+        .unwrap();
+
+        let snapshot = read_live_config_at(Some(temp.path())).unwrap().unwrap();
+
+        assert_eq!(snapshot["defaultModel"], DEFAULT_MODEL_ID);
+        assert_eq!(snapshot["baseURL"], "https://api.example");
+    }
+
+    #[test]
+    fn reads_model_only_override_with_bundled_official_provider() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(SETTINGS_FILENAME),
+            "agent-default-model:\n  model: private-model\n",
+        )
+        .unwrap();
+
+        let snapshot = read_live_config_at(Some(temp.path())).unwrap().unwrap();
+
+        assert_eq!(snapshot["defaultModel"], "private-model");
+    }
+
+    #[test]
+    fn reads_provider_override_without_selection_from_bundled_base() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(SETTINGS_FILENAME),
+            "llm-deepseek:\n  baseURL: https://api.example\n",
+        )
+        .unwrap();
+
+        let snapshot = read_live_config_at(Some(temp.path())).unwrap().unwrap();
+
+        assert_eq!(snapshot["defaultModel"], DEFAULT_MODEL_ID);
+        assert_eq!(snapshot["baseURL"], "https://api.example");
+    }
+
+    #[test]
+    fn read_round_trips_managed_secret_and_unknown_profile_fields() {
+        let temp = tempfile::tempdir().unwrap();
+        let input = json!({
+            "apiKey": "stored-secret",
+            "defaultModel": "private-model",
+            "apiKeyEnv": "TEST_MANAGED_KEY",
+            "models": [{ "id": "private-model", "description": "custom" }],
+            "newHarnessOption": [1, 2, 3]
+        });
+        write_live_config_at(Some(temp.path()), &input).unwrap();
+        let actual = read_live_config_at(Some(temp.path())).unwrap().unwrap();
+        assert_eq!(actual, input);
+        assert_eq!(
+            get_current_model_at(Some(temp.path())).unwrap().as_deref(),
+            Some("private-model")
+        );
+    }
+
+    #[test]
+    fn replacing_owned_sections_preserves_unrelated_sections_and_comments() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(SETTINGS_FILENAME),
+            "llm-deepseek:\n  baseURL: https://old.example\n\n# belongs to unrelated section\nlogging:\n  level: debug\nagent-default-model:\n  provider: another-route\n  model: old\n# trailing note\n",
+        )
+        .unwrap();
+        write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "defaultModel": "new-model",
+                "baseURL": "https://new.example"
+            }),
+        )
+        .unwrap();
+        let actual = fs::read_to_string(temp.path().join(SETTINGS_FILENAME)).unwrap();
+        assert!(actual.contains("# belongs to unrelated section\nlogging:"));
+        assert!(actual.contains("level: debug"));
+        assert!(actual.contains("# trailing note"));
+        assert!(!actual.contains("https://old.example"));
+        assert!(!actual.contains("model: old"));
+    }
+
+    #[test]
+    fn patches_owned_children_without_reformatting_unchanged_keys_or_comments() {
+        let temp = tempfile::tempdir().unwrap();
+        let original = concat!(
+            "llm-deepseek:\n",
+            "  # endpoint chosen by ops\n",
+            "  baseURL: 'https://old.example' # replace this leaf\n",
+            "  maxTokens: 0x3e800 # preserve numeric formatting\n",
+            "  models: [ { id: deepseek-v4-pro } ] # preserve flow style\n",
+            "  # preserve this retry note\n",
+            "  retryPolicy: { mode: always }\n",
+            "agent-default-model:\n",
+            "  provider: 'deepseek-official' # keep provider formatting\n",
+            "  # selected deployment\n",
+            "  model: 'old-model'\n",
+            "  reasoningEffort: max # unchanged leaf\n",
+        );
+        fs::write(temp.path().join(SETTINGS_FILENAME), original).unwrap();
+
+        write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "defaultModel": "new-model",
+                "defaultReasoningEffort": "max",
+                "baseURL": "https://new.example",
+                "maxTokens": 256000,
+                "models": [{ "id": "deepseek-v4-pro" }],
+                "retryPolicy": { "mode": "always" }
+            }),
+        )
+        .unwrap();
+
+        let actual = fs::read_to_string(temp.path().join(SETTINGS_FILENAME)).unwrap();
+        assert!(actual.contains("  # endpoint chosen by ops\n"));
+        assert!(actual.contains("  maxTokens: 0x3e800 # preserve numeric formatting\n"));
+        assert!(actual.contains("  models: [ { id: deepseek-v4-pro } ] # preserve flow style\n"));
+        assert!(actual.contains("  # preserve this retry note\n"));
+        assert!(actual.contains("  retryPolicy: { mode: always }\n"));
+        assert!(actual.contains("  provider: 'deepseek-official' # keep provider formatting\n"));
+        assert!(actual.contains("  # selected deployment\n"));
+        assert!(actual.contains("  reasoningEffort: max # unchanged leaf\n"));
+        assert!(!actual.contains("https://old.example"));
+        assert!(!actual.contains("model: 'old-model'"));
+    }
+
+    #[test]
+    fn keep_credential_action_does_not_wait_for_credentials_lock() {
+        let temp = tempfile::tempdir().unwrap();
+        ensure_private_home(temp.path()).unwrap();
+        let credentials_lock = acquire_file_lock(&temp.path().join(CREDENTIALS_FILENAME)).unwrap();
+
+        write_live_config_at(
+            Some(temp.path()),
+            &json!({ "defaultModel": "deepseek-v4-flash" }),
+        )
+        .expect("settings-only writes must not acquire the credentials lock");
+
+        drop(credentials_lock);
+        assert!(temp.path().join(SETTINGS_FILENAME).exists());
+    }
+
+    #[test]
+    fn rejects_invalid_model_catalog_without_touching_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "defaultModel": "model-a",
+                "models": [{ "id": "model-a" }, { "id": "model-a" }]
+            }),
+        );
+        assert!(result.is_err());
+        assert!(!temp.path().join(SETTINGS_FILENAME).exists());
+        assert!(!temp.path().join(CREDENTIALS_FILENAME).exists());
+    }
+
+    #[test]
+    fn rejects_invalid_retry_policy_and_unsafe_integers_before_writing() {
+        let temp = tempfile::tempdir().unwrap();
+        for input in [
+            json!({
+                "defaultModel": "model-a",
+                "maxTokens": MAX_SAFE_INTEGER + 1
+            }),
+            json!({
+                "defaultModel": "model-a",
+                "retryPolicy": { "mode": "normal", "maxRetries": -1 }
+            }),
+            json!({
+                "defaultModel": "model-a",
+                "retryPolicy": {
+                    "mode": "normal",
+                    "backoff": { "initialDelayMs": 20, "maxDelayMs": 10 }
+                }
+            }),
+        ] {
+            assert!(write_live_config_at(Some(temp.path()), &input).is_err());
+        }
+        assert!(!temp.path().join(SETTINGS_FILENAME).exists());
+        assert!(!temp.path().join(CREDENTIALS_FILENAME).exists());
+    }
+
+    #[test]
+    fn current_model_is_none_when_another_provider_is_selected() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join(SETTINGS_FILENAME),
+            "llm-deepseek:\n  baseURL: https://api.example\nagent-default-model:\n  provider: custom-route\n  model: other-model\n",
+        )
+        .unwrap();
+        assert_eq!(get_current_model_at(Some(temp.path())).unwrap(), None);
+        assert_eq!(read_live_config_at(Some(temp.path())).unwrap(), None);
+    }
+
+    #[test]
+    fn profile_reasoning_effort_does_not_materialize_default_selection_effort() {
+        let temp = tempfile::tempdir().unwrap();
+        write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "defaultModel": "deepseek-v4-pro",
+                "reasoningEffort": "max"
+            }),
+        )
+        .unwrap();
+
+        let settings = fs::read_to_string(temp.path().join(SETTINGS_FILENAME)).unwrap();
+        assert_eq!(settings.matches("reasoningEffort: max").count(), 1);
+        let selection = settings
+            .split("agent-default-model:")
+            .nth(1)
+            .expect("default-model selection");
+        assert!(!selection.contains("reasoningEffort:"));
+    }
+
+    #[test]
+    fn disabled_thinking_rejects_non_off_effort_before_writing() {
+        let temp = tempfile::tempdir().unwrap();
+        let result = write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "defaultModel": "deepseek-v4-pro",
+                "thinking": "disabled",
+                "reasoningEffort": "high"
+            }),
+        );
+        assert!(result.is_err());
+        assert!(!temp.path().join(SETTINGS_FILENAME).exists());
+    }
+
+    #[test]
+    fn empty_api_key_unsets_only_the_managed_reference() {
+        let temp = tempfile::tempdir().unwrap();
+        write_private(
+            &temp.path().join(CREDENTIALS_FILENAME),
+            "DEEPSEEK_API_KEY: old-secret\nOTHER_KEY: keep-me\n",
+        );
+
+        write_live_config_at(
+            Some(temp.path()),
+            &json!({
+                "apiKey": "",
+                "defaultModel": "deepseek-v4-flash"
+            }),
+        )
+        .unwrap();
+
+        let credentials = fs::read_to_string(temp.path().join(CREDENTIALS_FILENAME)).unwrap();
+        assert!(!credentials.contains("DEEPSEEK_API_KEY"));
+        assert!(credentials.contains("OTHER_KEY: keep-me"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod commands;
 mod config;
 mod database;
 mod deeplink;
+mod dsh_config;
 mod error;
 mod gemini_config;
 mod gemini_mcp;

--- a/src-tauri/src/prompt_files.rs
+++ b/src-tauri/src/prompt_files.rs
@@ -10,7 +10,7 @@ use crate::opencode_config::get_opencode_dir;
 
 /// 返回指定应用所使用的提示词文件路径。
 pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
-    if matches!(app, AppType::ClaudeDesktop) {
+    if matches!(app, AppType::ClaudeDesktop | AppType::DeepSeekHarness) {
         return Err(AppError::localized(
             "app.prompts_unsupported",
             "当前应用暂不支持 Prompts",
@@ -28,6 +28,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
         AppType::Pi => crate::pi_config::get_pi_agent_dir()?,
         AppType::ClaudeDesktop => unreachable!("handled above"),
+        AppType::DeepSeekHarness => unreachable!("handled above"),
     };
 
     let filename = match app {
@@ -38,6 +39,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::Hermes => "SOUL.md",
         AppType::Pi => "AGENTS.md",
         AppType::ClaudeDesktop => unreachable!("handled above"),
+        AppType::DeepSeekHarness => unreachable!("handled above"),
     };
 
     Ok(base_dir.join(filename))

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -220,6 +220,8 @@ impl Provider {
                     str_at(options.and_then(|o| o.get("apiKey"))),
                 )
             }
+            // Native usage/proxy queries are intentionally unsupported for Harness.
+            AppType::DeepSeekHarness => (String::new(), String::new()),
             // Claude and Claude Desktop both use the Anthropic-style env map, keeping
             // the OpenRouter/Google key fallbacks the JS-script path relies on.
             // Listed explicitly (not `_`) so a new AppType fails to compile here.

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -208,7 +208,7 @@ impl ProviderType {
             }
             AppType::GrokBuild => ProviderType::Codex,
             AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => ProviderType::Codex,
-            AppType::Pi => return None,
+            AppType::Pi | AppType::DeepSeekHarness => return None,
         };
         Some(provider_type)
     }
@@ -264,7 +264,7 @@ pub fn get_adapter(app_type: &AppType) -> Option<Box<dyn ProviderAdapter>> {
         AppType::Gemini => Box::new(GeminiAdapter::new()),
         AppType::GrokBuild => Box::new(CodexAdapter::new()),
         AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => Box::new(CodexAdapter::new()),
-        AppType::Pi => return None,
+        AppType::Pi | AppType::DeepSeekHarness => return None,
     })
 }
 

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -89,6 +89,7 @@ impl ConfigService {
         Self::sync_current_provider_for_app(config, &AppType::Codex)?;
         Self::sync_current_provider_for_app(config, &AppType::Gemini)?;
         Self::sync_current_provider_for_app(config, &AppType::GrokBuild)?;
+        Self::sync_current_provider_for_app(config, &AppType::DeepSeekHarness)?;
         Ok(())
     }
 
@@ -141,6 +142,9 @@ impl ConfigService {
             AppType::Pi => {
                 // Pi owns its shared models/settings documents; this legacy
                 // single-provider live-sync path must not rewrite them.
+            }
+            AppType::DeepSeekHarness => {
+                crate::dsh_config::write_live_settings(&provider.settings_config)?;
             }
         }
 

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -146,6 +146,9 @@ impl McpService {
                 mcp::sync_single_server_to_hermes(&Default::default(), &server.id, &server.server)?;
             }
             AppType::Pi => {}
+            AppType::DeepSeekHarness => {
+                log::debug!("DeepSeek Harness MCP switching is not supported, skipping sync");
+            }
         }
         Ok(())
     }
@@ -183,6 +186,9 @@ impl McpService {
                 mcp::remove_server_from_hermes(id)?;
             }
             AppType::Pi => {}
+            AppType::DeepSeekHarness => {
+                log::debug!("DeepSeek Harness MCP switching is not supported, skipping remove");
+            }
         }
         Ok(())
     }
@@ -229,7 +235,7 @@ impl McpService {
     ) -> Result<(), AppError> {
         if matches!(
             app,
-            AppType::OpenClaw | AppType::ClaudeDesktop | AppType::Pi
+            AppType::OpenClaw | AppType::ClaudeDesktop | AppType::Pi | AppType::DeepSeekHarness
         ) {
             return Ok(());
         }

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -243,7 +243,10 @@ impl PromptService {
     pub fn sync_to_live(state: &AppState, app: AppType) -> Result<(), AppError> {
         // Pi derives activation from its native AGENTS.md; its persisted prompt
         // rows are intentionally disabled and must not drive generic projection.
-        if matches!(app, AppType::ClaudeDesktop | AppType::Pi) {
+        if matches!(
+            app,
+            AppType::ClaudeDesktop | AppType::Pi | AppType::DeepSeekHarness
+        ) {
             return Ok(());
         }
 
@@ -259,7 +262,7 @@ impl PromptService {
     pub fn sync_all_to_live(state: &AppState) -> Result<(), AppError> {
         let mut failures = Vec::new();
         for app in AppType::all() {
-            if matches!(app, AppType::ClaudeDesktop) {
+            if matches!(app, AppType::ClaudeDesktop | AppType::DeepSeekHarness) {
                 continue;
             }
             if let Err(error) = Self::sync_to_live(state, app.clone()) {

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -531,7 +531,8 @@ fn settings_contain_common_config(app_type: &AppType, settings: &Value, snippet:
         | AppType::OpenClaw
         | AppType::Hermes
         | AppType::Pi
-        | AppType::ClaudeDesktop => false,
+        | AppType::ClaudeDesktop
+        | AppType::DeepSeekHarness => false,
     }
 }
 
@@ -606,7 +607,8 @@ pub(crate) fn remove_common_config_from_settings(
         | AppType::OpenClaw
         | AppType::Hermes
         | AppType::Pi
-        | AppType::ClaudeDesktop => Ok(settings.clone()),
+        | AppType::ClaudeDesktop
+        | AppType::DeepSeekHarness => Ok(settings.clone()),
     }
 }
 
@@ -666,7 +668,8 @@ fn apply_common_config_to_settings(
         | AppType::OpenClaw
         | AppType::Hermes
         | AppType::Pi
-        | AppType::ClaudeDesktop => Ok(settings.clone()),
+        | AppType::ClaudeDesktop
+        | AppType::DeepSeekHarness => Ok(settings.clone()),
     }
 }
 
@@ -1005,6 +1008,25 @@ fn restore_live_settings_for_provider_backfill(
     provider: &Provider,
     live_settings: Value,
 ) -> Value {
+    if matches!(app_type, AppType::DeepSeekHarness) {
+        let mut settings = live_settings;
+        let Some(object) = settings.as_object_mut() else {
+            return settings;
+        };
+        // The managed credential store is shared native state, not part of the
+        // provider profile being switched away. Preserve the provider-owned
+        // secret/reference instead of absorbing an externally changed key into
+        // the wrong CC Switch snapshot during backfill.
+        object.remove("apiKey");
+        object.remove("apiKeyEnv");
+        if let Some(stored) = provider.settings_config.get("apiKey") {
+            object.insert("apiKey".to_string(), stored.clone());
+        }
+        if let Some(stored) = provider.settings_config.get("apiKeyEnv") {
+            object.insert("apiKeyEnv".to_string(), stored.clone());
+        }
+        return settings;
+    }
     if matches!(app_type, AppType::Claude) {
         let mut settings = live_settings;
         strip_injected_codex_oauth_context_defaults(&mut settings, provider);
@@ -1276,6 +1298,9 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
         AppType::Gemini => {
             // Delegate to write_gemini_live which handles env file writing correctly
             write_gemini_live(provider)?;
+        }
+        AppType::DeepSeekHarness => {
+            crate::dsh_config::write_live_settings(&provider.settings_config)?;
         }
         AppType::GrokBuild => {
             crate::grok_config::write_grok_provider_live(provider)?;
@@ -1633,6 +1658,15 @@ pub fn read_live_settings(app_type: AppType) -> Result<Value, AppError> {
             let config = read_opencode_config()?;
             Ok(config)
         }
+        AppType::DeepSeekHarness => {
+            crate::dsh_config::read_live_settings()?.ok_or_else(|| {
+                AppError::localized(
+                    "deepseek_harness.live.missing",
+                    "DeepSeek Harness 配置文件不存在",
+                    "DeepSeek Harness configuration files are missing",
+                )
+            })
+        }
         AppType::GrokBuild => crate::grok_config::read_grok_live_settings(),
         AppType::OpenClaw => {
             use crate::openclaw_config::{get_openclaw_config_path, read_openclaw_config};
@@ -1773,6 +1807,13 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
                 "config": config_obj
             })
         }
+        AppType::DeepSeekHarness => crate::dsh_config::read_live_settings()?.ok_or_else(|| {
+            AppError::localized(
+                "deepseek_harness.live.missing",
+                "DeepSeek Harness 配置文件不存在",
+                "DeepSeek Harness configuration files are missing",
+            )
+        })?,
         // OpenCode, OpenClaw and Hermes use additive mode and are handled by early return above
         AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Pi => {
             unreachable!("additive mode apps are handled by early return")

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -1502,18 +1502,16 @@ fn sync_current_provider_for_app_respecting_takeover(
 
     // `enabled` is set only after takeover writes complete. During that
     // activation window, backup/live placeholders are the authoritative signal
-    // that normal provider sync must not rewrite the managed live file.
-    if has_live_backup || live_taken_over {
-        if matches!(app_type, AppType::ClaudeDesktop) {
-            write_live_with_common_config_for_state(state, app_type, provider)?;
-        } else {
-            futures::executor::block_on(
-                state
-                    .proxy_service
-                    .update_live_backup_from_provider(app_type.as_str(), provider),
-            )
-            .map_err(|e| AppError::Message(format!("更新 Live 备份失败: {e}")))?;
-        }
+    // that normal provider sync must not rewrite a proxy-managed live file.
+    // Apps without local-proxy support (including DeepSeek Harness and Claude
+    // Desktop) must ignore stale backup rows and keep using their native writer.
+    if app_type.supports_local_proxy() && (has_live_backup || live_taken_over) {
+        futures::executor::block_on(
+            state
+                .proxy_service
+                .update_live_backup_from_provider(app_type.as_str(), provider),
+        )
+        .map_err(|e| AppError::Message(format!("更新 Live 备份失败: {e}")))?;
         return Ok(());
     }
 
@@ -2266,7 +2264,123 @@ pub fn remove_openclaw_provider_from_live(provider_id: &str) -> Result<(), AppEr
 mod tests {
     use super::*;
     use crate::provider::{AuthBinding, AuthBindingSource, ProviderMeta};
+    use crate::settings::{get_settings, update_settings, AppSettings};
     use serde_json::json;
+    use serial_test::serial;
+    use std::env;
+    use std::ffi::OsString;
+    use tempfile::TempDir;
+
+    struct DeepSeekSyncTestHome {
+        dir: TempDir,
+        original_settings: AppSettings,
+        original_home: Option<OsString>,
+        original_userprofile: Option<OsString>,
+        original_test_home: Option<OsString>,
+        original_dsh_home: Option<OsString>,
+        #[cfg(windows)]
+        original_local_app_data: Option<OsString>,
+    }
+
+    impl DeepSeekSyncTestHome {
+        fn new() -> Self {
+            let dir = tempfile::tempdir().expect("create isolated sync home");
+            let original_settings = get_settings();
+            let original_home = env::var_os("HOME");
+            let original_userprofile = env::var_os("USERPROFILE");
+            let original_test_home = env::var_os("CC_SWITCH_TEST_HOME");
+            let original_dsh_home = env::var_os("DSH_HOME");
+            #[cfg(windows)]
+            let original_local_app_data = env::var_os("LOCALAPPDATA");
+
+            env::set_var("HOME", dir.path());
+            env::set_var("USERPROFILE", dir.path());
+            env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+            env::set_var("DSH_HOME", dir.path().join(".dsh"));
+            #[cfg(windows)]
+            env::set_var("LOCALAPPDATA", dir.path().join("AppData").join("Local"));
+
+            update_settings(AppSettings {
+                deepseek_harness_config_dir: Some(
+                    dir.path().join(".dsh").to_string_lossy().into_owned(),
+                ),
+                ..Default::default()
+            })
+            .expect("configure isolated Harness home");
+
+            Self {
+                dir,
+                original_settings,
+                original_home,
+                original_userprofile,
+                original_test_home,
+                original_dsh_home,
+                #[cfg(windows)]
+                original_local_app_data,
+            }
+        }
+
+        fn path(&self) -> &std::path::Path {
+            self.dir.path()
+        }
+    }
+
+    impl Drop for DeepSeekSyncTestHome {
+        fn drop(&mut self) {
+            // Restore the process-global settings while writes are still
+            // redirected to the disposable test home.
+            let _ = update_settings(self.original_settings.clone());
+
+            for (name, value) in [
+                ("HOME", &self.original_home),
+                ("USERPROFILE", &self.original_userprofile),
+                ("CC_SWITCH_TEST_HOME", &self.original_test_home),
+                ("DSH_HOME", &self.original_dsh_home),
+            ] {
+                match value {
+                    Some(value) => env::set_var(name, value),
+                    None => env::remove_var(name),
+                }
+            }
+
+            #[cfg(windows)]
+            match &self.original_local_app_data {
+                Some(value) => env::set_var("LOCALAPPDATA", value),
+                None => env::remove_var("LOCALAPPDATA"),
+            }
+        }
+    }
+
+    fn seed_deepseek_sync_state() -> (DeepSeekSyncTestHome, AppState) {
+        let home = DeepSeekSyncTestHome::new();
+        let db = Arc::new(Database::memory().expect("create in-memory database"));
+        let state = AppState::new(db);
+        let provider = Provider::with_id(
+            "dsh-sync".to_string(),
+            "DeepSeek Sync".to_string(),
+            json!({
+                "defaultModel": "deepseek-v4-pro",
+                "apiKeyEnv": "TEST_DSH_API_KEY",
+                "reasoningEffort": "low"
+            }),
+            None,
+        );
+        state
+            .db
+            .save_provider(AppType::DeepSeekHarness.as_str(), &provider)
+            .expect("seed Harness provider");
+        state
+            .db
+            .set_current_provider(AppType::DeepSeekHarness.as_str(), &provider.id)
+            .expect("set current Harness provider");
+        futures::executor::block_on(
+            state
+                .db
+                .save_live_backup(AppType::DeepSeekHarness.as_str(), "stale-proxy-backup"),
+        )
+        .expect("seed stale Harness proxy backup");
+        (home, state)
+    }
 
     #[test]
     fn kimi_for_coding_effective_settings_backfill_256k_context() {
@@ -3147,5 +3261,49 @@ base_url = "https://a.example/v1"
 
         assert!(!config_text.contains("mcp_servers"));
         assert!(config_text.contains("model = \"grok-4.5\""));
+    }
+
+    #[test]
+    #[serial]
+    fn single_app_sync_ignores_stale_deepseek_harness_proxy_backup() {
+        let (home, state) = seed_deepseek_sync_state();
+
+        sync_current_provider_for_app_respecting_takeover(&state, &AppType::DeepSeekHarness)
+            .expect("stale proxy state must not divert single-app Harness sync");
+
+        let settings = std::fs::read_to_string(home.path().join(".dsh/settings.yaml"))
+            .expect("read projected Harness settings");
+        assert!(settings.contains("model: deepseek-v4-pro"));
+        assert_eq!(
+            futures::executor::block_on(
+                state.db.get_live_backup(AppType::DeepSeekHarness.as_str())
+            )
+            .expect("read stale backup")
+            .expect("stale backup remains present")
+            .original_config,
+            "stale-proxy-backup"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn aggregate_sync_ignores_stale_deepseek_harness_proxy_backup() {
+        let (home, state) = seed_deepseek_sync_state();
+
+        sync_current_to_live(&state)
+            .expect("aggregate sync must directly project non-proxy Harness providers");
+
+        let settings = std::fs::read_to_string(home.path().join(".dsh/settings.yaml"))
+            .expect("read projected Harness settings");
+        assert!(settings.contains("model: deepseek-v4-pro"));
+        assert_eq!(
+            futures::executor::block_on(
+                state.db.get_live_backup(AppType::DeepSeekHarness.as_str())
+            )
+            .expect("read stale backup")
+            .expect("stale backup remains present")
+            .original_config,
+            "stale-proxy-backup"
+        );
     }
 }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -5557,11 +5557,9 @@ impl ProviderService {
                     }
                 }
             } else {
-                if let Err(err) = write_live_with_common_config_for_state(
-                    state,
-                    &app_type,
-                    &provider,
-                ) {
+                if let Err(err) =
+                    write_live_with_common_config_for_state(state, &app_type, &provider)
+                {
                     // Harness native writes can be rejected by its cross-process
                     // lock or by an inherited environment override. Restore the
                     // provider snapshot so a reported save failure does not leave

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -23,10 +23,9 @@ use crate::store::AppState;
 
 // Re-export sub-module functions for external access
 pub use live::{
-    import_default_config, import_hermes_providers_from_live, import_openclaw_providers_from_live,
+    import_hermes_providers_from_live, import_openclaw_providers_from_live,
     import_opencode_providers_from_live, read_live_settings,
-    should_import_default_config_on_startup, sync_current_to_live,
-    update_toml_common_config_snippet,
+    should_import_default_config_on_startup, update_toml_common_config_snippet,
 };
 
 pub fn import_pi_providers_from_live(state: &AppState) -> Result<usize, AppError> {
@@ -49,6 +48,137 @@ use live::{
     remove_opencode_provider_from_live, write_gemini_live,
 };
 use usage::validate_usage_script;
+
+/// Import is a read/decide/commit transaction for Harness: the provider row,
+/// database current, and device-local current must be derived from one locked
+/// view. Other applications retain the existing lock-free import behavior.
+pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool, AppError> {
+    if matches!(app_type, AppType::DeepSeekHarness) {
+        let _deepseek_harness_guard =
+            futures::executor::block_on(state.proxy_service.lock_switch_for_app(app_type.as_str()));
+        return import_deepseek_harness_default_config_locked(state);
+    }
+    live::import_default_config(state, app_type)
+}
+
+fn import_deepseek_harness_default_config_locked(state: &AppState) -> Result<bool, AppError> {
+    let app_type = AppType::DeepSeekHarness;
+    let app_type_str = app_type.as_str();
+
+    // Keep the generic import contract: an official seed alone does not block
+    // importing the user's native configuration, but any real provider does.
+    if state.db.has_non_official_seed_provider(app_type_str)? {
+        return Ok(false);
+    }
+    if state
+        .proxy_service
+        .detect_takeover_in_live_config_for_app(&app_type)
+    {
+        return Err(AppError::localized(
+            "provider.import.live_taken_over",
+            "Live 配置当前处于代理接管状态（包含占位符），不能导入为供应商。请先关闭代理接管或恢复 Live 配置后重试。",
+            "The live config is currently taken over by the proxy (contains placeholders) and cannot be imported as a provider. Disable proxy takeover or restore the live config first.",
+        ));
+    }
+
+    let settings_config = crate::dsh_config::read_live_settings()?.ok_or_else(|| {
+        AppError::localized(
+            "deepseek_harness.live.missing",
+            "DeepSeek Harness 配置文件不存在",
+            "DeepSeek Harness configuration files are missing",
+        )
+    })?;
+    crate::dsh_config::validate_settings_config(&settings_config)?;
+
+    let mut provider = Provider::with_id(
+        "default".to_string(),
+        "default".to_string(),
+        settings_config,
+        None,
+    );
+    provider.category = Some("custom".to_string());
+
+    let previous_provider = state.db.get_provider_by_id(&provider.id, app_type_str)?;
+    let previous_local_current = crate::settings::get_current_provider(&app_type);
+    let previous_db_current = state.db.get_current_provider(app_type_str)?;
+    let mut provider_saved = false;
+    let mut local_current_committed = false;
+    let commit_result = (|| {
+        state.db.save_provider(app_type_str, &provider)?;
+        provider_saved = true;
+        crate::settings::set_current_provider(&app_type, Some(provider.id.as_str()))?;
+        local_current_committed = true;
+        state
+            .db
+            .set_current_provider(app_type_str, provider.id.as_str())?;
+        Ok::<(), AppError>(())
+    })();
+
+    if let Err(error) = commit_result {
+        let mut rollback_failures = Vec::new();
+        if local_current_committed {
+            if let Err(rollback_error) =
+                crate::settings::set_current_provider(&app_type, previous_local_current.as_deref())
+            {
+                rollback_failures.push(format!("恢复本地 current 失败: {rollback_error}"));
+            }
+        }
+        if provider_saved {
+            let provider_rollback = match previous_provider.as_ref() {
+                Some(previous) => state.db.save_provider(app_type_str, previous),
+                None => state.db.delete_provider(app_type_str, provider.id.as_str()),
+            };
+            if let Err(rollback_error) = provider_rollback {
+                rollback_failures.push(format!("恢复 Provider 数据失败: {rollback_error}"));
+            }
+        }
+        match state.db.get_current_provider(app_type_str) {
+            Ok(current) if current == previous_db_current => {}
+            Ok(_) => {
+                if let Some(previous_db_current) = previous_db_current.as_deref() {
+                    if let Err(rollback_error) = state
+                        .db
+                        .set_current_provider(app_type_str, previous_db_current)
+                    {
+                        rollback_failures
+                            .push(format!("恢复数据库 current 失败: {rollback_error}"));
+                    }
+                } else {
+                    rollback_failures.push(
+                        "数据库 current 在失败提交后发生变化，且原状态为空，无法安全恢复"
+                            .to_string(),
+                    );
+                }
+            }
+            Err(rollback_error) => {
+                rollback_failures.push(format!("核验数据库 current 失败: {rollback_error}"));
+            }
+        }
+
+        return if rollback_failures.is_empty() {
+            Err(error)
+        } else {
+            Err(AppError::Message(format!(
+                "导入 DeepSeek Harness 默认配置失败: {error}; 回滚同时失败: {}",
+                rollback_failures.join("; ")
+            )))
+        };
+    }
+
+    Ok(true)
+}
+
+/// Serialize the all-app sync with Harness CRUD/switch operations. The live
+/// implementation performs the Harness read/current/write window while this
+/// guard is held; its per-file writer locks still coordinate other processes.
+pub fn sync_current_to_live(state: &AppState) -> Result<(), AppError> {
+    let _deepseek_harness_guard = futures::executor::block_on(
+        state
+            .proxy_service
+            .lock_switch_for_app(AppType::DeepSeekHarness.as_str()),
+    );
+    live::sync_current_to_live(state)
+}
 
 /// Codex official providers are safe to select during takeover: Codex keeps
 /// ownership of the active ChatGPT login and the proxy only forwards the
@@ -120,6 +250,24 @@ pub struct ProviderService;
 #[serde(rename_all = "camelCase")]
 pub struct SwitchResult {
     pub warnings: Vec<String>,
+}
+
+struct DeepSeekHarnessAddRollback<'a> {
+    provider: &'a Provider,
+    previous_provider: Option<&'a Provider>,
+    provider_saved: bool,
+    previous_local_current: Option<&'a str>,
+    local_current_committed: bool,
+    outcome: &'a crate::dsh_config::DshWriteOutcome,
+}
+
+struct DeepSeekHarnessSwitchRollback<'a> {
+    outcome: &'a crate::dsh_config::DshWriteOutcome,
+    previous_local_current: Option<&'a str>,
+    local_current_committed: bool,
+    previous_db_current: Option<&'a str>,
+    previous_provider_before_backfill: Option<&'a Provider>,
+    backfill_completed: bool,
 }
 
 #[cfg(test)]
@@ -430,6 +578,24 @@ mod tests {
             json!({
                 "defaultModel": model,
                 "apiKeyEnv": "TEST_DSH_API_KEY"
+            }),
+            None,
+        )
+    }
+
+    fn deepseek_harness_provider_with_key(
+        id: &str,
+        model: &str,
+        credential_ref: &str,
+        api_key: &str,
+    ) -> Provider {
+        Provider::with_id(
+            id.to_string(),
+            format!("Provider {id}"),
+            json!({
+                "defaultModel": model,
+                "apiKeyEnv": credential_ref,
+                "apiKey": api_key
             }),
             None,
         )
@@ -2406,6 +2572,641 @@ requires_openai_auth = true
             assert_eq!(
                 stored.settings_config, original.settings_config,
                 "failed native writes must restore the exact previous provider snapshot"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn add_deepseek_harness_uses_effective_local_current_before_first_provider_flow() {
+        with_test_home(|state, _| {
+            crate::settings::reload_settings().expect("reload isolated settings");
+            let provider_a = deepseek_harness_provider("p1", "deepseek-v4-flash");
+            let provider_b = deepseek_harness_provider("p2", "deepseek-v4-pro");
+            state
+                .db
+                .save_provider(AppType::DeepSeekHarness.as_str(), &provider_a)
+                .expect("save existing provider without DB current");
+            crate::settings::set_current_provider(&AppType::DeepSeekHarness, Some("p1"))
+                .expect("set device-local current");
+            crate::dsh_config::write_live_settings(&provider_a.settings_config)
+                .expect("write existing live provider");
+
+            ProviderService::add(state, AppType::DeepSeekHarness, provider_b.clone(), false)
+                .expect("a valid local current means this is a non-current add");
+
+            assert_eq!(
+                crate::settings::get_current_provider(&AppType::DeepSeekHarness).as_deref(),
+                Some("p1")
+            );
+            assert_eq!(
+                state
+                    .db
+                    .get_current_provider(AppType::DeepSeekHarness.as_str())
+                    .expect("read DB current"),
+                None,
+                "non-current add must not invent a synced default pointer"
+            );
+            assert_eq!(
+                crate::dsh_config::read_live_settings()
+                    .expect("read Harness live")
+                    .and_then(|settings| settings["defaultModel"].as_str().map(str::to_string))
+                    .as_deref(),
+                Some("deepseek-v4-flash"),
+                "non-current add must not replace live configuration"
+            );
+            assert_eq!(
+                state
+                    .db
+                    .get_provider_by_id("p2", AppType::DeepSeekHarness.as_str())
+                    .expect("read added provider")
+                    .expect("provider should be saved")
+                    .settings_config,
+                provider_b.settings_config
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn add_duplicate_current_deepseek_harness_provider_leaves_db_and_live_unchanged() {
+        with_test_home(|state, home| {
+            crate::settings::reload_settings().expect("reload isolated settings");
+            let original = deepseek_harness_provider_with_key(
+                "duplicate-harness",
+                "deepseek-v4-flash",
+                "TEST_DSH_DUPLICATE_ORIGINAL_KEY",
+                "original-secret",
+            );
+            state
+                .db
+                .save_provider(AppType::DeepSeekHarness.as_str(), &original)
+                .expect("save original provider");
+            state
+                .db
+                .set_current_provider(AppType::DeepSeekHarness.as_str(), &original.id)
+                .expect("set DB current");
+            crate::settings::set_current_provider(
+                &AppType::DeepSeekHarness,
+                Some(original.id.as_str()),
+            )
+            .expect("set local current");
+            crate::dsh_config::write_live_settings(&original.settings_config)
+                .expect("write original Harness live files");
+
+            let dsh_home = home.join(".dsh");
+            let settings_before =
+                fs::read(dsh_home.join("settings.yaml")).expect("read settings before add");
+            let credentials_before =
+                fs::read(dsh_home.join(".credentials.yaml")).expect("read credentials before add");
+            let duplicate = deepseek_harness_provider_with_key(
+                &original.id,
+                "deepseek-v4-pro",
+                "TEST_DSH_DUPLICATE_RETRY_KEY",
+                "retry-secret",
+            );
+
+            let error = ProviderService::add(state, AppType::DeepSeekHarness, duplicate, false)
+                .expect_err("duplicate Harness add must be rejected");
+            assert!(
+                error.to_string().contains("already exists"),
+                "unexpected duplicate error: {error}"
+            );
+
+            let stored = state
+                .db
+                .get_provider_by_id(&original.id, AppType::DeepSeekHarness.as_str())
+                .expect("read original provider")
+                .expect("original provider remains");
+            assert_eq!(stored.settings_config, original.settings_config);
+            assert_eq!(
+                state
+                    .db
+                    .get_current_provider(AppType::DeepSeekHarness.as_str())
+                    .expect("read DB current")
+                    .as_deref(),
+                Some(original.id.as_str())
+            );
+            assert_eq!(
+                crate::settings::get_current_provider(&AppType::DeepSeekHarness).as_deref(),
+                Some(original.id.as_str())
+            );
+            assert_eq!(
+                fs::read(dsh_home.join("settings.yaml")).expect("read settings after add"),
+                settings_before
+            );
+            assert_eq!(
+                fs::read(dsh_home.join(".credentials.yaml")).expect("read credentials after add"),
+                credentials_before
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn add_first_deepseek_harness_db_current_failure_restores_live_provider_and_local_current() {
+        with_test_home(|state, home| {
+            crate::settings::reload_settings().expect("reload isolated settings");
+            let baseline = deepseek_harness_provider_with_key(
+                "baseline",
+                "deepseek-v4-flash",
+                "TEST_DSH_BASELINE_KEY",
+                "baseline-secret",
+            );
+            crate::dsh_config::write_live_settings(&baseline.settings_config)
+                .expect("write baseline Harness live files");
+            let dsh_home = home.join(".dsh");
+            let settings_before =
+                fs::read(dsh_home.join("settings.yaml")).expect("read baseline settings bytes");
+            let credentials_before = fs::read(dsh_home.join(".credentials.yaml"))
+                .expect("read baseline credential bytes");
+
+            {
+                let conn = state.db.conn.lock().expect("lock database");
+                conn.execute_batch(
+                    "CREATE TRIGGER reject_first_harness_current_update
+                     BEFORE UPDATE OF is_current ON providers
+                     WHEN NEW.app_type = 'deepseek-harness'
+                       AND NEW.id = 'first-harness'
+                       AND NEW.is_current = 1
+                     BEGIN
+                       SELECT RAISE(ABORT, 'forced first Harness current failure');
+                     END;",
+                )
+                .expect("install first Harness current failure trigger");
+            }
+
+            let provider = deepseek_harness_provider_with_key(
+                "first-harness",
+                "deepseek-v4-pro",
+                "TEST_DSH_FIRST_KEY",
+                "first-secret",
+            );
+            let error =
+                ProviderService::add(state, AppType::DeepSeekHarness, provider.clone(), false)
+                    .expect_err("DB current failure must abort first Harness add");
+            assert!(
+                error
+                    .to_string()
+                    .contains("forced first Harness current failure"),
+                "unexpected add failure: {error}"
+            );
+
+            assert!(state
+                .db
+                .get_provider_by_id(&provider.id, AppType::DeepSeekHarness.as_str())
+                .expect("read rolled-back provider")
+                .is_none());
+            assert_eq!(
+                state
+                    .db
+                    .get_current_provider(AppType::DeepSeekHarness.as_str())
+                    .expect("read rolled-back DB current"),
+                None
+            );
+            assert_eq!(
+                crate::settings::get_current_provider(&AppType::DeepSeekHarness),
+                None
+            );
+            assert_eq!(
+                fs::read(dsh_home.join("settings.yaml")).expect("read restored settings"),
+                settings_before,
+                "failed first add must restore settings.yaml byte-for-byte"
+            );
+            assert_eq!(
+                fs::read(dsh_home.join(".credentials.yaml")).expect("read restored credentials"),
+                credentials_before,
+                "failed first add must restore .credentials.yaml byte-for-byte"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn switch_deepseek_harness_db_current_failure_restores_live_current_and_backfill() {
+        with_test_home(|state, home| {
+            crate::settings::reload_settings().expect("reload isolated settings");
+            let provider_a = deepseek_harness_provider_with_key(
+                "harness-a",
+                "deepseek-v4-flash",
+                "TEST_DSH_SWITCH_A_KEY",
+                "switch-secret-a",
+            );
+            let provider_b = deepseek_harness_provider_with_key(
+                "harness-b",
+                "deepseek-v4-pro",
+                "TEST_DSH_SWITCH_B_KEY",
+                "switch-secret-b",
+            );
+            state
+                .db
+                .save_provider(AppType::DeepSeekHarness.as_str(), &provider_a)
+                .expect("save first provider");
+            state
+                .db
+                .save_provider(AppType::DeepSeekHarness.as_str(), &provider_b)
+                .expect("save second provider");
+            state
+                .db
+                .set_current_provider(AppType::DeepSeekHarness.as_str(), &provider_a.id)
+                .expect("set initial DB current");
+            crate::settings::set_current_provider(
+                &AppType::DeepSeekHarness,
+                Some(provider_a.id.as_str()),
+            )
+            .expect("set initial local current");
+
+            let mut externally_edited_a = provider_a.clone();
+            externally_edited_a.settings_config["defaultModel"] = json!("deepseek-v4-flash-manual");
+            crate::dsh_config::write_live_settings(&externally_edited_a.settings_config)
+                .expect("write externally edited outgoing live state");
+            let dsh_home = home.join(".dsh");
+            let settings_before =
+                fs::read(dsh_home.join("settings.yaml")).expect("read pre-switch settings bytes");
+            let credentials_before = fs::read(dsh_home.join(".credentials.yaml"))
+                .expect("read pre-switch credential bytes");
+
+            {
+                let conn = state.db.conn.lock().expect("lock database");
+                conn.execute_batch(
+                    "CREATE TRIGGER reject_harness_b_current_update
+                     BEFORE UPDATE OF is_current ON providers
+                     WHEN NEW.app_type = 'deepseek-harness'
+                       AND NEW.id = 'harness-b'
+                       AND NEW.is_current = 1
+                     BEGIN
+                       SELECT RAISE(ABORT, 'forced Harness switch current failure');
+                     END;",
+                )
+                .expect("install Harness switch current failure trigger");
+            }
+
+            let error =
+                ProviderService::switch(state, AppType::DeepSeekHarness, provider_b.id.as_str())
+                    .expect_err("DB current failure must abort Harness switch");
+            assert!(
+                error
+                    .to_string()
+                    .contains("forced Harness switch current failure"),
+                "unexpected switch failure: {error}"
+            );
+
+            assert_eq!(
+                crate::settings::get_current_provider(&AppType::DeepSeekHarness).as_deref(),
+                Some(provider_a.id.as_str())
+            );
+            assert_eq!(
+                state
+                    .db
+                    .get_current_provider(AppType::DeepSeekHarness.as_str())
+                    .expect("read restored DB current")
+                    .as_deref(),
+                Some(provider_a.id.as_str())
+            );
+            assert_eq!(
+                state
+                    .db
+                    .get_provider_by_id(&provider_a.id, AppType::DeepSeekHarness.as_str())
+                    .expect("read restored outgoing provider")
+                    .expect("outgoing provider remains")
+                    .settings_config,
+                provider_a.settings_config,
+                "failed pointer commit must undo the outgoing-provider backfill"
+            );
+            assert_eq!(
+                fs::read(dsh_home.join("settings.yaml")).expect("read restored settings"),
+                settings_before,
+                "failed switch must restore settings.yaml byte-for-byte"
+            );
+            assert_eq!(
+                fs::read(dsh_home.join(".credentials.yaml")).expect("read restored credentials"),
+                credentials_before,
+                "failed switch must restore .credentials.yaml byte-for-byte"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn switch_deepseek_harness_local_current_failure_restores_live_and_backfill() {
+        with_test_home(|state, home| {
+            crate::settings::reload_settings().expect("reload isolated settings");
+            let provider_a = deepseek_harness_provider_with_key(
+                "local-a",
+                "deepseek-v4-flash",
+                "TEST_DSH_LOCAL_A_KEY",
+                "local-secret-a",
+            );
+            let provider_b = deepseek_harness_provider_with_key(
+                "local-b",
+                "deepseek-v4-pro",
+                "TEST_DSH_LOCAL_B_KEY",
+                "local-secret-b",
+            );
+            state
+                .db
+                .save_provider(AppType::DeepSeekHarness.as_str(), &provider_a)
+                .expect("save current provider");
+            state
+                .db
+                .save_provider(AppType::DeepSeekHarness.as_str(), &provider_b)
+                .expect("save target provider");
+            state
+                .db
+                .set_current_provider(AppType::DeepSeekHarness.as_str(), &provider_a.id)
+                .expect("set initial DB current");
+            crate::settings::set_current_provider(
+                &AppType::DeepSeekHarness,
+                Some(provider_a.id.as_str()),
+            )
+            .expect("set initial local current");
+
+            let mut externally_edited_a = provider_a.clone();
+            externally_edited_a.settings_config["defaultModel"] =
+                json!("deepseek-v4-flash-local-edit");
+            crate::dsh_config::write_live_settings(&externally_edited_a.settings_config)
+                .expect("write externally edited outgoing live state");
+            let dsh_home = home.join(".dsh");
+            let settings_before =
+                fs::read(dsh_home.join("settings.yaml")).expect("read live settings bytes");
+            let credentials_before =
+                fs::read(dsh_home.join(".credentials.yaml")).expect("read live credential bytes");
+
+            let settings_path = home.join(".cc-switch").join("settings.json");
+            let settings_backup_path = home.join(".cc-switch").join("settings.json.before-test");
+            fs::rename(&settings_path, &settings_backup_path)
+                .expect("move settings file aside for deterministic write fault");
+            fs::create_dir(&settings_path)
+                .expect("replace settings file path with a directory fault");
+
+            let switch_result =
+                ProviderService::switch(state, AppType::DeepSeekHarness, provider_b.id.as_str());
+            fs::remove_dir(&settings_path).expect("remove settings fault directory");
+            fs::rename(&settings_backup_path, &settings_path)
+                .expect("restore original settings file");
+            let error = switch_result
+                .expect_err("local current persistence failure must abort Harness switch");
+            assert!(
+                error.to_string().contains("settings.json"),
+                "unexpected local-current failure: {error}"
+            );
+
+            assert_eq!(
+                crate::settings::get_current_provider(&AppType::DeepSeekHarness).as_deref(),
+                Some(provider_a.id.as_str())
+            );
+            assert_eq!(
+                state
+                    .db
+                    .get_current_provider(AppType::DeepSeekHarness.as_str())
+                    .expect("read unchanged DB current")
+                    .as_deref(),
+                Some(provider_a.id.as_str())
+            );
+            assert_eq!(
+                state
+                    .db
+                    .get_provider_by_id(&provider_a.id, AppType::DeepSeekHarness.as_str())
+                    .expect("read restored outgoing provider")
+                    .expect("outgoing provider remains")
+                    .settings_config,
+                provider_a.settings_config
+            );
+            assert_eq!(
+                fs::read(dsh_home.join("settings.yaml")).expect("read restored live settings"),
+                settings_before
+            );
+            assert_eq!(
+                fs::read(dsh_home.join(".credentials.yaml"))
+                    .expect("read restored live credentials"),
+                credentials_before
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn switch_deepseek_harness_waits_for_app_lock_before_reading_target_provider() {
+        with_test_home(|state, _| {
+            crate::settings::reload_settings().expect("reload isolated settings");
+            let provider_a = deepseek_harness_provider_with_key(
+                "lock-a",
+                "deepseek-v4-flash",
+                "TEST_DSH_LOCK_A_KEY",
+                "lock-secret-a",
+            );
+            let provider_b = deepseek_harness_provider_with_key(
+                "lock-b",
+                "deepseek-v4-pro",
+                "TEST_DSH_LOCK_B_KEY",
+                "lock-secret-b",
+            );
+            state
+                .db
+                .save_provider(AppType::DeepSeekHarness.as_str(), &provider_a)
+                .expect("save current provider");
+            state
+                .db
+                .save_provider(AppType::DeepSeekHarness.as_str(), &provider_b)
+                .expect("save target provider");
+            state
+                .db
+                .set_current_provider(AppType::DeepSeekHarness.as_str(), &provider_a.id)
+                .expect("set DB current");
+            crate::settings::set_current_provider(
+                &AppType::DeepSeekHarness,
+                Some(provider_a.id.as_str()),
+            )
+            .expect("set local current");
+            crate::dsh_config::write_live_settings(&provider_a.settings_config)
+                .expect("write initial Harness live state");
+
+            let transaction_guard = futures::executor::block_on(
+                state
+                    .proxy_service
+                    .lock_switch_for_app(AppType::DeepSeekHarness.as_str()),
+            );
+            let (started_tx, started_rx) = std::sync::mpsc::channel();
+            let (done_tx, done_rx) = std::sync::mpsc::channel();
+            std::thread::scope(|scope| {
+                scope.spawn(|| {
+                    started_tx.send(()).expect("signal switch start");
+                    let result = ProviderService::switch(
+                        state,
+                        AppType::DeepSeekHarness,
+                        provider_b.id.as_str(),
+                    );
+                    done_tx.send(result).expect("send switch result");
+                });
+
+                started_rx.recv().expect("wait for switch task");
+                assert!(
+                    done_rx
+                        .recv_timeout(std::time::Duration::from_millis(100))
+                        .is_err(),
+                    "Harness switch must wait while another transaction owns its app lock"
+                );
+
+                // Mutate the target while the switch is known to be waiting.
+                // Reading providers before acquiring the lock would project the
+                // stale model after the guard is released.
+                let mut updated_b = provider_b.clone();
+                updated_b.settings_config["defaultModel"] = json!("deepseek-v4-pro-updated");
+                state
+                    .db
+                    .save_provider(AppType::DeepSeekHarness.as_str(), &updated_b)
+                    .expect("update target while switch waits");
+                drop(transaction_guard);
+
+                done_rx
+                    .recv_timeout(std::time::Duration::from_secs(5))
+                    .expect("switch should finish after lock release")
+                    .expect("switch updated target");
+            });
+
+            assert_eq!(
+                crate::dsh_config::read_live_settings()
+                    .expect("read switched Harness live state")
+                    .and_then(|settings| settings["defaultModel"].as_str().map(str::to_string))
+                    .as_deref(),
+                Some("deepseek-v4-pro-updated"),
+                "switch must read the target provider only after acquiring the app lock"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn add_non_current_deepseek_harness_provider_runs_native_writer_validation() {
+        with_test_home(|state, _| {
+            crate::settings::reload_settings().expect("reload isolated settings");
+            let current = deepseek_harness_provider("current", "deepseek-v4-flash");
+            state
+                .db
+                .save_provider(AppType::DeepSeekHarness.as_str(), &current)
+                .expect("save current provider");
+            state
+                .db
+                .set_current_provider(AppType::DeepSeekHarness.as_str(), &current.id)
+                .expect("set DB current");
+            crate::settings::set_current_provider(
+                &AppType::DeepSeekHarness,
+                Some(current.id.as_str()),
+            )
+            .expect("set local current");
+
+            let mut invalid = deepseek_harness_provider("invalid", "deepseek-v4-pro");
+            invalid.settings_config["apiKey"] = json!(42);
+            let error =
+                ProviderService::add(state, AppType::DeepSeekHarness, invalid.clone(), false)
+                    .expect_err("non-current invalid provider must be rejected before DB save");
+            assert!(error.to_string().contains("apiKey must be a string"));
+            assert!(state
+                .db
+                .get_provider_by_id(&invalid.id, AppType::DeepSeekHarness.as_str())
+                .expect("read rejected provider")
+                .is_none());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn import_deepseek_harness_db_current_failure_rolls_back_provider_and_local_current() {
+        with_test_home(|state, _| {
+            crate::settings::reload_settings().expect("reload isolated settings");
+            let live = deepseek_harness_provider_with_key(
+                "native",
+                "deepseek-v4-flash",
+                "TEST_DSH_IMPORT_KEY",
+                "import-secret",
+            );
+            crate::dsh_config::write_live_settings(&live.settings_config)
+                .expect("seed Harness live configuration");
+            {
+                let conn = state.db.conn.lock().expect("lock database");
+                conn.execute_batch(
+                    "CREATE TRIGGER reject_imported_harness_current_update
+                     BEFORE UPDATE OF is_current ON providers
+                     WHEN NEW.app_type = 'deepseek-harness'
+                       AND NEW.id = 'default'
+                       AND NEW.is_current = 1
+                     BEGIN
+                       SELECT RAISE(ABORT, 'forced Harness import current failure');
+                     END;",
+                )
+                .expect("install Harness import current failure trigger");
+            }
+
+            let error = import_default_config(state, AppType::DeepSeekHarness)
+                .expect_err("DB current failure must abort Harness import");
+            assert!(
+                error
+                    .to_string()
+                    .contains("forced Harness import current failure"),
+                "unexpected import failure: {error}"
+            );
+            assert!(state
+                .db
+                .get_provider_by_id("default", AppType::DeepSeekHarness.as_str())
+                .expect("read rolled-back imported provider")
+                .is_none());
+            assert_eq!(
+                state
+                    .db
+                    .get_current_provider(AppType::DeepSeekHarness.as_str())
+                    .expect("read DB current"),
+                None
+            );
+            assert_eq!(
+                crate::settings::get_current_provider(&AppType::DeepSeekHarness),
+                None
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn import_deepseek_harness_local_current_failure_rolls_back_provider_before_db_current() {
+        with_test_home(|state, home| {
+            crate::settings::reload_settings().expect("reload isolated settings");
+            let live = deepseek_harness_provider("native", "deepseek-v4-flash");
+            crate::dsh_config::write_live_settings(&live.settings_config)
+                .expect("seed Harness live configuration");
+
+            let settings_path = home.join(".cc-switch").join("settings.json");
+            fs::create_dir_all(
+                settings_path
+                    .parent()
+                    .expect("settings path must have a parent"),
+            )
+            .expect("create settings parent");
+            fs::create_dir(&settings_path)
+                .expect("replace settings file path with a directory fault");
+
+            let error = import_default_config(state, AppType::DeepSeekHarness)
+                .expect_err("local current persistence failure must abort Harness import");
+            fs::remove_dir(&settings_path).expect("remove settings fault directory");
+
+            assert!(
+                error.to_string().contains("settings.json"),
+                "unexpected local-current failure: {error}"
+            );
+            assert!(state
+                .db
+                .get_provider_by_id("default", AppType::DeepSeekHarness.as_str())
+                .expect("read rolled-back imported provider")
+                .is_none());
+            assert_eq!(
+                state
+                    .db
+                    .get_current_provider(AppType::DeepSeekHarness.as_str())
+                    .expect("read DB current"),
+                None,
+                "DB current must not commit before local current"
+            );
+            assert_eq!(
+                crate::settings::get_current_provider(&AppType::DeepSeekHarness),
+                None
             );
         });
     }
@@ -4623,6 +5424,156 @@ impl ProviderService {
         }
     }
 
+    /// Harness needs the writer-produced compare-and-restore token so pointer
+    /// commit failures can roll back exactly without overwriting a newer native
+    /// edit. Build the same effective settings used by the ordinary live path,
+    /// then retain the writer outcome instead of discarding it.
+    fn write_deepseek_harness_live_transactional(
+        state: &AppState,
+        provider: &Provider,
+    ) -> Result<crate::dsh_config::DshWriteOutcome, AppError> {
+        let app_type = AppType::DeepSeekHarness;
+        let effective_settings =
+            build_effective_settings_with_common_config(state.db.as_ref(), &app_type, provider)?;
+        crate::dsh_config::write_live_settings_transactional(&effective_settings)
+    }
+
+    fn restore_deepseek_harness_live_after_commit_error(
+        outcome: &crate::dsh_config::DshWriteOutcome,
+        rollback_failures: &mut Vec<String>,
+    ) {
+        if let Some(snapshot) = outcome.rollback_token.as_ref() {
+            if let Err(rollback_error) = snapshot.restore() {
+                rollback_failures.push(format!(
+                    "恢复 DeepSeek Harness Live 配置失败: {rollback_error}"
+                ));
+            }
+        }
+    }
+
+    fn deepseek_harness_add_transaction_error(
+        state: &AppState,
+        error: AppError,
+        rollback: DeepSeekHarnessAddRollback<'_>,
+    ) -> AppError {
+        let mut rollback_failures = Vec::new();
+
+        // Restore the native pair first while its compare-and-restore token is
+        // still current. A concurrent Harness edit causes a conflict and is
+        // preserved rather than being overwritten by rollback.
+        Self::restore_deepseek_harness_live_after_commit_error(
+            rollback.outcome,
+            &mut rollback_failures,
+        );
+
+        if rollback.local_current_committed {
+            if let Err(rollback_error) = crate::settings::set_current_provider(
+                &AppType::DeepSeekHarness,
+                rollback.previous_local_current,
+            ) {
+                rollback_failures.push(format!("恢复本地 current 失败: {rollback_error}"));
+            }
+        }
+
+        if rollback.provider_saved {
+            let provider_rollback = match rollback.previous_provider {
+                Some(previous) => state
+                    .db
+                    .save_provider(AppType::DeepSeekHarness.as_str(), previous),
+                None => state.db.delete_provider(
+                    AppType::DeepSeekHarness.as_str(),
+                    rollback.provider.id.as_str(),
+                ),
+            };
+            if let Err(rollback_error) = provider_rollback {
+                rollback_failures.push(format!("恢复 Provider 数据失败: {rollback_error}"));
+            }
+        }
+
+        if rollback_failures.is_empty() {
+            error
+        } else {
+            AppError::Message(format!(
+                "新增首个 DeepSeek Harness provider 失败: {error}; 回滚同时失败: {}",
+                rollback_failures.join("; ")
+            ))
+        }
+    }
+
+    fn deepseek_harness_switch_transaction_error(
+        state: &AppState,
+        error: AppError,
+        rollback: DeepSeekHarnessSwitchRollback<'_>,
+    ) -> AppError {
+        let mut rollback_failures = Vec::new();
+
+        Self::restore_deepseek_harness_live_after_commit_error(
+            rollback.outcome,
+            &mut rollback_failures,
+        );
+
+        if rollback.backfill_completed {
+            if let Some(previous_provider) = rollback.previous_provider_before_backfill {
+                if let Err(rollback_error) = state
+                    .db
+                    .save_provider(AppType::DeepSeekHarness.as_str(), previous_provider)
+                {
+                    rollback_failures.push(format!(
+                        "恢复切换前 Provider 回填快照失败: {rollback_error}"
+                    ));
+                }
+            }
+        }
+
+        if rollback.local_current_committed {
+            if let Err(rollback_error) = crate::settings::set_current_provider(
+                &AppType::DeepSeekHarness,
+                rollback.previous_local_current,
+            ) {
+                rollback_failures.push(format!("恢复本地 current 失败: {rollback_error}"));
+            }
+        }
+
+        // set_current_provider uses one SQLite transaction, so a reported DB
+        // failure normally leaves this untouched. Verify and repair it anyway
+        // when there was a previous pointer, keeping the rollback resilient to
+        // future implementation changes.
+        match state
+            .db
+            .get_current_provider(AppType::DeepSeekHarness.as_str())
+        {
+            Ok(current) if current.as_deref() == rollback.previous_db_current => {}
+            Ok(_) => {
+                if let Some(previous_db_current) = rollback.previous_db_current {
+                    if let Err(rollback_error) = state.db.set_current_provider(
+                        AppType::DeepSeekHarness.as_str(),
+                        previous_db_current,
+                    ) {
+                        rollback_failures
+                            .push(format!("恢复数据库 current 失败: {rollback_error}"));
+                    }
+                } else {
+                    rollback_failures.push(
+                        "数据库 current 在失败提交后发生变化，且原状态为空，无法安全恢复"
+                            .to_string(),
+                    );
+                }
+            }
+            Err(rollback_error) => {
+                rollback_failures.push(format!("核验数据库 current 失败: {rollback_error}"));
+            }
+        }
+
+        if rollback_failures.is_empty() {
+            error
+        } else {
+            AppError::Message(format!(
+                "切换 DeepSeek Harness provider 失败: {error}; 回滚同时失败: {}",
+                rollback_failures.join("; ")
+            ))
+        }
+    }
+
     fn managed_codex_transaction_error(
         operation: &str,
         error: AppError,
@@ -4936,6 +5887,36 @@ impl ProviderService {
             return pi::add(state, provider, add_to_live);
         }
 
+        // Harness provider/current/live state is one logical transaction. Take
+        // the per-app lock before validation or any provider/current read so a
+        // concurrent add/update/switch/delete/import/sync cannot act on a stale
+        // snapshot.
+        let _deepseek_harness_add_guard = if matches!(app_type, AppType::DeepSeekHarness) {
+            Some(futures::executor::block_on(
+                state.proxy_service.lock_switch_for_app(app_type.as_str()),
+            ))
+        } else {
+            None
+        };
+
+        // `save_provider` is an upsert. Treating a retried/double-submitted add
+        // as an update would replace a current Harness DB row while the add
+        // path (correctly for a new non-current row) skips its Live projection.
+        // Reject duplicates after taking the app lock so the existence check
+        // and insert decision share one serialized view.
+        if matches!(app_type, AppType::DeepSeekHarness)
+            && state
+                .db
+                .get_provider_by_id(provider.id.as_str(), app_type.as_str())?
+                .is_some()
+        {
+            return Err(AppError::localized(
+                "provider.deepseek_harness.duplicate_id",
+                format!("DeepSeek Harness 供应商 {} 已存在", provider.id),
+                format!("DeepSeek Harness provider {} already exists", provider.id),
+            ));
+        }
+
         let mut provider = provider;
         // Normalize Claude model keys
         Self::normalize_provider_if_claude(&app_type, &mut provider);
@@ -5010,13 +5991,59 @@ impl ProviderService {
             return Ok(true);
         }
 
-        // First Harness provider: validate and project the native files before
-        // persisting a provider/current pointer. This avoids a failed native
-        // lock or environment-shadow check leaving a phantom DB provider.
-        let harness_first = matches!(app_type, AppType::DeepSeekHarness)
-            && state.db.get_current_provider(app_type.as_str())?.is_none();
-        if harness_first {
-            write_live_with_common_config_for_state(state, &app_type, &provider)?;
+        // Device-local current is authoritative when valid. Looking only at the
+        // DB bit would misclassify a second provider as the first on devices
+        // whose local selection differs from the synced default.
+        let harness_effective_current = if matches!(app_type, AppType::DeepSeekHarness) {
+            Some(crate::settings::get_effective_current_provider(
+                &state.db, &app_type,
+            )?)
+        } else {
+            None
+        };
+
+        if harness_effective_current
+            .as_ref()
+            .is_some_and(Option::is_none)
+        {
+            let previous_provider = state
+                .db
+                .get_provider_by_id(provider.id.as_str(), app_type.as_str())?;
+            let previous_local_current = crate::settings::get_current_provider(&app_type);
+
+            // The native writer returns a CAS rollback token captured under the
+            // same native locks as the write. It restores exact bytes only if no
+            // newer Harness edit has replaced them.
+            let outcome = Self::write_deepseek_harness_live_transactional(state, &provider)?;
+            let mut provider_saved = false;
+            let mut local_current_committed = false;
+            let commit_result = (|| {
+                state.db.save_provider(app_type.as_str(), &provider)?;
+                provider_saved = true;
+                crate::settings::set_current_provider(&app_type, Some(provider.id.as_str()))?;
+                local_current_committed = true;
+                state
+                    .db
+                    .set_current_provider(app_type.as_str(), provider.id.as_str())?;
+                Ok::<(), AppError>(())
+            })();
+
+            if let Err(error) = commit_result {
+                return Err(Self::deepseek_harness_add_transaction_error(
+                    state,
+                    error,
+                    DeepSeekHarnessAddRollback {
+                        provider: &provider,
+                        previous_provider: previous_provider.as_ref(),
+                        provider_saved,
+                        previous_local_current: previous_local_current.as_deref(),
+                        local_current_committed,
+                        outcome: &outcome,
+                    },
+                ));
+            }
+
+            return Ok(true);
         }
 
         // Save to database
@@ -5039,26 +6066,17 @@ impl ProviderService {
             return Ok(true);
         }
 
-        // For other apps: Check if sync is needed (if this is current provider, or no current provider)
-        let current = state.db.get_current_provider(app_type.as_str())?;
+        // For other apps: Check if sync is needed (if this is current provider, or no current provider).
+        // Harness reuses the effective pointer read under its transaction lock.
+        let current = match harness_effective_current {
+            Some(current) => current,
+            None => state.db.get_current_provider(app_type.as_str())?,
+        };
         if current.is_none() {
-            // Harness may reject a native writer lock or environment-shadow
-            // conflict. Do not mark the first provider current until its live
-            // projection has succeeded.
-            if !matches!(app_type, AppType::DeepSeekHarness) {
-                state
-                    .db
-                    .set_current_provider(app_type.as_str(), &provider.id)?;
-            }
-            if !harness_first {
-                write_live_with_common_config_for_state(state, &app_type, &provider)?;
-            }
-            if matches!(app_type, AppType::DeepSeekHarness) {
-                state
-                    .db
-                    .set_current_provider(app_type.as_str(), &provider.id)?;
-                crate::settings::set_current_provider(&app_type, Some(&provider.id))?;
-            }
+            state
+                .db
+                .set_current_provider(app_type.as_str(), &provider.id)?;
+            write_live_with_common_config_for_state(state, &app_type, &provider)?;
         }
 
         Ok(true)
@@ -5074,6 +6092,17 @@ impl ProviderService {
         if app_type == AppType::Pi {
             return pi::update(state, original_id, provider);
         }
+
+        // Keep the complete Harness read/validate/DB/live window serialized.
+        // This guard is deliberately separate from the Codex guard below:
+        // only the latter is dropped before proxy helpers that lock internally.
+        let _deepseek_harness_update_guard = if matches!(app_type, AppType::DeepSeekHarness) {
+            Some(futures::executor::block_on(
+                state.proxy_service.lock_switch_for_app(app_type.as_str()),
+            ))
+        } else {
+            None
+        };
 
         let mut provider = provider;
         let original_id = original_id.unwrap_or(provider.id.as_str()).to_string();
@@ -5614,6 +6643,14 @@ impl ProviderService {
             return pi::delete(state, id);
         }
 
+        let _deepseek_harness_delete_guard = if matches!(app_type, AppType::DeepSeekHarness) {
+            Some(futures::executor::block_on(
+                state.proxy_service.lock_switch_for_app(app_type.as_str()),
+            ))
+        } else {
+            None
+        };
+
         // Additive mode apps - no current provider concept
         if app_type.is_additive_mode() {
             // Single DB read shared across all additive-mode sub-paths below.
@@ -5757,6 +6794,17 @@ impl ProviderService {
             return pi::enable(state, id);
         }
 
+        // DSH bypasses proxy takeover below, so it owns one dedicated guard
+        // spanning provider/current reads, backfill, native write, and pointer
+        // commit. `switch_normal` must never acquire this lock again.
+        let _deepseek_harness_switch_guard = if matches!(app_type, AppType::DeepSeekHarness) {
+            Some(futures::executor::block_on(
+                state.proxy_service.lock_switch_for_app(app_type.as_str()),
+            ))
+        } else {
+            None
+        };
+
         // Check if provider exists
         let providers = state.db.get_all_providers(app_type.as_str())?;
         let _provider = providers
@@ -5879,20 +6927,36 @@ impl ProviderService {
         // Backfill: Backfill current live config to current provider
         // Use effective current provider (validated existence) to ensure backfill targets valid provider
         let current_id = crate::settings::get_effective_current_provider(&state.db, &app_type)?;
+        let deepseek_harness_previous_local_current = matches!(app_type, AppType::DeepSeekHarness)
+            .then(|| crate::settings::get_current_provider(&app_type));
+        let deepseek_harness_previous_db_current = if matches!(app_type, AppType::DeepSeekHarness) {
+            Some(state.db.get_current_provider(app_type.as_str())?)
+        } else {
+            None
+        };
+        let deepseek_harness_provider_before_backfill =
+            if matches!(app_type, AppType::DeepSeekHarness) {
+                current_id
+                    .as_deref()
+                    .and_then(|current_id| providers.get(current_id))
+                    .cloned()
+            } else {
+                None
+            };
         let current_managed_codex_account_id = current_id
             .as_deref()
             .and_then(|current_id| providers.get(current_id))
             .and_then(Self::managed_codex_oauth_account_id);
 
         let mut backfill_completed = false;
-        if let Some(current_id) = current_id {
+        if let Some(current_id) = current_id.as_deref() {
             if current_id != id {
                 // Additive mode apps - all providers coexist in the same file,
                 // no backfill needed (backfill is for exclusive mode apps like Claude/Codex/Gemini)
                 if !app_type.is_additive_mode() {
                     // Only backfill when switching to a different provider
                     if let Ok(live_config) = read_live_settings(app_type.clone()) {
-                        if let Some(mut current_provider) = providers.get(&current_id).cloned() {
+                        if let Some(mut current_provider) = providers.get(current_id).cloned() {
                             // 切走前先把 live 里的可共享改动（含用户直接在应用内
                             // 装插件/加 hook/改偏好）同步进通用配置片段，再做剥离回填。
                             // 详见 sync_common_config_snippet_from_live 的文档。
@@ -6004,17 +7068,52 @@ impl ProviderService {
                 state.db.set_current_provider(app_type.as_str(), id)?;
             }
 
-            // Sync to live (write_gemini_live handles security flag internally for Gemini).
-            Self::write_preflighted_or_current_live(
-                state,
-                &app_type,
-                provider,
-                preflighted_provider.as_ref(),
-            )?;
+            // Harness retains the native writer's CAS rollback token until both
+            // current pointers commit. Other apps keep the ordinary live path.
+            let deepseek_harness_write_outcome = if commit_current_after_live {
+                Some(Self::write_deepseek_harness_live_transactional(
+                    state, provider,
+                )?)
+            } else {
+                Self::write_preflighted_or_current_live(
+                    state,
+                    &app_type,
+                    provider,
+                    preflighted_provider.as_ref(),
+                )?;
+                None
+            };
 
             if commit_current_after_live {
-                crate::settings::set_current_provider(&app_type, Some(id))?;
-                state.db.set_current_provider(app_type.as_str(), id)?;
+                let mut local_current_committed = false;
+                let pointer_commit = (|| {
+                    crate::settings::set_current_provider(&app_type, Some(id))?;
+                    local_current_committed = true;
+                    state.db.set_current_provider(app_type.as_str(), id)?;
+                    Ok::<(), AppError>(())
+                })();
+
+                if let Err(error) = pointer_commit {
+                    return Err(Self::deepseek_harness_switch_transaction_error(
+                        state,
+                        error,
+                        DeepSeekHarnessSwitchRollback {
+                            outcome: deepseek_harness_write_outcome
+                                .as_ref()
+                                .expect("Harness live write outcome must exist"),
+                            previous_local_current: deepseek_harness_previous_local_current
+                                .as_ref()
+                                .and_then(|current| current.as_deref()),
+                            local_current_committed,
+                            previous_db_current: deepseek_harness_previous_db_current
+                                .as_ref()
+                                .and_then(|current| current.as_deref()),
+                            previous_provider_before_backfill:
+                                deepseek_harness_provider_before_backfill.as_ref(),
+                            backfill_completed,
+                        },
+                    ));
+                }
             }
         }
         // A material-less official Codex provider gets a config-only live
@@ -6122,6 +7221,14 @@ impl ProviderService {
             return sync_current_provider_for_app_to_live(state, &app_type);
         }
 
+        let _deepseek_harness_sync_guard = if matches!(app_type, AppType::DeepSeekHarness) {
+            Some(futures::executor::block_on(
+                state.proxy_service.lock_switch_for_app(app_type.as_str()),
+            ))
+        } else {
+            None
+        };
+
         let current_id =
             match crate::settings::get_effective_current_provider(&state.db, &app_type)? {
                 Some(id) => id,
@@ -6145,7 +7252,7 @@ impl ProviderService {
 
         // See the save path above: backup/placeholders are the ownership signal
         // here, not just proxy_config.enabled.
-        if has_live_backup || live_taken_over {
+        if !matches!(app_type, AppType::DeepSeekHarness) && (has_live_backup || live_taken_over) {
             if matches!(app_type, AppType::ClaudeDesktop) {
                 write_live_with_common_config_for_state(state, &app_type, provider)?;
                 return Ok(());
@@ -6977,13 +8084,12 @@ impl ProviderService {
         app_type: AppType,
         updates: Vec<ProviderSortUpdate>,
     ) -> Result<bool, AppError> {
-        let mut providers = state.db.get_all_providers(app_type.as_str())?;
-
         for update in updates {
-            if let Some(provider) = providers.get_mut(&update.id) {
-                provider.sort_index = Some(update.sort_index);
-                state.db.save_provider(app_type.as_str(), provider)?;
-            }
+            state.db.update_provider_sort_index(
+                app_type.as_str(),
+                &update.id,
+                update.sort_index,
+            )?;
         }
 
         Ok(true)
@@ -7151,78 +8257,11 @@ impl ProviderService {
                 crate::pi_config::validate_provider_node(&provider.id, &provider.settings_config)?;
             }
             AppType::DeepSeekHarness => {
-                let settings = provider.settings_config.as_object().ok_or_else(|| {
-                    AppError::localized(
-                        "provider.deepseek_harness.settings.not_object",
-                        "DeepSeek Harness 配置必须是 JSON 对象",
-                        "DeepSeek Harness configuration must be a JSON object",
-                    )
-                })?;
-
-                if settings
-                    .get("defaultModel")
-                    .and_then(Value::as_str)
-                    .is_none_or(|value| value.trim().is_empty())
-                {
-                    return Err(AppError::localized(
-                        "provider.deepseek_harness.default_model.missing",
-                        "DeepSeek Harness 配置缺少 defaultModel",
-                        "DeepSeek Harness configuration is missing defaultModel",
-                    ));
-                }
-
-                if settings.contains_key("apiKeyEnv")
-                    && settings
-                        .get("apiKeyEnv")
-                        .and_then(Value::as_str)
-                        .is_none_or(|value| value.trim().is_empty())
-                {
-                    return Err(AppError::localized(
-                        "provider.deepseek_harness.api_key_env.invalid",
-                        "DeepSeek Harness apiKeyEnv 必须是非空字符串",
-                        "DeepSeek Harness apiKeyEnv must be a non-empty string",
-                    ));
-                }
-
-                let thinking = settings.get("thinking").and_then(Value::as_str);
-                if settings.contains_key("thinking")
-                    && !matches!(thinking, Some("enabled" | "disabled"))
-                {
-                    return Err(AppError::localized(
-                        "provider.deepseek_harness.thinking.invalid",
-                        "DeepSeek Harness thinking 必须是 enabled 或 disabled",
-                        "DeepSeek Harness thinking must be enabled or disabled",
-                    ));
-                }
-
-                let effort = settings.get("reasoningEffort").and_then(Value::as_str);
-                if settings.contains_key("reasoningEffort")
-                    && !matches!(effort, Some("off" | "high" | "max"))
-                {
-                    return Err(AppError::localized(
-                        "provider.deepseek_harness.reasoning_effort.invalid",
-                        "DeepSeek Harness reasoningEffort 必须是 off、high 或 max",
-                        "DeepSeek Harness reasoningEffort must be off, high, or max",
-                    ));
-                }
-
-                if thinking == Some("disabled") && effort.is_some_and(|value| value != "off") {
-                    return Err(AppError::localized(
-                        "provider.deepseek_harness.thinking_effort.conflict",
-                        "thinking 为 disabled 时 reasoningEffort 只能为 off",
-                        "reasoningEffort must be off when thinking is disabled",
-                    ));
-                }
-
-                if let Some(default_effort) = settings.get("defaultReasoningEffort") {
-                    if !matches!(default_effort.as_str(), Some("off" | "high" | "max")) {
-                        return Err(AppError::localized(
-                            "provider.deepseek_harness.default_reasoning_effort.invalid",
-                            "DeepSeek Harness defaultReasoningEffort 必须是 off、high 或 max",
-                            "DeepSeek Harness defaultReasoningEffort must be off, high, or max",
-                        ));
-                    }
-                }
+                // Use the exact same pure preparation/validation path as the
+                // native writer, including credential-reference combinations.
+                // This is required even for non-current CRUD rows, which may not
+                // be projected to live until a much later switch.
+                crate::dsh_config::validate_settings_config(&provider.settings_config)?;
             }
         }
 

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -235,8 +235,10 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let old_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
         let old_home = std::env::var_os("HOME");
+        let old_dsh_home = std::env::var_os("DSH_HOME");
         std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
         std::env::set_var("HOME", temp.path());
+        std::env::set_var("DSH_HOME", temp.path().join(".dsh"));
 
         let db = Arc::new(Database::memory().expect("in-memory database"));
         let state = AppState::new(db);
@@ -249,6 +251,10 @@ mod tests {
         match old_home {
             Some(value) => std::env::set_var("HOME", value),
             None => std::env::remove_var("HOME"),
+        }
+        match old_dsh_home {
+            Some(value) => std::env::set_var("DSH_HOME", value),
+            None => std::env::remove_var("DSH_HOME"),
         }
 
         result
@@ -415,6 +421,18 @@ mod tests {
             icon_color: None,
             in_failover_queue: false,
         }
+    }
+
+    fn deepseek_harness_provider(id: &str, model: &str) -> Provider {
+        Provider::with_id(
+            id.to_string(),
+            format!("Provider {id}"),
+            json!({
+                "defaultModel": model,
+                "apiKeyEnv": "TEST_DSH_API_KEY"
+            }),
+            None,
+        )
     }
 
     fn opencode_omo_provider(id: &str, category: &str) -> Provider {
@@ -2349,6 +2367,95 @@ requires_openai_auth = true
             json!([{ "name": "claude-sonnet-4-6", "labelOverride": "DeepSeek V4 Flash Updated", "supports1m": true }]),
             "provider edits should propagate into the Claude Desktop 3P profile during takeover"
         );
+    }
+
+    #[test]
+    #[serial]
+    fn update_current_deepseek_harness_provider_rolls_back_db_when_native_write_fails() {
+        with_test_home(|state, home| {
+            let dsh_home = home.join(".dsh");
+            fs::create_dir_all(&dsh_home).expect("create isolated DSH home");
+            let original = deepseek_harness_provider("p1", "deepseek-v4-flash");
+            state
+                .db
+                .save_provider(AppType::DeepSeekHarness.as_str(), &original)
+                .expect("save original provider");
+            state
+                .db
+                .set_current_provider(AppType::DeepSeekHarness.as_str(), "p1")
+                .expect("set current provider");
+            crate::settings::set_current_provider(&AppType::DeepSeekHarness, Some("p1"))
+                .expect("set local current provider");
+
+            let lock_path = dsh_home.join("settings.yaml.lock");
+            fs::write(&lock_path, "contender\n").expect("hold native writer lock");
+            let updated = deepseek_harness_provider("p1", "deepseek-v4-pro");
+            let error = ProviderService::update(state, AppType::DeepSeekHarness, None, updated)
+                .expect_err("native writer lock must reject the update");
+            fs::remove_file(&lock_path).expect("release native writer lock");
+
+            assert!(
+                error.to_string().contains("Timed out"),
+                "unexpected write failure: {error}"
+            );
+            let stored = state
+                .db
+                .get_provider_by_id("p1", AppType::DeepSeekHarness.as_str())
+                .expect("read stored provider")
+                .expect("provider remains stored");
+            assert_eq!(
+                stored.settings_config, original.settings_config,
+                "failed native writes must restore the exact previous provider snapshot"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn update_current_deepseek_harness_provider_ignores_stale_proxy_backup() {
+        with_test_home(|state, home| {
+            let original = deepseek_harness_provider("p1", "deepseek-v4-flash");
+            state
+                .db
+                .save_provider(AppType::DeepSeekHarness.as_str(), &original)
+                .expect("save original provider");
+            state
+                .db
+                .set_current_provider(AppType::DeepSeekHarness.as_str(), "p1")
+                .expect("set current provider");
+            crate::settings::set_current_provider(&AppType::DeepSeekHarness, Some("p1"))
+                .expect("set local current provider");
+
+            futures::executor::block_on(
+                state
+                    .db
+                    .save_live_backup(AppType::DeepSeekHarness.as_str(), "stale-backup"),
+            )
+            .expect("seed stale proxy backup");
+
+            let updated = deepseek_harness_provider("p1", "deepseek-v4-pro");
+            ProviderService::update(state, AppType::DeepSeekHarness, None, updated.clone())
+                .expect("stale proxy state must not divert the native write");
+
+            let settings = fs::read_to_string(home.join(".dsh").join("settings.yaml"))
+                .expect("native Harness settings were written");
+            assert!(settings.contains("model: deepseek-v4-pro"));
+            let stored = state
+                .db
+                .get_provider_by_id("p1", AppType::DeepSeekHarness.as_str())
+                .expect("read stored provider")
+                .expect("provider remains stored");
+            assert_eq!(stored.settings_config, updated.settings_config);
+            assert_eq!(
+                futures::executor::block_on(
+                    state.db.get_live_backup(AppType::DeepSeekHarness.as_str())
+                )
+                .expect("read stale backup")
+                .expect("stale backup remains untouched")
+                .original_config,
+                "stale-backup"
+            );
+        });
     }
 
     #[test]
@@ -4903,6 +5010,15 @@ impl ProviderService {
             return Ok(true);
         }
 
+        // First Harness provider: validate and project the native files before
+        // persisting a provider/current pointer. This avoids a failed native
+        // lock or environment-shadow check leaving a phantom DB provider.
+        let harness_first = matches!(app_type, AppType::DeepSeekHarness)
+            && state.db.get_current_provider(app_type.as_str())?.is_none();
+        if harness_first {
+            write_live_with_common_config_for_state(state, &app_type, &provider)?;
+        }
+
         // Save to database
         state.db.save_provider(app_type.as_str(), &provider)?;
 
@@ -4926,12 +5042,23 @@ impl ProviderService {
         // For other apps: Check if sync is needed (if this is current provider, or no current provider)
         let current = state.db.get_current_provider(app_type.as_str())?;
         if current.is_none() {
-            // No current provider, set as current and sync. Managed Codex adds
-            // use the transactional path above because token resolution can fail.
-            state
-                .db
-                .set_current_provider(app_type.as_str(), &provider.id)?;
-            write_live_with_common_config_for_state(state, &app_type, &provider)?;
+            // Harness may reject a native writer lock or environment-shadow
+            // conflict. Do not mark the first provider current until its live
+            // projection has succeeded.
+            if !matches!(app_type, AppType::DeepSeekHarness) {
+                state
+                    .db
+                    .set_current_provider(app_type.as_str(), &provider.id)?;
+            }
+            if !harness_first {
+                write_live_with_common_config_for_state(state, &app_type, &provider)?;
+            }
+            if matches!(app_type, AppType::DeepSeekHarness) {
+                state
+                    .db
+                    .set_current_provider(app_type.as_str(), &provider.id)?;
+                crate::settings::set_current_provider(&app_type, Some(&provider.id))?;
+            }
         }
 
         Ok(true)
@@ -5387,7 +5514,11 @@ impl ProviderService {
             // Backup or live placeholders mean the live file is currently owned
             // by proxy takeover, including the short activation window before
             // proxy_config.enabled is committed.
-            let should_sync_via_proxy = has_live_backup || live_taken_over;
+            // DeepSeek Harness is never proxy-managed. A stale backup row from a
+            // previous app version must not divert its native settings write into
+            // the proxy takeover path.
+            let should_sync_via_proxy = !matches!(app_type, AppType::DeepSeekHarness)
+                && (has_live_backup || live_taken_over);
 
             if should_sync_via_proxy {
                 if matches!(app_type, AppType::ClaudeDesktop) {
@@ -5426,7 +5557,32 @@ impl ProviderService {
                     }
                 }
             } else {
-                write_live_with_common_config_for_state(state, &app_type, &provider)?;
+                if let Err(err) = write_live_with_common_config_for_state(
+                    state,
+                    &app_type,
+                    &provider,
+                ) {
+                    // Harness native writes can be rejected by its cross-process
+                    // lock or by an inherited environment override. Restore the
+                    // provider snapshot so a reported save failure does not leave
+                    // CC Switch ahead of the live Harness configuration.
+                    if matches!(app_type, AppType::DeepSeekHarness) {
+                        let rollback_result = match existing_provider.as_ref() {
+                            Some(previous) => state.db.save_provider(app_type.as_str(), previous),
+                            None => state
+                                .db
+                                .delete_provider(app_type.as_str(), provider.id.as_str()),
+                        };
+                        if let Err(rollback_err) = rollback_result {
+                            return Err(AppError::Message(format!(
+                                "Failed to write DeepSeek Harness live configuration ({err}); \
+                                 restoring the previous provider snapshot also failed: \
+                                 {rollback_err}"
+                            )));
+                        }
+                    }
+                    return Err(err);
+                }
                 // 重写 live 后只重投影本应用的 MCP：全量 sync_all_enabled 会把
                 // 无关应用的 live 损坏（如 ~/.claude.json 坏 JSON）牵连进保存
                 // 流程。走到这里 DB 与 live 都已按新配置落盘，保存事实上已
@@ -5621,7 +5777,7 @@ impl ProviderService {
             return Self::switch_normal(state, app_type, id, &providers);
         }
 
-        if matches!(app_type, AppType::ClaudeDesktop) {
+        if matches!(app_type, AppType::ClaudeDesktop | AppType::DeepSeekHarness) {
             return Self::switch_normal(state, app_type, id, &providers);
         }
 
@@ -5783,6 +5939,11 @@ impl ProviderService {
             outgoing_managed_codex_account_id.as_deref(),
         )?;
 
+        // Harness writes two live documents and may reject a native writer-lock
+        // or environment-shadow conflict. Commit the current pointer only after
+        // that write succeeds so a failed switch cannot claim it took effect.
+        let commit_current_after_live = matches!(app_type, AppType::DeepSeekHarness);
+
         // 提交 current 前预检托管 Codex token（见 preflight_managed_codex_live）。
         let preflighted_provider = Self::preflight_managed_codex_live(state, &app_type, provider)?;
         let use_managed_codex_transaction = matches!(app_type, AppType::Codex)
@@ -5840,7 +6001,7 @@ impl ProviderService {
             }
         } else {
             // Additive mode apps skip setting is_current (no such concept).
-            if !app_type.is_additive_mode() {
+            if !app_type.is_additive_mode() && !commit_current_after_live {
                 crate::settings::set_current_provider(&app_type, Some(id))?;
                 state.db.set_current_provider(app_type.as_str(), id)?;
             }
@@ -5852,8 +6013,12 @@ impl ProviderService {
                 provider,
                 preflighted_provider.as_ref(),
             )?;
-        }
 
+            if commit_current_after_live {
+                crate::settings::set_current_provider(&app_type, Some(id))?;
+                state.db.set_current_provider(app_type.as_str(), id)?;
+            }
+        }
         // A material-less official Codex provider gets a config-only live
         // write, which can leave the previous third-party key in
         // ~/.codex/auth.json and strand the user on a 401 with no login
@@ -6199,6 +6364,7 @@ impl ProviderService {
             AppType::OpenClaw => Self::extract_openclaw_common_config(&provider.settings_config),
             AppType::Hermes => Ok(String::new()), // Hermes doesn't use common config snippets
             AppType::Pi => Ok(String::new()),
+            AppType::DeepSeekHarness => Ok(String::new()),
         }
     }
 
@@ -6217,6 +6383,7 @@ impl ProviderService {
             AppType::OpenClaw => Self::extract_openclaw_common_config(settings_config),
             AppType::Hermes => Ok(String::new()), // Hermes doesn't use common config snippets
             AppType::Pi => Ok(String::new()),
+            AppType::DeepSeekHarness => Ok(String::new()),
         }
     }
 
@@ -6985,6 +7152,80 @@ impl ProviderService {
             AppType::Pi => {
                 crate::pi_config::validate_provider_node(&provider.id, &provider.settings_config)?;
             }
+            AppType::DeepSeekHarness => {
+                let settings = provider.settings_config.as_object().ok_or_else(|| {
+                    AppError::localized(
+                        "provider.deepseek_harness.settings.not_object",
+                        "DeepSeek Harness 配置必须是 JSON 对象",
+                        "DeepSeek Harness configuration must be a JSON object",
+                    )
+                })?;
+
+                if settings
+                    .get("defaultModel")
+                    .and_then(Value::as_str)
+                    .is_none_or(|value| value.trim().is_empty())
+                {
+                    return Err(AppError::localized(
+                        "provider.deepseek_harness.default_model.missing",
+                        "DeepSeek Harness 配置缺少 defaultModel",
+                        "DeepSeek Harness configuration is missing defaultModel",
+                    ));
+                }
+
+                if settings.contains_key("apiKeyEnv")
+                    && settings
+                        .get("apiKeyEnv")
+                        .and_then(Value::as_str)
+                        .is_none_or(|value| value.trim().is_empty())
+                {
+                    return Err(AppError::localized(
+                        "provider.deepseek_harness.api_key_env.invalid",
+                        "DeepSeek Harness apiKeyEnv 必须是非空字符串",
+                        "DeepSeek Harness apiKeyEnv must be a non-empty string",
+                    ));
+                }
+
+                let thinking = settings.get("thinking").and_then(Value::as_str);
+                if settings.contains_key("thinking")
+                    && !matches!(thinking, Some("enabled" | "disabled"))
+                {
+                    return Err(AppError::localized(
+                        "provider.deepseek_harness.thinking.invalid",
+                        "DeepSeek Harness thinking 必须是 enabled 或 disabled",
+                        "DeepSeek Harness thinking must be enabled or disabled",
+                    ));
+                }
+
+                let effort = settings.get("reasoningEffort").and_then(Value::as_str);
+                if settings.contains_key("reasoningEffort")
+                    && !matches!(effort, Some("off" | "high" | "max"))
+                {
+                    return Err(AppError::localized(
+                        "provider.deepseek_harness.reasoning_effort.invalid",
+                        "DeepSeek Harness reasoningEffort 必须是 off、high 或 max",
+                        "DeepSeek Harness reasoningEffort must be off, high, or max",
+                    ));
+                }
+
+                if thinking == Some("disabled") && effort.is_some_and(|value| value != "off") {
+                    return Err(AppError::localized(
+                        "provider.deepseek_harness.thinking_effort.conflict",
+                        "thinking 为 disabled 时 reasoningEffort 只能为 off",
+                        "reasoningEffort must be off when thinking is disabled",
+                    ));
+                }
+
+                if let Some(default_effort) = settings.get("defaultReasoningEffort") {
+                    if !matches!(default_effort.as_str(), Some("off" | "high" | "max")) {
+                        return Err(AppError::localized(
+                            "provider.deepseek_harness.default_reasoning_effort.invalid",
+                            "DeepSeek Harness defaultReasoningEffort 必须是 off、high 或 max",
+                            "DeepSeek Harness defaultReasoningEffort must be off, high, or max",
+                        ));
+                    }
+                }
+            }
         }
 
         // Validate and clean UsageScript configuration (common for all app types)
@@ -7213,6 +7454,11 @@ impl ProviderService {
 
                 Ok((api_key, base_url))
             }
+            AppType::DeepSeekHarness => Err(AppError::localized(
+                "provider.deepseek_harness.credentials.unsupported",
+                "DeepSeek Harness 暂不支持用量或代理凭据提取",
+                "DeepSeek Harness usage and proxy credential extraction is not supported",
+            )),
         }
     }
 }

--- a/src-tauri/src/services/provider/usage.rs
+++ b/src-tauri/src/services/provider/usage.rs
@@ -128,6 +128,13 @@ pub async fn query_usage(
     app_type: AppType,
     provider_id: &str,
 ) -> Result<UsageResult, AppError> {
+    if matches!(app_type, AppType::DeepSeekHarness) {
+        return Err(AppError::localized(
+            "provider.deepseek_harness.usage.unsupported",
+            "DeepSeek Harness 暂不支持用量查询",
+            "DeepSeek Harness usage queries are not supported",
+        ));
+    }
     let (script_code, timeout, api_key, base_url, access_token, user_id, template_type) = {
         let providers = state.db.get_all_providers(app_type.as_str())?;
         let provider = providers.get(provider_id).ok_or_else(|| {
@@ -202,6 +209,13 @@ pub async fn test_usage_script(
     user_id: Option<&str>,
     template_type: Option<&str>,
 ) -> Result<UsageResult, AppError> {
+    if matches!(app_type, AppType::DeepSeekHarness) {
+        return Err(AppError::localized(
+            "provider.deepseek_harness.usage.unsupported",
+            "DeepSeek Harness 暂不支持用量查询",
+            "DeepSeek Harness usage queries are not supported",
+        ));
+    }
     let providers = state.db.get_all_providers(app_type.as_str())?;
     let provider = providers.get(provider_id).ok_or_else(|| {
         AppError::localized(

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1143,6 +1143,12 @@ impl ProxyService {
     /// - 关闭：仅恢复当前 app 的 Live 配置；若无其它接管，则自动停止代理服务
     pub async fn set_takeover_for_app(&self, app_type: &str, enabled: bool) -> Result<(), String> {
         let app = AppType::from_str(app_type).map_err(|e| format!("无效的应用类型: {e}"))?;
+        if matches!(app, AppType::DeepSeekHarness) {
+            return Err(
+                "DeepSeek Harness 暂不支持代理接管 (DeepSeek Harness proxy takeover is not supported)"
+                    .to_string(),
+            );
+        }
         if !app.supports_local_proxy() {
             return Err(format!("{} 不支持本地路由", app.as_str()));
         }
@@ -2947,6 +2953,12 @@ impl ProxyService {
     ) -> Result<HotSwitchOutcome, String> {
         let app_type_enum =
             AppType::from_str(app_type).map_err(|_| format!("无效的应用类型: {app_type}"))?;
+        if matches!(app_type_enum, AppType::DeepSeekHarness) {
+            return Err(
+                "DeepSeek Harness 暂不支持代理切换 (DeepSeek Harness proxy switching is not supported)"
+                    .to_string(),
+            );
+        }
         let provider = self
             .db
             .get_provider_by_id(provider_id, app_type)

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -608,6 +608,9 @@ impl SkillService {
             AppType::Pi => {
                 return Ok(crate::pi_config::get_pi_agent_dir()?.join("skills"));
             }
+            AppType::DeepSeekHarness => {
+                log::debug!("DeepSeek Harness skill sync is not supported, skipping");
+            }
         }
 
         // 默认路径：回退到用户主目录下的标准位置。
@@ -625,6 +628,9 @@ impl SkillService {
             AppType::OpenClaw => home.join(".openclaw").join("skills"),
             AppType::Hermes => crate::hermes_config::get_hermes_dir().join("skills"),
             AppType::Pi => crate::pi_config::get_pi_agent_dir()?.join("skills"),
+            AppType::DeepSeekHarness => {
+                return Err(anyhow!("DeepSeek Harness does not support Skills"));
+            }
         })
     }
 
@@ -2239,7 +2245,7 @@ impl SkillService {
     /// - Symlink: 仅使用 symlink
     /// - Copy: 仅使用文件复制
     pub fn sync_to_app_dir(directory: &str, app: &AppType) -> Result<()> {
-        if matches!(app, AppType::ClaudeDesktop) {
+        if matches!(app, AppType::ClaudeDesktop | AppType::DeepSeekHarness) {
             return Ok(());
         }
 
@@ -2426,7 +2432,7 @@ impl SkillService {
         app: &AppType,
         preserved_path: Option<&Path>,
     ) -> Result<()> {
-        if matches!(app, AppType::ClaudeDesktop) {
+        if matches!(app, AppType::ClaudeDesktop | AppType::DeepSeekHarness) {
             return Ok(());
         }
 
@@ -2463,7 +2469,10 @@ impl SkillService {
 
     /// Caller must hold either the Skills state read or write guard.
     fn sync_to_app_unlocked(db: &Arc<Database>, app: &AppType) -> Result<()> {
-        if matches!(app, AppType::ClaudeDesktop | AppType::Pi) {
+        if matches!(
+            app,
+            AppType::ClaudeDesktop | AppType::Pi | AppType::DeepSeekHarness
+        ) {
             return Ok(());
         }
 

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -688,7 +688,7 @@ impl SkillService {
 
     fn validate_skill_storage_destination(ssot_dir: &Path) -> Result<()> {
         for app in AppType::all() {
-            if matches!(app, AppType::ClaudeDesktop) {
+            if matches!(app, AppType::ClaudeDesktop | AppType::DeepSeekHarness) {
                 continue;
             }
             let app_dir = Self::get_app_skills_dir(&app)?;
@@ -5532,6 +5532,20 @@ mod tests {
             source.join("SKILL.md").exists(),
             "validation must happen before any source is moved"
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn validate_skill_storage_destination_ignores_apps_without_skill_storage() {
+        let temp = tempdir().expect("tempdir");
+        let _home = TestHomeGuard::set(temp.path());
+        let _pi_dir =
+            crate::pi_config::test_support::TestAgentDir::at(&temp.path().join("pi-agent"));
+        let target = temp.path().join("custom-skills");
+        fs::create_dir_all(&target).expect("create target");
+
+        SkillService::validate_skill_storage_destination(&target)
+            .expect("apps without managed Skills directories must be ignored");
     }
 
     #[test]

--- a/src-tauri/src/services/stream_check.rs
+++ b/src-tauri/src/services/stream_check.rs
@@ -182,6 +182,11 @@ impl StreamCheckService {
             AppType::OpenClaw => Self::extract_openclaw_base_url(provider),
             AppType::Hermes => Self::extract_hermes_base_url(provider),
             AppType::Pi => crate::pi_config::provider_base_url(&provider.settings_config),
+            AppType::DeepSeekHarness => Err(AppError::localized(
+                "provider.deepseek_harness.stream_check.unsupported",
+                "DeepSeek Harness 暂不支持连通性检测",
+                "DeepSeek Harness reachability checks are not supported",
+            )),
             AppType::ClaudeDesktop => ClaudeAdapter::new()
                 .extract_base_url(provider)
                 .map_err(|e| AppError::Message(format!("Failed to extract base_url: {e}"))),

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -209,6 +209,10 @@ fn provider_roots(provider_id: &str) -> Result<Vec<PathBuf>, String> {
         "grokbuild" => grokbuild::session_roots(),
         "hermes" => vec![crate::hermes_config::get_hermes_dir().join("sessions")],
         "pi" => pi::session_roots(),
+        // Harness session storage is not managed in the initial integration.
+        "deepseek-harness" | "deepseek_harness" | "dsh" => {
+            return Err("DeepSeek Harness session management is not supported".to_string())
+        }
         _ => return Err(format!("Unsupported provider: {provider_id}")),
     };
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -704,35 +704,9 @@ fn save_settings_file(settings: &AppSettings) -> Result<(), AppError> {
         return Err(AppError::Config("无法获取用户主目录".to_string()));
     };
 
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
-    }
-
     let json = serde_json::to_string_pretty(&normalized)
         .map_err(|e| AppError::JsonSerialize { source: e })?;
-    #[cfg(unix)]
-    {
-        use std::fs::OpenOptions;
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-
-        let mut file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(&path)
-            .map_err(|e| AppError::io(&path, e))?;
-        file.write_all(json.as_bytes())
-            .map_err(|e| AppError::io(&path, e))?;
-    }
-
-    #[cfg(not(unix))]
-    {
-        fs::write(&path, json).map_err(|e| AppError::io(&path, e))?;
-    }
-
-    Ok(())
+    crate::config::atomic_write_private(&path, json.as_bytes())
 }
 
 static SETTINGS_STORE: OnceLock<RwLock<AppSettings>> = OnceLock::new();
@@ -788,32 +762,38 @@ pub fn get_settings_for_frontend() -> AppSettings {
     settings
 }
 
-pub fn update_settings(mut new_settings: AppSettings) -> Result<(), AppError> {
-    new_settings.normalize_paths();
-    save_settings_file(&new_settings)?;
-
+/// Replace settings while holding the in-process write lock across both the
+/// read/derive step and persistence. This keeps the JSON file and the memory
+/// cache on the same generation and lets callers merge against the latest
+/// backend-owned fields without a read-then-write race.
+pub(crate) fn update_settings_atomically<F, R>(update: F) -> Result<R, AppError>
+where
+    F: FnOnce(&AppSettings) -> (AppSettings, R),
+{
     let mut guard = settings_store().write().unwrap_or_else(|e| {
         log::warn!("设置锁已毒化，使用恢复值: {e}");
         e.into_inner()
     });
-    *guard = new_settings;
-    Ok(())
+    let (mut next, result) = update(&guard);
+    next.normalize_paths();
+    save_settings_file(&next)?;
+    *guard = next;
+    Ok(result)
+}
+
+pub fn update_settings(new_settings: AppSettings) -> Result<(), AppError> {
+    update_settings_atomically(|_| (new_settings, ()))
 }
 
 fn mutate_settings<F>(mutator: F) -> Result<(), AppError>
 where
     F: FnOnce(&mut AppSettings),
 {
-    let mut guard = settings_store().write().unwrap_or_else(|e| {
-        log::warn!("设置锁已毒化，使用恢复值: {e}");
-        e.into_inner()
-    });
-    let mut next = guard.clone();
-    mutator(&mut next);
-    next.normalize_paths();
-    save_settings_file(&next)?;
-    *guard = next;
-    Ok(())
+    update_settings_atomically(|current| {
+        let mut next = current.clone();
+        mutator(&mut next);
+        (next, ())
+    })
 }
 
 pub fn is_codex_third_party_history_provider_bucket_migrated() -> bool {
@@ -1249,5 +1229,81 @@ mod tests {
             resolve_override_path(r"~\pi\agent"),
             home.join("pi").join("agent")
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn atomic_settings_update_keeps_concurrent_backend_pointer_and_file_in_sync() {
+        let temp = tempfile::tempdir().expect("create isolated settings home");
+        let previous_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+
+        let previous = get_settings();
+        update_settings(AppSettings::default()).expect("seed isolated settings");
+
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let (update_done_tx, update_done_rx) = std::sync::mpsc::channel();
+        let (pointer_done_tx, pointer_done_rx) = std::sync::mpsc::channel();
+
+        std::thread::scope(|scope| {
+            scope.spawn(move || {
+                let result = update_settings_atomically(|current| {
+                    entered_tx.send(()).expect("signal locked merge");
+                    release_rx.recv().expect("release locked merge");
+                    let mut next = current.clone();
+                    next.language = Some("zh".to_string());
+                    (next, ())
+                });
+                update_done_tx.send(result).expect("send update result");
+            });
+
+            entered_rx.recv().expect("wait for settings write lock");
+            scope.spawn(move || {
+                let result = set_current_provider(&AppType::DeepSeekHarness, Some("harness-new"));
+                pointer_done_tx
+                    .send(result)
+                    .expect("send pointer update result");
+            });
+
+            assert!(
+                pointer_done_rx
+                    .recv_timeout(std::time::Duration::from_millis(100))
+                    .is_err(),
+                "backend pointer update must wait for the atomic settings commit"
+            );
+            release_tx.send(()).expect("release settings commit");
+            update_done_rx
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .expect("atomic update should finish")
+                .expect("atomic update should succeed");
+            pointer_done_rx
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .expect("pointer update should finish")
+                .expect("pointer update should succeed");
+        });
+
+        let memory = get_settings();
+        let persisted: AppSettings = serde_json::from_slice(
+            &std::fs::read(temp.path().join(".cc-switch").join("settings.json"))
+                .expect("read persisted settings"),
+        )
+        .expect("parse persisted settings");
+        assert_eq!(memory.language.as_deref(), Some("zh"));
+        assert_eq!(
+            memory.current_provider_deepseek_harness.as_deref(),
+            Some("harness-new")
+        );
+        assert_eq!(persisted.language, memory.language);
+        assert_eq!(
+            persisted.current_provider_deepseek_harness,
+            memory.current_provider_deepseek_harness
+        );
+
+        update_settings(previous).expect("restore process-global settings");
+        match previous_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -48,6 +48,13 @@ pub struct VisibleApps {
     pub hermes: bool,
     #[serde(default = "default_true")]
     pub pi: bool,
+    #[serde(
+        rename = "deepseek-harness",
+        alias = "deepseekHarness",
+        alias = "deepseek_harness",
+        default
+    )]
+    pub deepseek_harness: bool,
 }
 
 impl Default for VisibleApps {
@@ -60,6 +67,7 @@ impl Default for VisibleApps {
             grokbuild: true,
             opencode: true,
             openclaw: true,
+            deepseek_harness: false,
             hermes: false, // 默认不显示，需用户手动启用
             pi: true,
         }
@@ -79,6 +87,7 @@ impl VisibleApps {
             AppType::OpenClaw => self.openclaw,
             AppType::Hermes => self.hermes,
             AppType::Pi => self.pi,
+            AppType::DeepSeekHarness => self.deepseek_harness,
         }
     }
 }
@@ -428,6 +437,8 @@ pub struct AppSettings {
     pub hermes_config_dir: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pi_config_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deepseek_harness_config_dir: Option<String>,
 
     // ===== 当前供应商 ID（设备级）=====
     /// 当前 Claude 供应商 ID（本地存储，优先于数据库 is_current）
@@ -454,6 +465,8 @@ pub struct AppSettings {
     /// 当前 Hermes 供应商 ID（本地存储，保持结构一致）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_hermes: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_deepseek_harness: Option<String>,
 
     // ===== Skill 同步设置 =====
     /// Skill 同步方式：auto（默认，优先 symlink）、symlink、copy
@@ -540,6 +553,7 @@ impl Default for AppSettings {
             openclaw_config_dir: None,
             hermes_config_dir: None,
             pi_config_dir: None,
+            deepseek_harness_config_dir: None,
             current_provider_claude: None,
             current_provider_claude_desktop: None,
             current_provider_codex: None,
@@ -548,6 +562,7 @@ impl Default for AppSettings {
             current_provider_opencode: None,
             current_provider_openclaw: None,
             current_provider_hermes: None,
+            current_provider_deepseek_harness: None,
             skill_sync_method: SyncMethod::default(),
             skill_storage_location: SkillStorageLocation::default(),
             webdav_sync: None,
@@ -623,6 +638,13 @@ impl AppSettings {
 
         self.pi_config_dir = self
             .pi_config_dir
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        self.deepseek_harness_config_dir = self
+            .deepseek_harness_config_dir
             .as_ref()
             .map(|s| s.trim())
             .filter(|s| !s.is_empty())
@@ -962,6 +984,14 @@ pub fn get_pi_override_dir() -> Option<PathBuf> {
         .map(|path| resolve_override_path(path))
 }
 
+pub fn get_deepseek_harness_override_dir() -> Option<PathBuf> {
+    let settings = settings_store().read().ok()?;
+    settings
+        .deepseek_harness_config_dir
+        .as_ref()
+        .map(|p| resolve_override_path(p))
+}
+
 pub fn preserve_codex_official_auth_on_switch() -> bool {
     settings_store()
         .read()
@@ -1000,6 +1030,7 @@ pub fn get_current_provider(app_type: &AppType) -> Option<String> {
         AppType::OpenClaw => settings.current_provider_openclaw.clone(),
         AppType::Hermes => settings.current_provider_hermes.clone(),
         AppType::Pi => None,
+        AppType::DeepSeekHarness => settings.current_provider_deepseek_harness.clone(),
     }
 }
 
@@ -1019,6 +1050,7 @@ pub fn set_current_provider(app_type: &AppType, id: Option<&str>) -> Result<(), 
         AppType::OpenClaw => settings.current_provider_openclaw = id_owned.clone(),
         AppType::Hermes => settings.current_provider_hermes = id_owned.clone(),
         AppType::Pi => {}
+        AppType::DeepSeekHarness => settings.current_provider_deepseek_harness = id_owned.clone(),
     })
 }
 

--- a/src-tauri/tests/app_type_parse.rs
+++ b/src-tauri/tests/app_type_parse.rs
@@ -19,6 +19,19 @@ fn parse_known_apps_case_insensitive_and_trim() {
         Ok(AppType::Claude)
     ));
     assert!(matches!(AppType::from_str("\tcoDeX\t"), Ok(AppType::Codex)));
+    for alias in ["deepseek-harness", "deepseek_harness", "DSH"] {
+        assert!(matches!(
+            AppType::from_str(alias),
+            Ok(AppType::DeepSeekHarness)
+        ));
+    }
+    assert_eq!(AppType::DeepSeekHarness.as_str(), "deepseek-harness");
+    assert!(!AppType::DeepSeekHarness.is_additive_mode());
+    assert!(AppType::all().any(|app| matches!(app, AppType::DeepSeekHarness)));
+    assert_eq!(
+        serde_json::to_string(&AppType::DeepSeekHarness).unwrap(),
+        "\"deepseek-harness\""
+    );
 }
 
 #[test]

--- a/src-tauri/tests/deeplink_import.rs
+++ b/src-tauri/tests/deeplink_import.rs
@@ -1,10 +1,22 @@
 use std::sync::Arc;
 
-use cc_switch_lib::{import_provider_from_deeplink, parse_deeplink_url, AppState, Database};
+use base64::prelude::*;
+use cc_switch_lib::{
+    import_provider_from_deeplink, parse_deeplink_url, update_settings, AppSettings, AppState,
+    Database, DeepLinkImportRequest,
+};
 
 #[path = "support.rs"]
 mod support;
 use support::{ensure_test_home, reset_test_fs, test_mutex};
+
+fn configure_deepseek_harness_test_home(home: &std::path::Path) {
+    update_settings(AppSettings {
+        deepseek_harness_config_dir: Some(home.join(".dsh").to_string_lossy().into_owned()),
+        ..Default::default()
+    })
+    .expect("configure isolated DeepSeek Harness home");
+}
 
 #[test]
 fn deeplink_import_claude_provider_persists_to_db() {
@@ -83,4 +95,99 @@ fn deeplink_import_codex_provider_builds_auth_and_config() {
         config_text.contains("model = \"gpt-4o\""),
         "config.toml content should contain model setting"
     );
+}
+
+#[test]
+fn deeplink_import_deepseek_harness_allows_native_connection_defaults() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+    configure_deepseek_harness_test_home(home);
+
+    let url = "ccswitch://v1/import?resource=provider&app=dsh&name=DeepSeek";
+    let request = parse_deeplink_url(url).expect("parse deeplink url");
+
+    let db = Arc::new(Database::memory().expect("create memory db"));
+    let state = AppState::new(db.clone());
+
+    let provider_id = import_provider_from_deeplink(&state, request)
+        .expect("import credential-free DeepSeek Harness provider");
+
+    let providers = db
+        .get_all_providers("deepseek-harness")
+        .expect("get DeepSeek Harness providers");
+    let provider = providers
+        .get(&provider_id)
+        .expect("DeepSeek Harness provider created via deeplink");
+
+    assert_eq!(provider.name, "DeepSeek");
+    assert_eq!(
+        provider.settings_config["defaultModel"],
+        "deepseek-v4-flash"
+    );
+    assert!(provider.settings_config.get("apiKey").is_none());
+    assert!(provider.settings_config.get("baseURL").is_none());
+    assert!(provider.website_url.is_none());
+
+    let settings = std::fs::read_to_string(home.join(".dsh/settings.yaml"))
+        .expect("read projected Harness settings");
+    assert!(settings.contains("provider: deepseek-official"));
+    assert!(settings.contains("model: deepseek-v4-flash"));
+    assert!(!home.join(".dsh/.credentials.yaml").exists());
+}
+
+#[test]
+fn deeplink_import_deepseek_harness_rejects_implicit_key_for_custom_endpoint() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+    configure_deepseek_harness_test_home(home);
+
+    let url = "ccswitch://v1/import?resource=provider&app=dsh&name=Unsafe&endpoint=https%3A%2F%2Fattacker.example";
+    let request = parse_deeplink_url(url).expect("parse deeplink url");
+
+    let db = Arc::new(Database::memory().expect("create memory db"));
+    let state = AppState::new(db.clone());
+
+    let error = import_provider_from_deeplink(&state, request)
+        .expect_err("custom endpoint must not reuse an implicit Harness credential");
+
+    assert!(error.to_string().contains("API key is required"));
+    assert!(db
+        .get_all_providers("deepseek-harness")
+        .expect("get DeepSeek Harness providers")
+        .is_empty());
+    assert!(!home.join(".dsh/settings.yaml").exists());
+}
+
+#[test]
+fn deeplink_import_deepseek_harness_checks_endpoint_after_inline_config_merge() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let home = ensure_test_home();
+    configure_deepseek_harness_test_home(home);
+
+    let config = serde_json::json!({ "baseURL": "https://attacker.example" }).to_string();
+    let request = DeepLinkImportRequest {
+        version: "v1".to_string(),
+        resource: "provider".to_string(),
+        app: Some("deepseek-harness".to_string()),
+        name: Some("Unsafe Config".to_string()),
+        config: Some(BASE64_STANDARD.encode(config)),
+        config_format: Some("json".to_string()),
+        ..Default::default()
+    };
+
+    let db = Arc::new(Database::memory().expect("create memory db"));
+    let state = AppState::new(db.clone());
+
+    let error = import_provider_from_deeplink(&state, request)
+        .expect_err("merged custom endpoint must require an explicit credential");
+
+    assert!(error.to_string().contains("API key is required"));
+    assert!(db
+        .get_all_providers("deepseek-harness")
+        .expect("get DeepSeek Harness providers")
+        .is_empty());
+    assert!(!home.join(".dsh/settings.yaml").exists());
 }

--- a/src-tauri/tests/support.rs
+++ b/src-tauri/tests/support.rs
@@ -32,6 +32,7 @@ pub fn reset_test_fs() {
         ".cc-switch",
         ".gemini",
         ".grok",
+        ".dsh",
         ".config",
         ".openclaw",
         "profiles",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,6 +110,7 @@ import HermesMemoryPanel from "@/components/hermes/HermesMemoryPanel";
 import {
   APP_IDS,
   DEFAULT_VISIBLE_APPS,
+  isMcpAppId,
   isProxyAppId,
 } from "@/config/appConfig";
 
@@ -226,7 +227,7 @@ function App() {
 
   // Fallback from sessions view when switching to an app without session support
   useEffect(() => {
-    if (currentView === "mcp" && sharedFeatureApp === "pi") {
+    if (currentView === "mcp" && !isMcpAppId(sharedFeatureApp)) {
       setCurrentView("providers");
       return;
     }
@@ -244,6 +245,17 @@ function App() {
       setCurrentView("providers");
     }
   }, [sharedFeatureApp, currentView]);
+
+  // Phase 1 exposes DeepSeek Harness as an exclusive provider-list app only.
+  useEffect(() => {
+    if (
+      activeApp === "deepseek-harness" &&
+      currentView !== "providers" &&
+      currentView !== "settings"
+    ) {
+      setCurrentView("providers");
+    }
+  }, [activeApp, currentView]);
 
   const [editingProvider, setEditingProvider] = useState<Provider | null>(null);
   const [usageProvider, setUsageProvider] = useState<Provider | null>(null);
@@ -307,7 +319,8 @@ function App() {
       currentView === "openclawAgents");
   const { data: openclawHealthWarnings = [] } =
     useOpenClawHealth(isOpenClawView);
-  const hasSkillsSupport = sharedFeatureApp !== "openclaw";
+  const hasSkillsSupport =
+    sharedFeatureApp !== "openclaw" && sharedFeatureApp !== "deepseek-harness";
   const hasSessionSupport =
     sharedFeatureApp === "claude" ||
     sharedFeatureApp === "codex" ||
@@ -317,7 +330,7 @@ function App() {
     sharedFeatureApp === "gemini" ||
     sharedFeatureApp === "hermes" ||
     sharedFeatureApp === "pi";
-  const hasMcpSupport = sharedFeatureApp !== "pi";
+  const hasMcpSupport = isMcpAppId(sharedFeatureApp);
 
   const {
     addProvider,
@@ -1139,7 +1152,11 @@ function App() {
                           : undefined
                       }
                       onDuplicate={handleDuplicateProvider}
-                      onConfigureUsage={setUsageProvider}
+                      onConfigureUsage={
+                        activeApp === "deepseek-harness"
+                          ? undefined
+                          : setUsageProvider
+                      }
                       onOpenWebsite={handleOpenWebsite}
                       onOpenTerminal={
                         activeApp === "claude" ? handleOpenTerminal : undefined
@@ -1389,6 +1406,7 @@ function App() {
                 </div>
               )}
             {currentView === "providers" &&
+              activeApp !== "deepseek-harness" &&
               (settingsData?.showProfileSwitcher ?? true) && (
                 <div
                   className="flex shrink-0 items-center"
@@ -1570,9 +1588,11 @@ function App() {
                               ? "openclaw"
                               : activeApp === "hermes"
                                 ? "hermes"
-                                : activeApp === "grokbuild"
-                                  ? "grokbuild"
-                                  : "default"
+                                : activeApp === "deepseek-harness"
+                                  ? "deepseek-harness"
+                                  : activeApp === "grokbuild"
+                                    ? "grokbuild"
+                                    : "default"
                           }
                           className="flex items-center gap-1"
                           initial={{ opacity: 0 }}
@@ -1669,7 +1689,7 @@ function App() {
                                 <History className="w-4 h-4" />
                               </Button>
                             </>
-                          ) : (
+                          ) : activeApp === "deepseek-harness" ? null : (
                             <>
                               <Button
                                 variant="ghost"

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -37,6 +37,7 @@ const APP_ICON_NAME: Record<AppId, string> = {
   openclaw: "openclaw",
   hermes: "hermes",
   pi: "pi",
+  "deepseek-harness": "deepseek",
 };
 
 const APP_DISPLAY_NAME: Record<AppId, string> = {
@@ -49,6 +50,7 @@ const APP_DISPLAY_NAME: Record<AppId, string> = {
   openclaw: "OpenClaw",
   hermes: "Hermes",
   pi: "Pi",
+  "deepseek-harness": "DeepSeek Harness",
 };
 
 /** 应用图标 + 角标（Claude Code / Desktop 用角标区分终端与桌面） */

--- a/src/components/prompts/PromptFormPanel.tsx
+++ b/src/components/prompts/PromptFormPanel.tsx
@@ -25,7 +25,7 @@ const PromptFormPanel: React.FC<PromptFormPanelProps> = ({
 }) => {
   const { t } = useTranslation();
   const appName = t(`apps.${appId}`);
-  const filenameMap: Record<AppId, string> = {
+  const filenameMap: Partial<Record<AppId, string>> = {
     claude: "CLAUDE.md",
     "claude-desktop": "CLAUDE.md",
     codex: "AGENTS.md",
@@ -36,7 +36,7 @@ const PromptFormPanel: React.FC<PromptFormPanelProps> = ({
     hermes: "SOUL.md",
     pi: "AGENTS.md",
   };
-  const filename = filenameMap[appId];
+  const filename = filenameMap[appId] ?? "";
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [content, setContent] = useState("");

--- a/src/components/providers/AddProviderDialog.tsx
+++ b/src/components/providers/AddProviderDialog.tsx
@@ -54,6 +54,7 @@ export function AddProviderDialog({
     appId !== "openclaw" &&
     appId !== "hermes" &&
     appId !== "pi" &&
+    appId !== "deepseek-harness" &&
     appId !== "grokbuild" &&
     appId !== "claude-desktop";
   const [activeTab, setActiveTab] = useState<"app-specific" | "universal">(

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -20,6 +20,28 @@ import { resolveManagedAccountId } from "@/lib/authBinding";
 import { CODEX_OFFICIAL_PROVIDER_ID } from "@/utils/providerCapabilities";
 import { generateUUID } from "@/utils/uuid";
 
+const DEEPSEEK_HARNESS_PRIVATE_FIELDS = ["apiKey", "apiKeyEnv"] as const;
+
+/**
+ * Harness credentials are shared live state, while a provider's credential
+ * fields belong to that stored provider. Refresh native settings without
+ * adopting a different live credential reference (or its resolved secret).
+ */
+export function mergeDeepSeekHarnessLiveSettings(
+  liveSettings: Record<string, unknown>,
+  storedSettings: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged = { ...liveSettings };
+  for (const key of DEEPSEEK_HARNESS_PRIVATE_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(storedSettings, key)) {
+      merged[key] = storedSettings[key];
+    } else {
+      delete merged[key];
+    }
+  }
+  return merged;
+}
+
 interface EditProviderDialogProps {
   open: boolean;
   provider: Provider | null;
@@ -152,29 +174,28 @@ export function EditProviderDialog({
       try {
         const currentId = await providersApi.getCurrent(appId);
         if (currentId && provider.id === currentId) {
-          try {
-            const live = (await vscodeApi.getLiveProviderSettings(
-              appId,
-            )) as Record<string, unknown>;
-            if (!cancelled && live && typeof live === "object") {
-              setLiveSettings(live);
-              setHasLoadedLive(true);
-            }
-          } catch {
-            // 读取实时配置失败则回退到 SSOT（不打断编辑流程）
-            if (!cancelled) {
-              setLiveSettings(null);
-              setHasLoadedLive(true);
-            }
-          }
-        } else {
+          const live = (await vscodeApi.getLiveProviderSettings(
+            appId,
+          )) as Record<string, unknown> | null;
           if (!cancelled) {
-            setLiveSettings(null);
-            setHasLoadedLive(true);
+            setLiveSettings(
+              live && typeof live === "object" && !Array.isArray(live)
+                ? live
+                : null,
+            );
           }
+        } else if (!cancelled) {
+          setLiveSettings(null);
+        }
+      } catch {
+        // Live read failures fall back to the stored provider.
+        if (!cancelled) {
+          setLiveSettings(null);
         }
       } finally {
-        // no-op
+        if (!cancelled) {
+          setHasLoadedLive(true);
+        }
       }
     };
     void load();
@@ -205,6 +226,16 @@ export function EditProviderDialog({
       if (dbCatalog !== undefined) {
         return { ...base, modelCatalog: dbCatalog };
       }
+    }
+
+    if (appId === "deepseek-harness" && liveSettings) {
+      const storedSettings =
+        provider?.settingsConfig &&
+        typeof provider.settingsConfig === "object" &&
+        !Array.isArray(provider.settingsConfig)
+          ? (provider.settingsConfig as Record<string, unknown>)
+          : {};
+      return mergeDeepSeekHarnessLiveSettings(liveSettings, storedSettings);
     }
 
     return base;
@@ -279,7 +310,13 @@ export function EditProviderDialog({
     [appId, onSubmit, closeDialog, provider],
   );
 
-  if (!provider || !initialData) {
+  // The Harness form initializes local state only when it mounts. Wait until
+  // the current native profile has been read so it cannot retain a stale DB
+  // snapshot after the asynchronous live refresh completes.
+  const waitingForDeepSeekHarnessLive =
+    open && appId === "deepseek-harness" && !hasLoadedLive;
+
+  if (!provider || !initialData || waitingForDeepSeekHarnessLive) {
     return null;
   }
 

--- a/src/components/providers/ProviderActions.tsx
+++ b/src/components/providers/ProviderActions.tsx
@@ -43,6 +43,8 @@ interface ProviderActionsProps {
   onDuplicate?: () => void;
   onTest?: () => void;
   onConfigureUsage?: () => void;
+  showConnectivity?: boolean;
+  showUsage?: boolean;
   onDelete: () => void;
   onRemoveFromConfig?: () => void;
   onDisableOmo?: () => void;
@@ -85,6 +87,8 @@ export function ProviderActions({
   onDuplicate,
   onTest,
   onConfigureUsage,
+  showConnectivity = true,
+  showUsage = true,
   onDelete,
   onRemoveFromConfig,
   onDisableOmo,
@@ -412,37 +416,41 @@ export function ProviderActions({
           </Button>
         )}
 
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={onTest || undefined}
-          disabled={isTesting}
-          title={t("provider.connectivityCheck", "检测连通")}
-          className={cn(
-            iconButtonClass,
-            !onTest && "opacity-40 cursor-not-allowed text-muted-foreground",
-          )}
-        >
-          {isTesting ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Activity className="h-4 w-4" />
-          )}
-        </Button>
+        {showConnectivity && (
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={onTest || undefined}
+            disabled={isTesting}
+            title={t("provider.connectivityCheck", "检测连通")}
+            className={cn(
+              iconButtonClass,
+              !onTest && "opacity-40 cursor-not-allowed text-muted-foreground",
+            )}
+          >
+            {isTesting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Activity className="h-4 w-4" />
+            )}
+          </Button>
+        )}
 
-        <Button
-          size="icon"
-          variant="ghost"
-          onClick={onConfigureUsage || undefined}
-          title={t("provider.configureUsage")}
-          className={cn(
-            iconButtonClass,
-            !onConfigureUsage &&
-              "opacity-40 cursor-not-allowed text-muted-foreground",
-          )}
-        >
-          <BarChart3 className="h-4 w-4" />
-        </Button>
+        {showUsage && (
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={onConfigureUsage || undefined}
+            title={t("provider.configureUsage")}
+            className={cn(
+              iconButtonClass,
+              !onConfigureUsage &&
+                "opacity-40 cursor-not-allowed text-muted-foreground",
+            )}
+          >
+            <BarChart3 className="h-4 w-4" />
+          </Button>
+        )}
 
         {onOpenTerminal && (
           <Button

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -138,6 +138,7 @@ const extractApiUrl = (provider: Provider, fallbackText: string) => {
     }
 
     const directBaseUrl =
+      object.baseURL ||
       object.baseUrl ||
       object.base_url ||
       object.options?.baseURL ||
@@ -266,7 +267,9 @@ export function ProviderCard({
     return true;
   }, [provider.notes, displayUrl, fallbackUrlText]);
 
-  const usageEnabled = provider.meta?.usage_script?.enabled ?? false;
+  const supportsUsage = appId !== "deepseek-harness";
+  const usageEnabled =
+    supportsUsage && (provider.meta?.usage_script?.enabled ?? false);
   const isOfficial = isOfficialProvider(provider, appId);
   const supportsOfficialSubscription =
     isOfficial && ["claude", "codex", "gemini", "grokbuild"].includes(appId);
@@ -624,7 +627,7 @@ export function ProviderCard({
         <div className="flex items-center ml-auto min-w-0 gap-3">
           <div className="ml-auto">
             <div className="flex items-center gap-1">
-              {isCopilot ? (
+              {!supportsUsage ? null : isCopilot ? (
                 <CopilotQuotaFooter
                   meta={provider.meta}
                   inline={true}
@@ -717,11 +720,14 @@ export function ProviderCard({
                 // (category === "official") 一律隐藏：它们 base_url 故意留空、走客户端
                 // 默认/OAuth 端点，cc-switch 没有可靠的探测目标（尤其 Claude Desktop
                 // 官方是原生 1P 模式，根本不在请求路径上）。
-                onTest && provider.category !== "official"
+                appId !== "deepseek-harness" &&
+                onTest &&
+                provider.category !== "official"
                   ? () => onTest(provider)
                   : undefined
               }
               onConfigureUsage={
+                !supportsUsage ||
                 (isOfficial && !supportsOfficialSubscription) ||
                 isCopilot ||
                 isCodexOauth ||
@@ -729,6 +735,8 @@ export function ProviderCard({
                   ? undefined
                   : () => onConfigureUsage(provider)
               }
+              showConnectivity={appId !== "deepseek-harness"}
+              showUsage={supportsUsage}
               onDelete={() => onDelete(provider)}
               onRemoveFromConfig={
                 onRemoveFromConfig

--- a/src/components/providers/ProviderList.tsx
+++ b/src/components/providers/ProviderList.tsx
@@ -476,7 +476,7 @@ export function ProviderList({
                 onConfigureUsage={onConfigureUsage}
                 onOpenWebsite={onOpenWebsite}
                 onOpenTerminal={onOpenTerminal}
-                onTest={handleTest}
+                onTest={appId === "deepseek-harness" ? undefined : handleTest}
                 isTesting={isChecking(provider.id)}
                 isProxyRunning={supportsFailover && isProxyRunning}
                 isProxyTakeover={supportsFailover && isProxyTakeover}

--- a/src/components/providers/forms/DeepSeekHarnessProviderForm.tsx
+++ b/src/components/providers/forms/DeepSeekHarnessProviderForm.tsx
@@ -31,7 +31,7 @@ import type { ProviderFormProps, ProviderFormValues } from "./ProviderForm";
 type DeepSeekHarnessProviderFormProps = Omit<ProviderFormProps, "appId">;
 
 export type DeepSeekThinking = "enabled" | "disabled";
-export type DeepSeekReasoningEffort = "off" | "high" | "max";
+export type DeepSeekReasoningEffort = "off" | "low" | "high" | "max";
 
 export interface DeepSeekHarnessModel {
   id: string;
@@ -207,16 +207,19 @@ export function DeepSeekHarnessProviderForm({
   const [defaultReasoningEffort, setDefaultReasoningEffort] =
     useState<DeepSeekReasoningEffort>(
       initialConfig.defaultReasoningEffort === "off" ||
+        initialConfig.defaultReasoningEffort === "low" ||
         initialConfig.defaultReasoningEffort === "high" ||
         initialConfig.defaultReasoningEffort === "max"
         ? initialConfig.defaultReasoningEffort
         : initialConfig.reasoningEffort === "off" ||
+            initialConfig.reasoningEffort === "low" ||
             initialConfig.reasoningEffort === "max"
           ? initialConfig.reasoningEffort
           : "high",
     );
   const [defaultReasoningConfigured, setDefaultReasoningConfigured] = useState(
     initialConfig.defaultReasoningEffort === "off" ||
+      initialConfig.defaultReasoningEffort === "low" ||
       initialConfig.defaultReasoningEffort === "high" ||
       initialConfig.defaultReasoningEffort === "max",
   );
@@ -454,6 +457,7 @@ export function DeepSeekHarnessProviderForm({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="off">off</SelectItem>
+                <SelectItem value="low">low</SelectItem>
                 <SelectItem value="high">high</SelectItem>
                 <SelectItem value="max">max</SelectItem>
               </SelectContent>

--- a/src/components/providers/forms/DeepSeekHarnessProviderForm.tsx
+++ b/src/components/providers/forms/DeepSeekHarnessProviderForm.tsx
@@ -1,0 +1,535 @@
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import JsonEditor from "@/components/JsonEditor";
+import { useDarkMode } from "@/hooks/useDarkMode";
+import { providerSchema, type ProviderFormData } from "@/lib/schemas/provider";
+import ApiKeyInput from "./ApiKeyInput";
+import { BasicFormFields } from "./BasicFormFields";
+import type { ProviderFormProps, ProviderFormValues } from "./ProviderForm";
+
+type DeepSeekHarnessProviderFormProps = Omit<ProviderFormProps, "appId">;
+
+export type DeepSeekThinking = "enabled" | "disabled";
+export type DeepSeekReasoningEffort = "off" | "high" | "max";
+
+export interface DeepSeekHarnessModel {
+  id: string;
+  name?: string;
+  description?: string;
+  contextWindow?: number;
+  maxTokens?: number;
+  [key: string]: unknown;
+}
+
+export interface DeepSeekHarnessSettingsConfig {
+  apiKey?: string;
+  defaultModel?: string;
+  defaultReasoningEffort?: DeepSeekReasoningEffort;
+  apiKeyEnv?: string;
+  baseURL?: string;
+  thinking?: DeepSeekThinking;
+  reasoningEffort?: DeepSeekReasoningEffort;
+  maxTokens?: number;
+  defaultContextWindow?: number;
+  models?: DeepSeekHarnessModel[];
+  [key: string]: unknown;
+}
+
+const PRIVATE_PROFILE_FIELDS = new Set([
+  "apiKey",
+  "defaultModel",
+  "defaultReasoningEffort",
+]);
+
+export const nativeDeepSeekHarnessProfile = (
+  config: DeepSeekHarnessSettingsConfig,
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(config).filter(([key]) => !PRIVATE_PROFILE_FIELDS.has(key)),
+  );
+
+const DEFAULT_BASE_URL = "https://api.deepseek.com";
+const DEFAULT_API_KEY_ENV = "DEEPSEEK_API_KEY";
+const DEFAULT_MODEL = "deepseek-v4-flash";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const parseModelsText = (value: string): DeepSeekHarnessModel[] => {
+  const seen = new Set<string>();
+  const models: DeepSeekHarnessModel[] = [];
+  for (const line of value.split(/\r?\n/)) {
+    const id = line.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    models.push({ id });
+  }
+  return models;
+};
+
+const stringifyModels = (value: unknown): string =>
+  Array.isArray(value)
+    ? value
+        .map((model) =>
+          isRecord(model) && typeof model.id === "string" ? model.id : "",
+        )
+        .filter(Boolean)
+        .join("\n")
+    : "";
+
+/**
+ * Applies form-owned fields on top of the raw object so editing an advanced
+ * Harness profile never discards fields CC Switch does not render yet.
+ */
+export function mergeDeepSeekHarnessConfig(
+  raw: Record<string, unknown>,
+  fields: {
+    apiKey: string;
+    includeApiKey: boolean;
+    defaultModel: string;
+    apiKeyEnv: string;
+    baseURL: string;
+    thinking: DeepSeekThinking;
+    defaultReasoningEffort: DeepSeekReasoningEffort;
+    includeDefaultReasoningEffort: boolean;
+    modelsText: string;
+  },
+): DeepSeekHarnessSettingsConfig {
+  const currentModels = Array.isArray(raw.models) ? raw.models : [];
+  const existingById = new Map<string, DeepSeekHarnessModel>();
+  for (const model of currentModels) {
+    if (isRecord(model) && typeof model.id === "string") {
+      existingById.set(model.id, model as DeepSeekHarnessModel);
+    }
+  }
+
+  const models = parseModelsText(fields.modelsText).map((model) => ({
+    ...(existingById.get(model.id) ?? {}),
+    id: model.id,
+  }));
+  const merged: DeepSeekHarnessSettingsConfig = {
+    ...raw,
+    defaultModel: fields.defaultModel.trim(),
+    apiKeyEnv: fields.apiKeyEnv.trim(),
+    baseURL: fields.baseURL.trim(),
+    thinking: fields.thinking,
+    models,
+  };
+
+  // Absence means "keep the referenced native credential" while an explicit
+  // empty string means "unset it". Do not collapse those two operations.
+  if (fields.includeApiKey) {
+    merged.apiKey = fields.apiKey.trim();
+  }
+
+  // The structured effort control owns agent-default-model.reasoningEffort,
+  // not llm-deepseek.reasoningEffort. Preserve the profile-level value from
+  // the advanced object unless disabling thinking requires correcting it.
+  if (fields.includeDefaultReasoningEffort) {
+    merged.defaultReasoningEffort =
+      fields.thinking === "disabled" ? "off" : fields.defaultReasoningEffort;
+  }
+  if (
+    fields.thinking === "disabled" &&
+    Object.prototype.hasOwnProperty.call(raw, "reasoningEffort")
+  ) {
+    merged.reasoningEffort = "off";
+  }
+
+  return merged;
+}
+
+export function DeepSeekHarnessProviderForm({
+  submitLabel,
+  onSubmit,
+  onCancel,
+  onSubmittingChange,
+  initialData,
+  showButtons = true,
+}: DeepSeekHarnessProviderFormProps) {
+  const { t } = useTranslation();
+  const isDarkMode = useDarkMode();
+  const initialConfig = useMemo<DeepSeekHarnessSettingsConfig>(() => {
+    return isRecord(initialData?.settingsConfig)
+      ? (initialData.settingsConfig as DeepSeekHarnessSettingsConfig)
+      : {};
+  }, [initialData?.settingsConfig]);
+
+  const [apiKey, setApiKey] = useState(
+    typeof initialConfig.apiKey === "string" ? initialConfig.apiKey : "",
+  );
+  const [apiKeyTouched, setApiKeyTouched] = useState(false);
+  const initialHasApiKey = Object.prototype.hasOwnProperty.call(
+    initialConfig,
+    "apiKey",
+  );
+  const [apiKeyEnv, setApiKeyEnv] = useState(
+    typeof initialConfig.apiKeyEnv === "string"
+      ? initialConfig.apiKeyEnv
+      : DEFAULT_API_KEY_ENV,
+  );
+  const [baseURL, setBaseURL] = useState(
+    typeof initialConfig.baseURL === "string" ? initialConfig.baseURL : "",
+  );
+  const [defaultModel, setDefaultModel] = useState(
+    typeof initialConfig.defaultModel === "string"
+      ? initialConfig.defaultModel
+      : DEFAULT_MODEL,
+  );
+  const [thinking, setThinking] = useState<DeepSeekThinking>(
+    initialConfig.thinking === "disabled" ? "disabled" : "enabled",
+  );
+  const [thinkingConfigured, setThinkingConfigured] = useState(
+    initialConfig.thinking === "enabled" ||
+      initialConfig.thinking === "disabled",
+  );
+  const [defaultReasoningEffort, setDefaultReasoningEffort] =
+    useState<DeepSeekReasoningEffort>(
+      initialConfig.defaultReasoningEffort === "off" ||
+        initialConfig.defaultReasoningEffort === "high" ||
+        initialConfig.defaultReasoningEffort === "max"
+        ? initialConfig.defaultReasoningEffort
+        : initialConfig.reasoningEffort === "off" ||
+            initialConfig.reasoningEffort === "max"
+          ? initialConfig.reasoningEffort
+          : "high",
+    );
+  const [defaultReasoningConfigured, setDefaultReasoningConfigured] = useState(
+    initialConfig.defaultReasoningEffort === "off" ||
+      initialConfig.defaultReasoningEffort === "high" ||
+      initialConfig.defaultReasoningEffort === "max",
+  );
+  const [thinkingTouched, setThinkingTouched] = useState(false);
+  const [modelsText, setModelsText] = useState(
+    stringifyModels(initialConfig.models),
+  );
+  const [rawConfig, setRawConfig] = useState(() =>
+    JSON.stringify(nativeDeepSeekHarnessProfile(initialConfig), null, 2),
+  );
+  const [rawError, setRawError] = useState<string>();
+
+  const form = useForm<ProviderFormData>({
+    resolver: zodResolver(providerSchema),
+    defaultValues: {
+      name:
+        initialData?.name ??
+        t("deepseekHarness.defaultProviderName", {
+          defaultValue: "DeepSeek Official",
+        }),
+      websiteUrl: initialData?.websiteUrl ?? "https://platform.deepseek.com/",
+      notes: initialData?.notes ?? "",
+      settingsConfig: JSON.stringify(initialConfig),
+      icon: initialData?.icon ?? "deepseek",
+      iconColor: initialData?.iconColor ?? "#4D6BFE",
+    },
+    mode: "onSubmit",
+  });
+  const { isSubmitting } = form.formState;
+
+  useEffect(() => {
+    onSubmittingChange?.(isSubmitting);
+  }, [isSubmitting, onSubmittingChange]);
+
+  const applyRawConfig = (value: string) => {
+    setRawConfig(value);
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      if (!isRecord(parsed)) {
+        throw new Error(
+          t("jsonEditor.mustBeObject", {
+            defaultValue: "Configuration must be a JSON object",
+          }),
+        );
+      }
+      setRawError(undefined);
+      // The advanced editor owns only fields not represented above. Keeping
+      // structured controls as the single source of truth prevents editing an
+      // unrelated advanced field from silently restoring stale endpoint,
+      // model, or credential values from the initial JSON snapshot.
+    } catch (error) {
+      setRawError(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const handleSubmit = async (values: ProviderFormData) => {
+    if (!values.name.trim()) {
+      toast.error(t("provider.nameRequired"));
+      return;
+    }
+    if (!defaultModel.trim()) {
+      toast.error(
+        t("deepseekHarness.defaultModelRequired", {
+          defaultValue: "Default model is required",
+        }),
+      );
+      return;
+    }
+    if (!apiKeyEnv.trim()) {
+      toast.error(
+        t("deepseekHarness.apiKeyEnvRequired", {
+          defaultValue: "Credential reference is required",
+        }),
+      );
+      return;
+    }
+
+    let advanced: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(rawConfig) as unknown;
+      if (!isRecord(parsed)) throw new Error("JSON must be an object");
+      advanced = parsed;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setRawError(message);
+      toast.error(
+        t("deepseekHarness.invalidAdvancedJson", {
+          error: message,
+          defaultValue: `Invalid advanced JSON: ${message}`,
+        }),
+      );
+      return;
+    }
+
+    const config = mergeDeepSeekHarnessConfig(advanced, {
+      apiKey,
+      includeApiKey: initialHasApiKey || apiKeyTouched,
+      defaultModel,
+      apiKeyEnv,
+      baseURL,
+      thinking,
+      defaultReasoningEffort,
+      includeDefaultReasoningEffort:
+        defaultReasoningConfigured ||
+        (thinkingTouched && thinking === "disabled"),
+      modelsText,
+    });
+    if (!baseURL.trim()) delete config.baseURL;
+    if (!thinkingConfigured) delete config.thinking;
+    if (
+      !defaultReasoningConfigured &&
+      !(thinkingTouched && thinking === "disabled")
+    ) {
+      delete config.defaultReasoningEffort;
+    }
+    if (!Array.isArray(advanced.models) && !modelsText.trim()) {
+      delete config.models;
+    }
+    await onSubmit({
+      ...values,
+      name: values.name.trim(),
+      websiteUrl: values.websiteUrl?.trim() ?? "",
+      notes: values.notes?.trim() ?? "",
+      settingsConfig: JSON.stringify(config),
+      presetCategory: "official",
+    } satisfies ProviderFormValues);
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        id="provider-form"
+        onSubmit={form.handleSubmit(handleSubmit)}
+        className="space-y-6 glass rounded-xl p-6 border border-white/10"
+      >
+        <BasicFormFields form={form} />
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <ApiKeyInput
+            id="deepseek-harness-api-key"
+            label={t("deepseekHarness.apiKey", { defaultValue: "API Key" })}
+            value={apiKey}
+            onChange={(value) => {
+              setApiKey(value);
+              setApiKeyTouched(true);
+            }}
+            placeholder="sk-..."
+          />
+          <FormItem>
+            <FormLabel htmlFor="deepseek-harness-api-key-env">
+              {t("deepseekHarness.apiKeyEnv", {
+                defaultValue: "Credential reference",
+              })}
+            </FormLabel>
+            <Input
+              id="deepseek-harness-api-key-env"
+              value={apiKeyEnv}
+              onChange={(event) => setApiKeyEnv(event.target.value)}
+              placeholder={DEFAULT_API_KEY_ENV}
+              autoComplete="off"
+            />
+          </FormItem>
+
+          <FormItem>
+            <FormLabel htmlFor="deepseek-harness-base-url">
+              {t("deepseekHarness.baseURL", { defaultValue: "Base URL" })}
+            </FormLabel>
+            <Input
+              id="deepseek-harness-base-url"
+              value={baseURL}
+              onChange={(event) => setBaseURL(event.target.value)}
+              placeholder={DEFAULT_BASE_URL}
+              autoComplete="off"
+            />
+          </FormItem>
+          <FormItem>
+            <FormLabel htmlFor="deepseek-harness-default-model">
+              {t("deepseekHarness.defaultModel", {
+                defaultValue: "Default model",
+              })}
+            </FormLabel>
+            <Input
+              id="deepseek-harness-default-model"
+              value={defaultModel}
+              onChange={(event) => setDefaultModel(event.target.value)}
+              placeholder={DEFAULT_MODEL}
+              autoComplete="off"
+            />
+          </FormItem>
+
+          <FormItem>
+            <FormLabel htmlFor="deepseek-harness-thinking">
+              {t("deepseekHarness.thinking", {
+                defaultValue: "Thinking policy",
+              })}
+            </FormLabel>
+            <Select
+              value={thinking}
+              onValueChange={(value) => {
+                const next = value as DeepSeekThinking;
+                setThinking(next);
+                setThinkingConfigured(true);
+                setThinkingTouched(true);
+              }}
+            >
+              <SelectTrigger id="deepseek-harness-thinking">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="enabled">
+                  {t("common.enabled", { defaultValue: "Enabled" })}
+                </SelectItem>
+                <SelectItem value="disabled">
+                  {t("deepseekHarness.disabled", { defaultValue: "Disabled" })}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </FormItem>
+          <FormItem>
+            <FormLabel htmlFor="deepseek-harness-reasoning-effort">
+              {t("deepseekHarness.reasoningEffort", {
+                defaultValue: "Default reasoning effort",
+              })}
+            </FormLabel>
+            <Select
+              value={thinking === "disabled" ? "off" : defaultReasoningEffort}
+              disabled={thinking === "disabled"}
+              onValueChange={(value) => {
+                setDefaultReasoningEffort(value as DeepSeekReasoningEffort);
+                setDefaultReasoningConfigured(true);
+              }}
+            >
+              <SelectTrigger id="deepseek-harness-reasoning-effort">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="off">off</SelectItem>
+                <SelectItem value="high">high</SelectItem>
+                <SelectItem value="max">max</SelectItem>
+              </SelectContent>
+            </Select>
+          </FormItem>
+        </div>
+
+        <FormItem>
+          <FormLabel htmlFor="deepseek-harness-models">
+            {t("deepseekHarness.models", {
+              defaultValue: "Advisory models (one ID per line)",
+            })}
+          </FormLabel>
+          <Textarea
+            id="deepseek-harness-models"
+            value={modelsText}
+            onChange={(event) => setModelsText(event.target.value)}
+            placeholder={"deepseek-v4-flash\ndeepseek-v4-pro"}
+            className="font-mono"
+          />
+          <p className="text-xs text-muted-foreground">
+            {t("deepseekHarness.modelsHint", {
+              defaultValue:
+                "The selected default model may also be an unlisted pass-through ID.",
+            })}
+          </p>
+        </FormItem>
+
+        <FormItem>
+          <FormLabel htmlFor="deepseek-harness-advanced-json">
+            {t("deepseekHarness.advancedJson", {
+              defaultValue: "Advanced llm-deepseek profile (JSON)",
+            })}
+          </FormLabel>
+          <JsonEditor
+            id="deepseek-harness-advanced-json"
+            value={rawConfig}
+            onChange={applyRawConfig}
+            darkMode={isDarkMode}
+            rows={8}
+          />
+          <p className="text-xs text-muted-foreground">
+            {t("deepseekHarness.advancedHint", {
+              defaultValue:
+                "Unknown native profile fields are retained. Structured fields above take precedence when saving.",
+            })}
+          </p>
+          {rawError ? (
+            <p className="text-xs text-destructive">{rawError}</p>
+          ) : null}
+        </FormItem>
+
+        <FormField
+          control={form.control}
+          name="settingsConfig"
+          render={() => (
+            <FormItem className="hidden">
+              <FormControl>
+                <Input type="hidden" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {showButtons && (
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" type="button" onClick={onCancel}>
+              {t("common.cancel")}
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {submitLabel}
+            </Button>
+          </div>
+        )}
+      </form>
+    </Form>
+  );
+}

--- a/src/components/providers/forms/EndpointSpeedTest.tsx
+++ b/src/components/providers/forms/EndpointSpeedTest.tsx
@@ -19,6 +19,7 @@ const ENDPOINT_TIMEOUT_SECS: Record<AppId, number> = {
   openclaw: 8,
   hermes: 8,
   pi: 8,
+  "deepseek-harness": 8,
 };
 
 interface TestResult {

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -83,6 +83,7 @@ import { BasicFormFields } from "./BasicFormFields";
 import { ClaudeFormFields } from "./ClaudeFormFields";
 import { ClaudeDesktopProviderForm } from "./ClaudeDesktopProviderForm";
 import { GrokBuildProviderForm } from "./GrokBuildProviderForm";
+import { DeepSeekHarnessProviderForm } from "./DeepSeekHarnessProviderForm";
 import { CodexFormFields } from "./CodexFormFields";
 import { GeminiFormFields } from "./GeminiFormFields";
 import { PiProviderForm } from "./PiProviderForm";
@@ -281,6 +282,9 @@ export function ProviderForm(props: ProviderFormProps) {
   }
   if (props.appId === "grokbuild") {
     return <GrokBuildProviderForm {...props} />;
+  }
+  if (props.appId === "deepseek-harness") {
+    return <DeepSeekHarnessProviderForm {...props} />;
   }
 
   return <ProviderFormFull {...props} />;

--- a/src/components/settings/AppVisibilitySettings.tsx
+++ b/src/components/settings/AppVisibilitySettings.tsx
@@ -32,6 +32,11 @@ const APP_CONFIG: Array<{
   { id: "openclaw", icon: "openclaw", nameKey: "apps.openclaw" },
   { id: "hermes", icon: "hermes", nameKey: "apps.hermes" },
   { id: "pi", icon: "pi", nameKey: "apps.pi" },
+  {
+    id: "deepseek-harness",
+    icon: "deepseek",
+    nameKey: "apps.deepseek-harness",
+  },
 ];
 
 export function AppVisibilitySettings({

--- a/src/components/settings/DirectorySettings.tsx
+++ b/src/components/settings/DirectorySettings.tsx
@@ -22,6 +22,7 @@ interface DirectorySettingsProps {
   openclawDir?: string;
   hermesDir?: string;
   piDir?: string;
+  deepseekHarnessDir?: string;
   onDirectoryChange: (app: DirectoryAppId, value?: string) => void;
   onBrowseDirectory: (app: DirectoryAppId) => Promise<void>;
   onResetDirectory: (app: DirectoryAppId) => Promise<void>;
@@ -41,6 +42,7 @@ export function DirectorySettings({
   openclawDir,
   hermesDir,
   piDir,
+  deepseekHarnessDir,
   onDirectoryChange,
   onBrowseDirectory,
   onResetDirectory,
@@ -183,6 +185,17 @@ export function DirectorySettings({
           onChange={(val) => onDirectoryChange("pi", val)}
           onBrowse={() => onBrowseDirectory("pi")}
           onReset={() => onResetDirectory("pi")}
+        />
+
+        <DirectoryInput
+          label={t("settings.deepseekHarnessConfigDir")}
+          description={undefined}
+          value={deepseekHarnessDir}
+          resolvedValue={resolvedDirs["deepseek-harness"]}
+          placeholder={t("settings.browsePlaceholderDeepSeekHarness")}
+          onChange={(val) => onDirectoryChange("deepseek-harness", val)}
+          onBrowse={() => onBrowseDirectory("deepseek-harness")}
+          onReset={() => onResetDirectory("deepseek-harness")}
         />
       </section>
     </div>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -357,6 +357,9 @@ export function SettingsPage({
                             openclawDir={settings.openclawConfigDir}
                             hermesDir={settings.hermesConfigDir}
                             piDir={settings.piConfigDir}
+                            deepseekHarnessDir={
+                              settings.deepseekHarnessConfigDir
+                            }
                             onDirectoryChange={updateDirectory}
                             onBrowseDirectory={browseDirectory}
                             onResetDirectory={resetDirectory}

--- a/src/config/appConfig.tsx
+++ b/src/config/appConfig.tsx
@@ -26,6 +26,7 @@ export const APP_IDS: AppId[] = [
   "openclaw",
   "hermes",
   "pi",
+  "deepseek-harness",
 ];
 
 export const DEFAULT_VISIBLE_APPS: VisibleApps = {
@@ -38,10 +39,16 @@ export const DEFAULT_VISIBLE_APPS: VisibleApps = {
   openclaw: true,
   hermes: true,
   pi: true,
+  "deepseek-harness": false,
 };
 
 /** App IDs shown in Skills panels. */
-export const SKILLS_APP_IDS: AppId[] = [
+export type SkillAppId = Extract<
+  AppId,
+  "claude" | "codex" | "gemini" | "grokbuild" | "opencode" | "hermes" | "pi"
+>;
+
+export const SKILLS_APP_IDS: SkillAppId[] = [
   "claude",
   "codex",
   "gemini",
@@ -84,8 +91,11 @@ export function isAdditiveAppId(appId: string): appId is AdditiveAppId {
   return (ADDITIVE_APP_IDS as string[]).includes(appId);
 }
 
-/** Pi has no native MCP registry; do not manufacture a disabled mirror. */
-export type McpAppId = Exclude<AppId, "claude-desktop" | "openclaw" | "pi">;
+/** Pi and DeepSeek Harness have no native MCP registry. */
+export type McpAppId = Exclude<
+  AppId,
+  "claude-desktop" | "openclaw" | "pi" | "deepseek-harness"
+>;
 export const MCP_APP_IDS: McpAppId[] = [
   "claude",
   "codex",
@@ -192,6 +202,21 @@ export const APP_ICON_MAP: Record<AppId, AppConfig> = {
       "bg-fuchsia-500/10 ring-1 ring-fuchsia-500/20 hover:bg-fuchsia-500/20 text-fuchsia-600 dark:text-fuchsia-400",
     badgeClass:
       "bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300 hover:bg-fuchsia-500/20 border-0 gap-1.5",
+  },
+  "deepseek-harness": {
+    label: "DeepSeek Harness",
+    icon: (
+      <ProviderIcon
+        icon="deepseek"
+        name="DeepSeek Harness"
+        size={14}
+        showFallback={false}
+      />
+    ),
+    activeClass:
+      "bg-blue-500/10 ring-1 ring-blue-500/20 hover:bg-blue-500/20 text-blue-600 dark:text-blue-400",
+    badgeClass:
+      "bg-blue-500/10 text-blue-700 dark:text-blue-300 hover:bg-blue-500/20 border-0 gap-1.5",
   },
 };
 

--- a/src/hooks/useDirectorySettings.ts
+++ b/src/hooks/useDirectorySettings.ts
@@ -14,7 +14,8 @@ type AppDirectoryKey =
   | "opencode"
   | "openclaw"
   | "hermes"
-  | "pi";
+  | "pi"
+  | "deepseek-harness";
 type DirectoryKey = "appConfig" | AppDirectoryKey;
 
 export interface ResolvedDirectories {
@@ -27,6 +28,7 @@ export interface ResolvedDirectories {
   openclaw: string;
   hermes: string;
   pi: string;
+  "deepseek-harness": string;
 }
 
 // Single source of truth for per-app directory metadata.
@@ -42,6 +44,10 @@ const APP_DIRECTORY_META: Record<
   openclaw: { key: "openclaw", defaultFolder: ".openclaw" },
   hermes: { key: "hermes", defaultFolder: ".hermes" },
   pi: { key: "pi", defaultFolder: ".pi/agent" },
+  "deepseek-harness": {
+    key: "deepseek-harness",
+    defaultFolder: ".dsh",
+  },
 };
 
 const DIRECTORY_KEY_TO_SETTINGS_FIELD: Record<
@@ -56,6 +62,7 @@ const DIRECTORY_KEY_TO_SETTINGS_FIELD: Record<
   openclaw: "openclawConfigDir",
   hermes: "hermesConfigDir",
   pi: "piConfigDir",
+  "deepseek-harness": "deepseekHarnessConfigDir",
 };
 
 const sanitizeDir = (value?: string | null): string | undefined => {
@@ -143,6 +150,7 @@ export function useDirectorySettings({
     openclaw: "",
     hermes: "",
     pi: "",
+    "deepseek-harness": "",
   });
   const [isLoading, setIsLoading] = useState(true);
 
@@ -156,6 +164,7 @@ export function useDirectorySettings({
     openclaw: "",
     hermes: "",
     pi: "",
+    "deepseek-harness": "",
   });
   const initialAppConfigDirRef = useRef<string | undefined>(undefined);
 
@@ -176,6 +185,7 @@ export function useDirectorySettings({
           openclawDir,
           hermesDir,
           piDir,
+          deepseekHarnessDir,
           defaultAppConfig,
           defaultClaudeDir,
           defaultCodexDir,
@@ -195,6 +205,7 @@ export function useDirectorySettings({
           settingsApi.getConfigDir("openclaw"),
           settingsApi.getConfigDir("hermes"),
           settingsApi.getConfigDir("pi"),
+          settingsApi.getConfigDir("deepseek-harness"),
           computeDefaultAppConfigDir(),
           computeDefaultConfigDir("claude"),
           computeDefaultConfigDir("codex"),
@@ -220,6 +231,9 @@ export function useDirectorySettings({
           openclaw: defaultOpenclawDir ?? "",
           hermes: defaultHermesDir ?? "",
           pi: defaultPiDir ?? "",
+          // The backend-resolved path includes the native DSH_HOME layer. Keep
+          // it as the reset target instead of assuming ~/.dsh in the renderer.
+          "deepseek-harness": deepseekHarnessDir,
         };
 
         setAppConfigDir(normalizedOverride);
@@ -235,6 +249,8 @@ export function useDirectorySettings({
           openclaw: openclawDir || defaultsRef.current.openclaw,
           hermes: hermesDir || defaultsRef.current.hermes,
           pi: piDir || defaultsRef.current.pi,
+          "deepseek-harness":
+            deepseekHarnessDir || defaultsRef.current["deepseek-harness"],
         });
       } catch (error) {
         console.error(
@@ -378,6 +394,9 @@ export function useDirectorySettings({
         openclaw: overrides?.openclaw ?? defaultsRef.current.openclaw,
         hermes: overrides?.hermes ?? defaultsRef.current.hermes,
         pi: overrides?.pi ?? defaultsRef.current.pi,
+        "deepseek-harness":
+          overrides?.["deepseek-harness"] ??
+          defaultsRef.current["deepseek-harness"],
       });
     },
     [],

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -119,6 +119,7 @@ export function useSettings(): UseSettingsResult {
       openclaw: sanitizeDir(data?.openclawConfigDir),
       hermes: sanitizeDir(data?.hermesConfigDir),
       pi: sanitizeDir(data?.piConfigDir),
+      "deepseek-harness": sanitizeDir(data?.deepseekHarnessConfigDir),
     });
     setRequiresRestart(false);
   }, [
@@ -200,7 +201,11 @@ export function useSettings(): UseSettingsResult {
         const sanitizedOpenclawDir = sanitizeDir(
           mergedSettings.openclawConfigDir,
         );
+        const sanitizedHermesDir = sanitizeDir(mergedSettings.hermesConfigDir);
         const sanitizedPiDir = sanitizeDir(mergedSettings.piConfigDir);
+        const sanitizedDeepSeekHarnessDir = sanitizeDir(
+          mergedSettings.deepseekHarnessConfigDir,
+        );
         const {
           webdavSync: _ignoredWebdavSync,
           s3Sync: _ignoredS3Sync,
@@ -215,7 +220,9 @@ export function useSettings(): UseSettingsResult {
           grokConfigDir: sanitizedGrokDir,
           opencodeConfigDir: sanitizedOpencodeDir,
           openclawConfigDir: sanitizedOpenclawDir,
+          hermesConfigDir: sanitizedHermesDir,
           piConfigDir: sanitizedPiDir,
+          deepseekHarnessConfigDir: sanitizedDeepSeekHarnessDir,
           language: mergedSettings.language,
         };
 
@@ -335,7 +342,11 @@ export function useSettings(): UseSettingsResult {
         const sanitizedOpenclawDir = sanitizeDir(
           mergedSettings.openclawConfigDir,
         );
+        const sanitizedHermesDir = sanitizeDir(mergedSettings.hermesConfigDir);
         const sanitizedPiDir = sanitizeDir(mergedSettings.piConfigDir);
+        const sanitizedDeepSeekHarnessDir = sanitizeDir(
+          mergedSettings.deepseekHarnessConfigDir,
+        );
         const previousAppDir = initialAppConfigDir;
         const previousClaudeDir = sanitizeDir(data?.claudeConfigDir);
         const previousCodexDir = sanitizeDir(data?.codexConfigDir);
@@ -343,7 +354,11 @@ export function useSettings(): UseSettingsResult {
         const previousGrokDir = sanitizeDir(data?.grokConfigDir);
         const previousOpencodeDir = sanitizeDir(data?.opencodeConfigDir);
         const previousOpenclawDir = sanitizeDir(data?.openclawConfigDir);
+        const previousHermesDir = sanitizeDir(data?.hermesConfigDir);
         const previousPiDir = sanitizeDir(data?.piConfigDir);
+        const previousDeepSeekHarnessDir = sanitizeDir(
+          data?.deepseekHarnessConfigDir,
+        );
         const {
           webdavSync: _ignoredWebdavSync,
           s3Sync: _ignoredS3Sync,
@@ -358,7 +373,9 @@ export function useSettings(): UseSettingsResult {
           grokConfigDir: sanitizedGrokDir,
           opencodeConfigDir: sanitizedOpencodeDir,
           openclawConfigDir: sanitizedOpenclawDir,
+          hermesConfigDir: sanitizedHermesDir,
           piConfigDir: sanitizedPiDir,
+          deepseekHarnessConfigDir: sanitizedDeepSeekHarnessDir,
           language: mergedSettings.language,
         };
 
@@ -446,7 +463,10 @@ export function useSettings(): UseSettingsResult {
         const grokDirChanged = sanitizedGrokDir !== previousGrokDir;
         const opencodeDirChanged = sanitizedOpencodeDir !== previousOpencodeDir;
         const openclawDirChanged = sanitizedOpenclawDir !== previousOpenclawDir;
+        const hermesDirChanged = sanitizedHermesDir !== previousHermesDir;
         const piDirChanged = sanitizedPiDir !== previousPiDir;
+        const deepseekHarnessDirChanged =
+          sanitizedDeepSeekHarnessDir !== previousDeepSeekHarnessDir;
         if (
           !pluginSynced &&
           (claudeDirChanged ||
@@ -454,7 +474,9 @@ export function useSettings(): UseSettingsResult {
             geminiDirChanged ||
             grokDirChanged ||
             opencodeDirChanged ||
-            openclawDirChanged)
+            openclawDirChanged ||
+            hermesDirChanged ||
+            deepseekHarnessDirChanged)
         ) {
           const syncResult = await syncCurrentProvidersLiveSafe();
           if (!syncResult.ok) {

--- a/src/hooks/useSettingsForm.ts
+++ b/src/hooks/useSettingsForm.ts
@@ -126,6 +126,8 @@ export function useSettingsForm(): UseSettingsFormResult {
       opencodeConfigDir: sanitizeDir(data.opencodeConfigDir),
       openclawConfigDir: sanitizeDir(data.openclawConfigDir),
       piConfigDir: sanitizeDir(data.piConfigDir),
+      hermesConfigDir: sanitizeDir(data.hermesConfigDir),
+      deepseekHarnessConfigDir: sanitizeDir(data.deepseekHarnessConfigDir),
       language: normalizedLanguage,
     };
 
@@ -194,6 +196,10 @@ export function useSettingsForm(): UseSettingsFormResult {
         opencodeConfigDir: sanitizeDir(serverData.opencodeConfigDir),
         openclawConfigDir: sanitizeDir(serverData.openclawConfigDir),
         piConfigDir: sanitizeDir(serverData.piConfigDir),
+        hermesConfigDir: sanitizeDir(serverData.hermesConfigDir),
+        deepseekHarnessConfigDir: sanitizeDir(
+          serverData.deepseekHarnessConfigDir,
+        ),
         language: normalizedLanguage,
       };
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -791,6 +791,8 @@
     "hermesConfigDirDescription": "Override Hermes configuration directory (config.yaml).",
     "piConfigDir": "Pi Configuration Directory",
     "piConfigDirDescription": "Override the Pi configuration directory (models.json, instruction files, prompts, skills, and sessions).",
+    "deepseekHarnessConfigDir": "DeepSeek Harness Configuration Directory",
+    "deepseekHarnessConfigDirDescription": "Override the DeepSeek Harness home directory (settings.yaml and .credentials.yaml).",
     "browsePlaceholderClaude": "e.g., /home/<your-username>/.claude",
     "browsePlaceholderCodex": "e.g., /home/<your-username>/.codex",
     "browsePlaceholderGemini": "e.g., /home/<your-username>/.gemini",
@@ -799,6 +801,7 @@
     "browsePlaceholderOpenclaw": "e.g., /home/<your-username>/.openclaw",
     "browsePlaceholderHermes": "e.g., /home/<your-username>/.hermes",
     "browsePlaceholderPi": "e.g., /home/<your-username>/.pi/agent",
+    "browsePlaceholderDeepSeekHarness": "e.g., /home/<your-username>/.dsh",
     "browseDirectory": "Browse Directory",
     "resetDefault": "Reset to default directory (takes effect after saving)",
     "checkForUpdates": "Check for Updates",
@@ -910,7 +913,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "deepseek-harness": "DeepSeek Harness"
   },
   "pi": {
     "empty": {
@@ -1054,6 +1058,23 @@
   },
   "appSwitcher": {
     "more": "More apps"
+  },
+  "deepseekHarness": {
+    "defaultProviderName": "DeepSeek Official",
+    "apiKey": "API Key",
+    "apiKeyEnv": "Credential reference",
+    "apiKeyEnvRequired": "Credential reference is required",
+    "baseURL": "Base URL",
+    "defaultModel": "Default model",
+    "defaultModelRequired": "Default model is required",
+    "thinking": "Thinking policy",
+    "disabled": "Disabled",
+    "reasoningEffort": "Default reasoning effort",
+    "models": "Advisory models (one ID per line)",
+    "modelsHint": "The selected default model may also be an unlisted pass-through ID.",
+    "advancedJson": "Advanced llm-deepseek profile (JSON)",
+    "advancedHint": "Unknown native profile fields are retained. Structured fields above take precedence when saving.",
+    "invalidAdvancedJson": "Invalid advanced JSON: {{error}}"
   },
   "grokBuild": {
     "apiBackend": "API backend",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -791,6 +791,8 @@
     "hermesConfigDirDescription": "Hermes の設定ディレクトリ（config.yaml）を上書きします。",
     "piConfigDir": "Pi 設定ディレクトリ",
     "piConfigDirDescription": "Pi の設定ディレクトリ（models.json、指示ファイル、プロンプト、Skills、セッション）を上書きします。",
+    "deepseekHarnessConfigDir": "DeepSeek Harness 設定ディレクトリ",
+    "deepseekHarnessConfigDirDescription": "DeepSeek Harness のホームディレクトリ（settings.yaml と .credentials.yaml）を上書きします。",
     "browsePlaceholderClaude": "例: /home/<your-username>/.claude",
     "browsePlaceholderCodex": "例: /home/<your-username>/.codex",
     "browsePlaceholderGemini": "例: /home/<your-username>/.gemini",
@@ -799,6 +801,7 @@
     "browsePlaceholderOpenclaw": "例: /home/<your-username>/.openclaw",
     "browsePlaceholderHermes": "例: /home/<your-username>/.hermes",
     "browsePlaceholderPi": "例: /home/<your-username>/.pi/agent",
+    "browsePlaceholderDeepSeekHarness": "例: /home/<your-username>/.dsh",
     "browseDirectory": "ディレクトリを選択",
     "resetDefault": "デフォルトに戻す（保存後に反映）",
     "checkForUpdates": "アップデートを確認",
@@ -910,7 +913,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "deepseek-harness": "DeepSeek Harness"
   },
   "pi": {
     "empty": {
@@ -1054,6 +1058,23 @@
   },
   "appSwitcher": {
     "more": "その他のアプリ"
+  },
+  "deepseekHarness": {
+    "defaultProviderName": "DeepSeek 公式",
+    "apiKey": "API Key",
+    "apiKeyEnv": "認証情報の参照",
+    "apiKeyEnvRequired": "認証情報の参照を入力してください",
+    "baseURL": "ベース URL",
+    "defaultModel": "デフォルトモデル",
+    "defaultModelRequired": "デフォルトモデルを入力してください",
+    "thinking": "思考ポリシー",
+    "disabled": "無効",
+    "reasoningEffort": "デフォルトの推論強度",
+    "models": "モデル一覧（1 行に 1 ID）",
+    "modelsHint": "一覧にないパススルー ID もデフォルトモデルに指定できます。",
+    "advancedJson": "高度な llm-deepseek 設定（JSON）",
+    "advancedHint": "未表示のネイティブ設定フィールドは保持され、保存時は上の構造化フィールドが優先されます。",
+    "invalidAdvancedJson": "高度な JSON が無効です：{{error}}"
   },
   "grokBuild": {
     "apiBackend": "API Backend",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -791,6 +791,8 @@
     "hermesConfigDirDescription": "覆寫 Hermes 設定目錄 (config.yaml)。",
     "piConfigDir": "Pi 設定目錄",
     "piConfigDirDescription": "覆寫 Pi 設定目錄（models.json、指示檔案、提示、Skills 與工作階段）。",
+    "deepseekHarnessConfigDir": "DeepSeek Harness 設定目錄",
+    "deepseekHarnessConfigDirDescription": "覆寫 DeepSeek Harness 主目錄（settings.yaml 與 .credentials.yaml）。",
     "browsePlaceholderClaude": "例如：/home/<您的帳號>/.claude",
     "browsePlaceholderCodex": "例如：/home/<您的帳號>/.codex",
     "browsePlaceholderGemini": "例如：/home/<您的帳號>/.gemini",
@@ -799,6 +801,7 @@
     "browsePlaceholderOpenclaw": "例如：/home/<您的帳號>/.openclaw",
     "browsePlaceholderHermes": "例如：/home/<您的帳號>/.hermes",
     "browsePlaceholderPi": "例如：/home/<您的帳號>/.pi/agent",
+    "browsePlaceholderDeepSeekHarness": "例如：/home/<您的帳號>/.dsh",
     "browseDirectory": "瀏覽目錄",
     "resetDefault": "還原預設目錄（需儲存後生效）",
     "checkForUpdates": "檢查更新",
@@ -911,7 +914,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "deepseek-harness": "DeepSeek Harness"
   },
   "pi": {
     "empty": {
@@ -1055,6 +1059,23 @@
   },
   "appSwitcher": {
     "more": "更多應用程式"
+  },
+  "deepseekHarness": {
+    "defaultProviderName": "DeepSeek 官方",
+    "apiKey": "API Key",
+    "apiKeyEnv": "憑證參照",
+    "apiKeyEnvRequired": "請填寫憑證參照",
+    "baseURL": "基礎 URL",
+    "defaultModel": "預設模型",
+    "defaultModelRequired": "請填寫預設模型",
+    "thinking": "思考策略",
+    "disabled": "停用",
+    "reasoningEffort": "預設推理強度",
+    "models": "模型清單（每行一個 ID）",
+    "modelsHint": "預設模型也可以使用未列出的透傳 ID。",
+    "advancedJson": "進階 llm-deepseek 設定（JSON）",
+    "advancedHint": "編輯時會保留未顯示的原生設定欄位；儲存時上方結構化欄位優先。",
+    "invalidAdvancedJson": "進階 JSON 無效：{{error}}"
   },
   "grokBuild": {
     "apiBackend": "API Backend",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -791,6 +791,8 @@
     "hermesConfigDirDescription": "覆盖 Hermes 配置目录 (config.yaml)。",
     "piConfigDir": "Pi 配置目录",
     "piConfigDirDescription": "覆盖 Pi 配置目录（models.json、指令文件、提示词、Skills 与会话）。",
+    "deepseekHarnessConfigDir": "DeepSeek Harness 配置目录",
+    "deepseekHarnessConfigDirDescription": "覆盖 DeepSeek Harness 主目录（settings.yaml 与 .credentials.yaml）。",
     "browsePlaceholderClaude": "例如：/home/<你的用户名>/.claude",
     "browsePlaceholderCodex": "例如：/home/<你的用户名>/.codex",
     "browsePlaceholderGemini": "例如：/home/<你的用户名>/.gemini",
@@ -799,6 +801,7 @@
     "browsePlaceholderOpenclaw": "例如：/home/<你的用户名>/.openclaw",
     "browsePlaceholderHermes": "例如：/home/<你的用户名>/.hermes",
     "browsePlaceholderPi": "例如：/home/<你的用户名>/.pi/agent",
+    "browsePlaceholderDeepSeekHarness": "例如：/home/<你的用户名>/.dsh",
     "browseDirectory": "浏览目录",
     "resetDefault": "恢复默认目录（需保存后生效）",
     "checkForUpdates": "检查更新",
@@ -910,7 +913,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "deepseek-harness": "DeepSeek Harness"
   },
   "pi": {
     "empty": {
@@ -1054,6 +1058,23 @@
   },
   "appSwitcher": {
     "more": "更多应用"
+  },
+  "deepseekHarness": {
+    "defaultProviderName": "DeepSeek 官方",
+    "apiKey": "API Key",
+    "apiKeyEnv": "凭据引用",
+    "apiKeyEnvRequired": "请填写凭据引用",
+    "baseURL": "基础 URL",
+    "defaultModel": "默认模型",
+    "defaultModelRequired": "请填写默认模型",
+    "thinking": "思考策略",
+    "disabled": "禁用",
+    "reasoningEffort": "默认推理强度",
+    "models": "模型列表（每行一个 ID）",
+    "modelsHint": "默认模型也可以使用未列出的透传 ID。",
+    "advancedJson": "高级 llm-deepseek 配置（JSON）",
+    "advancedHint": "编辑时会保留未展示的原生配置字段；保存时上方结构化字段优先。",
+    "invalidAdvancedJson": "高级 JSON 无效：{{error}}"
   },
   "grokBuild": {
     "apiBackend": "API Backend",

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -24,6 +24,7 @@ export interface SkillApps {
   openclaw: boolean;
   hermes: boolean;
   pi: boolean;
+  "deepseek-harness"?: never;
 }
 
 /** 已安装的 Skill（v3.10.0+ 统一结构） */

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -8,4 +8,5 @@ export type AppId =
   | "opencode"
   | "openclaw"
   | "hermes"
-  | "pi";
+  | "pi"
+  | "deepseek-harness";

--- a/src/types.ts
+++ b/src/types.ts
@@ -298,6 +298,7 @@ export interface VisibleApps {
   openclaw: boolean;
   hermes: boolean;
   pi: boolean;
+  "deepseek-harness": boolean;
 }
 
 // WebDAV 同步状态
@@ -419,6 +420,8 @@ export interface Settings {
   hermesConfigDir?: string;
   // 覆盖 Pi agent 配置目录（可选）
   piConfigDir?: string;
+  // Override DeepSeek Harness configuration directory (optional)
+  deepseekHarnessConfigDir?: string;
 
   // ===== 当前供应商 ID（设备级）=====
   // 当前 Claude 供应商 ID（优先于数据库 is_current）
@@ -511,6 +514,7 @@ export interface McpApps {
   opencode: boolean;
   openclaw: boolean;
   hermes: boolean;
+  "deepseek-harness"?: never;
 }
 
 // MCP 服务器条目（v3.7.0 统一结构）

--- a/src/types/proxy.ts
+++ b/src/types/proxy.ts
@@ -50,6 +50,7 @@ export interface ProxyTakeoverStatus {
   opencode: boolean;
   openclaw: boolean;
   hermes: boolean;
+  "deepseek-harness"?: boolean;
 }
 
 export interface ProviderHealth {

--- a/tests/components/DeepSeekHarnessProviderForm.test.tsx
+++ b/tests/components/DeepSeekHarnessProviderForm.test.tsx
@@ -1,0 +1,240 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DeepSeekHarnessProviderForm,
+  mergeDeepSeekHarnessConfig,
+  nativeDeepSeekHarnessProfile,
+} from "@/components/providers/forms/DeepSeekHarnessProviderForm";
+
+vi.mock("@/components/JsonEditor", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <textarea
+      aria-label="advanced-config"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}));
+
+describe("mergeDeepSeekHarnessConfig", () => {
+  it("retains unknown native profile and model fields", () => {
+    const result = mergeDeepSeekHarnessConfig(
+      {
+        retryPolicy: { mode: "always" },
+        streamIdleTimeoutMs: 30_000,
+        models: [
+          {
+            id: "deepseek-v4-pro",
+            name: "Pro",
+            contextWindow: 1_000_000,
+            maxTokens: 256_000,
+          },
+        ],
+      },
+      {
+        apiKey: "  sk-test  ",
+        includeApiKey: true,
+        defaultModel: "  deepseek-v4-pro  ",
+        apiKeyEnv: "  DEEPSEEK_API_KEY  ",
+        baseURL: "  https://api.deepseek.com  ",
+        thinking: "enabled",
+        defaultReasoningEffort: "max",
+        includeDefaultReasoningEffort: true,
+        modelsText: "deepseek-v4-pro\nprivate-reasoner",
+      },
+    );
+
+    expect(result).toMatchObject({
+      apiKey: "sk-test",
+      defaultModel: "deepseek-v4-pro",
+      apiKeyEnv: "DEEPSEEK_API_KEY",
+      baseURL: "https://api.deepseek.com",
+      thinking: "enabled",
+      defaultReasoningEffort: "max",
+      retryPolicy: { mode: "always" },
+      streamIdleTimeoutMs: 30_000,
+    });
+    expect(result.models).toEqual([
+      {
+        id: "deepseek-v4-pro",
+        name: "Pro",
+        contextWindow: 1_000_000,
+        maxTokens: 256_000,
+      },
+      { id: "private-reasoner" },
+    ]);
+  });
+
+  it("keeps structured edits when advanced fields change and never exposes the key", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <DeepSeekHarnessProviderForm
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        initialData={{
+          name: "DeepSeek Official",
+          settingsConfig: {
+            apiKey: "sk-private",
+            apiKeyEnv: "DEEPSEEK_API_KEY",
+            defaultModel: "deepseek-v4-pro",
+            baseURL: "https://old.example.com",
+            retryPolicy: { maxAttempts: 2 },
+          },
+        }}
+      />,
+    );
+
+    const advanced = screen.getByLabelText("advanced-config");
+    expect(advanced).not.toHaveValue(expect.stringContaining("sk-private"));
+
+    const baseURL = container.querySelector<HTMLInputElement>(
+      "#deepseek-harness-base-url",
+    );
+    expect(baseURL).not.toBeNull();
+    fireEvent.change(baseURL!, {
+      target: { value: "https://new.example.com" },
+    });
+    fireEvent.change(advanced, {
+      target: {
+        value: JSON.stringify({
+          baseURL: "https://stale.example.com",
+          retryPolicy: { maxAttempts: 4 },
+        }),
+      },
+    });
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+
+    const submitted = JSON.parse(onSubmit.mock.calls[0][0].settingsConfig);
+    expect(submitted).toMatchObject({
+      apiKey: "sk-private",
+      baseURL: "https://new.example.com",
+      defaultModel: "deepseek-v4-pro",
+      retryPolicy: { maxAttempts: 4 },
+    });
+  });
+
+  it("forces reasoning off when thinking is disabled", () => {
+    const result = mergeDeepSeekHarnessConfig(
+      {},
+      {
+        apiKey: "",
+        includeApiKey: true,
+        defaultModel: "deepseek-v4-flash",
+        apiKeyEnv: "DEEPSEEK_API_KEY",
+        baseURL: "https://api.deepseek.com",
+        thinking: "disabled",
+        defaultReasoningEffort: "max",
+        includeDefaultReasoningEffort: true,
+        modelsText: "deepseek-v4-flash\ndeepseek-v4-flash",
+      },
+    );
+
+    expect(result.reasoningEffort).toBeUndefined();
+    expect(result.defaultReasoningEffort).toBe("off");
+    expect(result.models).toEqual([{ id: "deepseek-v4-flash" }]);
+  });
+
+  it("keeps absent credentials absent until the API key field is touched", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <DeepSeekHarnessProviderForm
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        initialData={{
+          name: "DeepSeek Official",
+          settingsConfig: {
+            apiKeyEnv: "DEEPSEEK_API_KEY",
+            defaultModel: "deepseek-v4-flash",
+          },
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(
+      JSON.parse(onSubmit.mock.calls[0][0].settingsConfig),
+    ).not.toHaveProperty("apiKey");
+
+    const keyInput = container.querySelector<HTMLInputElement>(
+      "#deepseek-harness-api-key",
+    );
+    expect(keyInput).not.toBeNull();
+    await user.type(keyInput!, "temporary");
+    await user.clear(keyInput!);
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(onSubmit.mock.calls[1][0].settingsConfig).apiKey).toBe(
+      "",
+    );
+  });
+
+  it("preserves profile and default reasoning efforts independently", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <DeepSeekHarnessProviderForm
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        initialData={{
+          name: "DeepSeek Official",
+          settingsConfig: {
+            defaultModel: "deepseek-v4-flash",
+            reasoningEffort: "high",
+            defaultReasoningEffort: "max",
+          },
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(JSON.parse(onSubmit.mock.calls[0][0].settingsConfig)).toMatchObject({
+      reasoningEffort: "high",
+      defaultReasoningEffort: "max",
+    });
+
+    const effortTrigger = container.querySelector<HTMLElement>(
+      "#deepseek-harness-reasoning-effort",
+    );
+    expect(effortTrigger).not.toBeNull();
+    Element.prototype.scrollIntoView = vi.fn();
+    await user.click(effortTrigger!);
+    await user.click(screen.getByRole("option", { name: "off" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(2));
+    expect(JSON.parse(onSubmit.mock.calls[1][0].settingsConfig)).toMatchObject({
+      reasoningEffort: "high",
+      defaultReasoningEffort: "off",
+    });
+  });
+
+  it("keeps private provider fields out of the advanced native profile", () => {
+    expect(
+      nativeDeepSeekHarnessProfile({
+        apiKey: "sk-private",
+        defaultModel: "deepseek-v4-pro",
+        defaultReasoningEffort: "max",
+        baseURL: "https://api.deepseek.com",
+        retryPolicy: { maxAttempts: 3 },
+      }),
+    ).toEqual({
+      baseURL: "https://api.deepseek.com",
+      retryPolicy: { maxAttempts: 3 },
+    });
+  });
+});

--- a/tests/components/DeepSeekHarnessProviderForm.test.tsx
+++ b/tests/components/DeepSeekHarnessProviderForm.test.tsx
@@ -194,8 +194,8 @@ describe("mergeDeepSeekHarnessConfig", () => {
           name: "DeepSeek Official",
           settingsConfig: {
             defaultModel: "deepseek-v4-flash",
-            reasoningEffort: "high",
-            defaultReasoningEffort: "max",
+            reasoningEffort: "max",
+            defaultReasoningEffort: "high",
           },
         }}
       />,
@@ -204,8 +204,8 @@ describe("mergeDeepSeekHarnessConfig", () => {
     await user.click(screen.getByRole("button", { name: "Save" }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(JSON.parse(onSubmit.mock.calls[0][0].settingsConfig)).toMatchObject({
-      reasoningEffort: "high",
-      defaultReasoningEffort: "max",
+      reasoningEffort: "max",
+      defaultReasoningEffort: "high",
     });
 
     const effortTrigger = container.querySelector<HTMLElement>(
@@ -214,13 +214,33 @@ describe("mergeDeepSeekHarnessConfig", () => {
     expect(effortTrigger).not.toBeNull();
     Element.prototype.scrollIntoView = vi.fn();
     await user.click(effortTrigger!);
-    await user.click(screen.getByRole("option", { name: "off" }));
+    await user.click(screen.getByRole("option", { name: "low" }));
     await user.click(screen.getByRole("button", { name: "Save" }));
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(2));
     expect(JSON.parse(onSubmit.mock.calls[1][0].settingsConfig)).toMatchObject({
-      reasoningEffort: "high",
-      defaultReasoningEffort: "off",
+      reasoningEffort: "max",
+      defaultReasoningEffort: "low",
     });
+  });
+
+  it("round-trips low at both reasoning levels without conflating them", () => {
+    const result = mergeDeepSeekHarnessConfig(
+      { reasoningEffort: "low" },
+      {
+        apiKey: "",
+        includeApiKey: false,
+        defaultModel: "deepseek-v4-flash",
+        apiKeyEnv: "DEEPSEEK_API_KEY",
+        baseURL: "",
+        thinking: "enabled",
+        defaultReasoningEffort: "max",
+        includeDefaultReasoningEffort: true,
+        modelsText: "",
+      },
+    );
+
+    expect(result.reasoningEffort).toBe("low");
+    expect(result.defaultReasoningEffort).toBe("max");
   });
 
   it("keeps private provider fields out of the advanced native profile", () => {

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -253,7 +253,6 @@ describe("EditProviderDialog", () => {
       JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
     ).toEqual(provider.settingsConfig);
   });
-
   it("clears the nested auth panel before the dialog reopens", async () => {
     const provider: Provider = {
       id: "official",
@@ -351,7 +350,6 @@ describe("EditProviderDialog", () => {
       accountId: "acct-managed",
     });
   });
-
   it("编辑 Pi 供应商时保留通用元数据", async () => {
     const provider: Provider = {
       id: "pi-provider",
@@ -425,5 +423,100 @@ describe("EditProviderDialog", () => {
 
     act(() => staleCallback?.(true));
     expect(reopenedButton).toBeDisabled();
+  });
+
+  it("loads current DeepSeek Harness live settings while retaining stored credentials", async () => {
+    const provider: Provider = {
+      id: "deepseek-official",
+      name: "DeepSeek Official",
+      category: "official",
+      settingsConfig: {
+        apiKey: "db-secret",
+        apiKeyEnv: "DB_DEEPSEEK_KEY",
+        defaultModel: "db-model",
+        baseURL: "https://db.example",
+      },
+    };
+    const liveSettings = {
+      apiKey: "live-resolved-secret",
+      apiKeyEnv: "LIVE_DEEPSEEK_KEY",
+      defaultModel: "live-model",
+      baseURL: "https://live.example",
+      retryPolicy: { mode: "always" },
+    };
+    const expectedSettings = {
+      ...liveSettings,
+      apiKey: "db-secret",
+      apiKeyEnv: "DB_DEEPSEEK_KEY",
+    };
+    const handleSubmit = vi.fn().mockResolvedValue(undefined);
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings.mockResolvedValue(liveSettings);
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={handleSubmit}
+        appId="deepseek-harness"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+      ).toEqual(expectedSettings);
+    });
+    expect(apiMocks.getCurrent).toHaveBeenCalledWith("deepseek-harness");
+    expect(apiMocks.getLiveProviderSettings).toHaveBeenCalledWith(
+      "deepseek-harness",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "common.save" }));
+
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
+    expect(handleSubmit.mock.calls[0][0].provider.settingsConfig).toEqual(
+      expectedSettings,
+    );
+  });
+
+  it("does not adopt DeepSeek Harness live credentials when the stored provider has none", async () => {
+    const provider: Provider = {
+      id: "deepseek-official",
+      name: "DeepSeek Official",
+      category: "official",
+      settingsConfig: {
+        defaultModel: "db-model",
+      },
+    };
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings.mockResolvedValue({
+      apiKey: "shared-live-secret",
+      apiKeyEnv: "SHARED_LIVE_KEY",
+      defaultModel: "live-model",
+      baseURL: "https://live.example",
+    });
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="deepseek-harness"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+      ).toEqual({
+        defaultModel: "live-model",
+        baseURL: "https://live.example",
+      });
+    });
   });
 });

--- a/tests/hooks/useDirectorySettings.test.tsx
+++ b/tests/hooks/useDirectorySettings.test.tsx
@@ -72,8 +72,9 @@ describe("useDirectorySettings", () => {
       if (app === "grokbuild") return "/remote/grok";
       if (app === "opencode") return "/remote/opencode";
       if (app === "openclaw") return "/remote/openclaw";
+      if (app === "hermes") return "/remote/hermes";
       if (app === "pi") return "/remote/pi";
-      return "/remote/hermes";
+      return "/remote/deepseek-harness";
     });
     selectConfigDirectoryMock.mockReset();
   });
@@ -98,6 +99,7 @@ describe("useDirectorySettings", () => {
       openclaw: "/remote/openclaw",
       hermes: "/remote/hermes",
       pi: "/remote/pi",
+      "deepseek-harness": "/remote/deepseek-harness",
     });
   });
 
@@ -241,6 +243,56 @@ describe("useDirectorySettings", () => {
       openclawConfigDir: "/picked/openclaw",
     });
     expect(result.current.resolvedDirs.openclaw).toBe("/picked/openclaw");
+  });
+
+  it("updates DeepSeek Harness directory when browsing succeeds", async () => {
+    selectConfigDirectoryMock.mockResolvedValue("/picked/deepseek-harness");
+
+    const { result } = renderHook(() =>
+      useDirectorySettings({
+        settings: createSettings({ deepseekHarnessConfigDir: undefined }),
+        onUpdateSettings,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.browseDirectory("deepseek-harness");
+    });
+
+    expect(selectConfigDirectoryMock).toHaveBeenCalledWith(
+      "/remote/deepseek-harness",
+    );
+    expect(onUpdateSettings).toHaveBeenCalledWith({
+      deepseekHarnessConfigDir: "/picked/deepseek-harness",
+    });
+    expect(result.current.resolvedDirs["deepseek-harness"]).toBe(
+      "/picked/deepseek-harness",
+    );
+  });
+
+  it("resets DeepSeek Harness to the backend-resolved DSH_HOME", async () => {
+    const { result } = renderHook(() =>
+      useDirectorySettings({
+        settings: createSettings({
+          deepseekHarnessConfigDir: "/custom/deepseek-harness",
+        }),
+        onUpdateSettings,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await act(async () => {
+      await result.current.resetDirectory("deepseek-harness");
+    });
+
+    expect(onUpdateSettings).toHaveBeenCalledWith({
+      deepseekHarnessConfigDir: undefined,
+    });
+    expect(result.current.resolvedDirs["deepseek-harness"]).toBe(
+      "/remote/deepseek-harness",
+    );
   });
 
   it("resetAllDirectories applies provided resolved values", async () => {

--- a/tests/hooks/useSettings.test.tsx
+++ b/tests/hooks/useSettings.test.tsx
@@ -496,6 +496,7 @@ describe("useSettings hook", () => {
       openclaw: "/server/openclaw",
       hermes: "/server/hermes",
       pi: "/server/pi",
+      "deepseek-harness": undefined,
     });
     expect(metadataMock.setRequiresRestart).toHaveBeenCalledWith(false);
   });

--- a/tests/hooks/useSettingsForm.test.tsx
+++ b/tests/hooks/useSettingsForm.test.tsx
@@ -36,6 +36,8 @@ describe("useSettingsForm Hook", () => {
         enableClaudePluginIntegration: undefined,
         claudeConfigDir: "  /Users/demo  ",
         codexConfigDir: "   ",
+        hermesConfigDir: "  /Users/demo/.hermes  ",
+        deepseekHarnessConfigDir: "  /Users/demo/.dsh  ",
         language: "en",
       },
       isLoading: false,
@@ -53,6 +55,8 @@ describe("useSettingsForm Hook", () => {
     expect(settings.enableClaudePluginIntegration).toBe(false);
     expect(settings.claudeConfigDir).toBe("/Users/demo");
     expect(settings.codexConfigDir).toBeUndefined();
+    expect(settings.hermesConfigDir).toBe("/Users/demo/.hermes");
+    expect(settings.deepseekHarnessConfigDir).toBe("/Users/demo/.dsh");
     expect(settings.language).toBe("en");
     expect(result.current.initialLanguage).toBe("en");
     expect(changeLanguageSpy).toHaveBeenCalledWith("en");
@@ -171,6 +175,8 @@ describe("useSettingsForm Hook", () => {
         claudeConfigDir: "  /reset  ",
         codexConfigDir: "   ",
         piConfigDir: "  /pi-reset  ",
+        hermesConfigDir: "  /reset/hermes  ",
+        deepseekHarnessConfigDir: "  /reset/dsh  ",
         language: "zh",
       });
     });
@@ -182,6 +188,8 @@ describe("useSettingsForm Hook", () => {
     expect(settings.claudeConfigDir).toBe("/reset");
     expect(settings.codexConfigDir).toBeUndefined();
     expect(settings.piConfigDir).toBe("/pi-reset");
+    expect(settings.hermesConfigDir).toBe("/reset/hermes");
+    expect(settings.deepseekHarnessConfigDir).toBe("/reset/dsh");
     expect(settings.language).toBe("zh");
     expect(result.current.initialLanguage).toBe("en");
     expect(changeLanguageSpy).toHaveBeenCalledWith("en");

--- a/tests/msw/state.ts
+++ b/tests/msw/state.ts
@@ -74,6 +74,7 @@ const createDefaultProviders = (): ProvidersByApp => ({
   openclaw: {},
   hermes: {},
   pi: {},
+  "deepseek-harness": {},
 });
 
 const createDefaultCurrent = (): CurrentProviderState => ({
@@ -86,6 +87,7 @@ const createDefaultCurrent = (): CurrentProviderState => ({
   openclaw: "",
   hermes: "",
   pi: "",
+  "deepseek-harness": "",
 });
 
 let providers = createDefaultProviders();
@@ -200,6 +202,7 @@ let mcpConfigs: McpConfigState = {
   openclaw: {},
   hermes: {},
   pi: {},
+  "deepseek-harness": {},
 };
 
 const cloneProviders = (value: ProvidersByApp) =>
@@ -270,6 +273,7 @@ export const resetProviderState = () => {
     openclaw: {},
     hermes: {},
     pi: {},
+    "deepseek-harness": {},
   };
 };
 


### PR DESCRIPTION
## Summary / 概述

Add first-class DeepSeek Harness (`dsh`) support focused on the basic provider/model-switching scope requested in #6430.

- register `deepseek-harness` as an opt-in app with provider CRUD, current-provider switching, deeplink import, visibility, and custom `DSH_HOME`/directory handling
- project profiles into native `settings.yaml` (`llm-deepseek` + `agent-default-model`) and `.credentials.yaml` without touching unrelated settings
- preserve unknown YAML fields, comments, and formatting through child-level patches; use Harness-compatible cross-process locks, atomic writes, rollback, backups, and owner-only permissions
- keep API keys masked in the UI, reject inherited-environment credential shadowing, and preserve profile/default reasoning settings independently
- explicitly gate unsupported Phase 1 features (proxy/failover, MCP, Skills, prompts, sessions, usage, connectivity, and search configuration)
- add all four locale updates and focused backend/frontend regression coverage

DeepSeek Harness is still a developer preview, so this PR deliberately keeps the integration narrow and the native YAML projection forward-compatible.

## Related Issue / 关联 Issue

Fixes #6430
Tracked in #1855

## Scope / 范围

Included: native DeepSeek provider/model configuration, import, switching, directory override, and UI visibility.

Deferred: MCP/Skills, proxy/failover, usage, sessions, search endpoint configuration, and non-native custom provider routes.

## Screenshots / 截图

UI changes are opt-in (`Settings -> App Visibility -> DeepSeek Harness`). Screenshot to be added during review if requested.

## Validation / 验证

- [x] TypeScript: `tsc --noEmit`
- [x] Formatting: Prettier check and `git diff --check`
- [x] Frontend unit suite: `vitest run` (full suite passed)
- [x] Frontend production build: `vite build`
- [x] Rust compile: `cargo check --all-targets`
- [x] Rust Clippy for changed code (strict run passes after allowing four pre-existing upstream warnings)
- [ ] Rust test binaries: compile reached the linker locally, but the available GNU linker cannot consume this project's existing MSVC `/MANIFEST:*` flags; GitHub Actions will run the supported Windows/macOS/Linux matrix
- [x] Updated `en`, `zh`, `zh-TW`, and `ja` locale files

## Notes for reviewers

The DSH adapter follows the upstream native contracts for `DSH_HOME`, `settings.yaml`, `.credentials.yaml`, `deepseek-official`, environment precedence, file locks, and `0600`/`0700` permissions. Existing sessions can retain their recorded model; switching affects new sessions/requests according to Harness semantics.