### PR TITLE
fix(proxy): grokbuild 流式响应字段补全

### DIFF
--- a/src-tauri/src/proxy/providers/codex_responses_sse.rs
+++ b/src-tauri/src/proxy/providers/codex_responses_sse.rs
@@ -24,6 +24,34 @@ pub(crate) fn sse_event(event: &str, data: Value) -> Bytes {
     ))
 }
 
+/// 给已序列化的 SSE 事件注入顶层 `sequence_number`。
+///
+/// Grok Build / Codex 的新版 Responses 解析器要求每个事件都带一个单调递增的
+/// `sequence_number`（与 `type` 平级）。事件由上层状态机用计数器统一盖章，
+/// 解析失败（如 `[DONE]`）时原样返回。
+pub(crate) fn inject_sequence_number(event: &Bytes, sequence_number: u64) -> Bytes {
+    let text = String::from_utf8_lossy(event);
+    let mut lines = text.splitn(3, '\n');
+    let Some(event_line) = lines.next() else {
+        return event.clone();
+    };
+    let Some(data_line) = lines.next() else {
+        return event.clone();
+    };
+    let Some(payload) = data_line.strip_prefix("data: ") else {
+        return event.clone();
+    };
+    let Ok(mut value) = serde_json::from_str::<Value>(payload) else {
+        return event.clone();
+    };
+    let Some(object) = value.as_object_mut() else {
+        return event.clone();
+    };
+    object.insert("sequence_number".to_string(), json!(sequence_number));
+    let new_payload = serde_json::to_string(&value).unwrap_or_default();
+    Bytes::from(format!("{event_line}\ndata: {new_payload}\n\n"))
+}
+
 // ---------------------------------------------------------------------------
 // Response lifecycle (created / in_progress / completed / failed)
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -70,6 +70,8 @@ struct ChatToResponsesState {
     response_id: String,
     model: String,
     created_at: u64,
+    /// Responses SSE 顶层事件的递增序号（Grok Build / Codex 严格解析要求）。
+    sequence_number: u64,
     next_output_index: u32,
     text: TextItemState,
     reasoning: ReasoningItemState,
@@ -92,6 +94,7 @@ impl Default for ChatToResponsesState {
             response_id: "resp_ccswitch".to_string(),
             model: String::new(),
             created_at: 0,
+            sequence_number: 0,
             next_output_index: 0,
             text: TextItemState::default(),
             reasoning: ReasoningItemState::default(),
@@ -113,6 +116,13 @@ impl ChatToResponsesState {
             tool_context,
             ..Self::default()
         }
+    }
+
+    /// 为单个 SSE 事件注入顶层 sequence_number 并递增计数器。
+    fn stamp(&mut self, event: Bytes) -> Bytes {
+        let stamped = sse::inject_sequence_number(&event, self.sequence_number);
+        self.sequence_number += 1;
+        stamped
     }
 
     fn handle_chat_chunk(&mut self, chunk: &Value) -> Vec<Bytes> {
@@ -861,7 +871,7 @@ pub fn create_responses_sse_stream_from_chat_with_context<E: std::error::Error +
                         let data = data_parts.join("\n");
                         if data.trim() == "[DONE]" {
                             for event in state.finalize() {
-                                yield Ok(event);
+                                yield Ok(state.stamp(event));
                             }
                             continue;
                         }
@@ -873,13 +883,14 @@ pub fn create_responses_sse_stream_from_chat_with_context<E: std::error::Error +
 
                         if event_name.as_deref() == Some("error") || chunk.get("error").is_some() {
                             let (message, error_type) = extract_chat_sse_error(&chunk);
-                            yield Ok(state.failed_event(message, error_type));
+                            let event = state.failed_event(message, error_type);
+                            yield Ok(state.stamp(event));
                             stream_failed = true;
                             break;
                         }
 
                         for event in state.handle_chat_chunk(&chunk) {
-                            yield Ok(event);
+                            yield Ok(state.stamp(event));
                         }
                     }
 
@@ -888,10 +899,11 @@ pub fn create_responses_sse_stream_from_chat_with_context<E: std::error::Error +
                     }
                 }
                 Err(e) => {
-                    yield Ok(state.failed_event(
+                    let event = state.failed_event(
                         format!("Stream error: {e}"),
                         Some("stream_error".to_string()),
-                    ));
+                    );
+                    yield Ok(state.stamp(event));
                     stream_failed = true;
                     break;
                 }
