### PR TITLE
fix(codex): 保存供应商时剥离 MCP 投影配置

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2062,8 +2062,8 @@ pub fn strip_codex_unified_session_bucket_from_settings(
     Ok(())
 }
 
-/// Backfill helper: strip `[mcp_servers]` from a live `{ auth, config }`
-/// settings object before it is stored back to the DB.
+/// Strip `[mcp_servers]` from a live `{ auth, config }` settings object before
+/// it is stored back to the DB by provider save or switch-away backfill.
 ///
 /// MCP 服务器的 SSOT 是 DB 的 mcp_servers 表，live `config.toml` 里的
 /// `[mcp_servers]` 只是每次写 live 之后由 MCP 同步重新投影的产物。若回填时

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -906,11 +906,18 @@ fn restore_live_settings_for_provider_backfill(
     settings
 }
 
-pub(crate) fn normalize_provider_common_config_for_storage(
+pub(crate) fn normalize_provider_settings_for_storage(
     db: &Database,
     app_type: &AppType,
     provider: &mut Provider,
 ) -> Result<(), AppError> {
+    // The editor loads the effective live config for the active Codex provider,
+    // which includes MCP entries projected from the dedicated DB table. Never
+    // persist that projection back into the provider-owned settings snapshot.
+    if matches!(app_type, AppType::Codex) {
+        crate::codex_config::strip_codex_mcp_servers_from_settings(&mut provider.settings_config)?;
+    }
+
     let uses_common_config = provider
         .meta
         .as_ref()

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -36,7 +36,7 @@ pub fn import_pi_providers_from_live(state: &AppState) -> Result<usize, AppError
 // Internal re-exports (pub(crate))
 pub(crate) use live::sanitize_claude_settings_for_live;
 pub(crate) use live::{
-    build_effective_settings_with_common_config, normalize_provider_common_config_for_storage,
+    build_effective_settings_with_common_config, normalize_provider_settings_for_storage,
     provider_exists_in_live_config, strip_common_config_from_live_settings,
     sync_current_provider_for_app_to_live, write_live_with_common_config,
 };
@@ -470,6 +470,72 @@ mod tests {
 
             assert_eq!(script.api_key, None);
             assert_eq!(script.base_url, None);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn update_codex_provider_strips_live_mcp_projection_before_storage() {
+        with_test_home(|state, _| {
+            state
+                .db
+                .set_config_snippet(
+                    AppType::Codex.as_str(),
+                    Some("[shared]\nreasoning = \"medium\"\n".to_string()),
+                )
+                .expect("save common config");
+            for uses_common_config in [true, false] {
+                let id = format!("codex-edit-{uses_common_config}");
+                let mut provider = Provider::with_id(
+                    id.clone(),
+                    "Codex Edit".to_string(),
+                    json!({
+                        "auth": { "OPENAI_API_KEY": "sk-test" },
+                        "config": "model = \"gpt-5.5\"\n"
+                    }),
+                    None,
+                );
+                provider.meta = Some(ProviderMeta {
+                    common_config_enabled: Some(uses_common_config),
+                    ..Default::default()
+                });
+                state
+                    .db
+                    .save_provider(AppType::Codex.as_str(), &provider)
+                    .expect("seed provider");
+
+                let shared = if uses_common_config {
+                    "[shared]\nreasoning = \"medium\"\n"
+                } else {
+                    ""
+                };
+                provider.settings_config["config"] = json!(format!(
+                    concat!(
+                        "model = \"gpt-5.5\"\n",
+                        "{}",
+                        "[mcp_servers.echo]\n",
+                        "command = \"echo\"\n",
+                        "http_headers = {{ Authorization = \"Bearer secret\" }}\n"
+                    ),
+                    shared
+                ));
+                ProviderService::update(state, AppType::Codex, None, provider)
+                    .expect("save edited provider");
+
+                let saved = state
+                    .db
+                    .get_provider_by_id(&id, AppType::Codex.as_str())
+                    .expect("query saved provider")
+                    .expect("saved provider should exist");
+                assert_eq!(saved.settings_config["auth"]["OPENAI_API_KEY"], "sk-test");
+                let config = saved.settings_config["config"]
+                    .as_str()
+                    .expect("config text");
+                assert!(config.contains("model = \"gpt-5.5\""));
+                assert!(!config.contains("[shared]"));
+                assert!(!config.contains("mcp_servers"), "got: {config}");
+                assert!(!config.contains("Bearer secret"), "got: {config}");
+            }
         });
     }
 
@@ -2570,7 +2636,7 @@ impl ProviderService {
         // Normalize Claude model keys
         Self::normalize_provider_if_claude(&app_type, &mut provider);
         Self::validate_provider_settings(&app_type, &provider)?;
-        normalize_provider_common_config_for_storage(state.db.as_ref(), &app_type, &mut provider)?;
+        normalize_provider_settings_for_storage(state.db.as_ref(), &app_type, &mut provider)?;
         Self::normalize_usage_script_credential_overrides(&app_type, &mut provider);
         if app_type.is_additive_mode() {
             Self::set_provider_live_config_managed(&mut provider, add_to_live);
@@ -2629,7 +2695,7 @@ impl ProviderService {
         // Normalize Claude model keys
         Self::normalize_provider_if_claude(&app_type, &mut provider);
         Self::validate_provider_settings(&app_type, &provider)?;
-        normalize_provider_common_config_for_storage(state.db.as_ref(), &app_type, &mut provider)?;
+        normalize_provider_settings_for_storage(state.db.as_ref(), &app_type, &mut provider)?;
         Self::normalize_usage_script_credential_overrides(&app_type, &mut provider);
 
         if provider_id_changed {


### PR DESCRIPTION
## Summary / 概述

- 在 Codex 供应商新增/更新写入数据库前，剥离 live 配置中由 MCP 数据表投影出的 `[mcp_servers]`，同时兼容历史 `[mcp.servers]` 写法。
- 复用现有的结构化 TOML 清理逻辑，继续以 `mcp_servers` 表作为 MCP 配置的唯一数据源，避免供应商快照保存重复副本。
- 增加供应商编辑保存的回归测试，覆盖启用和关闭「应用通用配置」两种情况。

## Root Cause / 问题原因

当前 Codex 供应商的编辑器会读取合并后的有效 live 配置，其中包含通用配置以及从 `mcp_servers` 表投影出的 MCP 配置。

此前供应商保存路径只会在持久化前剥离通用配置，没有像切换供应商时的回填路径一样剥离 MCP 投影。因此用户即使不修改内容、直接点击「保存」，也会把整段 `[mcp_servers]` 重新写入 `providers.settings_config`，其中还可能包含 MCP HTTP Header。之后切换供应商时，旧快照就可能再次恢复已经删除或修改过的 MCP。

## Fix / 修复方案

将供应商存储前的规范化函数扩展为统一处理以下内容：

1. 仅当应用为 Codex 时，调用现有 `strip_codex_mcp_servers_from_settings` 清除 MCP 投影。
2. 继续按照原有逻辑剥离启用的通用配置。
3. TOML 解析失败时在数据库写入前返回错误，避免保存部分规范化结果。

该处理由供应商 add/update 共用，但通过 `AppType::Codex` 明确限定，不改变 Claude Code、Gemini、OpenCode、OpenClaw、Pi 等其他应用的存储行为。

## Related Issue / 关联 Issue

Related: #4699

本 PR 修复 issue 评论中补充的「供应商编辑页直接保存会重新污染快照」路径。代理接管备份中孤儿 MCP 的恢复问题不在本 PR 范围内，仍由 #4012 跟踪。

## Screenshots / 截图

N/A，后端存储规范化修复，无 UI 变化。

## Verification / 验证

- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib update_codex_provider_strips_live_mcp_projection_before_storage -- --test-threads=1`（1 passed）
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib services::provider::tests -- --test-threads=1`（45 passed）
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- [x] 无用户可见文案变化，无需更新 i18n

回归测试确认：

- 供应商自身的模型配置和认证信息保持不变；
- 启用通用配置时，通用配置仍按原逻辑从供应商快照中剥离；
- MCP 命令及其 `Authorization` Header 不再写入供应商快照；
- 关闭通用配置时同样会清除 MCP 投影。
