### PR TITLE
feat(skills): group installed skills by source

### DIFF
--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -954,18 +954,20 @@ const SkillSourceGroupSection: React.FC<SkillSourceGroupSectionProps> = ({
           onToggle={onToggleGroupApp}
         />
 
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-          aria-label={disclosureLabel}
-          aria-expanded={isExpanded}
-          title={disclosureLabel}
-          onClick={() => setIsExpanded((expanded) => !expanded)}
-        >
-          {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-        </Button>
+        <div className="flex w-[3.625rem] shrink-0 justify-end">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+            aria-label={disclosureLabel}
+            aria-expanded={isExpanded}
+            title={disclosureLabel}
+            onClick={() => setIsExpanded((expanded) => !expanded)}
+          >
+            {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          </Button>
+        </div>
       </div>
 
       {isExpanded &&
@@ -1136,7 +1138,7 @@ const InstalledSkillListItem: React.FC<InstalledSkillListItemProps> = ({
       />
 
       <div
-        className="flex-shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+        className="flex w-[3.625rem] shrink-0 items-center justify-end gap-0.5 opacity-0 transition-opacity group-hover:opacity-100"
         style={hasUpdate ? { opacity: 1 } : undefined}
       >
         {hasUpdate && onUpdate && (

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -7,10 +7,16 @@ import {
   RefreshCw,
   Loader2,
   Search,
+  FolderTree,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { TooltipProvider } from "@/components/ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   type ImportSkillSelection,
   type SkillBackupEntry,
@@ -34,7 +40,7 @@ import { cn } from "@/lib/utils";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { settingsApi, skillsApi } from "@/lib/api";
 import { toast } from "sonner";
-import { SKILLS_APP_IDS } from "@/config/appConfig";
+import { APP_ICON_MAP, SKILLS_APP_IDS } from "@/config/appConfig";
 import { AppCountBar } from "@/components/common/AppCountBar";
 import { AppToggleGroup } from "@/components/common/AppToggleGroup";
 import { ListItemRow } from "@/components/common/ListItemRow";
@@ -72,6 +78,83 @@ export interface UnifiedSkillsPanelHandle {
   checkUpdates: () => void;
 }
 
+interface SkillSourceGroup {
+  key: string;
+  label: string;
+  skills: InstalledSkill[];
+}
+
+interface VisibleSkillSourceGroup extends SkillSourceGroup {
+  visibleSkills: InstalledSkill[];
+}
+
+type SourceGroupAppState = "enabled" | "disabled" | "mixed";
+
+const ALL_SKILLS_SOURCE_KEY = "all";
+const LOCAL_SKILLS_SOURCE_KEY = "local";
+
+function getSkillSourceGroup(
+  skill: InstalledSkill,
+  localLabel: string,
+): Pick<SkillSourceGroup, "key" | "label"> {
+  if (skill.repoOwner && skill.repoName) {
+    return {
+      key: `repo:${skill.repoOwner.toLowerCase()}/${skill.repoName.toLowerCase()}`,
+      label: `${skill.repoOwner}/${skill.repoName}`,
+    };
+  }
+
+  return { key: LOCAL_SKILLS_SOURCE_KEY, label: localLabel };
+}
+
+function groupSkillsBySource(
+  skills: InstalledSkill[],
+  localLabel: string,
+): SkillSourceGroup[] {
+  const groups = new Map<string, SkillSourceGroup>();
+
+  for (const skill of skills) {
+    const source = getSkillSourceGroup(skill, localLabel);
+    const existing = groups.get(source.key);
+    if (existing) {
+      groups.set(source.key, {
+        ...existing,
+        skills: [...existing.skills, skill],
+      });
+    } else {
+      groups.set(source.key, { ...source, skills: [skill] });
+    }
+  }
+
+  return Array.from(groups.values());
+}
+
+function getSourceGroupAppState(
+  skills: InstalledSkill[],
+  app: AppId,
+): SourceGroupAppState {
+  const enabledCount = skills.filter((skill) =>
+    Boolean(skill.apps[app]),
+  ).length;
+  if (enabledCount === 0) return "disabled";
+  if (enabledCount === skills.length) return "enabled";
+  return "mixed";
+}
+
+function getSourceGroupAppButtonClassName(
+  state: SourceGroupAppState,
+  activeClass: string,
+): string {
+  const baseClass =
+    "relative w-7 h-7 rounded-lg flex items-center justify-center transition-all disabled:cursor-not-allowed disabled:opacity-45";
+
+  if (state === "enabled") return `${baseClass} ${activeClass}`;
+  if (state === "mixed") {
+    return `${baseClass} ${activeClass} opacity-90 ring-2 ring-yellow-400/70 ring-offset-1 ring-offset-background`;
+  }
+  return `${baseClass} opacity-35 hover:opacity-70`;
+}
+
 function formatSkillBackupDate(unixSeconds: number): string {
   const date = new Date(unixSeconds * 1000);
   return Number.isNaN(date.getTime())
@@ -102,6 +185,9 @@ const UnifiedSkillsPanel = React.forwardRef<
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const [pendingBulkSourceKey, setPendingBulkSourceKey] = useState<
+    string | null
+  >(null);
   const [writePending, setWritePending] = useState(false);
   const writeLockRef = React.useRef(false);
   const checkUpdatesLockRef = React.useRef(false);
@@ -259,10 +345,30 @@ const UnifiedSkillsPanel = React.forwardRef<
     });
   }, [searchQuery, skills]);
 
+  const sourceGroups = useMemo<VisibleSkillSourceGroup[]>(() => {
+    if (!skills) return [];
+
+    const visibleSkillIds = new Set(filteredSkills.map((skill) => skill.id));
+    return groupSkillsBySource(skills, t("skills.local"))
+      .map((group) => ({
+        ...group,
+        visibleSkills: group.skills.filter((skill) =>
+          visibleSkillIds.has(skill.id),
+        ),
+      }))
+      .filter((group) => group.visibleSkills.length > 0);
+  }, [filteredSkills, skills, t]);
+
   const pendingApp = bulkToggleAppMutation.isPending
     ? bulkToggleAppMutation.variables?.app
     : toggleAppMutation.isPending
       ? toggleAppMutation.variables?.app
+      : null;
+
+  const pendingAllApp =
+    !bulkToggleAppMutation.isPending ||
+    pendingBulkSourceKey === ALL_SKILLS_SOURCE_KEY
+      ? pendingApp
       : null;
 
   const handleToggleApp = async (id: string, app: AppId, enabled: boolean) => {
@@ -277,10 +383,15 @@ const UnifiedSkillsPanel = React.forwardRef<
     }
   };
 
-  const handleToggleAll = async (app: AppId, enabled: boolean) => {
-    if (!skills || !beginWrite()) return;
+  const handleToggleSkills = async (
+    targetSkills: InstalledSkill[],
+    sourceKey: string,
+    app: AppId,
+    enabled: boolean,
+  ) => {
+    if (!beginWrite()) return;
 
-    const ids = skills
+    const ids = targetSkills
       .filter((skill) => Boolean(skill.apps[app]) !== enabled)
       .map((skill) => skill.id);
     if (ids.length === 0) {
@@ -288,6 +399,7 @@ const UnifiedSkillsPanel = React.forwardRef<
       return;
     }
 
+    setPendingBulkSourceKey(sourceKey);
     try {
       const result = await bulkToggleAppMutation.mutateAsync({
         ids,
@@ -305,8 +417,22 @@ const UnifiedSkillsPanel = React.forwardRef<
         description: String(error),
       });
     } finally {
+      setPendingBulkSourceKey(null);
       endWrite();
     }
+  };
+
+  const handleToggleAll = async (app: AppId, enabled: boolean) => {
+    if (!skills) return;
+    await handleToggleSkills(skills, ALL_SKILLS_SOURCE_KEY, app, enabled);
+  };
+
+  const handleToggleSourceGroup = async (
+    group: SkillSourceGroup,
+    app: AppId,
+    enabled: boolean,
+  ) => {
+    await handleToggleSkills(group.skills, group.key, app, enabled);
   };
 
   const handleUninstall = (skill: InstalledSkill) => {
@@ -629,7 +755,7 @@ const UnifiedSkillsPanel = React.forwardRef<
             appIds={visibleSkillAppIds}
             totalCount={skills?.length ?? 0}
             onToggleAll={handleToggleAll}
-            pendingApp={pendingApp}
+            pendingApp={pendingAllApp}
             disabled={interactionBlocked}
           />
         </div>
@@ -695,22 +821,31 @@ const UnifiedSkillsPanel = React.forwardRef<
             </div>
           ) : (
             <TooltipProvider delayDuration={300}>
-              <div className="rounded-xl border border-border-default overflow-hidden">
-                {filteredSkills.map((skill, index) => (
-                  <InstalledSkillListItem
-                    key={skill.id}
-                    skill={skill}
-                    hasUpdate={!!updatesMap[skill.id]}
-                    isUpdating={
-                      updateSkillMutation.isPending &&
-                      updateSkillMutation.variables === skill.id
+              <div className="space-y-3">
+                {sourceGroups.map((group) => (
+                  <SkillSourceGroupSection
+                    key={group.key}
+                    group={group}
+                    updatesMap={updatesMap}
+                    isUpdatingSkillId={
+                      updateSkillMutation.isPending
+                        ? updateSkillMutation.variables
+                        : undefined
+                    }
+                    pendingApp={
+                      bulkToggleAppMutation.isPending &&
+                      pendingBulkSourceKey === group.key
+                        ? pendingApp
+                        : null
                     }
                     actionsDisabled={interactionBlocked}
                     appIds={visibleSkillAppIds}
+                    onToggleGroupApp={(app, enabled) =>
+                      handleToggleSourceGroup(group, app, enabled)
+                    }
                     onToggleApp={handleToggleApp}
-                    onUninstall={() => handleUninstall(skill)}
-                    onUpdate={() => handleUpdateSkill(skill)}
-                    isLast={index === filteredSkills.length - 1}
+                    onUninstall={handleUninstall}
+                    onUpdate={handleUpdateSkill}
                   />
                 ))}
               </div>
@@ -757,6 +892,137 @@ const UnifiedSkillsPanel = React.forwardRef<
 });
 
 UnifiedSkillsPanel.displayName = "UnifiedSkillsPanel";
+
+interface SkillSourceGroupSectionProps {
+  group: VisibleSkillSourceGroup;
+  updatesMap: Record<string, SkillUpdateInfo>;
+  isUpdatingSkillId?: string;
+  pendingApp: AppId | null;
+  actionsDisabled: boolean;
+  appIds: AppId[];
+  onToggleGroupApp: (app: AppId, enabled: boolean) => void;
+  onToggleApp: (id: string, app: AppId, enabled: boolean) => void;
+  onUninstall: (skill: InstalledSkill) => void;
+  onUpdate: (skill: InstalledSkill) => void;
+}
+
+const SkillSourceGroupSection: React.FC<SkillSourceGroupSectionProps> = ({
+  group,
+  updatesMap,
+  isUpdatingSkillId,
+  pendingApp,
+  actionsDisabled,
+  appIds,
+  onToggleGroupApp,
+  onToggleApp,
+  onUninstall,
+  onUpdate,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <section
+      aria-label={group.label}
+      className="overflow-hidden rounded-xl border border-border-default bg-background/60"
+    >
+      <div className="flex items-center gap-3 border-b border-border-default bg-muted/30 px-4 py-2.5">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <FolderTree size={14} className="shrink-0 text-muted-foreground" />
+          <span className="truncate text-sm font-medium">{group.label}</span>
+          <Badge variant="outline" className="h-5 shrink-0 text-[10px]">
+            {t("skills.count", { count: group.skills.length })}
+          </Badge>
+        </div>
+
+        <SourceGroupAppToggleBar
+          groupLabel={group.label}
+          skills={group.skills}
+          pendingApp={pendingApp}
+          disabled={actionsDisabled}
+          appIds={appIds}
+          onToggle={onToggleGroupApp}
+        />
+      </div>
+
+      {group.visibleSkills.map((skill, index) => (
+        <InstalledSkillListItem
+          key={skill.id}
+          skill={skill}
+          appIds={appIds}
+          hasUpdate={!!updatesMap[skill.id]}
+          isUpdating={isUpdatingSkillId === skill.id}
+          actionsDisabled={actionsDisabled}
+          onToggleApp={onToggleApp}
+          onUninstall={() => onUninstall(skill)}
+          onUpdate={() => onUpdate(skill)}
+          isLast={index === group.visibleSkills.length - 1}
+        />
+      ))}
+    </section>
+  );
+};
+
+interface SourceGroupAppToggleBarProps {
+  groupLabel: string;
+  skills: InstalledSkill[];
+  pendingApp: AppId | null;
+  disabled: boolean;
+  appIds: AppId[];
+  onToggle: (app: AppId, enabled: boolean) => void;
+}
+
+const SourceGroupAppToggleBar: React.FC<SourceGroupAppToggleBarProps> = ({
+  groupLabel,
+  skills,
+  pendingApp,
+  disabled,
+  appIds,
+  onToggle,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex shrink-0 items-center gap-1.5">
+      {appIds.map((app) => {
+        const { label, icon, activeClass } = APP_ICON_MAP[app];
+        const state = getSourceGroupAppState(skills, app);
+        const pending = pendingApp === app;
+        const allEnabled = state === "enabled";
+        const actionLabel = allEnabled
+          ? t("common.disableAllForApp", { app: label })
+          : t("common.enableAllForApp", { app: label });
+        const scopedActionLabel = `${groupLabel}: ${label} ${actionLabel}`;
+
+        return (
+          <Tooltip key={app}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                role="checkbox"
+                aria-checked={state === "mixed" ? "mixed" : allEnabled}
+                aria-busy={pending}
+                aria-label={scopedActionLabel}
+                title={scopedActionLabel}
+                data-selection-state={pending ? "pending" : state}
+                disabled={disabled}
+                onClick={() => onToggle(app, !allEnabled)}
+                className={getSourceGroupAppButtonClassName(state, activeClass)}
+              >
+                {icon}
+                {state === "mixed" && (
+                  <span className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-yellow-400 ring-1 ring-background" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+              <p>{scopedActionLabel}</p>
+            </TooltipContent>
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+};
 
 interface InstalledSkillListItemProps {
   skill: InstalledSkill;

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -8,6 +8,8 @@ import {
   Loader2,
   Search,
   FolderTree,
+  ChevronUp,
+  ChevronDown,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -919,13 +921,22 @@ const SkillSourceGroupSection: React.FC<SkillSourceGroupSectionProps> = ({
   onUpdate,
 }) => {
   const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(true);
+  const disclosureLabel = `${group.label}: ${t(
+    isExpanded ? "usage.collapse" : "usage.expand",
+  )}`;
 
   return (
     <section
       aria-label={group.label}
       className="overflow-hidden rounded-xl border border-border-default bg-background/60"
     >
-      <div className="flex items-center gap-3 border-b border-border-default bg-muted/30 px-4 py-2.5">
+      <div
+        className={cn(
+          "group flex items-center gap-3 bg-muted/30 px-4 py-2.5",
+          isExpanded && "border-b border-border-default",
+        )}
+      >
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <FolderTree size={14} className="shrink-0 text-muted-foreground" />
           <span className="truncate text-sm font-medium">{group.label}</span>
@@ -942,22 +953,36 @@ const SkillSourceGroupSection: React.FC<SkillSourceGroupSectionProps> = ({
           appIds={appIds}
           onToggle={onToggleGroupApp}
         />
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+          aria-label={disclosureLabel}
+          aria-expanded={isExpanded}
+          title={disclosureLabel}
+          onClick={() => setIsExpanded((expanded) => !expanded)}
+        >
+          {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </Button>
       </div>
 
-      {group.visibleSkills.map((skill, index) => (
-        <InstalledSkillListItem
-          key={skill.id}
-          skill={skill}
-          appIds={appIds}
-          hasUpdate={!!updatesMap[skill.id]}
-          isUpdating={isUpdatingSkillId === skill.id}
-          actionsDisabled={actionsDisabled}
-          onToggleApp={onToggleApp}
-          onUninstall={() => onUninstall(skill)}
-          onUpdate={() => onUpdate(skill)}
-          isLast={index === group.visibleSkills.length - 1}
-        />
-      ))}
+      {isExpanded &&
+        group.visibleSkills.map((skill, index) => (
+          <InstalledSkillListItem
+            key={skill.id}
+            skill={skill}
+            appIds={appIds}
+            hasUpdate={!!updatesMap[skill.id]}
+            isUpdating={isUpdatingSkillId === skill.id}
+            actionsDisabled={actionsDisabled}
+            onToggleApp={onToggleApp}
+            onUninstall={() => onUninstall(skill)}
+            onUpdate={() => onUpdate(skill)}
+            isLast={index === group.visibleSkills.length - 1}
+          />
+        ))}
     </section>
   );
 };

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -1018,7 +1018,7 @@ const SourceGroupAppToggleBar: React.FC<SourceGroupAppToggleBarProps> = ({
         const actionLabel = allEnabled
           ? t("common.disableAllForApp", { app: label })
           : t("common.enableAllForApp", { app: label });
-        const scopedActionLabel = `${groupLabel}: ${label} ${actionLabel}`;
+        const scopedActionLabel = `${groupLabel}: ${actionLabel}`;
 
         return (
           <Tooltip key={app}>

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -390,11 +390,19 @@ describe("UnifiedSkillsPanel", () => {
         name: "Repo A Beta",
         repoName: "repo-a",
       }),
+      makeInstalledSkill({
+        id: "owner/repo-b:gamma",
+        name: "Repo B Gamma",
+        repoName: "repo-b",
+      }),
     ];
     renderPanel();
 
     const user = userEvent.setup();
     const repoGroup = screen.getByRole("region", { name: "owner/repo-a" });
+    const otherRepoGroup = screen.getByRole("region", {
+      name: "owner/repo-b",
+    });
     const collapseButton = within(repoGroup).getByRole("button", {
       name: "owner/repo-a: usage.collapse",
     });
@@ -412,6 +420,14 @@ describe("UnifiedSkillsPanel", () => {
     expect(
       within(repoGroup).queryByText("Repo A Beta"),
     ).not.toBeInTheDocument();
+    expect(
+      within(otherRepoGroup).getByText("Repo B Gamma"),
+    ).toBeInTheDocument();
+    expect(
+      within(otherRepoGroup).getByRole("button", {
+        name: "owner/repo-b: usage.collapse",
+      }),
+    ).toHaveAttribute("aria-expanded", "true");
 
     await user.click(
       within(repoGroup).getByRole("button", {
@@ -445,7 +461,35 @@ describe("UnifiedSkillsPanel", () => {
       "group-hover:opacity-100",
       "focus-visible:opacity-100",
     );
+    expect(disclosureButton.parentElement).toHaveClass(
+      "w-[3.625rem]",
+      "shrink-0",
+      "justify-end",
+    );
     expect(disclosureButton.closest(".group")).not.toBeNull();
+  });
+
+  it("reserves the same action-column width for repository headers and Skill rows", () => {
+    installedSkillsMock = [
+      makeInstalledSkill({
+        id: "owner/repo-a:alpha",
+        name: "Repo A Alpha",
+        repoName: "repo-a",
+      }),
+    ];
+    renderPanel();
+
+    const repoGroup = screen.getByRole("region", { name: "owner/repo-a" });
+    const disclosureButton = within(repoGroup).getByRole("button", {
+      name: "owner/repo-a: usage.collapse",
+    });
+    const uninstallButton = within(repoGroup).getByTitle("skills.uninstall");
+
+    expect(disclosureButton.parentElement).toHaveClass("w-[3.625rem]");
+    expect(uninstallButton.parentElement).toHaveClass(
+      "w-[3.625rem]",
+      "justify-end",
+    );
   });
 
   it("toggles every Skill from one repository when search hides a sibling", async () => {
@@ -1067,7 +1111,12 @@ describe("UnifiedSkillsPanel", () => {
     render(<UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="pi" />);
 
     const piToggle = screen.getByRole("button", { name: "Pi" });
+    const sourceGroup = screen.getByRole("region", { name: "owner/repo" });
+    const sourcePiToggle = within(sourceGroup).getByRole("checkbox", {
+      name: "owner/repo: Pi common.disableAllForApp",
+    });
     expect(piToggle).toHaveAttribute("aria-pressed", "true");
+    expect(sourcePiToggle).toHaveAttribute("aria-checked", "true");
 
     await userEvent.setup().click(piToggle);
 
@@ -1110,8 +1159,14 @@ describe("UnifiedSkillsPanel", () => {
       <UnifiedSkillsPanel onOpenDiscovery={() => {}} currentApp="claude" />,
     );
 
+    const sourceGroup = screen.getByRole("region", { name: "owner/repo" });
     expect(
       screen.queryByRole("button", { name: "Pi" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(sourceGroup).queryByRole("checkbox", {
+        name: /owner\/repo: Pi/,
+      }),
     ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Claude" })).toBeInTheDocument();
   });

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -378,6 +378,76 @@ describe("UnifiedSkillsPanel", () => {
     expect(within(localGroup).getByText("Local Epsilon")).toBeInTheDocument();
   });
 
+  it("collapses and expands one repository source group", async () => {
+    installedSkillsMock = [
+      makeInstalledSkill({
+        id: "owner/repo-a:alpha",
+        name: "Repo A Alpha",
+        repoName: "repo-a",
+      }),
+      makeInstalledSkill({
+        id: "owner/repo-a:beta",
+        name: "Repo A Beta",
+        repoName: "repo-a",
+      }),
+    ];
+    renderPanel();
+
+    const user = userEvent.setup();
+    const repoGroup = screen.getByRole("region", { name: "owner/repo-a" });
+    const collapseButton = within(repoGroup).getByRole("button", {
+      name: "owner/repo-a: usage.collapse",
+    });
+
+    expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+    expect(within(repoGroup).getByText("Repo A Alpha")).toBeInTheDocument();
+    expect(within(repoGroup).getByText("Repo A Beta")).toBeInTheDocument();
+
+    await user.click(collapseButton);
+
+    expect(collapseButton).toHaveAttribute("aria-expanded", "false");
+    expect(
+      within(repoGroup).queryByText("Repo A Alpha"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(repoGroup).queryByText("Repo A Beta"),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      within(repoGroup).getByRole("button", {
+        name: "owner/repo-a: usage.expand",
+      }),
+    );
+
+    expect(within(repoGroup).getByText("Repo A Alpha")).toBeInTheDocument();
+    expect(within(repoGroup).getByText("Repo A Beta")).toBeInTheDocument();
+  });
+
+  it("reveals the aligned repository disclosure control on hover or focus", () => {
+    installedSkillsMock = [
+      makeInstalledSkill({
+        id: "owner/repo-a:alpha",
+        name: "Repo A Alpha",
+        repoName: "repo-a",
+      }),
+    ];
+    renderPanel();
+
+    const repoGroup = screen.getByRole("region", { name: "owner/repo-a" });
+    const disclosureButton = within(repoGroup).getByRole("button", {
+      name: "owner/repo-a: usage.collapse",
+    });
+
+    expect(disclosureButton).toHaveClass(
+      "h-7",
+      "w-7",
+      "opacity-0",
+      "group-hover:opacity-100",
+      "focus-visible:opacity-100",
+    );
+    expect(disclosureButton.closest(".group")).not.toBeNull();
+  });
+
   it("toggles every Skill from one repository when search hides a sibling", async () => {
     installedSkillsMock = [
       makeInstalledSkill({

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -2,6 +2,7 @@ import { createRef } from "react";
 import { render, screen, waitFor, act, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import i18n from "i18next";
 
 import UnifiedSkillsPanel, {
   type UnifiedSkillsPanelHandle,
@@ -151,6 +152,18 @@ const renderPanel = () =>
 
 describe("UnifiedSkillsPanel", () => {
   beforeEach(() => {
+    i18n.addResource(
+      "zh",
+      "translation",
+      "common.enableAllForApp",
+      "common.enableAllForApp {{app}}",
+    );
+    i18n.addResource(
+      "zh",
+      "translation",
+      "common.disableAllForApp",
+      "common.disableAllForApp {{app}}",
+    );
     installedSkillsMock = [];
     skillBackupsMock = [];
     skillUpdatesMock = [];
@@ -529,7 +542,7 @@ describe("UnifiedSkillsPanel", () => {
 
     await user.click(
       within(repoAGroup).getByRole("checkbox", {
-        name: "owner/repo-a: Claude common.enableAllForApp",
+        name: "owner/repo-a: common.enableAllForApp Claude",
       }),
     );
 
@@ -565,10 +578,14 @@ describe("UnifiedSkillsPanel", () => {
     const user = userEvent.setup();
     const repoAGroup = screen.getByRole("region", { name: "owner/repo-a" });
     const claudeToggle = within(repoAGroup).getByRole("checkbox", {
-      name: "owner/repo-a: Claude common.enableAllForApp",
+      name: "owner/repo-a: common.enableAllForApp Claude",
     });
 
     expect(claudeToggle).toHaveAttribute("aria-checked", "mixed");
+    expect(claudeToggle).toHaveAttribute(
+      "title",
+      "owner/repo-a: common.enableAllForApp Claude",
+    );
     await user.click(claudeToggle);
 
     await waitFor(() => {
@@ -605,10 +622,10 @@ describe("UnifiedSkillsPanel", () => {
     const user = userEvent.setup();
     const repoAGroup = screen.getByRole("region", { name: "owner/repo-a" });
     const claudeToggle = within(repoAGroup).getByRole("checkbox", {
-      name: "owner/repo-a: Claude common.enableAllForApp",
+      name: "owner/repo-a: common.enableAllForApp Claude",
     });
     const codexToggle = within(repoAGroup).getByRole("checkbox", {
-      name: "owner/repo-a: Codex common.enableAllForApp",
+      name: "owner/repo-a: common.enableAllForApp Codex",
     });
 
     await user.click(claudeToggle);
@@ -1113,7 +1130,7 @@ describe("UnifiedSkillsPanel", () => {
     const piToggle = screen.getByRole("button", { name: "Pi" });
     const sourceGroup = screen.getByRole("region", { name: "owner/repo" });
     const sourcePiToggle = within(sourceGroup).getByRole("checkbox", {
-      name: "owner/repo: Pi common.disableAllForApp",
+      name: "owner/repo: common.disableAllForApp Pi",
     });
     expect(piToggle).toHaveAttribute("aria-pressed", "true");
     expect(sourcePiToggle).toHaveAttribute("aria-checked", "true");

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -332,6 +332,192 @@ describe("UnifiedSkillsPanel", () => {
     expect(screen.queryByText("Unrelated Skill")).not.toBeInTheDocument();
   });
 
+  it("groups installed Skills by repository source", () => {
+    installedSkillsMock = [
+      makeInstalledSkill({
+        id: "owner/repo-a:alpha",
+        name: "Repo A Alpha",
+        repoName: "repo-a",
+      }),
+      makeInstalledSkill({
+        id: "owner/repo-a:beta",
+        name: "Repo A Beta",
+        repoOwner: "OWNER",
+        repoName: "REPO-A",
+      }),
+      makeInstalledSkill({
+        id: "owner/repo-b:gamma",
+        name: "Repo B Gamma",
+        repoName: "repo-b",
+      }),
+      makeInstalledSkill({
+        id: "local:delta",
+        name: "Local Delta",
+        repoOwner: undefined,
+        repoBranch: undefined,
+      }),
+      makeInstalledSkill({
+        id: "local:epsilon",
+        name: "Local Epsilon",
+        repoName: undefined,
+        repoBranch: undefined,
+      }),
+    ];
+
+    renderPanel();
+
+    const repoAGroup = screen.getByRole("region", { name: "owner/repo-a" });
+    expect(within(repoAGroup).getByText("Repo A Alpha")).toBeInTheDocument();
+    expect(within(repoAGroup).getByText("Repo A Beta")).toBeInTheDocument();
+    expect(
+      within(repoAGroup).queryByText("Repo B Gamma"),
+    ).not.toBeInTheDocument();
+
+    const localGroup = screen.getByRole("region", { name: "skills.local" });
+    expect(within(localGroup).getByText("Local Delta")).toBeInTheDocument();
+    expect(within(localGroup).getByText("Local Epsilon")).toBeInTheDocument();
+  });
+
+  it("toggles every Skill from one repository when search hides a sibling", async () => {
+    installedSkillsMock = [
+      makeInstalledSkill({
+        id: "owner/repo-a:visible",
+        name: "Visible Repo A Skill",
+        repoName: "repo-a",
+      }),
+      makeInstalledSkill({
+        id: "owner/repo-a:hidden",
+        name: "Hidden Repo A Skill",
+        repoName: "repo-a",
+      }),
+      makeInstalledSkill({
+        id: "owner/repo-b:other",
+        name: "Other Repository Skill",
+        repoName: "repo-b",
+      }),
+    ];
+    bulkToggleSkillAppMock.mockResolvedValue({
+      succeeded: ["owner/repo-a:visible", "owner/repo-a:hidden"],
+      failed: [],
+    });
+    renderPanel();
+
+    const user = userEvent.setup();
+    await user.type(
+      screen.getByRole("textbox", {
+        name: "skills.installedSearchAriaLabel",
+      }),
+      "Visible Repo A Skill",
+    );
+
+    const repoAGroup = screen.getByRole("region", { name: "owner/repo-a" });
+    expect(screen.queryByRole("region", { name: "owner/repo-b" })).toBeNull();
+
+    await user.click(
+      within(repoAGroup).getByRole("checkbox", {
+        name: "owner/repo-a: Claude common.enableAllForApp",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(bulkToggleSkillAppMock).toHaveBeenCalledWith({
+        ids: ["owner/repo-a:visible", "owner/repo-a:hidden"],
+        app: "claude",
+        enabled: true,
+      });
+    });
+  });
+
+  it("fills in disabled Skills when a repository app toggle is mixed", async () => {
+    installedSkillsMock = [
+      makeInstalledSkill({
+        id: "owner/repo-a:enabled",
+        name: "Enabled Repo A Skill",
+        repoName: "repo-a",
+        apps: { claude: true },
+      }),
+      makeInstalledSkill({
+        id: "owner/repo-a:disabled",
+        name: "Disabled Repo A Skill",
+        repoName: "repo-a",
+      }),
+    ];
+    bulkToggleSkillAppMock.mockResolvedValue({
+      succeeded: ["owner/repo-a:disabled"],
+      failed: [],
+    });
+    renderPanel();
+
+    const user = userEvent.setup();
+    const repoAGroup = screen.getByRole("region", { name: "owner/repo-a" });
+    const claudeToggle = within(repoAGroup).getByRole("checkbox", {
+      name: "owner/repo-a: Claude common.enableAllForApp",
+    });
+
+    expect(claudeToggle).toHaveAttribute("aria-checked", "mixed");
+    await user.click(claudeToggle);
+
+    await waitFor(() => {
+      expect(bulkToggleSkillAppMock).toHaveBeenCalledWith({
+        ids: ["owner/repo-a:disabled"],
+        app: "claude",
+        enabled: true,
+      });
+    });
+  });
+
+  it("marks only the active app as pending during a repository bulk toggle", async () => {
+    installedSkillsMock = [
+      makeInstalledSkill({
+        id: "owner/repo-a:alpha",
+        name: "Repo A Alpha",
+        repoName: "repo-a",
+      }),
+    ];
+    let resolveBulkToggle!: (value: {
+      succeeded: string[];
+      failed: string[];
+    }) => void;
+    bulkToggleSkillAppMock.mockImplementation((variables) => {
+      bulkToggleSkillAppPending = true;
+      bulkToggleSkillAppVariables = variables;
+      return new Promise((resolve) => {
+        resolveBulkToggle = resolve;
+      });
+    });
+
+    renderPanel();
+
+    const user = userEvent.setup();
+    const repoAGroup = screen.getByRole("region", { name: "owner/repo-a" });
+    const claudeToggle = within(repoAGroup).getByRole("checkbox", {
+      name: "owner/repo-a: Claude common.enableAllForApp",
+    });
+    const codexToggle = within(repoAGroup).getByRole("checkbox", {
+      name: "owner/repo-a: Codex common.enableAllForApp",
+    });
+
+    await user.click(claudeToggle);
+
+    await waitFor(() => {
+      expect(claudeToggle).toHaveAttribute("aria-busy", "true");
+      expect(claudeToggle).toHaveAttribute("data-selection-state", "pending");
+      expect(codexToggle).toHaveAttribute("aria-busy", "false");
+      expect(codexToggle).toHaveAttribute("data-selection-state", "disabled");
+      expect(codexToggle).toBeDisabled();
+    });
+
+    bulkToggleSkillAppPending = false;
+    bulkToggleSkillAppVariables = undefined;
+    await act(async () => {
+      resolveBulkToggle({
+        succeeded: ["owner/repo-a:alpha"],
+        failed: [],
+      });
+      await Promise.resolve();
+    });
+  });
+
   it("distinguishes an empty list from an installed-Skill search miss", async () => {
     const { rerender } = renderPanel();
 


### PR DESCRIPTION
## Summary / 概述

- Group installed Skills by existing `repoOwner/repoName` source metadata, with source keys matched case-insensitively.
- Put historical or unmanaged Skills missing either source field into the existing localized Local group.
- Add per-source tri-state bulk controls for Claude, Codex, Gemini, Grok Build, OpenCode, Hermes, and Pi when Pi is the active context.
- Keep repository bulk scope independent from search filtering: hidden sibling Skills from the same source are still included.
- Add independent expand/collapse state per repository group, with localized accessible labels and hover/focus disclosure controls.
- Reserve a consistent action column so repository controls, app toggles, update actions, and row deletion remain aligned.
- Keep the change frontend-only: no database, Rust, data-model, or i18n-key changes.

Scope note: #4367 contains a broader Skills-management redesign. This PR is intentionally limited to the repository-source grouping requested in #4450, avoiding manual-group and schema complexity. Repository-level update execution is not changed by this PR.

## Related Issue / 关联 Issue

Related to #4450

## Screenshots / 截图

<img width="2189" height="1562" alt="Repository-grouped Skills management page" src="https://github.com/user-attachments/assets/48b3bf25-7e0c-4a00-87f3-e6ca39a03bec" />

<img width="2189" height="1562" alt="Repository group disclosure control on hover" src="https://github.com/user-attachments/assets/8301bf34-d0b7-4a98-8aba-2ea7c70a8f30" />

The screenshots demonstrate repository-level grouping, per-source app controls, the localized Local fallback, and the repository disclosure control aligned with row actions.

Component tests cover grouping, independent collapse state, hover/focus disclosure styling, mixed and pending states, case-insensitive sources, Pi visibility, action-column alignment, and repository-wide bulk operations when sibling Skills are hidden by search.

## Verification / 验证

- `pnpm test:unit -- tests/components/UnifiedSkillsPanel.test.tsx` — 36 passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm build:renderer`
- `git diff --check`
- `pnpm exec vitest run --maxWorkers=1 --minWorkers=1` — 882 passed

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 未修改 Rust，Not applicable
- [x] Updated i18n files if user-facing text changed / 复用现有翻译键，无需修改 i18n