@@ -901,18 +913,19 @@ pub fn create_responses_sse_stream_from_chat_with_context<E: std::error::Error +
         if !stream_failed {
             if state.completed || state.finish_reason.is_some() {
                 for event in state.finalize() {
-                    yield Ok(event);
+                    yield Ok(state.stamp(event));
                 }
             } else if state.has_substantive_output() {
                 state.finish_reason = Some("length".to_string());
                 for event in state.finalize() {
-                    yield Ok(event);
+                    yield Ok(state.stamp(event));
                 }
             } else {
-                yield Ok(state.failed_event(
+                let event = state.failed_event(
                     "Upstream Chat Completions stream ended before sending finish_reason".to_string(),
                     Some("stream_truncated".to_string()),
-                ));
+                );
+                yield Ok(state.stamp(event));
             }
         }
     }
@@ -1004,6 +1017,26 @@ mod tests {
             created["response"]["usage"]["input_tokens_details"]["cached_tokens"],
             0
         );
+    }
+
+    #[tokio::test]
+    async fn events_carry_monotonic_sequence_number() {
+        // 回归保护：Grok Build 新版解析器要求每个 SSE 事件带顶层
+        // sequence_number，且从 0 开始连续递增。
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_1\",\"created\":123,\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_1\",\"created\":123,\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":\"lo\"},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":4,\"completion_tokens\":2,\"total_tokens\":6}}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        let events = parse_sse_events(&output);
+        let seqs: Vec<u64> = events
+            .iter()
+            .map(|e| e["sequence_number"].as_u64().expect("event missing sequence_number"))
+            .collect();
+        let expected: Vec<u64> = (0..events.len() as u64).collect();
+        assert_eq!(seqs, expected);
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -764,8 +764,16 @@ impl ChatToResponsesState {
 
     fn failed_event(&mut self, message: String, error_type: Option<String>) -> Bytes {
         self.completed = true;
-        let mut error = json!({ "message": message });
-        if let Some(error_type) = error_type.filter(|value| !value.is_empty()) {
+        let error_type = error_type.filter(|value| !value.is_empty());
+        // Grok Build / Codex 的 Responses 错误解析器要求 error 对象必须带
+        // code 字段，缺失会报 "missing field `code`"。
+        let code = match error_type.as_deref() {
+            Some("rate_limit_error") => "rate_limit_exceeded".to_string(),
+            Some(other) => other.to_string(),
+            None => "proxy_error".to_string(),
+        };
+        let mut error = json!({ "message": message, "code": code });
+        if let Some(error_type) = error_type {
             error["type"] = json!(error_type);
         }
 
@@ -1492,6 +1500,22 @@ mod tests {
         assert!(output.contains("event: response.failed"));
         assert!(output.contains("quota exceeded"));
         assert!(output.contains("rate_limit_exceeded"));
+        assert!(!output.contains("event: response.completed"));
+    }
+
+    #[tokio::test]
+    async fn failed_event_includes_error_code_field() {
+        // 回归保护：上游错误只带 type 不带 code 时，代理也必须补 code，
+        // 否则 Grok Build 报 "missing field `code`"。
+        let output = collect(vec![
+            "data: {\"error\":{\"message\":\"boom\",\"type\":\"rate_limit_error\"}}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+
+        assert!(output.contains("event: response.failed"));
+        assert!(output.contains("\"code\":\"rate_limit_exceeded\""));
+        assert!(output.contains("\"type\":\"rate_limit_error\""));
         assert!(!output.contains("event: response.completed"));
     }
 }

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -749,6 +749,7 @@ impl ChatToResponsesState {
                     "input_tokens": 0,
                     "output_tokens": 0,
                     "total_tokens": 0,
+                    "input_tokens_details": { "cached_tokens": 0 },
                     "output_tokens_details": { "reasoning_tokens": 0 }
                 })
             })
@@ -975,6 +976,26 @@ mod tests {
         assert!(output.contains("\"text\":\"Hello\""));
         assert!(output.contains("event: response.completed"));
         assert!(output.contains("\"input_tokens\":4"));
+    }
+
+    #[tokio::test]
+    async fn response_created_event_carries_input_tokens_details_even_when_empty() {
+        // 回归保护：首个 response.created 事件的空 usage 也必须带
+        // input_tokens_details，否则 Grok Build 在流首帧就解析失败。
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_1\",\"created\":123,\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":\"Hel\"}}]}\n\n",
+        ])
+        .await;
+
+        let events = parse_sse_events(&output);
+        let created = events
+            .iter()
+            .find(|e| e["type"] == "response.created")
+            .expect("response.created event missing");
+        assert_eq!(
+            created["response"]["usage"]["input_tokens_details"]["cached_tokens"],
+            0
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1796,6 +1796,7 @@ pub(crate) fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
             "input_tokens": 0,
             "output_tokens": 0,
             "total_tokens": 0,
+            "input_tokens_details": { "cached_tokens": 0 },
             "output_tokens_details": { "reasoning_tokens": 0 }
         });
     };
