### PR TITLE
fix(usage): 修复非代理模式下 Claude API 403 未导入请求日志

### DIFF
--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -174,8 +174,157 @@ struct ParsedAssistantUsage {
     cache_read_tokens: u32,
     cache_creation_tokens: u32,
     stop_reason: Option<String>,
+    api_error_status: Option<u16>,
+    error_message: Option<String>,
     timestamp: Option<String>,
     session_id: Option<String>,
+}
+
+const CLAUDE_API_ERROR_BACKFILL_SUFFIX: &str = "#api-errors-v1";
+
+fn claude_api_error_backfill_key(file_path: &Path) -> String {
+    format!(
+        "{}{}",
+        file_path.to_string_lossy(),
+        CLAUDE_API_ERROR_BACKFILL_SUFFIX
+    )
+}
+
+fn parse_api_error_fields(value: &serde_json::Value) -> (Option<u16>, Option<String>) {
+    let status = value
+        .get("isApiErrorMessage")
+        .and_then(|v| v.as_bool())
+        .filter(|is_error| *is_error)
+        .and_then(|_| value.get("apiErrorStatus"))
+        .and_then(|v| v.as_u64())
+        .filter(|status| (400..=599).contains(status))
+        .map(|status| status as u16);
+    let error_message = status.and_then(|_| {
+        value
+            .get("error")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+    });
+    (status, error_message)
+}
+
+/// One-time error-only rescan for existing installs whose normal Claude
+/// cursor has already advanced past zero-token API failures. Successful
+/// usage rows are never replayed, avoiding double-counting pruned rollups.
+fn backfill_api_errors_once(
+    db: &Database,
+    file_path: &Path,
+    already_done: bool,
+) -> Result<u32, AppError> {
+    if already_done {
+        return Ok(0);
+    }
+
+    let metadata = fs::metadata(file_path)
+        .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?;
+    let file_modified = metadata_modified_nanos(&metadata);
+    let file =
+        fs::File::open(file_path).map_err(|e| AppError::Config(format!("无法打开文件: {e}")))?;
+    let mut reader = BufReader::new(file);
+    let mut buf = Vec::new();
+    let mut current_session_id: Option<String> = None;
+    let mut errors = Vec::new();
+
+    loop {
+        buf.clear();
+        let read = reader
+            .read_until(b'\n', &mut buf)
+            .map_err(|e| AppError::Config(format!("API 错误历史回填读取失败: {e}")))?;
+        if read == 0 {
+            break;
+        }
+        if !buf.ends_with(
+            b"
+",
+        ) {
+            return Err(AppError::Config(
+                "API 错误历史回填遇到未完成尾行，将在后续同步重试".to_string(),
+            ));
+        }
+        if buf.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+        let value: serde_json::Value = match serde_json::from_slice(&buf) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        if current_session_id.is_none() {
+            if let Some(sid) = value.get("sessionId").and_then(|v| v.as_str()) {
+                current_session_id = Some(sid.to_string());
+            }
+        }
+        if value.get("type").and_then(|v| v.as_str()) != Some("assistant") {
+            continue;
+        }
+        let (api_error_status, error_message) = parse_api_error_fields(&value);
+        if api_error_status.is_none() {
+            continue;
+        }
+        let message = match value.get("message") {
+            Some(message) => message,
+            None => continue,
+        };
+        let message_id = match message.get("id").and_then(|v| v.as_str()) {
+            Some(id) => id.to_string(),
+            None => continue,
+        };
+        let usage = message.get("usage");
+        let token = |name: &str| {
+            usage
+                .and_then(|u| u.get(name))
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0) as u32
+        };
+        errors.push(ParsedAssistantUsage {
+            message_id,
+            model: message
+                .get("model")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string(),
+            input_tokens: token("input_tokens"),
+            output_tokens: token("output_tokens"),
+            cache_read_tokens: token("cache_read_input_tokens"),
+            cache_creation_tokens: token("cache_creation_input_tokens"),
+            stop_reason: message
+                .get("stop_reason")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            api_error_status,
+            error_message,
+            timestamp: value
+                .get("timestamp")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            session_id: current_session_id.clone(),
+        });
+    }
+
+    let conn = lock_conn!(db.conn);
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::Database(format!("启动 API 错误历史回填事务失败: {e}")))?;
+    let mut imported = 0;
+    for msg in &errors {
+        let request_id = format!(
+            "{}{}",
+            crate::proxy::usage::parser::SESSION_REQUEST_ID_PREFIX,
+            msg.message_id
+        );
+        if insert_session_log_entry_on_conn(&tx, &request_id, msg)? {
+            imported += 1;
+        }
+    }
+    let marker_key = claude_api_error_backfill_key(file_path);
+    update_sync_state_on_conn(&tx, &marker_key, file_modified, 0)?;
+    tx.commit()
+        .map_err(|e| AppError::Database(format!("提交 API 错误历史回填事务失败: {e}")))?;
+    Ok(imported)
 }
 
 /// 同步 Claude Code 会话日志到使用统计数据库
@@ -207,6 +356,17 @@ pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppE
 
     for file_path in &jsonl_files {
         result.files_scanned += 1;
+
+        let backfill_key = claude_api_error_backfill_key(file_path);
+        let backfill_done = cursors.contains_key(&backfill_key);
+        match backfill_api_errors_once(db, file_path, backfill_done) {
+            Ok(imported) => result.imported += imported,
+            Err(e) => {
+                let msg = format!("{}: API 错误历史回填失败: {e}", file_path.display());
+                log::warn!("[SESSION-SYNC] {msg}");
+                result.errors.push(msg);
+            }
+        }
 
         let cursor = cursors.get(file_path.to_string_lossy().as_ref());
         match sync_single_file(db, file_path, cursor) {
@@ -558,6 +718,7 @@ fn sync_single_file(
             Some(u) => u,
             None => continue,
         };
+        let (api_error_status, error_message) = parse_api_error_fields(&value);
 
         let parsed = ParsedAssistantUsage {
             message_id: msg_id.clone(),
@@ -586,6 +747,8 @@ fn sync_single_file(
                 .get("stop_reason")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string()),
+            api_error_status,
+            error_message,
             timestamp: value
                 .get("timestamp")
                 .and_then(|v| v.as_str())
@@ -642,7 +805,7 @@ fn sync_single_file(
             || msg.output_tokens > 0
             || msg.cache_read_tokens > 0
             || msg.cache_creation_tokens > 0;
-        if !has_billable_tokens {
+        if !has_billable_tokens && msg.api_error_status.is_none() {
             continue;
         }
 
@@ -656,6 +819,9 @@ fn sync_single_file(
             Ok(true) => imported += 1,
             Ok(false) => skipped += 1,
             Err(e) => {
+                if msg.api_error_status.is_some() {
+                    return Err(e);
+                }
                 log::warn!("[SESSION-SYNC] 插入失败 ({}): {e}", msg.message_id);
                 skipped += 1;
             }
@@ -820,7 +986,7 @@ fn insert_session_log_entry_on_conn(
         cache_creation_tokens: msg.cache_creation_tokens,
         created_at,
     };
-    if should_skip_session_insert(conn, request_id, &dedup_key)? {
+    if msg.api_error_status.is_none() && should_skip_session_insert(conn, request_id, &dedup_key)? {
         return Ok(false);
     }
 
@@ -883,8 +1049,8 @@ fn insert_session_log_entry_on_conn(
                 total_cost,
                 0i64,               // latency_ms: 会话日志无此数据
                 Option::<i64>::None, // first_token_ms
-                200i64,             // status_code: 会话日志中的请求只要产生计费 token 即视为成功
-                Option::<String>::None, // error_message
+                msg.api_error_status.unwrap_or(200) as i64,
+                msg.error_message.as_deref(),
                 msg.session_id,
                 Some("session_log"), // provider_type
                 1i64,               // is_streaming: Claude Code 通常使用流式
@@ -1013,6 +1179,8 @@ mod tests {
             cache_read_tokens: 5000,
             cache_creation_tokens: 10000,
             stop_reason: None,
+            api_error_status: None,
+            error_message: None,
             timestamp: Some("2026-04-05T12:00:00Z".to_string()),
             session_id: None,
         };
@@ -1027,6 +1195,8 @@ mod tests {
             cache_read_tokens: 5000,
             cache_creation_tokens: 10000,
             stop_reason: Some("end_turn".to_string()),
+            api_error_status: None,
+            error_message: None,
             timestamp: Some("2026-04-05T12:00:00Z".to_string()),
             session_id: None,
         };
@@ -1038,6 +1208,45 @@ mod tests {
 
         messages.insert("msg_1".to_string(), final_entry);
         assert_eq!(messages.get("msg_1").unwrap().output_tokens, 1349);
+    }
+
+    #[test]
+    fn test_api_error_backfill_imports_zero_token_error_once() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp).unwrap();
+        let file = tmp.join("claude-api-error.jsonl");
+        let api_error = r#"{"type":"assistant","message":{"id":"msg_api_error","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        fs::write(
+            &file,
+            format!(
+                "{api_error}
+"
+            ),
+        )
+        .unwrap();
+
+        let modified = metadata_modified_nanos(&fs::metadata(&file).unwrap());
+        update_sync_state(&db, file.to_string_lossy().as_ref(), modified, 1)?;
+
+        assert_eq!(backfill_api_errors_once(&db, &file, false)?, 1);
+        let marker = claude_api_error_backfill_key(&file);
+        assert!(load_sync_cursors(&db)?.contains_key(&marker));
+        assert_eq!(backfill_api_errors_once(&db, &file, true)?, 0);
+
+        let conn = lock_conn!(db.conn);
+        let (count, status, error): (i64, i64, Option<String>) = conn.query_row(
+            "SELECT COUNT(*), MAX(status_code), MAX(error_message) FROM proxy_request_logs WHERE request_id = 'session:msg_api_error'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(count, 1);
+        assert_eq!(status, 403);
+        assert_eq!(error.as_deref(), Some("authentication_failed"));
+        drop(conn);
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
     }
 
     #[test]
@@ -1078,6 +1287,8 @@ mod tests {
             cache_read_tokens: 10,
             cache_creation_tokens: 5,
             stop_reason: Some("end_turn".to_string()),
+            api_error_status: None,
+            error_message: None,
             timestamp: Some("1970-01-01T00:16:45Z".to_string()),
             session_id: Some("session-1".to_string()),
         };

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -120,9 +120,17 @@ struct ParsedAssistantUsage {
     cache_read_tokens: u32,
     cache_creation_tokens: u32,
     stop_reason: Option<String>,
+    status_code: u16,
+    error_message: Option<String>,
+    is_api_error: bool,
     timestamp: Option<String>,
     session_id: Option<String>,
 }
+
+/// One-time cursor marker for the parser version that started importing
+/// structured Claude Code API errors. Existing installations have already
+/// advanced past those zero-token rows, so they need one idempotent full scan.
+const CLAUDE_API_ERROR_BACKFILL_MARKER: &str = "__claude_api_error_backfill_v1__";
 
 /// 同步 Claude Code 会话日志到使用统计数据库
 pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppError> {
@@ -150,10 +158,12 @@ pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppE
     // 收集所有 .jsonl 文件
     let jsonl_files = collect_jsonl_files(&projects_dir);
 
+    let force_full_scan = get_sync_state(db, CLAUDE_API_ERROR_BACKFILL_MARKER)? == (0, 0);
+
     for file_path in &jsonl_files {
         result.files_scanned += 1;
 
-        match sync_single_file(db, file_path) {
+        match sync_single_file_with_options(db, file_path, force_full_scan) {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -164,6 +174,10 @@ pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppE
                 result.errors.push(msg);
             }
         }
+    }
+
+    if force_full_scan {
+        update_sync_state(db, CLAUDE_API_ERROR_BACKFILL_MARKER, 1, 1)?;
     }
 
     if result.imported > 0 {
@@ -250,7 +264,16 @@ fn push_jsonl_children(dir: &Path, files: &mut Vec<PathBuf>) {
 }
 
 /// 同步单个 JSONL 文件，返回 (imported, skipped)
+#[cfg(test)]
 fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
+    sync_single_file_with_options(db, file_path, false)
+}
+
+fn sync_single_file_with_options(
+    db: &Database,
+    file_path: &Path,
+    force_full_scan: bool,
+) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
 
     // 获取文件元数据
@@ -259,7 +282,11 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
     let file_modified = metadata_modified_nanos(&metadata);
 
     // 检查同步状态
-    let (last_modified, last_offset) = get_sync_state(db, &file_path_str)?;
+    let (last_modified, last_offset) = if force_full_scan {
+        (0, 0)
+    } else {
+        get_sync_state(db, &file_path_str)?
+    };
 
     // 文件未变化则跳过
     if file_modified <= last_modified {
@@ -324,6 +351,17 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
             None => continue,
         };
 
+        let api_error_status = value
+            .get("apiErrorStatus")
+            .and_then(|v| v.as_u64())
+            .filter(|status| (400..=599).contains(status))
+            .map(|status| status as u16);
+        let is_api_error = value
+            .get("isApiErrorMessage")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+            && api_error_status.is_some();
+
         let parsed = ParsedAssistantUsage {
             message_id: msg_id.clone(),
             model: message
@@ -351,6 +389,16 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
                 .get("stop_reason")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string()),
+            status_code: api_error_status.unwrap_or(200),
+            error_message: if is_api_error {
+                value
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            } else {
+                None
+            },
+            is_api_error,
             timestamp: value
                 .get("timestamp")
                 .and_then(|v| v.as_str())
@@ -401,7 +449,7 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
             || msg.output_tokens > 0
             || msg.cache_read_tokens > 0
             || msg.cache_creation_tokens > 0;
-        if !has_billable_tokens {
+        if !has_billable_tokens && !msg.is_api_error {
             continue;
         }
 
@@ -583,8 +631,8 @@ fn insert_session_log_entry(
                 total_cost,
                 0i64,               // latency_ms: 会话日志无此数据
                 Option::<i64>::None, // first_token_ms
-                200i64,             // status_code: 会话日志中的请求只要产生计费 token 即视为成功
-                Option::<String>::None, // error_message
+                msg.status_code as i64,
+                msg.error_message,
                 msg.session_id,
                 Some("session_log"), // provider_type
                 1i64,               // is_streaming: Claude Code 通常使用流式
@@ -713,6 +761,9 @@ mod tests {
             cache_read_tokens: 5000,
             cache_creation_tokens: 10000,
             stop_reason: None,
+            status_code: 200,
+            error_message: None,
+            is_api_error: false,
             timestamp: Some("2026-04-05T12:00:00Z".to_string()),
             session_id: None,
         };
@@ -727,6 +778,9 @@ mod tests {
             cache_read_tokens: 5000,
             cache_creation_tokens: 10000,
             stop_reason: Some("end_turn".to_string()),
+            status_code: 200,
+            error_message: None,
+            is_api_error: false,
             timestamp: Some("2026-04-05T12:00:00Z".to_string()),
             session_id: None,
         };
@@ -778,6 +832,9 @@ mod tests {
             cache_read_tokens: 10,
             cache_creation_tokens: 5,
             stop_reason: Some("end_turn".to_string()),
+            status_code: 200,
+            error_message: None,
+            is_api_error: false,
             timestamp: Some("1970-01-01T00:16:45Z".to_string()),
             session_id: Some("session-1".to_string()),
         };
@@ -887,6 +944,41 @@ mod tests {
             |row| row.get(0),
         )?;
         assert!(!empty_exists, "全 0 token 的 message 应被跳过");
+        drop(conn);
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_imports_claude_api_error_without_tokens() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp).unwrap();
+        let file = tmp.join("claude-api-error.jsonl");
+
+        let api_error = r#"{"type":"assistant","message":{"id":"msg_api_error","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"stop_reason":"stop_sequence","content":[{"type":"text","text":"Please run /login · API Error: 403 Access to model denied."}]},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        fs::write(&file, format!("{api_error}\n")).unwrap();
+
+        let modified = metadata_modified_nanos(&fs::metadata(&file).unwrap());
+        update_sync_state(&db, &file.to_string_lossy(), modified, 1)?;
+        assert_eq!(
+            sync_single_file(&db, &file)?,
+            (0, 0),
+            "普通增量同步不会重读已推进的游标"
+        );
+
+        let (imported, _skipped) = sync_single_file_with_options(&db, &file, true)?;
+        assert_eq!(imported, 1, "结构化 API 错误即使没有 token 也必须被导入");
+
+        let conn = lock_conn!(db.conn);
+        let (status, error): (i64, Option<String>) = conn.query_row(
+            "SELECT status_code, error_message FROM proxy_request_logs WHERE request_id = 'session:msg_api_error'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(status, 403);
+        assert_eq!(error.as_deref(), Some("authentication_failed"));
         drop(conn);
 
         fs::remove_dir_all(&tmp).ok();

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -257,6 +257,7 @@ fn push_jsonl_children(dir: &Path, files: &mut Vec<PathBuf>) {
 fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
     let sync_state_key = format!("{file_path_str}#{CLAUDE_SYNC_CURSOR_VERSION}");
+    let incomplete_tail_key = format!("{sync_state_key}#incomplete-tail");
 
     // 获取文件元数据
     let metadata = fs::metadata(file_path)
@@ -265,9 +266,17 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
 
     // 检查同步状态
     let (last_modified, last_offset) = get_sync_state(db, &sync_state_key)?;
+    let (incomplete_tail_len, _) = get_sync_state(db, &incomplete_tail_key)?;
+    let legacy_processed_offset = if (last_modified, last_offset) == (0, 0) {
+        get_sync_state(db, &file_path_str)?.1
+    } else {
+        0
+    };
 
     // 文件未变化则跳过
-    if file_modified <= last_modified {
+    if file_modified <= last_modified
+        && (incomplete_tail_len == 0 || incomplete_tail_len == metadata.len() as i64)
+    {
         return Ok((0, 0));
     }
 
@@ -277,8 +286,9 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
     let mut reader = BufReader::new(file);
 
     let mut line_offset: i64 = 0;
+    let mut scanned_len: i64 = 0;
     let mut has_incomplete_tail = false;
-    let mut messages: HashMap<String, ParsedAssistantUsage> = HashMap::new();
+    let mut messages: HashMap<String, (ParsedAssistantUsage, i64)> = HashMap::new();
     let mut current_session_id: Option<String> = None;
     let mut line_bytes = Vec::new();
 
@@ -286,11 +296,8 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
         line_bytes.clear();
         match reader.read_until(b'\n', &mut line_bytes) {
             Ok(0) => break,
-            Ok(_) => {}
-            Err(_) => {
-                has_incomplete_tail = true;
-                break;
-            }
+            Ok(read) => scanned_len += read as i64,
+            Err(e) => return Err(AppError::Config(format!("无法读取文件: {e}"))),
         }
         line_offset += 1;
 
@@ -404,7 +411,7 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
         // 按 message.id 去重：优先保留有 stop_reason 的条目，否则保留最新的
         let should_replace = match messages.get(&msg_id) {
             None => true,
-            Some(existing) => {
+            Some((existing, _)) => {
                 // 新条目有 stop_reason 而旧条目没有 → 替换
                 if parsed.stop_reason.is_some() && existing.stop_reason.is_none() {
                     true
@@ -419,7 +426,7 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
         };
 
         if should_replace {
-            messages.insert(msg_id, parsed);
+            messages.insert(msg_id, (parsed, line_offset));
         }
     }
 
@@ -427,7 +434,7 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
     let mut imported: u32 = 0;
     let mut skipped: u32 = 0;
 
-    for msg in messages.values() {
+    for (msg, message_line_offset) in messages.values() {
         // 只要产生了真实计费 token 就导入，不再强制要求 stop_reason 或 output>0。
         //
         // Anthropic 在受理请求时即对 input + cache_read + cache_creation 计费
@@ -447,6 +454,9 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
         if !has_billable_tokens && msg.api_error_status.is_none() {
             continue;
         }
+        if msg.api_error_status.is_none() && *message_line_offset <= legacy_processed_offset {
+            continue;
+        }
 
         let request_id = format!(
             "{}{}",
@@ -464,10 +474,20 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
         }
     }
 
-    // Claude 可能仍在写最后一条 JSONL；不要把未完成尾行计入游标。
-    if !has_incomplete_tail {
-        update_sync_state(db, &sync_state_key, file_modified, line_offset)?;
-    }
+    // 未完成尾行已从 line_offset 中扣除；长度变化后再重试该行。
+    let conn = lock_conn!(db.conn);
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::Database(format!("开启 Claude 会话游标事务失败: {e}")))?;
+    update_sync_state_on_conn(
+        &tx,
+        &incomplete_tail_key,
+        if has_incomplete_tail { scanned_len } else { 0 },
+        0,
+    )?;
+    update_sync_state_on_conn(&tx, &sync_state_key, file_modified, line_offset)?;
+    tx.commit()
+        .map_err(|e| AppError::Database(format!("提交 Claude 会话游标事务失败: {e}")))?;
 
     Ok((imported, skipped))
 }
@@ -951,12 +971,13 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&tmp).unwrap();
         let file = tmp.join("claude-api-error.jsonl");
+        let old_success = r#"{"type":"assistant","message":{"id":"msg_old_success","model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"output_tokens":5,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:30:00Z","sessionId":"session-error"}"#;
         let api_error = r#"{"type":"assistant","message":{"id":"msg_api_error","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
-        fs::write(&file, format!("{api_error}\n")).unwrap();
+        fs::write(&file, format!("{old_success}\n{api_error}\n")).unwrap();
 
         let file_path = file.to_string_lossy();
         let modified = metadata_modified_nanos(&fs::metadata(&file).unwrap());
-        update_sync_state(&db, &file_path, modified, 1)?;
+        update_sync_state(&db, &file_path, modified, 2)?;
 
         assert_eq!(sync_single_file(&db, &file)?.0, 1);
         assert_eq!(sync_single_file(&db, &file)?.0, 0);
@@ -971,6 +992,15 @@ mod tests {
         assert_eq!(count, 1, "版本化游标重扫必须保持幂等");
         assert_eq!(status, 403);
         assert_eq!(error.as_deref(), Some("authentication_failed"));
+        let old_success_exists: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM proxy_request_logs WHERE request_id = 'session:msg_old_success')",
+            [],
+            |row| row.get(0),
+        )?;
+        assert!(
+            !old_success_exists,
+            "旧游标之前的成功记录可能已进入汇总表，不得在版本重扫时重新导入"
+        );
         drop(conn);
 
         fs::remove_dir_all(&tmp).ok();
@@ -1024,7 +1054,9 @@ mod tests {
 
         assert_eq!(sync_single_file(&db, &file)?.0, 0);
         let sync_state_key = format!("{}#{CLAUDE_SYNC_CURSOR_VERSION}", file.to_string_lossy());
-        assert_eq!(get_sync_state(&db, &sync_state_key)?, (0, 0));
+        let (partial_mtime, completed_offset) = get_sync_state(&db, &sync_state_key)?;
+        assert!(partial_mtime > 0);
+        assert_eq!(completed_offset, 0, "游标不得越过未完成的第 1 行");
 
         fs::write(&file, format!("{api_error}\n")).unwrap();
         assert_eq!(sync_single_file(&db, &file)?.0, 1);

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -135,17 +135,13 @@ const CLAUDE_API_ERROR_BACKFILL_MARKER: &str = "__claude_api_error_backfill_v1__
 /// 同步 Claude Code 会话日志到使用统计数据库
 pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppError> {
     let projects_dir = get_claude_config_dir().join("projects");
-    if !projects_dir.exists() {
-        return Ok(SessionSyncResult {
-            imported: 0,
-            skipped: 0,
-            files_scanned: 0,
-            suspected_duplicates: 0,
-            deferred_files: 0,
-            errors: vec![],
-        });
-    }
+    sync_claude_session_logs_from_projects_dir(db, &projects_dir)
+}
 
+fn sync_claude_session_logs_from_projects_dir(
+    db: &Database,
+    projects_dir: &Path,
+) -> Result<SessionSyncResult, AppError> {
     let mut result = SessionSyncResult {
         imported: 0,
         skipped: 0,
@@ -155,8 +151,28 @@ pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppE
         errors: vec![],
     };
 
+    match fs::metadata(projects_dir) {
+        Ok(metadata) if metadata.is_dir() => {}
+        Ok(_) => {
+            result.errors.push(format!(
+                "Claude projects 路径不是目录: {}",
+                projects_dir.display()
+            ));
+            return Ok(result);
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(result),
+        Err(error) => {
+            result.errors.push(format!(
+                "无法读取 Claude projects 目录 {}: {error}",
+                projects_dir.display()
+            ));
+            return Ok(result);
+        }
+    }
+
     // 收集所有 .jsonl 文件
-    let jsonl_files = collect_jsonl_files(&projects_dir);
+    let (jsonl_files, collection_errors) = collect_jsonl_files(projects_dir);
+    result.errors.extend(collection_errors);
 
     let force_full_scan = get_sync_state(db, CLAUDE_API_ERROR_BACKFILL_MARKER)? == (0, 0);
 
@@ -213,62 +229,86 @@ fn complete_api_error_backfill_if_successful(
 /// agent 多嵌套一层 `workflows/wf_<ID>/`。漏掉这一层会让 Workflow 的 token
 /// 用量完全不计入统计；`journal.jsonl` 不含 `type=="assistant"` 行，解析时
 /// 会被 `sync_single_file` 天然跳过，因此这里无需按文件名过滤。
-fn collect_jsonl_files(projects_dir: &Path) -> Vec<PathBuf> {
+fn collect_jsonl_files(projects_dir: &Path) -> (Vec<PathBuf>, Vec<String>) {
     let mut files = Vec::new();
+    let mut errors = Vec::new();
 
-    let entries = match fs::read_dir(projects_dir) {
-        Ok(e) => e,
-        Err(_) => return files,
-    };
-
-    for entry in entries.flatten() {
+    for entry in read_dir_entries(projects_dir, false, &mut errors) {
         let path = entry.path();
-        if !path.is_dir() {
+        if !path_is_dir(&path, &mut errors) {
             continue;
         }
         // 每个项目目录下的 .jsonl 文件
-        if let Ok(sub_entries) = fs::read_dir(&path) {
-            for sub_entry in sub_entries.flatten() {
-                let sub_path = sub_entry.path();
-                if sub_path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-                    // 主会话 JSONL 文件
-                    files.push(sub_path);
-                } else if sub_path.is_dir() {
-                    // 扫描子 agent 目录: 项目/SESSION_ID/subagents/*.jsonl
-                    let subagents_dir = sub_path.join("subagents");
-                    if subagents_dir.is_dir() {
-                        push_jsonl_children(&subagents_dir, &mut files);
+        for sub_entry in read_dir_entries(&path, false, &mut errors) {
+            let sub_path = sub_entry.path();
+            if sub_path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                // 主会话 JSONL 文件
+                files.push(sub_path);
+            } else if path_is_dir(&sub_path, &mut errors) {
+                // 扫描子 agent 目录: 项目/SESSION_ID/subagents/*.jsonl
+                let subagents_dir = sub_path.join("subagents");
+                push_jsonl_children(&subagents_dir, true, &mut files, &mut errors);
 
-                        // 额外下探 Workflow 子 agent:
-                        // 项目/SESSION_ID/subagents/workflows/wf_<ID>/*.jsonl
-                        let workflows_dir = subagents_dir.join("workflows");
-                        if workflows_dir.is_dir() {
-                            if let Ok(wf_entries) = fs::read_dir(&workflows_dir) {
-                                for wf_entry in wf_entries.flatten() {
-                                    let wf_path = wf_entry.path();
-                                    if wf_path.is_dir() {
-                                        push_jsonl_children(&wf_path, &mut files);
-                                    }
-                                }
-                            }
-                        }
+                // 额外下探 Workflow 子 agent:
+                // 项目/SESSION_ID/subagents/workflows/wf_<ID>/*.jsonl
+                let workflows_dir = subagents_dir.join("workflows");
+                for wf_entry in read_dir_entries(&workflows_dir, true, &mut errors) {
+                    let wf_path = wf_entry.path();
+                    if path_is_dir(&wf_path, &mut errors) {
+                        push_jsonl_children(&wf_path, false, &mut files, &mut errors);
                     }
                 }
             }
         }
     }
 
-    files
+    (files, errors)
 }
 
 /// 将 `dir` 下直接子层的所有 `.jsonl` 文件追加到 `files`（不递归）。
-fn push_jsonl_children(dir: &Path, files: &mut Vec<PathBuf>) {
-    if let Ok(entries) = fs::read_dir(dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-                files.push(path);
+fn push_jsonl_children(
+    dir: &Path,
+    optional: bool,
+    files: &mut Vec<PathBuf>,
+    errors: &mut Vec<String>,
+) {
+    for entry in read_dir_entries(dir, optional, errors) {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+            files.push(path);
+        }
+    }
+}
+
+fn read_dir_entries(dir: &Path, optional: bool, errors: &mut Vec<String>) -> Vec<fs::DirEntry> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if optional && error.kind() == std::io::ErrorKind::NotFound => {
+            return Vec::new();
+        }
+        Err(error) => {
+            errors.push(format!("无法读取目录 {}: {error}", dir.display()));
+            return Vec::new();
+        }
+    };
+
+    entries
+        .filter_map(|entry| match entry {
+            Ok(entry) => Some(entry),
+            Err(error) => {
+                errors.push(format!("无法读取目录项 {}: {error}", dir.display()));
+                None
             }
+        })
+        .collect()
+}
+
+fn path_is_dir(path: &Path, errors: &mut Vec<String>) -> bool {
+    match fs::metadata(path) {
+        Ok(metadata) => metadata.is_dir(),
+        Err(error) => {
+            errors.push(format!("无法读取路径元数据 {}: {error}", path.display()));
+            false
         }
     }
 }
@@ -289,7 +329,7 @@ fn sync_single_file_with_options(
     // 获取文件元数据
     let metadata = fs::metadata(file_path)
         .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?;
-    let file_modified = metadata_modified_nanos(&metadata);
+    let file_modified = metadata_modified_nanos_checked(&metadata)?;
 
     // 检查同步状态
     let (last_modified, last_offset) = if force_full_scan {
@@ -320,19 +360,23 @@ fn sync_single_file_with_options(
             continue;
         }
 
-        let line = match line_result {
-            Ok(l) => l,
-            Err(_) => continue, // 容忍不完整的最后一行
-        };
+        let line = line_result.map_err(|error| {
+            AppError::Config(format!(
+                "读取 JSONL 失败 ({} 第 {line_offset} 行): {error}",
+                file_path.display()
+            ))
+        })?;
 
         if line.trim().is_empty() {
             continue;
         }
 
-        let value: serde_json::Value = match serde_json::from_str(&line) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
+        let value: serde_json::Value = serde_json::from_str(&line).map_err(|error| {
+            AppError::Config(format!(
+                "解析 JSONL 失败 ({} 第 {line_offset} 行): {error}",
+                file_path.display()
+            ))
+        })?;
 
         // 提取 session ID (从 system 或首条消息)
         if current_session_id.is_none() {
@@ -474,7 +518,7 @@ fn sync_single_file_with_options(
             Ok(false) => skipped += 1,
             Err(e) => {
                 log::warn!("[SESSION-SYNC] 插入失败 ({}): {e}", msg.message_id);
-                skipped += 1;
+                return Err(e);
             }
         }
     }
@@ -503,12 +547,16 @@ pub(crate) fn get_sync_state(db: &Database, file_path: &str) -> Result<(i64, i64
 /// `session_log_sync.last_modified` 旧数据是秒级时间戳；新写入纳秒值不需要
 /// schema 迁移，旧值会自然触发一次增量重扫，并继续依赖行 offset 避免重复导入。
 pub(crate) fn metadata_modified_nanos(metadata: &fs::Metadata) -> i64 {
+    metadata_modified_nanos_checked(metadata).unwrap_or(0)
+}
+
+fn metadata_modified_nanos_checked(metadata: &fs::Metadata) -> Result<i64, AppError> {
     metadata
         .modified()
-        .ok()
-        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
+        .map_err(|error| AppError::Config(format!("无法读取文件修改时间: {error}")))?
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_err(|error| AppError::Config(format!("文件修改时间早于 UNIX epoch: {error}")))
         .map(|d| d.as_nanos().min(i64::MAX as u128) as i64)
-        .unwrap_or(0)
 }
 
 /// 更新 session_log_sync 表中某条目的同步进度。
@@ -872,7 +920,8 @@ mod tests {
         fs::write(project.join("main.jsonl"), "{}").unwrap();
         fs::write(subagents_dir.join("agent-abc.jsonl"), "{}").unwrap();
 
-        let files = collect_jsonl_files(&tmp);
+        let (files, errors) = collect_jsonl_files(&tmp);
+        assert!(errors.is_empty());
         assert_eq!(files.len(), 2);
         let paths: Vec<String> = files
             .iter()
@@ -901,7 +950,8 @@ mod tests {
         // journal.jsonl 也会被收集，但解析时因无 assistant 行而产出 0 条
         fs::write(wf_dir.join("journal.jsonl"), "{}").unwrap();
 
-        let files = collect_jsonl_files(&tmp);
+        let (files, errors) = collect_jsonl_files(&tmp);
+        assert!(errors.is_empty());
         let paths: Vec<String> = files
             .iter()
             .map(|p| p.to_string_lossy().to_string())
@@ -1017,6 +1067,133 @@ mod tests {
             "所有文件扫描成功后才应完成回填"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_api_error_backfill_marker_waits_for_directory_scan_errors() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp).unwrap();
+        let not_a_directory = tmp.join("projects");
+        fs::write(&not_a_directory, "not a directory").unwrap();
+
+        let result = sync_claude_session_logs_from_projects_dir(&db, &not_a_directory)?;
+        assert!(
+            !result.errors.is_empty(),
+            "目录枚举失败必须进入同步错误列表"
+        );
+
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (0, 0),
+            "目录扫描不完整时必须保留回填待重试状态"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_optional_scan_path_that_is_not_a_directory_is_an_error() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        let session_dir = tmp.join("project").join("session");
+        fs::create_dir_all(&session_dir).unwrap();
+        fs::write(session_dir.join("subagents"), "not a directory").unwrap();
+
+        let result = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(
+            !result.errors.is_empty(),
+            "存在但不是目录的可选扫描路径必须被报告，不能视为目录缺失"
+        );
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (0, 0),
+            "嵌套目录扫描失败时必须保留回填待重试状态"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_sync_does_not_advance_cursor_when_insert_fails() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        let project_dir = tmp.join("project");
+        fs::create_dir_all(&project_dir).unwrap();
+        let file = project_dir.join("claude-api-error.jsonl");
+        let api_error = r#"{"type":"assistant","message":{"id":"msg_insert_error","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        fs::write(&file, format!("{api_error}\n")).unwrap();
+
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute_batch("DROP TABLE proxy_request_logs")?;
+        }
+
+        let result = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(
+            !result.errors.is_empty(),
+            "数据库插入失败必须进入顶层同步错误列表"
+        );
+        assert_eq!(
+            get_sync_state(&db, &file.to_string_lossy())?,
+            (0, 0),
+            "插入失败后不能推进文件游标，后续同步必须能够重试"
+        );
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (0, 0),
+            "数据库插入失败时必须保留回填待重试状态"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_incomplete_jsonl_keeps_backfill_pending_until_retry() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        let project_dir = tmp.join("project");
+        fs::create_dir_all(&project_dir).unwrap();
+        let file = project_dir.join("claude-api-error.jsonl");
+        fs::write(
+            &file,
+            r#"{"type":"assistant","message":{"id":"msg_partial""#,
+        )
+        .unwrap();
+
+        let first = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(
+            !first.errors.is_empty(),
+            "未写完的 JSONL 行必须使本次回填失败"
+        );
+        assert_eq!(
+            get_sync_state(&db, &file.to_string_lossy())?,
+            (0, 0),
+            "未写完的行不能被文件游标越过"
+        );
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (0, 0),
+            "未写完的行必须让全量回填保持待重试"
+        );
+
+        let api_error = r#"{"type":"assistant","message":{"id":"msg_partial","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        fs::write(&file, format!("{api_error}\n")).unwrap();
+
+        let retry = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert_eq!(retry.imported, 1, "文件写完后重试必须导入原来的 403");
+        assert!(retry.errors.is_empty());
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (1, 1),
+            "完整重试成功后才能完成回填"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
         Ok(())
     }
 }

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -16,12 +16,11 @@ use crate::proxy::usage::parser::TokenUsage;
 use crate::services::usage_stats::{
     effective_usage_log_filter, find_model_pricing, should_skip_session_insert, DedupKey,
 };
-use rusqlite::OptionalExtension;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::SystemTime;
@@ -121,38 +120,28 @@ struct ParsedAssistantUsage {
     cache_read_tokens: u32,
     cache_creation_tokens: u32,
     stop_reason: Option<String>,
-    status_code: u16,
+    api_error_status: Option<u16>,
     error_message: Option<String>,
-    is_api_error: bool,
     timestamp: Option<String>,
     session_id: Option<String>,
 }
 
-/// One-time cursor marker for the parser version that started importing
-/// structured Claude Code API errors. Existing installations have already
-/// advanced past those zero-token rows, so they need one idempotent full scan.
-const CLAUDE_API_ERROR_BACKFILL_MARKER: &str = "__claude_api_error_backfill_v1__";
-const CLAUDE_BACKFILL_ERROR_MARKER: &str = "__claude_api_error_backfill_error_v1__";
-const CLAUDE_INCOMPLETE_TAIL_MARKER_PREFIX: &str = "__claude_incomplete_tail_v1__:";
-const CLAUDE_FILE_STATE_MARKER_PREFIX: &str = "__claude_file_state_v1__:";
-const CLAUDE_FILE_HASH_MARKER_PREFIX: &str = "__claude_file_hash_v1__:";
-const CLAUDE_FILE_FULL_HASH_MARKER_PREFIX: &str = "__claude_file_full_hash_v1__:";
-const CLAUDE_PROXY_ERROR_DEDUP_MARKER_PREFIX: &str = "__claude_proxy_error_dedup_v1__:";
-const FNV1A_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
-const FNV1A_PRIME: u64 = 0x100000001b3;
-const FILE_FINGERPRINT_SAMPLE_SIZE: i64 = 4096;
-const FILE_FULL_HASH_VERIFY_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
+const CLAUDE_SYNC_CURSOR_VERSION: &str = "api-errors-v1";
 
 /// 同步 Claude Code 会话日志到使用统计数据库
 pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppError> {
     let projects_dir = get_claude_config_dir().join("projects");
-    sync_claude_session_logs_from_projects_dir(db, &projects_dir)
-}
+    if !projects_dir.exists() {
+        return Ok(SessionSyncResult {
+            imported: 0,
+            skipped: 0,
+            files_scanned: 0,
+            suspected_duplicates: 0,
+            deferred_files: 0,
+            errors: vec![],
+        });
+    }
 
-fn sync_claude_session_logs_from_projects_dir(
-    db: &Database,
-    projects_dir: &Path,
-) -> Result<SessionSyncResult, AppError> {
     let mut result = SessionSyncResult {
         imported: 0,
         skipped: 0,
@@ -162,35 +151,13 @@ fn sync_claude_session_logs_from_projects_dir(
         errors: vec![],
     };
 
-    match fs::metadata(projects_dir) {
-        Ok(metadata) if metadata.is_dir() => {}
-        Ok(_) => {
-            result.errors.push(format!(
-                "Claude projects 路径不是目录: {}",
-                projects_dir.display()
-            ));
-            return Ok(result);
-        }
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(result),
-        Err(error) => {
-            result.errors.push(format!(
-                "无法读取 Claude projects 目录 {}: {error}",
-                projects_dir.display()
-            ));
-            return Ok(result);
-        }
-    }
-
     // 收集所有 .jsonl 文件
-    let (jsonl_files, collection_errors) = collect_jsonl_files(projects_dir);
-    result.errors.extend(collection_errors);
-
-    let force_full_scan = get_sync_state(db, CLAUDE_API_ERROR_BACKFILL_MARKER)? == (0, 0);
+    let jsonl_files = collect_jsonl_files(&projects_dir);
 
     for file_path in &jsonl_files {
         result.files_scanned += 1;
 
-        match sync_single_file_with_options(db, file_path, force_full_scan) {
+        match sync_single_file(db, file_path) {
             Ok((imported, skipped)) => {
                 result.imported += imported;
                 result.skipped += skipped;
@@ -202,8 +169,6 @@ fn sync_claude_session_logs_from_projects_dir(
             }
         }
     }
-
-    complete_api_error_backfill_if_successful(db, force_full_scan, &result.errors)?;
 
     if result.imported > 0 {
         log::info!(
@@ -217,49 +182,6 @@ fn sync_claude_session_logs_from_projects_dir(
     Ok(result)
 }
 
-fn complete_api_error_backfill_if_successful(
-    db: &Database,
-    force_full_scan: bool,
-    errors: &[String],
-) -> Result<(), AppError> {
-    if !force_full_scan {
-        return Ok(());
-    }
-
-    if errors.is_empty() {
-        update_sync_state(db, CLAUDE_API_ERROR_BACKFILL_MARKER, 1, 1)?;
-        update_sync_state(db, CLAUDE_BACKFILL_ERROR_MARKER, 0, 0)?;
-        return Ok(());
-    }
-
-    // 同一组错误连续出现两次后停止每分钟强制全量回扫。普通增量同步仍会
-    // 每分钟枚举并重试这些路径；而旧文件没有内容指纹，会在恢复可读后保守
-    // 全量解析，因此不会因结束一次性 backfill 而永久漏记。
-    let mut sorted_errors = errors.to_vec();
-    sorted_errors.sort_unstable();
-    let mut signature_hash = FNV1A_OFFSET_BASIS;
-    for error in &sorted_errors {
-        update_fnv1a(&mut signature_hash, error.as_bytes());
-        update_fnv1a(&mut signature_hash, b"\0");
-    }
-    let signature = (
-        signature_hash as i64,
-        sorted_errors.len().min(i64::MAX as usize) as i64,
-    );
-    if get_sync_state(db, CLAUDE_BACKFILL_ERROR_MARKER)? == signature {
-        log::warn!(
-            "[SESSION-SYNC] backfill 连续遇到相同的 {} 个错误，结束强制全量扫描并保留普通重试",
-            errors.len()
-        );
-        update_sync_state(db, CLAUDE_API_ERROR_BACKFILL_MARKER, 1, 1)?;
-        update_sync_state(db, CLAUDE_BACKFILL_ERROR_MARKER, 0, 0)?;
-    } else {
-        update_sync_state(db, CLAUDE_BACKFILL_ERROR_MARKER, signature.0, signature.1)?;
-    }
-
-    Ok(())
-}
-
 /// 收集目录下所有 .jsonl 文件（含子 agent 文件）
 ///
 /// 扫描固定深度，不使用递归，避免死循环：
@@ -271,198 +193,94 @@ fn complete_api_error_backfill_if_successful(
 /// agent 多嵌套一层 `workflows/wf_<ID>/`。漏掉这一层会让 Workflow 的 token
 /// 用量完全不计入统计；`journal.jsonl` 不含 `type=="assistant"` 行，解析时
 /// 会被 `sync_single_file` 天然跳过，因此这里无需按文件名过滤。
-fn collect_jsonl_files(projects_dir: &Path) -> (Vec<PathBuf>, Vec<String>) {
+fn collect_jsonl_files(projects_dir: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
-    let mut errors = Vec::new();
 
-    for entry in read_dir_entries(projects_dir, false, &mut errors) {
+    let entries = match fs::read_dir(projects_dir) {
+        Ok(e) => e,
+        Err(_) => return files,
+    };
+
+    for entry in entries.flatten() {
         let path = entry.path();
-        if !path_is_dir(&path, &mut errors) {
+        if !path.is_dir() {
             continue;
         }
         // 每个项目目录下的 .jsonl 文件
-        for sub_entry in read_dir_entries(&path, false, &mut errors) {
-            let sub_path = sub_entry.path();
-            if sub_path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-                // 主会话 JSONL 文件
-                files.push(sub_path);
-            } else if path_is_dir(&sub_path, &mut errors) {
-                // 扫描子 agent 目录: 项目/SESSION_ID/subagents/*.jsonl
-                let subagents_dir = sub_path.join("subagents");
-                push_jsonl_children(&subagents_dir, true, &mut files, &mut errors);
+        if let Ok(sub_entries) = fs::read_dir(&path) {
+            for sub_entry in sub_entries.flatten() {
+                let sub_path = sub_entry.path();
+                if sub_path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                    // 主会话 JSONL 文件
+                    files.push(sub_path);
+                } else if sub_path.is_dir() {
+                    // 扫描子 agent 目录: 项目/SESSION_ID/subagents/*.jsonl
+                    let subagents_dir = sub_path.join("subagents");
+                    if subagents_dir.is_dir() {
+                        push_jsonl_children(&subagents_dir, &mut files);
 
-                // 额外下探 Workflow 子 agent:
-                // 项目/SESSION_ID/subagents/workflows/wf_<ID>/*.jsonl
-                let workflows_dir = subagents_dir.join("workflows");
-                for wf_entry in read_dir_entries(&workflows_dir, true, &mut errors) {
-                    let wf_path = wf_entry.path();
-                    if path_is_dir(&wf_path, &mut errors) {
-                        push_jsonl_children(&wf_path, false, &mut files, &mut errors);
+                        // 额外下探 Workflow 子 agent:
+                        // 项目/SESSION_ID/subagents/workflows/wf_<ID>/*.jsonl
+                        let workflows_dir = subagents_dir.join("workflows");
+                        if workflows_dir.is_dir() {
+                            if let Ok(wf_entries) = fs::read_dir(&workflows_dir) {
+                                for wf_entry in wf_entries.flatten() {
+                                    let wf_path = wf_entry.path();
+                                    if wf_path.is_dir() {
+                                        push_jsonl_children(&wf_path, &mut files);
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
         }
     }
 
-    (files, errors)
+    files
 }
 
 /// 将 `dir` 下直接子层的所有 `.jsonl` 文件追加到 `files`（不递归）。
-fn push_jsonl_children(
-    dir: &Path,
-    optional: bool,
-    files: &mut Vec<PathBuf>,
-    errors: &mut Vec<String>,
-) {
-    for entry in read_dir_entries(dir, optional, errors) {
-        let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-            files.push(path);
-        }
-    }
-}
-
-fn read_dir_entries(dir: &Path, optional: bool, errors: &mut Vec<String>) -> Vec<fs::DirEntry> {
-    let entries = match fs::read_dir(dir) {
-        Ok(entries) => entries,
-        Err(error) if optional && error.kind() == std::io::ErrorKind::NotFound => {
-            return Vec::new();
-        }
-        Err(error) => {
-            errors.push(format!("无法读取目录 {}: {error}", dir.display()));
-            return Vec::new();
-        }
-    };
-
-    entries
-        .filter_map(|entry| match entry {
-            Ok(entry) => Some(entry),
-            Err(error) => {
-                errors.push(format!("无法读取目录项 {}: {error}", dir.display()));
-                None
+fn push_jsonl_children(dir: &Path, files: &mut Vec<PathBuf>) {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
+                files.push(path);
             }
-        })
-        .collect()
-}
-
-fn path_is_dir(path: &Path, errors: &mut Vec<String>) -> bool {
-    match fs::metadata(path) {
-        Ok(metadata) => metadata.is_dir(),
-        Err(error) => {
-            errors.push(format!("无法读取路径元数据 {}: {error}", path.display()));
-            false
         }
     }
 }
 
 /// 同步单个 JSONL 文件，返回 (imported, skipped)
-#[cfg(test)]
 fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppError> {
-    sync_single_file_with_options(db, file_path, false)
-}
-
-fn sync_single_file_with_options(
-    db: &Database,
-    file_path: &Path,
-    force_full_scan: bool,
-) -> Result<(u32, u32), AppError> {
     let file_path_str = file_path.to_string_lossy().to_string();
+    let sync_state_key = format!("{file_path_str}#{CLAUDE_SYNC_CURSOR_VERSION}");
 
     // 获取文件元数据
     let metadata = fs::metadata(file_path)
         .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?;
-    let file_modified = metadata_modified_nanos_checked(&metadata)?;
-    let file_len = metadata.len().min(i64::MAX as u64) as i64;
+    let file_modified = metadata_modified_nanos(&metadata);
 
-    // 检查同步状态。mtime 不能单独代表文件内容：日志可能在时间戳不变时追加，
-    // 也可能被截断或替换，因此额外保存 (mtime, length) 文件签名。
-    let (_, saved_offset) = if force_full_scan {
-        (0, 0)
-    } else {
-        get_sync_state(db, &file_path_str)?
-    };
-    let file_state_marker = format!("{CLAUDE_FILE_STATE_MARKER_PREFIX}{file_path_str}");
-    let previous_file_state = get_sync_state(db, &file_state_marker)?;
-    let file_hash_marker = format!("{CLAUDE_FILE_HASH_MARKER_PREFIX}{file_path_str}");
-    let previous_file_hash = get_sync_state(db, &file_hash_marker)?;
-    let file_full_hash_marker = format!("{CLAUDE_FILE_FULL_HASH_MARKER_PREFIX}{file_path_str}");
-    let previous_full_hash = get_sync_state(db, &file_full_hash_marker)?;
-    let now = unix_timestamp_seconds();
+    // 检查同步状态
+    let (last_modified, last_offset) = get_sync_state(db, &sync_state_key)?;
 
-    // 稳态先用固定大小采样避免每分钟读取全部历史日志；每天再全量校验一次，
-    // 让刻意保留 mtime/长度及采样窗口的替换也不会永久漏掉。
-    let mut full_content_changed = false;
-    if !force_full_scan
-        && previous_file_state == (file_modified, file_len)
-        && previous_file_hash.1 == file_len
-        && hash_file_prefix(file_path, file_len)? == previous_file_hash.0
-    {
-        if previous_full_hash != (0, 0)
-            && now.saturating_sub(previous_full_hash.1) < FILE_FULL_HASH_VERIFY_INTERVAL_SECONDS
-        {
-            return Ok((0, 0));
-        }
-        let current_full_hash = hash_entire_file_prefix(file_path, file_len)?;
-        if previous_full_hash.0 == current_full_hash {
-            update_sync_state(db, &file_full_hash_marker, current_full_hash, now)?;
-            return Ok((0, 0));
-        }
-        full_content_changed = true;
+    // 文件未变化则跳过
+    if file_modified <= last_modified {
+        return Ok((0, 0));
     }
-
-    let can_continue_from_cursor = !force_full_scan
-        && !full_content_changed
-        && previous_file_state != (0, 0)
-        && previous_file_hash.1 == previous_file_state.1
-        && file_len >= previous_file_state.1
-        && hash_file_prefix(file_path, previous_file_state.1)? == previous_file_hash.0;
-    let last_offset = if can_continue_from_cursor {
-        saved_offset
-    } else {
-        // 文件被截断、替换，或尚无内容指纹时，旧行号不再可信。
-        0
-    };
 
     // 从上次偏移位置开始增量解析
     let file =
         fs::File::open(file_path).map_err(|e| AppError::Config(format!("无法打开文件: {e}")))?;
-    let mut reader = BufReader::new(file);
-    let incomplete_tail_marker = format!("{CLAUDE_INCOMPLETE_TAIL_MARKER_PREFIX}{file_path_str}");
-    let observed_incomplete_tail = get_sync_state(db, &incomplete_tail_marker)?;
+    let reader = BufReader::new(file);
 
     let mut line_offset: i64 = 0;
     let mut messages: HashMap<String, ParsedAssistantUsage> = HashMap::new();
     let mut current_session_id: Option<String> = None;
-    let mut line = Vec::new();
-    let mut full_hash = FNV1A_OFFSET_BASIS;
-    let mut full_hashed_bytes = 0_i64;
-    let mut previous_prefix_hash = FNV1A_OFFSET_BASIS;
-    let mut previous_prefix_hashed_bytes = 0_i64;
 
-    loop {
-        line.clear();
-        let bytes_read = reader.read_until(b'\n', &mut line).map_err(|error| {
-            AppError::Config(format!(
-                "读取 JSONL 失败 ({} 第 {} 行): {error}",
-                file_path.display(),
-                line_offset + 1
-            ))
-        })?;
-        if bytes_read == 0 {
-            break;
-        }
-
-        let bytes_to_hash = (file_len - full_hashed_bytes).clamp(0, bytes_read as i64) as usize;
-        update_fnv1a(&mut full_hash, &line[..bytes_to_hash]);
-        full_hashed_bytes += bytes_to_hash as i64;
-        if can_continue_from_cursor {
-            let prefix_len = previous_file_state.1;
-            let prefix_bytes =
-                (prefix_len - previous_prefix_hashed_bytes).clamp(0, bytes_read as i64) as usize;
-            update_fnv1a(&mut previous_prefix_hash, &line[..prefix_bytes]);
-            previous_prefix_hashed_bytes += prefix_bytes as i64;
-        }
-
+    for line_result in reader.lines() {
         line_offset += 1;
 
         // 跳过已处理的行
@@ -470,50 +288,23 @@ fn sync_single_file_with_options(
             continue;
         }
 
-        if line.iter().all(|byte| byte.is_ascii_whitespace()) {
+        let line = match line_result {
+            Ok(l) => l,
+            Err(_) => continue, // 容忍不完整的最后一行
+        };
+
+        if line.trim().is_empty() {
             continue;
         }
 
-        let value: serde_json::Value = match serde_json::from_slice(&line) {
-            Ok(value) => value,
-            Err(error) if !line.ends_with(b"\n") => {
-                let tail_signature = (fnv1a_hash(&line), line.len().min(i64::MAX as usize) as i64);
-                if observed_incomplete_tail == tail_signature {
-                    log::warn!(
-                        "[SESSION-SYNC] 跳过稳定未变化的损坏 JSONL 末行 ({} 第 {line_offset} 行): {error}",
-                        file_path.display()
-                    );
-                    line_offset -= 1;
-                    break;
-                }
-
-                update_sync_state(
-                    db,
-                    &incomplete_tail_marker,
-                    tail_signature.0,
-                    tail_signature.1,
-                )?;
-                return Err(AppError::Config(format!(
-                    "解析可能尚未写完的 JSONL 末行失败 ({} 第 {line_offset} 行): {error}",
-                    file_path.display()
-                )));
-            }
-            Err(error) => {
-                log::warn!(
-                    "[SESSION-SYNC] 跳过损坏的 JSONL 记录 ({} 第 {line_offset} 行): {error}",
-                    file_path.display()
-                );
-                continue;
-            }
+        let value: serde_json::Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
         };
 
         // 提取 session ID (从 system 或首条消息)
         if current_session_id.is_none() {
-            if let Some(sid) = value
-                .get("sessionId")
-                .and_then(|v| v.as_str())
-                .filter(|sid| !sid.trim().is_empty())
-            {
+            if let Some(sid) = value.get("sessionId").and_then(|v| v.as_str()) {
                 current_session_id = Some(sid.to_string());
             }
         }
@@ -539,15 +330,13 @@ fn sync_single_file_with_options(
         };
 
         let api_error_status = value
-            .get("apiErrorStatus")
+            .get("isApiErrorMessage")
+            .and_then(|v| v.as_bool())
+            .filter(|is_error| *is_error)
+            .and_then(|_| value.get("apiErrorStatus"))
             .and_then(|v| v.as_u64())
             .filter(|status| (400..=599).contains(status))
             .map(|status| status as u16);
-        let is_api_error = value
-            .get("isApiErrorMessage")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false)
-            && api_error_status.is_some();
 
         let parsed = ParsedAssistantUsage {
             message_id: msg_id.clone(),
@@ -576,16 +365,13 @@ fn sync_single_file_with_options(
                 .get("stop_reason")
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string()),
-            status_code: api_error_status.unwrap_or(200),
-            error_message: if is_api_error {
+            api_error_status,
+            error_message: api_error_status.and_then(|_| {
                 value
                     .get("error")
                     .and_then(|v| v.as_str())
                     .map(str::to_string)
-            } else {
-                None
-            },
-            is_api_error,
+            }),
             timestamp: value
                 .get("timestamp")
                 .and_then(|v| v.as_str())
@@ -615,14 +401,6 @@ fn sync_single_file_with_options(
         }
     }
 
-    if can_continue_from_cursor
-        && (previous_prefix_hashed_bytes != previous_file_state.1
-            || previous_prefix_hash as i64 != previous_full_hash.0)
-    {
-        // 追加期间旧前缀也被改写；尚未执行任何插入，安全回退为一次全量解析。
-        return sync_single_file_with_options(db, file_path, true);
-    }
-
     // 写入数据库
     let mut imported: u32 = 0;
     let mut skipped: u32 = 0;
@@ -644,7 +422,7 @@ fn sync_single_file_with_options(
             || msg.output_tokens > 0
             || msg.cache_read_tokens > 0
             || msg.cache_creation_tokens > 0;
-        if !has_billable_tokens && !msg.is_api_error {
+        if !has_billable_tokens && msg.api_error_status.is_none() {
             continue;
         }
 
@@ -659,105 +437,15 @@ fn sync_single_file_with_options(
             Ok(false) => skipped += 1,
             Err(e) => {
                 log::warn!("[SESSION-SYNC] 插入失败 ({}): {e}", msg.message_id);
-                return Err(e);
+                skipped += 1;
             }
         }
     }
 
     // 更新同步状态
-    update_sync_state(db, &file_path_str, file_modified, line_offset)?;
-    update_sync_state(db, &file_full_hash_marker, full_hash as i64, now)?;
-    update_sync_state(
-        db,
-        &file_hash_marker,
-        hash_file_prefix(file_path, file_len)?,
-        file_len,
-    )?;
-    update_sync_state(db, &file_state_marker, file_modified, file_len)?;
-    if observed_incomplete_tail != (0, 0) {
-        update_sync_state(db, &incomplete_tail_marker, 0, 0)?;
-    }
+    update_sync_state(db, &sync_state_key, file_modified, line_offset)?;
 
     Ok((imported, skipped))
-}
-
-fn update_fnv1a(hash: &mut u64, bytes: &[u8]) {
-    for byte in bytes {
-        *hash ^= u64::from(*byte);
-        *hash = hash.wrapping_mul(FNV1A_PRIME);
-    }
-}
-
-fn fnv1a_hash(bytes: &[u8]) -> i64 {
-    let mut hash = FNV1A_OFFSET_BASIS;
-    update_fnv1a(&mut hash, bytes);
-    hash as i64
-}
-
-fn hash_file_prefix(file_path: &Path, length: i64) -> Result<i64, AppError> {
-    let mut file = fs::File::open(file_path)
-        .map_err(|error| AppError::Config(format!("无法打开文件: {error}")))?;
-    let length = length.max(0);
-    let mut hash = FNV1A_OFFSET_BASIS;
-    update_fnv1a(&mut hash, &length.to_le_bytes());
-
-    let sample_size = FILE_FINGERPRINT_SAMPLE_SIZE.min(length);
-    let offsets = if length <= FILE_FINGERPRINT_SAMPLE_SIZE * 3 {
-        vec![0]
-    } else {
-        vec![0, length / 2 - sample_size / 2, length - sample_size]
-    };
-
-    for offset in offsets {
-        file.seek(SeekFrom::Start(offset as u64))
-            .map_err(|error| AppError::Config(format!("定位文件指纹失败: {error}")))?;
-        let bytes_to_read = if length <= FILE_FINGERPRINT_SAMPLE_SIZE * 3 {
-            length as usize
-        } else {
-            sample_size as usize
-        };
-        let mut buffer = vec![0_u8; bytes_to_read];
-        file.read_exact(&mut buffer)
-            .map_err(|error| AppError::Config(format!("读取文件指纹失败: {error}")))?;
-        update_fnv1a(&mut hash, &offset.to_le_bytes());
-        update_fnv1a(&mut hash, &buffer);
-    }
-
-    Ok(hash as i64)
-}
-
-fn hash_entire_file_prefix(file_path: &Path, length: i64) -> Result<i64, AppError> {
-    let file = fs::File::open(file_path)
-        .map_err(|error| AppError::Config(format!("无法打开文件: {error}")))?;
-    let length = length.max(0);
-    let mut reader = file.take(length as u64);
-    let mut buffer = [0_u8; 8192];
-    let mut hash = FNV1A_OFFSET_BASIS;
-    let mut bytes_read = 0_i64;
-
-    loop {
-        let read = reader
-            .read(&mut buffer)
-            .map_err(|error| AppError::Config(format!("读取完整文件指纹失败: {error}")))?;
-        if read == 0 {
-            break;
-        }
-        update_fnv1a(&mut hash, &buffer[..read]);
-        bytes_read += read as i64;
-    }
-    if bytes_read != length {
-        return Err(AppError::Config(format!(
-            "读取完整文件指纹失败: 文件在同步期间被截断 ({bytes_read}/{length})"
-        )));
-    }
-    Ok(hash as i64)
-}
-
-fn unix_timestamp_seconds() -> i64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|duration| duration.as_secs().min(i64::MAX as u64) as i64)
-        .unwrap_or(0)
 }
 
 /// 获取 session_log_sync 表中某条目的同步进度。
@@ -778,16 +466,12 @@ pub(crate) fn get_sync_state(db: &Database, file_path: &str) -> Result<(i64, i64
 /// `session_log_sync.last_modified` 旧数据是秒级时间戳；新写入纳秒值不需要
 /// schema 迁移，旧值会自然触发一次增量重扫，并继续依赖行 offset 避免重复导入。
 pub(crate) fn metadata_modified_nanos(metadata: &fs::Metadata) -> i64 {
-    metadata_modified_nanos_checked(metadata).unwrap_or(0)
-}
-
-fn metadata_modified_nanos_checked(metadata: &fs::Metadata) -> Result<i64, AppError> {
     metadata
         .modified()
-        .map_err(|error| AppError::Config(format!("无法读取文件修改时间: {error}")))?
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_err(|error| AppError::Config(format!("文件修改时间早于 UNIX epoch: {error}")))
+        .ok()
+        .and_then(|t| t.duration_since(SystemTime::UNIX_EPOCH).ok())
         .map(|d| d.as_nanos().min(i64::MAX as u128) as i64)
+        .unwrap_or(0)
 }
 
 /// 更新 session_log_sync 表中某条目的同步进度。
@@ -857,12 +541,8 @@ fn insert_session_log_entry(
         cache_creation_tokens: msg.cache_creation_tokens,
         created_at,
     };
-    let should_skip = if msg.is_api_error {
-        should_skip_api_error_insert(&conn, request_id, msg, created_at)?
-    } else {
-        should_skip_session_insert(&conn, request_id, &dedup_key)?
-    };
-    if should_skip {
+    if msg.api_error_status.is_none() && should_skip_session_insert(&conn, request_id, &dedup_key)?
+    {
         return Ok(false);
     }
 
@@ -925,7 +605,7 @@ fn insert_session_log_entry(
                 total_cost,
                 0i64,               // latency_ms: 会话日志无此数据
                 Option::<i64>::None, // first_token_ms
-                msg.status_code as i64,
+                msg.api_error_status.unwrap_or(200) as i64,
                 msg.error_message,
                 msg.session_id,
                 Some("session_log"), // provider_type
@@ -938,67 +618,6 @@ fn insert_session_log_entry(
         .map_err(|e| AppError::Database(format!("插入会话日志失败: {e}")))?;
 
     Ok(inserted_rows > 0)
-}
-
-fn should_skip_api_error_insert(
-    conn: &rusqlite::Connection,
-    request_id: &str,
-    msg: &ParsedAssistantUsage,
-    created_at: i64,
-) -> Result<bool, AppError> {
-    let session_id = msg
-        .session_id
-        .as_deref()
-        .filter(|session_id| !session_id.trim().is_empty());
-    let request_exists = conn
-        .prepare_cached("SELECT EXISTS(SELECT 1 FROM proxy_request_logs WHERE request_id = ?1)")
-        .and_then(|mut stmt| stmt.query_row([request_id], |row| row.get::<_, bool>(0)))
-        .map_err(|error| AppError::Database(format!("查询 API 错误 request_id 失败: {error}")))?;
-    if request_exists {
-        return Ok(true);
-    }
-    let Some(session_id) = session_id else {
-        return Ok(false);
-    };
-
-    let marker_prefix = CLAUDE_PROXY_ERROR_DEDUP_MARKER_PREFIX;
-    let proxy_request_id = conn
-        .prepare_cached(
-            "SELECT l.request_id
-             FROM proxy_request_logs l
-             WHERE COALESCE(l.data_source, 'proxy') = 'proxy'
-               AND l.app_type = 'claude'
-               AND l.status_code = ?1
-               AND l.session_id = ?2
-               AND l.created_at = ?3
-               AND NOT EXISTS (
-                   SELECT 1 FROM session_log_sync s
-                   WHERE s.file_path = ?4 || l.request_id
-                     AND s.last_modified = 1
-               )
-             ORDER BY l.request_id
-             LIMIT 1",
-        )
-        .and_then(|mut stmt| {
-            stmt.query_row(
-                rusqlite::params![
-                    msg.status_code as i64,
-                    session_id,
-                    created_at,
-                    marker_prefix,
-                ],
-                |row| row.get::<_, String>(0),
-            )
-            .optional()
-        })
-        .map_err(|error| AppError::Database(format!("查询重复代理 API 错误失败: {error}")))?;
-
-    if let Some(proxy_request_id) = proxy_request_id {
-        update_sync_state_on_conn(conn, &format!("{marker_prefix}{proxy_request_id}"), 1, 1)?;
-        Ok(true)
-    } else {
-        Ok(false)
-    }
 }
 
 /// 从 model_pricing 表查找模型定价（支持模糊匹配）
@@ -1116,9 +735,8 @@ mod tests {
             cache_read_tokens: 5000,
             cache_creation_tokens: 10000,
             stop_reason: None,
-            status_code: 200,
+            api_error_status: None,
             error_message: None,
-            is_api_error: false,
             timestamp: Some("2026-04-05T12:00:00Z".to_string()),
             session_id: None,
         };
@@ -1133,9 +751,8 @@ mod tests {
             cache_read_tokens: 5000,
             cache_creation_tokens: 10000,
             stop_reason: Some("end_turn".to_string()),
-            status_code: 200,
+            api_error_status: None,
             error_message: None,
-            is_api_error: false,
             timestamp: Some("2026-04-05T12:00:00Z".to_string()),
             session_id: None,
         };
@@ -1187,9 +804,8 @@ mod tests {
             cache_read_tokens: 10,
             cache_creation_tokens: 5,
             stop_reason: Some("end_turn".to_string()),
-            status_code: 200,
+            api_error_status: None,
             error_message: None,
-            is_api_error: false,
             timestamp: Some("1970-01-01T00:16:45Z".to_string()),
             session_id: Some("session-1".to_string()),
         };
@@ -1207,128 +823,6 @@ mod tests {
     }
 
     #[test]
-    fn test_insert_api_error_does_not_use_token_heuristic_dedup() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        {
-            let conn = lock_conn!(db.conn);
-            conn.execute(
-                "INSERT INTO proxy_request_logs (
-                    request_id, provider_id, app_type, model, request_model,
-                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
-                    total_cost_usd, latency_ms, status_code, created_at, data_source
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                rusqlite::params![
-                    "proxy-zero-success",
-                    "openai-compatible",
-                    "claude",
-                    "<synthetic>",
-                    "<synthetic>",
-                    0,
-                    0,
-                    0,
-                    0,
-                    "0",
-                    100,
-                    200,
-                    1000,
-                    "proxy"
-                ],
-            )?;
-        }
-
-        let msg = ParsedAssistantUsage {
-            message_id: "msg_zero_403".to_string(),
-            model: "<synthetic>".to_string(),
-            input_tokens: 0,
-            output_tokens: 0,
-            cache_read_tokens: 0,
-            cache_creation_tokens: 0,
-            stop_reason: None,
-            status_code: 403,
-            error_message: Some("authentication_failed".to_string()),
-            is_api_error: true,
-            timestamp: Some("1970-01-01T00:16:40Z".to_string()),
-            session_id: Some("session-error".to_string()),
-        };
-
-        assert!(
-            insert_session_log_entry(&db, "session:msg_zero_403", &msg)?,
-            "API 错误不能被零 token 的成功代理日志近似去重"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_insert_api_error_skips_matching_proxy_error() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        {
-            let conn = lock_conn!(db.conn);
-            conn.execute(
-                "INSERT INTO proxy_request_logs (
-                    request_id, provider_id, app_type, model, request_model,
-                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
-                    total_cost_usd, latency_ms, status_code, error_message, session_id,
-                    created_at, data_source
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                rusqlite::params![
-                    "proxy-403",
-                    "openai-compatible",
-                    "claude",
-                    "deepseek-v4-flash-0731",
-                    "deepseek-v4-flash-0731",
-                    0,
-                    0,
-                    0,
-                    0,
-                    "0",
-                    100,
-                    403,
-                    "authentication_failed",
-                    "session-error",
-                    1000,
-                    "proxy"
-                ],
-            )?;
-        }
-
-        let msg = ParsedAssistantUsage {
-            message_id: "msg_duplicate_403".to_string(),
-            model: "<synthetic>".to_string(),
-            input_tokens: 0,
-            output_tokens: 0,
-            cache_read_tokens: 0,
-            cache_creation_tokens: 0,
-            stop_reason: None,
-            status_code: 403,
-            error_message: Some("authentication_failed".to_string()),
-            is_api_error: true,
-            timestamp: Some("1970-01-01T00:16:40Z".to_string()),
-            session_id: Some("session-error".to_string()),
-        };
-
-        assert!(
-            !insert_session_log_entry(&db, "session:msg_duplicate_403", &msg)?,
-            "代理已经记录同一会话的 403 时不能重复导入 session 错误"
-        );
-
-        let mut second_error = msg;
-        second_error.message_id = "msg_second_403".to_string();
-        assert!(
-            insert_session_log_entry(&db, "session:msg_second_403", &second_error)?,
-            "一条代理错误只能抵消一条 session 错误"
-        );
-
-        let mut unidentified = second_error;
-        unidentified.message_id = "msg_empty_session_403".to_string();
-        unidentified.session_id = Some(String::new());
-        assert!(
-            insert_session_log_entry(&db, "session:msg_empty_session_403", &unidentified)?,
-            "空 session_id 不是可靠身份，不能把无关的 403 合并"
-        );
-        Ok(())
-    }
-
-    #[test]
     fn test_collect_jsonl_files_includes_subagents() {
         let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
         let project = tmp.join("project");
@@ -1339,8 +833,7 @@ mod tests {
         fs::write(project.join("main.jsonl"), "{}").unwrap();
         fs::write(subagents_dir.join("agent-abc.jsonl"), "{}").unwrap();
 
-        let (files, errors) = collect_jsonl_files(&tmp);
-        assert!(errors.is_empty());
+        let files = collect_jsonl_files(&tmp);
         assert_eq!(files.len(), 2);
         let paths: Vec<String> = files
             .iter()
@@ -1369,8 +862,7 @@ mod tests {
         // journal.jsonl 也会被收集，但解析时因无 assistant 行而产出 0 条
         fs::write(wf_dir.join("journal.jsonl"), "{}").unwrap();
 
-        let (files, errors) = collect_jsonl_files(&tmp);
-        assert!(errors.is_empty());
+        let files = collect_jsonl_files(&tmp);
         let paths: Vec<String> = files
             .iter()
             .map(|p| p.to_string_lossy().to_string())
@@ -1430,547 +922,32 @@ mod tests {
     }
 
     #[test]
-    fn test_sync_imports_claude_api_error_without_tokens() -> Result<(), AppError> {
+    fn test_sync_imports_api_error_with_versioned_cursor() -> Result<(), AppError> {
         let db = Database::memory()?;
         let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&tmp).unwrap();
         let file = tmp.join("claude-api-error.jsonl");
-
-        let api_error = r#"{"type":"assistant","message":{"id":"msg_api_error","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"stop_reason":"stop_sequence","content":[{"type":"text","text":"Please run /login · API Error: 403 Access to model denied."}]},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        let api_error = r#"{"type":"assistant","message":{"id":"msg_api_error","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
         fs::write(&file, format!("{api_error}\n")).unwrap();
 
-        let metadata = fs::metadata(&file).unwrap();
-        let modified = metadata_modified_nanos(&metadata);
-        let file_len = metadata.len() as i64;
         let file_path = file.to_string_lossy();
+        let modified = metadata_modified_nanos(&fs::metadata(&file).unwrap());
         update_sync_state(&db, &file_path, modified, 1)?;
-        update_sync_state(
-            &db,
-            &format!("{CLAUDE_FILE_HASH_MARKER_PREFIX}{file_path}"),
-            hash_file_prefix(&file, file_len)?,
-            file_len,
-        )?;
-        update_sync_state(
-            &db,
-            &format!("{CLAUDE_FILE_FULL_HASH_MARKER_PREFIX}{file_path}"),
-            hash_entire_file_prefix(&file, file_len)?,
-            unix_timestamp_seconds(),
-        )?;
-        update_sync_state(
-            &db,
-            &format!("{CLAUDE_FILE_STATE_MARKER_PREFIX}{file_path}"),
-            modified,
-            file_len,
-        )?;
-        assert_eq!(
-            sync_single_file(&db, &file)?,
-            (0, 0),
-            "普通增量同步不会重读已推进的游标"
-        );
 
-        let (imported, _skipped) = sync_single_file_with_options(&db, &file, true)?;
-        assert_eq!(imported, 1, "结构化 API 错误即使没有 token 也必须被导入");
+        assert_eq!(sync_single_file(&db, &file)?.0, 1);
+        assert_eq!(sync_single_file(&db, &file)?.0, 0);
 
         let conn = lock_conn!(db.conn);
-        let (status, error): (i64, Option<String>) = conn.query_row(
-            "SELECT status_code, error_message FROM proxy_request_logs WHERE request_id = 'session:msg_api_error'",
+        let (count, status, error): (i64, i64, Option<String>) = conn.query_row(
+            "SELECT COUNT(*), MAX(status_code), MAX(error_message)
+             FROM proxy_request_logs WHERE request_id = 'session:msg_api_error'",
             [],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )?;
+        assert_eq!(count, 1, "版本化游标重扫必须保持幂等");
         assert_eq!(status, 403);
         assert_eq!(error.as_deref(), Some("authentication_failed"));
         drop(conn);
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_api_error_backfill_marker_waits_for_all_files() -> Result<(), AppError> {
-        let db = Database::memory()?;
-
-        complete_api_error_backfill_if_successful(
-            &db,
-            true,
-            &["temporarily unreadable.jsonl".to_string()],
-        )?;
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (0, 0),
-            "存在文件错误时必须保留回填待重试状态"
-        );
-
-        complete_api_error_backfill_if_successful(&db, true, &[])?;
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (1, 1),
-            "所有文件扫描成功后才应完成回填"
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_stable_backfill_error_stops_repeated_force_scans() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let errors = ["permanently unreadable.jsonl".to_string()];
-
-        complete_api_error_backfill_if_successful(&db, true, &errors)?;
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (0, 0),
-            "第一次错误仍应保留一次强制重试"
-        );
-
-        complete_api_error_backfill_if_successful(&db, true, &errors)?;
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (1, 1),
-            "相同永久错误不能导致每分钟全量回扫所有历史日志"
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_api_error_backfill_marker_waits_for_directory_scan_errors() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&tmp).unwrap();
-        let not_a_directory = tmp.join("projects");
-        fs::write(&not_a_directory, "not a directory").unwrap();
-
-        let result = sync_claude_session_logs_from_projects_dir(&db, &not_a_directory)?;
-        assert!(
-            !result.errors.is_empty(),
-            "目录枚举失败必须进入同步错误列表"
-        );
-
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (0, 0),
-            "目录扫描不完整时必须保留回填待重试状态"
-        );
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_optional_scan_path_that_is_not_a_directory_is_an_error() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        let session_dir = tmp.join("project").join("session");
-        fs::create_dir_all(&session_dir).unwrap();
-        fs::write(session_dir.join("subagents"), "not a directory").unwrap();
-
-        let result = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(
-            !result.errors.is_empty(),
-            "存在但不是目录的可选扫描路径必须被报告，不能视为目录缺失"
-        );
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (0, 0),
-            "嵌套目录扫描失败时必须保留回填待重试状态"
-        );
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_sync_does_not_advance_cursor_when_insert_fails() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        let project_dir = tmp.join("project");
-        fs::create_dir_all(&project_dir).unwrap();
-        let file = project_dir.join("claude-api-error.jsonl");
-        let api_error = r#"{"type":"assistant","message":{"id":"msg_insert_error","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
-        fs::write(&file, format!("{api_error}\n")).unwrap();
-
-        {
-            let conn = lock_conn!(db.conn);
-            conn.execute_batch("DROP TABLE proxy_request_logs")?;
-        }
-
-        let result = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(
-            !result.errors.is_empty(),
-            "数据库插入失败必须进入顶层同步错误列表"
-        );
-        assert_eq!(
-            get_sync_state(&db, &file.to_string_lossy())?,
-            (0, 0),
-            "插入失败后不能推进文件游标，后续同步必须能够重试"
-        );
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (0, 0),
-            "数据库插入失败时必须保留回填待重试状态"
-        );
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_incomplete_jsonl_keeps_backfill_pending_until_retry() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        let project_dir = tmp.join("project");
-        fs::create_dir_all(&project_dir).unwrap();
-        let file = project_dir.join("claude-api-error.jsonl");
-        fs::write(
-            &file,
-            r#"{"type":"assistant","message":{"id":"msg_partial""#,
-        )
-        .unwrap();
-
-        let first = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(
-            !first.errors.is_empty(),
-            "未写完的 JSONL 行必须使本次回填失败"
-        );
-        assert_eq!(
-            get_sync_state(&db, &file.to_string_lossy())?,
-            (0, 0),
-            "未写完的行不能被文件游标越过"
-        );
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (0, 0),
-            "未写完的行必须让全量回填保持待重试"
-        );
-
-        let api_error = r#"{"type":"assistant","message":{"id":"msg_partial","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
-        fs::write(&file, format!("{api_error}\n")).unwrap();
-
-        let retry = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert_eq!(retry.imported, 1, "文件写完后重试必须导入原来的 403");
-        assert!(retry.errors.is_empty());
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (1, 1),
-            "完整重试成功后才能完成回填"
-        );
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_corrupt_complete_line_does_not_block_later_api_errors() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        let project_dir = tmp.join("project");
-        fs::create_dir_all(&project_dir).unwrap();
-        let file = project_dir.join("claude-api-error.jsonl");
-        let api_error = r#"{"type":"assistant","message":{"id":"msg_after_corrupt","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
-        fs::write(&file, format!("{{corrupt-json}}\n{api_error}\n")).unwrap();
-
-        let result = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(
-            result.errors.is_empty(),
-            "有换行边界的永久损坏记录应被跳过，不能卡住整个文件"
-        );
-        assert_eq!(result.imported, 1, "损坏记录后的有效 403 必须继续导入");
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (1, 1),
-            "跳过确定损坏的记录后应能完成回填"
-        );
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_invalid_utf8_complete_line_does_not_block_later_api_errors() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        let project_dir = tmp.join("project");
-        fs::create_dir_all(&project_dir).unwrap();
-        let file = project_dir.join("claude-api-error.jsonl");
-        let api_error = r#"{"type":"assistant","message":{"id":"msg_after_invalid_utf8","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
-        let mut content = vec![0xff, b'\n'];
-        content.extend_from_slice(api_error.as_bytes());
-        content.push(b'\n');
-        fs::write(&file, content).unwrap();
-
-        let result = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(
-            result.errors.is_empty(),
-            "有换行边界的非法 UTF-8 记录应被跳过"
-        );
-        assert_eq!(result.imported, 1, "非法 UTF-8 记录后的有效 403 必须导入");
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (1, 1)
-        );
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_stable_corrupt_tail_does_not_block_future_appends() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        let project_dir = tmp.join("project");
-        fs::create_dir_all(&project_dir).unwrap();
-        let file = project_dir.join("claude-api-error.jsonl");
-        let corrupt_tail = r#"{"type":"assistant","message":{"id":"abandoned""#;
-        fs::write(&file, corrupt_tail).unwrap();
-
-        let first = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(!first.errors.is_empty(), "首次观察坏尾行时必须等待重试");
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (0, 0)
-        );
-
-        let stable_retry = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(
-            stable_retry.errors.is_empty(),
-            "文件保持不变后应把坏尾行认定为永久损坏"
-        );
-        assert_eq!(
-            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
-            (1, 1),
-            "稳定的坏尾行不能让全局回填永久 pending"
-        );
-
-        let original_modified = fs::metadata(&file).unwrap().modified().unwrap();
-        let api_error = r#"{"type":"assistant","message":{"id":"msg_after_stable_tail","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
-        fs::write(&file, format!("{corrupt_tail}\n{api_error}\n")).unwrap();
-        fs::File::options()
-            .write(true)
-            .open(&file)
-            .unwrap()
-            .set_times(fs::FileTimes::new().set_modified(original_modified))
-            .unwrap();
-
-        let appended = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(appended.errors.is_empty());
-        assert_eq!(
-            appended.imported, 1,
-            "坏尾行稳定后仍必须保留游标，以导入未来追加的 403"
-        );
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_truncated_file_restarts_before_importing_new_api_error() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        let project_dir = tmp.join("project");
-        fs::create_dir_all(&project_dir).unwrap();
-        let file = project_dir.join("claude-api-error.jsonl");
-        let old_one = r#"{"type":"assistant","message":{"id":"msg_before_truncate_1","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
-        let old_two = r#"{"type":"assistant","message":{"id":"msg_before_truncate_2","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:45Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
-        let corrupt_tail = r#"{"type":"assistant","message":{"id":"abandoned""#;
-        fs::write(&file, format!("{old_one}\n{old_two}\n{corrupt_tail}")).unwrap();
-
-        let first = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(!first.errors.is_empty());
-        let stable_retry = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(stable_retry.errors.is_empty());
-        assert_eq!(stable_retry.imported, 2);
-
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        let replacement = r#"{"type":"assistant","message":{"id":"msg_after_truncate","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:46Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
-        fs::write(&file, format!("{replacement}\n")).unwrap();
-
-        let truncated = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(truncated.errors.is_empty());
-        assert_eq!(
-            truncated.imported, 1,
-            "日志截断或替换后必须从文件开头导入新的 403"
-        );
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_longer_replacement_restarts_before_importing_new_api_error() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&tmp).unwrap();
-        let file = tmp.join("claude-api-error.jsonl");
-        let old = r#"{"type":"assistant","message":{"id":"msg_old_file","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"old"}"#;
-        fs::write(&file, format!("{old}\n")).unwrap();
-        assert_eq!(sync_single_file(&db, &file)?.0, 1);
-
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        let replacement = r#"{"type":"assistant","message":{"id":"msg_new_first_line","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:45Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"new"}"#;
-        let padding = r#"{"type":"system","sessionId":"session-error","padding":"this replacement is intentionally longer than the previous file so length alone cannot identify an append"}"#;
-        fs::write(&file, format!("{replacement}\n{padding}\n")).unwrap();
-
-        let (imported, _) = sync_single_file(&db, &file)?;
-        assert_eq!(
-            imported, 1,
-            "更长的替换文件也必须通过前缀指纹识别并从头扫描"
-        );
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_legacy_cursor_does_not_hide_same_mtime_append() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&tmp).unwrap();
-        let file = tmp.join("claude-api-error.jsonl");
-        let old = r#"{"type":"assistant","message":{"id":"msg_legacy_old","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"old"}"#;
-        fs::write(&file, format!("{old}\n")).unwrap();
-        assert_eq!(sync_single_file(&db, &file)?.0, 1);
-        let original_modified = fs::metadata(&file).unwrap().modified().unwrap();
-
-        let file_path = file.to_string_lossy();
-        update_sync_state(
-            &db,
-            &format!("{CLAUDE_FILE_STATE_MARKER_PREFIX}{file_path}"),
-            0,
-            0,
-        )?;
-        update_sync_state(
-            &db,
-            &format!("{CLAUDE_FILE_HASH_MARKER_PREFIX}{file_path}"),
-            0,
-            0,
-        )?;
-
-        let appended = r#"{"type":"assistant","message":{"id":"msg_legacy_new","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:45Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"new"}"#;
-        fs::write(&file, format!("{old}\n{appended}\n")).unwrap();
-        fs::File::options()
-            .write(true)
-            .open(&file)
-            .unwrap()
-            .set_times(fs::FileTimes::new().set_modified(original_modified))
-            .unwrap();
-
-        assert_eq!(
-            sync_single_file(&db, &file)?.0,
-            1,
-            "旧版游标没有文件指纹时必须保守重扫，不能吞掉相同 mtime 的追加"
-        );
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_same_metadata_replacement_is_verified_by_content_hash() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&tmp).unwrap();
-        let file = tmp.join("claude-api-error.jsonl");
-        let old = r#"{"type":"assistant","message":{"id":"msg_equal_old","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"old"}"#;
-        let replacement = r#"{"type":"assistant","message":{"id":"msg_equal_new","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"new"}"#;
-        assert_eq!(old.len(), replacement.len());
-        fs::write(&file, format!("{old}\n")).unwrap();
-        assert_eq!(sync_single_file(&db, &file)?.0, 1);
-        let original_modified = fs::metadata(&file).unwrap().modified().unwrap();
-
-        fs::write(&file, format!("{replacement}\n")).unwrap();
-        fs::File::options()
-            .write(true)
-            .open(&file)
-            .unwrap()
-            .set_times(fs::FileTimes::new().set_modified(original_modified))
-            .unwrap();
-
-        assert_eq!(
-            sync_single_file(&db, &file)?.0,
-            1,
-            "mtime 和长度都相同也必须校验内容指纹"
-        );
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_equal_metadata_corrupt_tail_requires_new_observation() -> Result<(), AppError> {
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        let project_dir = tmp.join("project");
-        fs::create_dir_all(&project_dir).unwrap();
-        let file = project_dir.join("claude-api-error.jsonl");
-        let first_tail = r#"{"type":"assistant","message":{"id":"tail_old_x""#;
-        let second_tail = r#"{"type":"assistant","message":{"id":"tail_new_y""#;
-        assert_eq!(first_tail.len(), second_tail.len());
-        fs::write(&file, first_tail).unwrap();
-        let original_modified = fs::metadata(&file).unwrap().modified().unwrap();
-
-        let first = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(!first.errors.is_empty());
-
-        fs::write(&file, second_tail).unwrap();
-        fs::File::options()
-            .write(true)
-            .open(&file)
-            .unwrap()
-            .set_times(fs::FileTimes::new().set_modified(original_modified))
-            .unwrap();
-
-        let changed = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(
-            !changed.errors.is_empty(),
-            "内容不同的坏尾即使 mtime 和长度相同，也应重新进行首次观察"
-        );
-        let stable = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
-        assert!(stable.errors.is_empty());
-
-        fs::remove_dir_all(&tmp).ok();
-        Ok(())
-    }
-
-    #[test]
-    fn test_periodic_full_hash_detects_change_outside_samples() -> Result<(), AppError> {
-        fn large_api_error(message_id: &str) -> String {
-            format!(
-                r#"{{"type":"assistant","padding_a":"{}","message":{{"id":"{message_id}","model":"<synthetic>","usage":{{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}},"padding_b":"{}","timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}}"#,
-                "a".repeat(6000),
-                "z".repeat(24000)
-            )
-        }
-
-        let db = Database::memory()?;
-        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&tmp).unwrap();
-        let file = tmp.join("claude-api-error.jsonl");
-        let old = large_api_error("msg_sample_old");
-        let replacement = large_api_error("msg_sample_new");
-        assert_eq!(old.len(), replacement.len());
-        fs::write(&file, format!("{old}\n")).unwrap();
-        assert_eq!(sync_single_file(&db, &file)?.0, 1);
-        let original_modified = fs::metadata(&file).unwrap().modified().unwrap();
-
-        fs::write(&file, format!("{replacement}\n")).unwrap();
-        fs::File::options()
-            .write(true)
-            .open(&file)
-            .unwrap()
-            .set_times(fs::FileTimes::new().set_modified(original_modified))
-            .unwrap();
-
-        let full_hash_marker = format!(
-            "{CLAUDE_FILE_FULL_HASH_MARKER_PREFIX}{}",
-            file.to_string_lossy()
-        );
-        let (old_full_hash, _) = get_sync_state(&db, &full_hash_marker)?;
-        update_sync_state(&db, &full_hash_marker, old_full_hash, 0)?;
-
-        assert_eq!(
-            sync_single_file(&db, &file)?.0,
-            1,
-            "采样窗口之外的等元数据替换也必须在周期全量校验时被发现"
-        );
 
         fs::remove_dir_all(&tmp).ok();
         Ok(())

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -274,13 +274,24 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
     // 从上次偏移位置开始增量解析
     let file =
         fs::File::open(file_path).map_err(|e| AppError::Config(format!("无法打开文件: {e}")))?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
 
     let mut line_offset: i64 = 0;
+    let mut has_incomplete_tail = false;
     let mut messages: HashMap<String, ParsedAssistantUsage> = HashMap::new();
     let mut current_session_id: Option<String> = None;
+    let mut line_bytes = Vec::new();
 
-    for line_result in reader.lines() {
+    loop {
+        line_bytes.clear();
+        match reader.read_until(b'\n', &mut line_bytes) {
+            Ok(0) => break,
+            Ok(_) => {}
+            Err(_) => {
+                has_incomplete_tail = true;
+                break;
+            }
+        }
         line_offset += 1;
 
         // 跳过已处理的行
@@ -288,17 +299,28 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
             continue;
         }
 
-        let line = match line_result {
-            Ok(l) => l,
-            Err(_) => continue, // 容忍不完整的最后一行
+        let has_line_terminator = line_bytes.ends_with(b"\n");
+        let line = match std::str::from_utf8(&line_bytes) {
+            Ok(line) => line,
+            Err(_) if !has_line_terminator => {
+                has_incomplete_tail = true;
+                line_offset -= 1;
+                break;
+            }
+            Err(_) => continue,
         };
 
         if line.trim().is_empty() {
             continue;
         }
 
-        let value: serde_json::Value = match serde_json::from_str(&line) {
+        let value: serde_json::Value = match serde_json::from_str(line) {
             Ok(v) => v,
+            Err(_) if !has_line_terminator => {
+                has_incomplete_tail = true;
+                line_offset -= 1;
+                break;
+            }
             Err(_) => continue,
         };
 
@@ -442,8 +464,10 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
         }
     }
 
-    // 更新同步状态
-    update_sync_state(db, &sync_state_key, file_modified, line_offset)?;
+    // Claude 可能仍在写最后一条 JSONL；不要把未完成尾行计入游标。
+    if !has_incomplete_tail {
+        update_sync_state(db, &sync_state_key, file_modified, line_offset)?;
+    }
 
     Ok((imported, skipped))
 }
@@ -983,6 +1007,26 @@ mod tests {
             conn.execute_batch("DROP TRIGGER reject_session_log_insert;")?;
         }
 
+        assert_eq!(sync_single_file(&db, &file)?.0, 1);
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_incomplete_api_error_tail_is_retried_after_completion() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp).unwrap();
+        let file = tmp.join("claude-api-error-tail.jsonl");
+        let api_error = r#"{"type":"assistant","message":{"id":"msg_api_error_tail","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        fs::write(&file, &api_error[..api_error.len() - 1]).unwrap();
+
+        assert_eq!(sync_single_file(&db, &file)?.0, 0);
+        let sync_state_key = format!("{}#{CLAUDE_SYNC_CURSOR_VERSION}", file.to_string_lossy());
+        assert_eq!(get_sync_state(&db, &sync_state_key)?, (0, 0));
+
+        fs::write(&file, format!("{api_error}\n")).unwrap();
         assert_eq!(sync_single_file(&db, &file)?.0, 1);
 
         fs::remove_dir_all(&tmp).ok();

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -16,11 +16,12 @@ use crate::proxy::usage::parser::TokenUsage;
 use crate::services::usage_stats::{
     effective_usage_log_filter, find_model_pricing, should_skip_session_insert, DedupKey,
 };
+use rusqlite::OptionalExtension;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::time::SystemTime;
@@ -131,6 +132,16 @@ struct ParsedAssistantUsage {
 /// structured Claude Code API errors. Existing installations have already
 /// advanced past those zero-token rows, so they need one idempotent full scan.
 const CLAUDE_API_ERROR_BACKFILL_MARKER: &str = "__claude_api_error_backfill_v1__";
+const CLAUDE_BACKFILL_ERROR_MARKER: &str = "__claude_api_error_backfill_error_v1__";
+const CLAUDE_INCOMPLETE_TAIL_MARKER_PREFIX: &str = "__claude_incomplete_tail_v1__:";
+const CLAUDE_FILE_STATE_MARKER_PREFIX: &str = "__claude_file_state_v1__:";
+const CLAUDE_FILE_HASH_MARKER_PREFIX: &str = "__claude_file_hash_v1__:";
+const CLAUDE_FILE_FULL_HASH_MARKER_PREFIX: &str = "__claude_file_full_hash_v1__:";
+const CLAUDE_PROXY_ERROR_DEDUP_MARKER_PREFIX: &str = "__claude_proxy_error_dedup_v1__:";
+const FNV1A_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+const FNV1A_PRIME: u64 = 0x100000001b3;
+const FILE_FINGERPRINT_SAMPLE_SIZE: i64 = 4096;
+const FILE_FULL_HASH_VERIFY_INTERVAL_SECONDS: i64 = 24 * 60 * 60;
 
 /// 同步 Claude Code 会话日志到使用统计数据库
 pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppError> {
@@ -211,8 +222,39 @@ fn complete_api_error_backfill_if_successful(
     force_full_scan: bool,
     errors: &[String],
 ) -> Result<(), AppError> {
-    if force_full_scan && errors.is_empty() {
+    if !force_full_scan {
+        return Ok(());
+    }
+
+    if errors.is_empty() {
         update_sync_state(db, CLAUDE_API_ERROR_BACKFILL_MARKER, 1, 1)?;
+        update_sync_state(db, CLAUDE_BACKFILL_ERROR_MARKER, 0, 0)?;
+        return Ok(());
+    }
+
+    // 同一组错误连续出现两次后停止每分钟强制全量回扫。普通增量同步仍会
+    // 每分钟枚举并重试这些路径；而旧文件没有内容指纹，会在恢复可读后保守
+    // 全量解析，因此不会因结束一次性 backfill 而永久漏记。
+    let mut sorted_errors = errors.to_vec();
+    sorted_errors.sort_unstable();
+    let mut signature_hash = FNV1A_OFFSET_BASIS;
+    for error in &sorted_errors {
+        update_fnv1a(&mut signature_hash, error.as_bytes());
+        update_fnv1a(&mut signature_hash, b"\0");
+    }
+    let signature = (
+        signature_hash as i64,
+        sorted_errors.len().min(i64::MAX as usize) as i64,
+    );
+    if get_sync_state(db, CLAUDE_BACKFILL_ERROR_MARKER)? == signature {
+        log::warn!(
+            "[SESSION-SYNC] backfill 连续遇到相同的 {} 个错误，结束强制全量扫描并保留普通重试",
+            errors.len()
+        );
+        update_sync_state(db, CLAUDE_API_ERROR_BACKFILL_MARKER, 1, 1)?;
+        update_sync_state(db, CLAUDE_BACKFILL_ERROR_MARKER, 0, 0)?;
+    } else {
+        update_sync_state(db, CLAUDE_BACKFILL_ERROR_MARKER, signature.0, signature.1)?;
     }
 
     Ok(())
@@ -330,29 +372,97 @@ fn sync_single_file_with_options(
     let metadata = fs::metadata(file_path)
         .map_err(|e| AppError::Config(format!("无法读取文件元数据: {e}")))?;
     let file_modified = metadata_modified_nanos_checked(&metadata)?;
+    let file_len = metadata.len().min(i64::MAX as u64) as i64;
 
-    // 检查同步状态
-    let (last_modified, last_offset) = if force_full_scan {
+    // 检查同步状态。mtime 不能单独代表文件内容：日志可能在时间戳不变时追加，
+    // 也可能被截断或替换，因此额外保存 (mtime, length) 文件签名。
+    let (_, saved_offset) = if force_full_scan {
         (0, 0)
     } else {
         get_sync_state(db, &file_path_str)?
     };
+    let file_state_marker = format!("{CLAUDE_FILE_STATE_MARKER_PREFIX}{file_path_str}");
+    let previous_file_state = get_sync_state(db, &file_state_marker)?;
+    let file_hash_marker = format!("{CLAUDE_FILE_HASH_MARKER_PREFIX}{file_path_str}");
+    let previous_file_hash = get_sync_state(db, &file_hash_marker)?;
+    let file_full_hash_marker = format!("{CLAUDE_FILE_FULL_HASH_MARKER_PREFIX}{file_path_str}");
+    let previous_full_hash = get_sync_state(db, &file_full_hash_marker)?;
+    let now = unix_timestamp_seconds();
 
-    // 文件未变化则跳过
-    if file_modified <= last_modified {
-        return Ok((0, 0));
+    // 稳态先用固定大小采样避免每分钟读取全部历史日志；每天再全量校验一次，
+    // 让刻意保留 mtime/长度及采样窗口的替换也不会永久漏掉。
+    let mut full_content_changed = false;
+    if !force_full_scan
+        && previous_file_state == (file_modified, file_len)
+        && previous_file_hash.1 == file_len
+        && hash_file_prefix(file_path, file_len)? == previous_file_hash.0
+    {
+        if previous_full_hash != (0, 0)
+            && now.saturating_sub(previous_full_hash.1) < FILE_FULL_HASH_VERIFY_INTERVAL_SECONDS
+        {
+            return Ok((0, 0));
+        }
+        let current_full_hash = hash_entire_file_prefix(file_path, file_len)?;
+        if previous_full_hash.0 == current_full_hash {
+            update_sync_state(db, &file_full_hash_marker, current_full_hash, now)?;
+            return Ok((0, 0));
+        }
+        full_content_changed = true;
     }
+
+    let can_continue_from_cursor = !force_full_scan
+        && !full_content_changed
+        && previous_file_state != (0, 0)
+        && previous_file_hash.1 == previous_file_state.1
+        && file_len >= previous_file_state.1
+        && hash_file_prefix(file_path, previous_file_state.1)? == previous_file_hash.0;
+    let last_offset = if can_continue_from_cursor {
+        saved_offset
+    } else {
+        // 文件被截断、替换，或尚无内容指纹时，旧行号不再可信。
+        0
+    };
 
     // 从上次偏移位置开始增量解析
     let file =
         fs::File::open(file_path).map_err(|e| AppError::Config(format!("无法打开文件: {e}")))?;
-    let reader = BufReader::new(file);
+    let mut reader = BufReader::new(file);
+    let incomplete_tail_marker = format!("{CLAUDE_INCOMPLETE_TAIL_MARKER_PREFIX}{file_path_str}");
+    let observed_incomplete_tail = get_sync_state(db, &incomplete_tail_marker)?;
 
     let mut line_offset: i64 = 0;
     let mut messages: HashMap<String, ParsedAssistantUsage> = HashMap::new();
     let mut current_session_id: Option<String> = None;
+    let mut line = Vec::new();
+    let mut full_hash = FNV1A_OFFSET_BASIS;
+    let mut full_hashed_bytes = 0_i64;
+    let mut previous_prefix_hash = FNV1A_OFFSET_BASIS;
+    let mut previous_prefix_hashed_bytes = 0_i64;
 
-    for line_result in reader.lines() {
+    loop {
+        line.clear();
+        let bytes_read = reader.read_until(b'\n', &mut line).map_err(|error| {
+            AppError::Config(format!(
+                "读取 JSONL 失败 ({} 第 {} 行): {error}",
+                file_path.display(),
+                line_offset + 1
+            ))
+        })?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        let bytes_to_hash = (file_len - full_hashed_bytes).clamp(0, bytes_read as i64) as usize;
+        update_fnv1a(&mut full_hash, &line[..bytes_to_hash]);
+        full_hashed_bytes += bytes_to_hash as i64;
+        if can_continue_from_cursor {
+            let prefix_len = previous_file_state.1;
+            let prefix_bytes =
+                (prefix_len - previous_prefix_hashed_bytes).clamp(0, bytes_read as i64) as usize;
+            update_fnv1a(&mut previous_prefix_hash, &line[..prefix_bytes]);
+            previous_prefix_hashed_bytes += prefix_bytes as i64;
+        }
+
         line_offset += 1;
 
         // 跳过已处理的行
@@ -360,27 +470,50 @@ fn sync_single_file_with_options(
             continue;
         }
 
-        let line = line_result.map_err(|error| {
-            AppError::Config(format!(
-                "读取 JSONL 失败 ({} 第 {line_offset} 行): {error}",
-                file_path.display()
-            ))
-        })?;
-
-        if line.trim().is_empty() {
+        if line.iter().all(|byte| byte.is_ascii_whitespace()) {
             continue;
         }
 
-        let value: serde_json::Value = serde_json::from_str(&line).map_err(|error| {
-            AppError::Config(format!(
-                "解析 JSONL 失败 ({} 第 {line_offset} 行): {error}",
-                file_path.display()
-            ))
-        })?;
+        let value: serde_json::Value = match serde_json::from_slice(&line) {
+            Ok(value) => value,
+            Err(error) if !line.ends_with(b"\n") => {
+                let tail_signature = (fnv1a_hash(&line), line.len().min(i64::MAX as usize) as i64);
+                if observed_incomplete_tail == tail_signature {
+                    log::warn!(
+                        "[SESSION-SYNC] 跳过稳定未变化的损坏 JSONL 末行 ({} 第 {line_offset} 行): {error}",
+                        file_path.display()
+                    );
+                    line_offset -= 1;
+                    break;
+                }
+
+                update_sync_state(
+                    db,
+                    &incomplete_tail_marker,
+                    tail_signature.0,
+                    tail_signature.1,
+                )?;
+                return Err(AppError::Config(format!(
+                    "解析可能尚未写完的 JSONL 末行失败 ({} 第 {line_offset} 行): {error}",
+                    file_path.display()
+                )));
+            }
+            Err(error) => {
+                log::warn!(
+                    "[SESSION-SYNC] 跳过损坏的 JSONL 记录 ({} 第 {line_offset} 行): {error}",
+                    file_path.display()
+                );
+                continue;
+            }
+        };
 
         // 提取 session ID (从 system 或首条消息)
         if current_session_id.is_none() {
-            if let Some(sid) = value.get("sessionId").and_then(|v| v.as_str()) {
+            if let Some(sid) = value
+                .get("sessionId")
+                .and_then(|v| v.as_str())
+                .filter(|sid| !sid.trim().is_empty())
+            {
                 current_session_id = Some(sid.to_string());
             }
         }
@@ -482,6 +615,14 @@ fn sync_single_file_with_options(
         }
     }
 
+    if can_continue_from_cursor
+        && (previous_prefix_hashed_bytes != previous_file_state.1
+            || previous_prefix_hash as i64 != previous_full_hash.0)
+    {
+        // 追加期间旧前缀也被改写；尚未执行任何插入，安全回退为一次全量解析。
+        return sync_single_file_with_options(db, file_path, true);
+    }
+
     // 写入数据库
     let mut imported: u32 = 0;
     let mut skipped: u32 = 0;
@@ -525,8 +666,98 @@ fn sync_single_file_with_options(
 
     // 更新同步状态
     update_sync_state(db, &file_path_str, file_modified, line_offset)?;
+    update_sync_state(db, &file_full_hash_marker, full_hash as i64, now)?;
+    update_sync_state(
+        db,
+        &file_hash_marker,
+        hash_file_prefix(file_path, file_len)?,
+        file_len,
+    )?;
+    update_sync_state(db, &file_state_marker, file_modified, file_len)?;
+    if observed_incomplete_tail != (0, 0) {
+        update_sync_state(db, &incomplete_tail_marker, 0, 0)?;
+    }
 
     Ok((imported, skipped))
+}
+
+fn update_fnv1a(hash: &mut u64, bytes: &[u8]) {
+    for byte in bytes {
+        *hash ^= u64::from(*byte);
+        *hash = hash.wrapping_mul(FNV1A_PRIME);
+    }
+}
+
+fn fnv1a_hash(bytes: &[u8]) -> i64 {
+    let mut hash = FNV1A_OFFSET_BASIS;
+    update_fnv1a(&mut hash, bytes);
+    hash as i64
+}
+
+fn hash_file_prefix(file_path: &Path, length: i64) -> Result<i64, AppError> {
+    let mut file = fs::File::open(file_path)
+        .map_err(|error| AppError::Config(format!("无法打开文件: {error}")))?;
+    let length = length.max(0);
+    let mut hash = FNV1A_OFFSET_BASIS;
+    update_fnv1a(&mut hash, &length.to_le_bytes());
+
+    let sample_size = FILE_FINGERPRINT_SAMPLE_SIZE.min(length);
+    let offsets = if length <= FILE_FINGERPRINT_SAMPLE_SIZE * 3 {
+        vec![0]
+    } else {
+        vec![0, length / 2 - sample_size / 2, length - sample_size]
+    };
+
+    for offset in offsets {
+        file.seek(SeekFrom::Start(offset as u64))
+            .map_err(|error| AppError::Config(format!("定位文件指纹失败: {error}")))?;
+        let bytes_to_read = if length <= FILE_FINGERPRINT_SAMPLE_SIZE * 3 {
+            length as usize
+        } else {
+            sample_size as usize
+        };
+        let mut buffer = vec![0_u8; bytes_to_read];
+        file.read_exact(&mut buffer)
+            .map_err(|error| AppError::Config(format!("读取文件指纹失败: {error}")))?;
+        update_fnv1a(&mut hash, &offset.to_le_bytes());
+        update_fnv1a(&mut hash, &buffer);
+    }
+
+    Ok(hash as i64)
+}
+
+fn hash_entire_file_prefix(file_path: &Path, length: i64) -> Result<i64, AppError> {
+    let file = fs::File::open(file_path)
+        .map_err(|error| AppError::Config(format!("无法打开文件: {error}")))?;
+    let length = length.max(0);
+    let mut reader = file.take(length as u64);
+    let mut buffer = [0_u8; 8192];
+    let mut hash = FNV1A_OFFSET_BASIS;
+    let mut bytes_read = 0_i64;
+
+    loop {
+        let read = reader
+            .read(&mut buffer)
+            .map_err(|error| AppError::Config(format!("读取完整文件指纹失败: {error}")))?;
+        if read == 0 {
+            break;
+        }
+        update_fnv1a(&mut hash, &buffer[..read]);
+        bytes_read += read as i64;
+    }
+    if bytes_read != length {
+        return Err(AppError::Config(format!(
+            "读取完整文件指纹失败: 文件在同步期间被截断 ({bytes_read}/{length})"
+        )));
+    }
+    Ok(hash as i64)
+}
+
+fn unix_timestamp_seconds() -> i64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_secs().min(i64::MAX as u64) as i64)
+        .unwrap_or(0)
 }
 
 /// 获取 session_log_sync 表中某条目的同步进度。
@@ -626,7 +857,12 @@ fn insert_session_log_entry(
         cache_creation_tokens: msg.cache_creation_tokens,
         created_at,
     };
-    if should_skip_session_insert(&conn, request_id, &dedup_key)? {
+    let should_skip = if msg.is_api_error {
+        should_skip_api_error_insert(&conn, request_id, msg, created_at)?
+    } else {
+        should_skip_session_insert(&conn, request_id, &dedup_key)?
+    };
+    if should_skip {
         return Ok(false);
     }
 
@@ -702,6 +938,67 @@ fn insert_session_log_entry(
         .map_err(|e| AppError::Database(format!("插入会话日志失败: {e}")))?;
 
     Ok(inserted_rows > 0)
+}
+
+fn should_skip_api_error_insert(
+    conn: &rusqlite::Connection,
+    request_id: &str,
+    msg: &ParsedAssistantUsage,
+    created_at: i64,
+) -> Result<bool, AppError> {
+    let session_id = msg
+        .session_id
+        .as_deref()
+        .filter(|session_id| !session_id.trim().is_empty());
+    let request_exists = conn
+        .prepare_cached("SELECT EXISTS(SELECT 1 FROM proxy_request_logs WHERE request_id = ?1)")
+        .and_then(|mut stmt| stmt.query_row([request_id], |row| row.get::<_, bool>(0)))
+        .map_err(|error| AppError::Database(format!("查询 API 错误 request_id 失败: {error}")))?;
+    if request_exists {
+        return Ok(true);
+    }
+    let Some(session_id) = session_id else {
+        return Ok(false);
+    };
+
+    let marker_prefix = CLAUDE_PROXY_ERROR_DEDUP_MARKER_PREFIX;
+    let proxy_request_id = conn
+        .prepare_cached(
+            "SELECT l.request_id
+             FROM proxy_request_logs l
+             WHERE COALESCE(l.data_source, 'proxy') = 'proxy'
+               AND l.app_type = 'claude'
+               AND l.status_code = ?1
+               AND l.session_id = ?2
+               AND l.created_at = ?3
+               AND NOT EXISTS (
+                   SELECT 1 FROM session_log_sync s
+                   WHERE s.file_path = ?4 || l.request_id
+                     AND s.last_modified = 1
+               )
+             ORDER BY l.request_id
+             LIMIT 1",
+        )
+        .and_then(|mut stmt| {
+            stmt.query_row(
+                rusqlite::params![
+                    msg.status_code as i64,
+                    session_id,
+                    created_at,
+                    marker_prefix,
+                ],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+        })
+        .map_err(|error| AppError::Database(format!("查询重复代理 API 错误失败: {error}")))?;
+
+    if let Some(proxy_request_id) = proxy_request_id {
+        update_sync_state_on_conn(conn, &format!("{marker_prefix}{proxy_request_id}"), 1, 1)?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
 }
 
 /// 从 model_pricing 表查找模型定价（支持模糊匹配）
@@ -910,6 +1207,128 @@ mod tests {
     }
 
     #[test]
+    fn test_insert_api_error_does_not_use_token_heuristic_dedup() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model, request_model,
+                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                    total_cost_usd, latency_ms, status_code, created_at, data_source
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                rusqlite::params![
+                    "proxy-zero-success",
+                    "openai-compatible",
+                    "claude",
+                    "<synthetic>",
+                    "<synthetic>",
+                    0,
+                    0,
+                    0,
+                    0,
+                    "0",
+                    100,
+                    200,
+                    1000,
+                    "proxy"
+                ],
+            )?;
+        }
+
+        let msg = ParsedAssistantUsage {
+            message_id: "msg_zero_403".to_string(),
+            model: "<synthetic>".to_string(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            stop_reason: None,
+            status_code: 403,
+            error_message: Some("authentication_failed".to_string()),
+            is_api_error: true,
+            timestamp: Some("1970-01-01T00:16:40Z".to_string()),
+            session_id: Some("session-error".to_string()),
+        };
+
+        assert!(
+            insert_session_log_entry(&db, "session:msg_zero_403", &msg)?,
+            "API 错误不能被零 token 的成功代理日志近似去重"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_insert_api_error_skips_matching_proxy_error() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model, request_model,
+                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                    total_cost_usd, latency_ms, status_code, error_message, session_id,
+                    created_at, data_source
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                rusqlite::params![
+                    "proxy-403",
+                    "openai-compatible",
+                    "claude",
+                    "deepseek-v4-flash-0731",
+                    "deepseek-v4-flash-0731",
+                    0,
+                    0,
+                    0,
+                    0,
+                    "0",
+                    100,
+                    403,
+                    "authentication_failed",
+                    "session-error",
+                    1000,
+                    "proxy"
+                ],
+            )?;
+        }
+
+        let msg = ParsedAssistantUsage {
+            message_id: "msg_duplicate_403".to_string(),
+            model: "<synthetic>".to_string(),
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            stop_reason: None,
+            status_code: 403,
+            error_message: Some("authentication_failed".to_string()),
+            is_api_error: true,
+            timestamp: Some("1970-01-01T00:16:40Z".to_string()),
+            session_id: Some("session-error".to_string()),
+        };
+
+        assert!(
+            !insert_session_log_entry(&db, "session:msg_duplicate_403", &msg)?,
+            "代理已经记录同一会话的 403 时不能重复导入 session 错误"
+        );
+
+        let mut second_error = msg;
+        second_error.message_id = "msg_second_403".to_string();
+        assert!(
+            insert_session_log_entry(&db, "session:msg_second_403", &second_error)?,
+            "一条代理错误只能抵消一条 session 错误"
+        );
+
+        let mut unidentified = second_error;
+        unidentified.message_id = "msg_empty_session_403".to_string();
+        unidentified.session_id = Some(String::new());
+        assert!(
+            insert_session_log_entry(&db, "session:msg_empty_session_403", &unidentified)?,
+            "空 session_id 不是可靠身份，不能把无关的 403 合并"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_collect_jsonl_files_includes_subagents() {
         let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
         let project = tmp.join("project");
@@ -1020,8 +1439,29 @@ mod tests {
         let api_error = r#"{"type":"assistant","message":{"id":"msg_api_error","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0},"stop_reason":"stop_sequence","content":[{"type":"text","text":"Please run /login · API Error: 403 Access to model denied."}]},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
         fs::write(&file, format!("{api_error}\n")).unwrap();
 
-        let modified = metadata_modified_nanos(&fs::metadata(&file).unwrap());
-        update_sync_state(&db, &file.to_string_lossy(), modified, 1)?;
+        let metadata = fs::metadata(&file).unwrap();
+        let modified = metadata_modified_nanos(&metadata);
+        let file_len = metadata.len() as i64;
+        let file_path = file.to_string_lossy();
+        update_sync_state(&db, &file_path, modified, 1)?;
+        update_sync_state(
+            &db,
+            &format!("{CLAUDE_FILE_HASH_MARKER_PREFIX}{file_path}"),
+            hash_file_prefix(&file, file_len)?,
+            file_len,
+        )?;
+        update_sync_state(
+            &db,
+            &format!("{CLAUDE_FILE_FULL_HASH_MARKER_PREFIX}{file_path}"),
+            hash_entire_file_prefix(&file, file_len)?,
+            unix_timestamp_seconds(),
+        )?;
+        update_sync_state(
+            &db,
+            &format!("{CLAUDE_FILE_STATE_MARKER_PREFIX}{file_path}"),
+            modified,
+            file_len,
+        )?;
         assert_eq!(
             sync_single_file(&db, &file)?,
             (0, 0),
@@ -1067,6 +1507,27 @@ mod tests {
             "所有文件扫描成功后才应完成回填"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_stable_backfill_error_stops_repeated_force_scans() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let errors = ["permanently unreadable.jsonl".to_string()];
+
+        complete_api_error_backfill_if_successful(&db, true, &errors)?;
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (0, 0),
+            "第一次错误仍应保留一次强制重试"
+        );
+
+        complete_api_error_backfill_if_successful(&db, true, &errors)?;
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (1, 1),
+            "相同永久错误不能导致每分钟全量回扫所有历史日志"
+        );
         Ok(())
     }
 
@@ -1191,6 +1652,324 @@ mod tests {
             get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
             (1, 1),
             "完整重试成功后才能完成回填"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_corrupt_complete_line_does_not_block_later_api_errors() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        let project_dir = tmp.join("project");
+        fs::create_dir_all(&project_dir).unwrap();
+        let file = project_dir.join("claude-api-error.jsonl");
+        let api_error = r#"{"type":"assistant","message":{"id":"msg_after_corrupt","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        fs::write(&file, format!("{{corrupt-json}}\n{api_error}\n")).unwrap();
+
+        let result = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(
+            result.errors.is_empty(),
+            "有换行边界的永久损坏记录应被跳过，不能卡住整个文件"
+        );
+        assert_eq!(result.imported, 1, "损坏记录后的有效 403 必须继续导入");
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (1, 1),
+            "跳过确定损坏的记录后应能完成回填"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_invalid_utf8_complete_line_does_not_block_later_api_errors() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        let project_dir = tmp.join("project");
+        fs::create_dir_all(&project_dir).unwrap();
+        let file = project_dir.join("claude-api-error.jsonl");
+        let api_error = r#"{"type":"assistant","message":{"id":"msg_after_invalid_utf8","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        let mut content = vec![0xff, b'\n'];
+        content.extend_from_slice(api_error.as_bytes());
+        content.push(b'\n');
+        fs::write(&file, content).unwrap();
+
+        let result = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(
+            result.errors.is_empty(),
+            "有换行边界的非法 UTF-8 记录应被跳过"
+        );
+        assert_eq!(result.imported, 1, "非法 UTF-8 记录后的有效 403 必须导入");
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (1, 1)
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_stable_corrupt_tail_does_not_block_future_appends() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        let project_dir = tmp.join("project");
+        fs::create_dir_all(&project_dir).unwrap();
+        let file = project_dir.join("claude-api-error.jsonl");
+        let corrupt_tail = r#"{"type":"assistant","message":{"id":"abandoned""#;
+        fs::write(&file, corrupt_tail).unwrap();
+
+        let first = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(!first.errors.is_empty(), "首次观察坏尾行时必须等待重试");
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (0, 0)
+        );
+
+        let stable_retry = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(
+            stable_retry.errors.is_empty(),
+            "文件保持不变后应把坏尾行认定为永久损坏"
+        );
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (1, 1),
+            "稳定的坏尾行不能让全局回填永久 pending"
+        );
+
+        let original_modified = fs::metadata(&file).unwrap().modified().unwrap();
+        let api_error = r#"{"type":"assistant","message":{"id":"msg_after_stable_tail","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        fs::write(&file, format!("{corrupt_tail}\n{api_error}\n")).unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_modified(original_modified))
+            .unwrap();
+
+        let appended = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(appended.errors.is_empty());
+        assert_eq!(
+            appended.imported, 1,
+            "坏尾行稳定后仍必须保留游标，以导入未来追加的 403"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_truncated_file_restarts_before_importing_new_api_error() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        let project_dir = tmp.join("project");
+        fs::create_dir_all(&project_dir).unwrap();
+        let file = project_dir.join("claude-api-error.jsonl");
+        let old_one = r#"{"type":"assistant","message":{"id":"msg_before_truncate_1","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        let old_two = r#"{"type":"assistant","message":{"id":"msg_before_truncate_2","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:45Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        let corrupt_tail = r#"{"type":"assistant","message":{"id":"abandoned""#;
+        fs::write(&file, format!("{old_one}\n{old_two}\n{corrupt_tail}")).unwrap();
+
+        let first = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(!first.errors.is_empty());
+        let stable_retry = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(stable_retry.errors.is_empty());
+        assert_eq!(stable_retry.imported, 2);
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let replacement = r#"{"type":"assistant","message":{"id":"msg_after_truncate","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:46Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        fs::write(&file, format!("{replacement}\n")).unwrap();
+
+        let truncated = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(truncated.errors.is_empty());
+        assert_eq!(
+            truncated.imported, 1,
+            "日志截断或替换后必须从文件开头导入新的 403"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_longer_replacement_restarts_before_importing_new_api_error() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp).unwrap();
+        let file = tmp.join("claude-api-error.jsonl");
+        let old = r#"{"type":"assistant","message":{"id":"msg_old_file","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"old"}"#;
+        fs::write(&file, format!("{old}\n")).unwrap();
+        assert_eq!(sync_single_file(&db, &file)?.0, 1);
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let replacement = r#"{"type":"assistant","message":{"id":"msg_new_first_line","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:45Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"new"}"#;
+        let padding = r#"{"type":"system","sessionId":"session-error","padding":"this replacement is intentionally longer than the previous file so length alone cannot identify an append"}"#;
+        fs::write(&file, format!("{replacement}\n{padding}\n")).unwrap();
+
+        let (imported, _) = sync_single_file(&db, &file)?;
+        assert_eq!(
+            imported, 1,
+            "更长的替换文件也必须通过前缀指纹识别并从头扫描"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_legacy_cursor_does_not_hide_same_mtime_append() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp).unwrap();
+        let file = tmp.join("claude-api-error.jsonl");
+        let old = r#"{"type":"assistant","message":{"id":"msg_legacy_old","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"old"}"#;
+        fs::write(&file, format!("{old}\n")).unwrap();
+        assert_eq!(sync_single_file(&db, &file)?.0, 1);
+        let original_modified = fs::metadata(&file).unwrap().modified().unwrap();
+
+        let file_path = file.to_string_lossy();
+        update_sync_state(
+            &db,
+            &format!("{CLAUDE_FILE_STATE_MARKER_PREFIX}{file_path}"),
+            0,
+            0,
+        )?;
+        update_sync_state(
+            &db,
+            &format!("{CLAUDE_FILE_HASH_MARKER_PREFIX}{file_path}"),
+            0,
+            0,
+        )?;
+
+        let appended = r#"{"type":"assistant","message":{"id":"msg_legacy_new","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:45Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"new"}"#;
+        fs::write(&file, format!("{old}\n{appended}\n")).unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_modified(original_modified))
+            .unwrap();
+
+        assert_eq!(
+            sync_single_file(&db, &file)?.0,
+            1,
+            "旧版游标没有文件指纹时必须保守重扫，不能吞掉相同 mtime 的追加"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_same_metadata_replacement_is_verified_by_content_hash() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp).unwrap();
+        let file = tmp.join("claude-api-error.jsonl");
+        let old = r#"{"type":"assistant","message":{"id":"msg_equal_old","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"old"}"#;
+        let replacement = r#"{"type":"assistant","message":{"id":"msg_equal_new","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"new"}"#;
+        assert_eq!(old.len(), replacement.len());
+        fs::write(&file, format!("{old}\n")).unwrap();
+        assert_eq!(sync_single_file(&db, &file)?.0, 1);
+        let original_modified = fs::metadata(&file).unwrap().modified().unwrap();
+
+        fs::write(&file, format!("{replacement}\n")).unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_modified(original_modified))
+            .unwrap();
+
+        assert_eq!(
+            sync_single_file(&db, &file)?.0,
+            1,
+            "mtime 和长度都相同也必须校验内容指纹"
+        );
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_equal_metadata_corrupt_tail_requires_new_observation() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        let project_dir = tmp.join("project");
+        fs::create_dir_all(&project_dir).unwrap();
+        let file = project_dir.join("claude-api-error.jsonl");
+        let first_tail = r#"{"type":"assistant","message":{"id":"tail_old_x""#;
+        let second_tail = r#"{"type":"assistant","message":{"id":"tail_new_y""#;
+        assert_eq!(first_tail.len(), second_tail.len());
+        fs::write(&file, first_tail).unwrap();
+        let original_modified = fs::metadata(&file).unwrap().modified().unwrap();
+
+        let first = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(!first.errors.is_empty());
+
+        fs::write(&file, second_tail).unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_modified(original_modified))
+            .unwrap();
+
+        let changed = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(
+            !changed.errors.is_empty(),
+            "内容不同的坏尾即使 mtime 和长度相同，也应重新进行首次观察"
+        );
+        let stable = sync_claude_session_logs_from_projects_dir(&db, &tmp)?;
+        assert!(stable.errors.is_empty());
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_periodic_full_hash_detects_change_outside_samples() -> Result<(), AppError> {
+        fn large_api_error(message_id: &str) -> String {
+            format!(
+                r#"{{"type":"assistant","padding_a":"{}","message":{{"id":"{message_id}","model":"<synthetic>","usage":{{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}},"padding_b":"{}","timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}}"#,
+                "a".repeat(6000),
+                "z".repeat(24000)
+            )
+        }
+
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp).unwrap();
+        let file = tmp.join("claude-api-error.jsonl");
+        let old = large_api_error("msg_sample_old");
+        let replacement = large_api_error("msg_sample_new");
+        assert_eq!(old.len(), replacement.len());
+        fs::write(&file, format!("{old}\n")).unwrap();
+        assert_eq!(sync_single_file(&db, &file)?.0, 1);
+        let original_modified = fs::metadata(&file).unwrap().modified().unwrap();
+
+        fs::write(&file, format!("{replacement}\n")).unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&file)
+            .unwrap()
+            .set_times(fs::FileTimes::new().set_modified(original_modified))
+            .unwrap();
+
+        let full_hash_marker = format!(
+            "{CLAUDE_FILE_FULL_HASH_MARKER_PREFIX}{}",
+            file.to_string_lossy()
+        );
+        let (old_full_hash, _) = get_sync_state(&db, &full_hash_marker)?;
+        update_sync_state(&db, &full_hash_marker, old_full_hash, 0)?;
+
+        assert_eq!(
+            sync_single_file(&db, &file)?.0,
+            1,
+            "采样窗口之外的等元数据替换也必须在周期全量校验时被发现"
         );
 
         fs::remove_dir_all(&tmp).ok();

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -176,9 +176,7 @@ pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppE
         }
     }
 
-    if force_full_scan {
-        update_sync_state(db, CLAUDE_API_ERROR_BACKFILL_MARKER, 1, 1)?;
-    }
+    complete_api_error_backfill_if_successful(db, force_full_scan, &result.errors)?;
 
     if result.imported > 0 {
         log::info!(
@@ -190,6 +188,18 @@ pub fn sync_claude_session_logs(db: &Database) -> Result<SessionSyncResult, AppE
     }
 
     Ok(result)
+}
+
+fn complete_api_error_backfill_if_successful(
+    db: &Database,
+    force_full_scan: bool,
+    errors: &[String],
+) -> Result<(), AppError> {
+    if force_full_scan && errors.is_empty() {
+        update_sync_state(db, CLAUDE_API_ERROR_BACKFILL_MARKER, 1, 1)?;
+    }
+
+    Ok(())
 }
 
 /// 收集目录下所有 .jsonl 文件（含子 agent 文件）
@@ -982,6 +992,31 @@ mod tests {
         drop(conn);
 
         fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_api_error_backfill_marker_waits_for_all_files() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        complete_api_error_backfill_if_successful(
+            &db,
+            true,
+            &["temporarily unreadable.jsonl".to_string()],
+        )?;
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (0, 0),
+            "存在文件错误时必须保留回填待重试状态"
+        );
+
+        complete_api_error_backfill_if_successful(&db, true, &[])?;
+        assert_eq!(
+            get_sync_state(&db, CLAUDE_API_ERROR_BACKFILL_MARKER)?,
+            (1, 1),
+            "所有文件扫描成功后才应完成回填"
+        );
+
         Ok(())
     }
 }

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -437,7 +437,7 @@ fn sync_single_file(db: &Database, file_path: &Path) -> Result<(u32, u32), AppEr
             Ok(false) => skipped += 1,
             Err(e) => {
                 log::warn!("[SESSION-SYNC] 插入失败 ({}): {e}", msg.message_id);
-                skipped += 1;
+                return Err(e);
             }
         }
     }
@@ -948,6 +948,42 @@ mod tests {
         assert_eq!(status, 403);
         assert_eq!(error.as_deref(), Some("authentication_failed"));
         drop(conn);
+
+        fs::remove_dir_all(&tmp).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn test_versioned_cursor_is_not_advanced_after_insert_failure() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let tmp = std::env::temp_dir().join(format!("cc-switch-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&tmp).unwrap();
+        let file = tmp.join("claude-api-error-retry.jsonl");
+        let api_error = r#"{"type":"assistant","message":{"id":"msg_api_error_retry","model":"<synthetic>","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}},"timestamp":"2026-08-12T07:34:44Z","sessionId":"session-error","isApiErrorMessage":true,"apiErrorStatus":403,"error":"authentication_failed"}"#;
+        fs::write(&file, format!("{api_error}\n")).unwrap();
+
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute_batch(
+                "CREATE TRIGGER reject_session_log_insert
+                 BEFORE INSERT ON proxy_request_logs
+                 WHEN NEW.data_source = 'session_log'
+                 BEGIN
+                     SELECT RAISE(FAIL, 'forced insert failure');
+                 END;",
+            )?;
+        }
+
+        assert!(sync_single_file(&db, &file).is_err());
+        let sync_state_key = format!("{}#{CLAUDE_SYNC_CURSOR_VERSION}", file.to_string_lossy());
+        assert_eq!(get_sync_state(&db, &sync_state_key)?, (0, 0));
+
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute_batch("DROP TRIGGER reject_session_log_insert;")?;
+        }
+
+        assert_eq!(sync_single_file(&db, &file)?.0, 1);
 
         fs::remove_dir_all(&tmp).ok();
         Ok(())

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -311,6 +311,8 @@ pub(crate) fn effective_usage_log_filter(log_alias: &str) -> String {
     format!(
         "NOT (
             {data_source} IN ('session_log', 'codex_session', 'gemini_session', 'opencode_session')
+            AND {log_alias}.status_code >= 200
+            AND {log_alias}.status_code < 300
             AND EXISTS (
                 SELECT 1
                 FROM proxy_request_logs proxy_dedup

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -307,12 +307,6 @@ pub(crate) fn effective_usage_log_filter(log_alias: &str) -> String {
     let proxy_data_source = data_source_expr("proxy_dedup");
     let app_type_match =
         dedup_app_type_match_sql("proxy_dedup.app_type", &format!("{log_alias}.app_type"));
-    let proxy_error_data_source = data_source_expr("proxy_error_dedup");
-    let proxy_error_app_type_match = dedup_app_type_match_sql(
-        "proxy_error_dedup.app_type",
-        &format!("{log_alias}.app_type"),
-    );
-    let session_error_data_source = data_source_expr("session_error_rank");
     format!(
         "NOT (
             {data_source} IN ('session_log', 'codex_session', 'gemini_session', 'opencode_session')
@@ -342,31 +336,7 @@ pub(crate) fn effective_usage_log_filter(log_alias: &str) -> String {
                       LOWER(proxy_dedup.model) = LOWER({log_alias}.model)
                       OR LOWER(proxy_dedup.model) = 'unknown'
                       OR LOWER({log_alias}.model) = 'unknown'
-                )
-            )
-        )
-        AND NOT (
-            {data_source} = 'session_log'
-            AND {log_alias}.status_code >= 400
-            AND {log_alias}.status_code < 600
-            AND NULLIF(TRIM({log_alias}.session_id), '') IS NOT NULL
-            AND (
-                SELECT COUNT(*)
-                FROM proxy_request_logs proxy_error_dedup
-                WHERE {proxy_error_data_source} = 'proxy'
-                  AND {proxy_error_app_type_match}
-                  AND proxy_error_dedup.status_code = {log_alias}.status_code
-                  AND proxy_error_dedup.session_id = {log_alias}.session_id
-                  AND proxy_error_dedup.created_at = {log_alias}.created_at
-            ) >= (
-                SELECT COUNT(*)
-                FROM proxy_request_logs session_error_rank
-                WHERE {session_error_data_source} = 'session_log'
-                  AND session_error_rank.app_type = {log_alias}.app_type
-                  AND session_error_rank.status_code = {log_alias}.status_code
-                  AND session_error_rank.session_id = {log_alias}.session_id
-                  AND session_error_rank.created_at = {log_alias}.created_at
-                  AND session_error_rank.request_id <= {log_alias}.request_id
+                  )
             )
         )"
     )
@@ -2459,7 +2429,6 @@ mod tests {
                 cache_read_tokens INTEGER NOT NULL,
                 cache_creation_tokens INTEGER NOT NULL,
                 status_code INTEGER NOT NULL,
-                session_id TEXT,
                 created_at INTEGER NOT NULL,
                 data_source TEXT
             )",
@@ -2580,58 +2549,6 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(request_ids, vec!["desktop-proxy"]);
 
-        Ok(())
-    }
-
-    #[test]
-    fn test_effective_filter_keeps_session_api_error_near_proxy_success() -> Result<(), AppError> {
-        let conn = Connection::open_in_memory()?;
-        create_legacy_nullable_logs_table(&conn)?;
-        conn.execute_batch(
-            "INSERT INTO proxy_request_logs (
-                request_id, app_type, model, input_tokens, output_tokens,
-                cache_read_tokens, cache_creation_tokens, status_code, created_at, data_source
-            ) VALUES
-                ('proxy-success', 'claude', '<synthetic>', 0, 0, 0, 0, 200, 1000, 'proxy'),
-                ('session-error', 'claude', '<synthetic>', 0, 0, 0, 0, 403, 1000, 'session_log');",
-        )?;
-
-        let filter = effective_usage_log_filter("l");
-        let sql = format!(
-            "SELECT request_id FROM proxy_request_logs l WHERE {filter} ORDER BY request_id"
-        );
-        let request_ids = conn
-            .prepare(&sql)?
-            .query_map([], |row| row.get::<_, String>(0))?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(request_ids, vec!["proxy-success", "session-error"]);
-        Ok(())
-    }
-
-    #[test]
-    fn test_effective_filter_pairs_proxy_and_session_errors_one_to_one() -> Result<(), AppError> {
-        let conn = Connection::open_in_memory()?;
-        create_legacy_nullable_logs_table(&conn)?;
-        conn.execute_batch(
-            "INSERT INTO proxy_request_logs (
-                request_id, app_type, model, input_tokens, output_tokens,
-                cache_read_tokens, cache_creation_tokens, status_code, session_id,
-                created_at, data_source
-            ) VALUES
-                ('proxy-error', 'claude', 'deepseek-v4', 0, 0, 0, 0, 403, 'session-1', 1000, 'proxy'),
-                ('session-error-a', 'claude', '<synthetic>', 0, 0, 0, 0, 403, 'session-1', 1000, 'session_log'),
-                ('session-error-b', 'claude', '<synthetic>', 0, 0, 0, 0, 403, 'session-1', 1000, 'session_log');",
-        )?;
-
-        let filter = effective_usage_log_filter("l");
-        let sql = format!(
-            "SELECT request_id FROM proxy_request_logs l WHERE {filter} ORDER BY request_id"
-        );
-        let request_ids = conn
-            .prepare(&sql)?
-            .query_map([], |row| row.get::<_, String>(0))?
-            .collect::<Result<Vec<_>, _>>()?;
-        assert_eq!(request_ids, vec!["proxy-error", "session-error-b"]);
         Ok(())
     }
 

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -307,9 +307,17 @@ pub(crate) fn effective_usage_log_filter(log_alias: &str) -> String {
     let proxy_data_source = data_source_expr("proxy_dedup");
     let app_type_match =
         dedup_app_type_match_sql("proxy_dedup.app_type", &format!("{log_alias}.app_type"));
+    let proxy_error_data_source = data_source_expr("proxy_error_dedup");
+    let proxy_error_app_type_match = dedup_app_type_match_sql(
+        "proxy_error_dedup.app_type",
+        &format!("{log_alias}.app_type"),
+    );
+    let session_error_data_source = data_source_expr("session_error_rank");
     format!(
         "NOT (
             {data_source} IN ('session_log', 'codex_session', 'gemini_session', 'opencode_session')
+            AND {log_alias}.status_code >= 200
+            AND {log_alias}.status_code < 300
             AND EXISTS (
                 SELECT 1
                 FROM proxy_request_logs proxy_dedup
@@ -334,7 +342,31 @@ pub(crate) fn effective_usage_log_filter(log_alias: &str) -> String {
                       LOWER(proxy_dedup.model) = LOWER({log_alias}.model)
                       OR LOWER(proxy_dedup.model) = 'unknown'
                       OR LOWER({log_alias}.model) = 'unknown'
-                  )
+                )
+            )
+        )
+        AND NOT (
+            {data_source} = 'session_log'
+            AND {log_alias}.status_code >= 400
+            AND {log_alias}.status_code < 600
+            AND NULLIF(TRIM({log_alias}.session_id), '') IS NOT NULL
+            AND (
+                SELECT COUNT(*)
+                FROM proxy_request_logs proxy_error_dedup
+                WHERE {proxy_error_data_source} = 'proxy'
+                  AND {proxy_error_app_type_match}
+                  AND proxy_error_dedup.status_code = {log_alias}.status_code
+                  AND proxy_error_dedup.session_id = {log_alias}.session_id
+                  AND proxy_error_dedup.created_at = {log_alias}.created_at
+            ) >= (
+                SELECT COUNT(*)
+                FROM proxy_request_logs session_error_rank
+                WHERE {session_error_data_source} = 'session_log'
+                  AND session_error_rank.app_type = {log_alias}.app_type
+                  AND session_error_rank.status_code = {log_alias}.status_code
+                  AND session_error_rank.session_id = {log_alias}.session_id
+                  AND session_error_rank.created_at = {log_alias}.created_at
+                  AND session_error_rank.request_id <= {log_alias}.request_id
             )
         )"
     )
@@ -2427,6 +2459,7 @@ mod tests {
                 cache_read_tokens INTEGER NOT NULL,
                 cache_creation_tokens INTEGER NOT NULL,
                 status_code INTEGER NOT NULL,
+                session_id TEXT,
                 created_at INTEGER NOT NULL,
                 data_source TEXT
             )",
@@ -2547,6 +2580,58 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()?;
         assert_eq!(request_ids, vec!["desktop-proxy"]);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_effective_filter_keeps_session_api_error_near_proxy_success() -> Result<(), AppError> {
+        let conn = Connection::open_in_memory()?;
+        create_legacy_nullable_logs_table(&conn)?;
+        conn.execute_batch(
+            "INSERT INTO proxy_request_logs (
+                request_id, app_type, model, input_tokens, output_tokens,
+                cache_read_tokens, cache_creation_tokens, status_code, created_at, data_source
+            ) VALUES
+                ('proxy-success', 'claude', '<synthetic>', 0, 0, 0, 0, 200, 1000, 'proxy'),
+                ('session-error', 'claude', '<synthetic>', 0, 0, 0, 0, 403, 1000, 'session_log');",
+        )?;
+
+        let filter = effective_usage_log_filter("l");
+        let sql = format!(
+            "SELECT request_id FROM proxy_request_logs l WHERE {filter} ORDER BY request_id"
+        );
+        let request_ids = conn
+            .prepare(&sql)?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(request_ids, vec!["proxy-success", "session-error"]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_effective_filter_pairs_proxy_and_session_errors_one_to_one() -> Result<(), AppError> {
+        let conn = Connection::open_in_memory()?;
+        create_legacy_nullable_logs_table(&conn)?;
+        conn.execute_batch(
+            "INSERT INTO proxy_request_logs (
+                request_id, app_type, model, input_tokens, output_tokens,
+                cache_read_tokens, cache_creation_tokens, status_code, session_id,
+                created_at, data_source
+            ) VALUES
+                ('proxy-error', 'claude', 'deepseek-v4', 0, 0, 0, 0, 403, 'session-1', 1000, 'proxy'),
+                ('session-error-a', 'claude', '<synthetic>', 0, 0, 0, 0, 403, 'session-1', 1000, 'session_log'),
+                ('session-error-b', 'claude', '<synthetic>', 0, 0, 0, 0, 403, 'session-1', 1000, 'session_log');",
+        )?;
+
+        let filter = effective_usage_log_filter("l");
+        let sql = format!(
+            "SELECT request_id FROM proxy_request_logs l WHERE {filter} ORDER BY request_id"
+        );
+        let request_ids = conn
+            .prepare(&sql)?
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(request_ids, vec!["proxy-error", "session-error-b"]);
         Ok(())
     }
 

--- a/src/components/usage/RequestLogTable.tsx
+++ b/src/components/usage/RequestLogTable.tsx
@@ -131,6 +131,7 @@ export function RequestLogTable({
               <SelectItem value="200">200 OK</SelectItem>
               <SelectItem value="400">400</SelectItem>
               <SelectItem value="401">401</SelectItem>
+              <SelectItem value="403">403</SelectItem>
               <SelectItem value="429">429</SelectItem>
               <SelectItem value="500">500</SelectItem>
             </SelectContent>

--- a/tests/components/RequestLogTable.test.tsx
+++ b/tests/components/RequestLogTable.test.tsx
@@ -42,8 +42,8 @@ vi.mock("@/components/ui/select", () => ({
     </button>
   ),
   SelectValue: ({ placeholder }: any) => <span>{placeholder ?? null}</span>,
-  SelectContent: () => null,
-  SelectItem: () => null,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
 }));
 
 vi.mock("@/components/ui/table", () => ({
@@ -157,5 +157,18 @@ describe("RequestLogTable", () => {
         }),
       );
     });
+  });
+
+  it("offers 403 as a status-code filter", () => {
+    render(
+      <RequestLogTable
+        range={{ preset: "today" }}
+        rangeLabel="Today"
+        appType="claude"
+        refreshIntervalMs={0}
+      />,
+    );
+
+    expect(screen.getByText("403")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概述 / Summary

- 从 Claude Code 会话 JSONL 日志导入结构化 API 错误，即使失败请求的 Token 使用量为 0。
- 对同步游标已经越过历史错误记录的现有安装执行一次性幂等回填。
- 在请求日志状态筛选中增加 HTTP 403，并补充导入器和界面的回归测试。

## 关联 Issue / Related Issue

Fixes #6424

## 截图 / Screenshots

### 请求日志显示 403 记录

<img width="901" height="624" alt="请求日志显示计费模型为 synthetic 的 403 记录" src="https://github.com/user-attachments/assets/7c28a835-5213-4c1f-a77d-a88a7fd654c1" />

### 状态筛选包含 403

<img width="901" height="624" alt="请求日志状态筛选包含 403" src="https://github.com/user-attachments/assets/c444d430-ca8f-4c76-ae55-a2f30d887d22" />

### 筛选后仅显示 403 记录

<img width="901" height="624" alt="筛选后仅显示计费模型为 synthetic 的 403 记录" src="https://github.com/user-attachments/assets/fa4ecb74-96b4-4497-b84a-e3559db5c409" />

## 测试 / Testing

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm vitest run tests/components/RequestLogTable.test.tsx`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test services::session_usage::tests`
- 使用本机真实 Claude Code 会话数据完成端到端验证，确认历史 403 被补录且筛选正常。

## 检查清单 / Checklist

- [x] `pnpm typecheck` 通过
- [x] `pnpm format:check` 通过
- [x] `cargo clippy` 通过（包含 Rust 改动）
- [x] 没有新增需要翻译的用户可见文本（仅增加数字状态码 `403`）