@@ -1836,12 +1837,13 @@ pub(crate) fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
                 .and_then(|v| v.as_u64())
         })
         .unwrap_or(0);
-    if cached > 0 || cache_write > 0 {
-        result["input_tokens_details"] = json!({
-            "cached_tokens": cached,
-            "cache_write_tokens": cache_write
-        });
-    }
+    // Grok Build / Codex 的 Responses 解析器要求 usage 中始终存在
+    // input_tokens_details（即便缓存令牌为 0），否则会报
+    // "missing field `input_tokens_details`" 序列化错误。
+    result["input_tokens_details"] = json!({
+        "cached_tokens": cached,
+        "cache_write_tokens": cache_write
+    });
 
     if let Some(details) = usage
         .get("completion_tokens_details")
@@ -3856,6 +3858,34 @@ mod tests {
             result["usage"]["input_tokens_details"]["cache_write_tokens"],
             2
         );
+    }
+
+    #[test]
+    fn chat_usage_to_responses_always_emits_input_tokens_details_even_when_zero() {
+        // 回归保护：上游 prompt_tokens_details 全为 0 时也必须输出
+        // input_tokens_details，否则 Grok Build 会因缺少该字段而解析失败。
+        let usage = json!({
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "prompt_tokens_details": { "cached_tokens": 0, "audio_tokens": 0 }
+        });
+
+        let result = chat_usage_to_responses_usage(Some(&usage));
+
+        assert_eq!(result["input_tokens"], 10);
+        assert_eq!(result["output_tokens"], 5);
+        assert_eq!(result["input_tokens_details"]["cached_tokens"], 0);
+        assert_eq!(result["input_tokens_details"]["cache_write_tokens"], 0);
+    }
+
+    #[test]
+    fn chat_usage_to_responses_emits_input_tokens_details_when_usage_missing() {
+        // 上游完全省略 usage 时，合成 usage 也必须带 input_tokens_details。
+        let result = chat_usage_to_responses_usage(None);
+
+        assert_eq!(result["input_tokens"], 0);
+        assert_eq!(result["input_tokens_details"]["cached_tokens"], 0);
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1840,10 +1840,10 @@ pub(crate) fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
     // Grok Build / Codex 的 Responses 解析器要求 usage 中始终存在
     // input_tokens_details（即便缓存令牌为 0），否则会报
     // "missing field `input_tokens_details`" 序列化错误。
-    result["input_tokens_details"] = json!({
-        "cached_tokens": cached,
-        "cache_write_tokens": cache_write
-    });
+    result["input_tokens_details"] = json!({ "cached_tokens": cached });
+    if cache_write > 0 {
+        result["input_tokens_details"]["cache_write_tokens"] = json!(cache_write);
+    }
 
     if let Some(details) = usage
         .get("completion_tokens_details")
@@ -3876,7 +3876,7 @@ mod tests {
         assert_eq!(result["input_tokens"], 10);
         assert_eq!(result["output_tokens"], 5);
         assert_eq!(result["input_tokens_details"]["cached_tokens"], 0);
-        assert_eq!(result["input_tokens_details"]["cache_write_tokens"], 0);
+        assert!(result["input_tokens_details"].get("cache_write_tokens").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

修复 grokbuild proxy 流式响应（SSE）中几个字段缺失问题，使输出符合 Responses API 规范：

1. **Chat 转 Responses 始终输出 `input_tokens_details`** — 转换时不再遗漏 token 用量细节字段
2. **流式首帧空 usage 也输出 `input_tokens_details`** — 首帧 usage 为空时也补全该字段，保证客户端解析一致
3. **流式错误对象补充 `code` 字段** — 错误响应携带 code 字段，便于客户端识别错误类型
4. **Responses SSE 事件补充顶层 `sequence_number`** — SSE 事件消息带顶层序号，符合 Responses API 规范

## Related Issue / 关联 Issue

无关联 Issue。

## Screenshots / 截图

不适用（后端 proxy 代码变更，无 UI 改动）。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（不适用：本次仅修改 Rust proxy 代码）