### PR TITLE
fix(openclaw): quote newly inserted keys to keep openclaw.json strict-JSON parsable

### DIFF
--- a/src-tauri/src/openclaw_config.rs
+++ b/src-tauri/src/openclaw_config.rs
@@ -990,7 +990,8 @@ mod tests {
         // Regression test for #6467: when the source file has no comments,
         // newly inserted root-level keys must be quoted so the file remains
         // parsable by strict JSON consumers.
-        let source = "{\n  \"models\": {\n    \"mode\": \"merge\",\n    \"providers\": {}\n  }\n}\n";
+        let source =
+            "{\n  \"models\": {\n    \"mode\": \"merge\",\n    \"providers\": {}\n  }\n}\n";
 
         with_test_paths(source, |_| {
             set_default_model(&OpenClawDefaultModel {

--- a/src-tauri/src/openclaw_config.rs
+++ b/src-tauri/src/openclaw_config.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
 const OPENCLAW_DEFAULT_SOURCE: &str =
-    "{\n  models: {\n    mode: 'merge',\n    providers: {},\n  },\n}\n";
+    "{\n  \"models\": {\n    \"mode\": \"merge\",\n    \"providers\": {}\n  }\n}\n";
 const OPENCLAW_TOOLS_PROFILES: &[&str] = &["minimal", "coding", "messaging", "full"];
 
 // ============================================================================
@@ -538,21 +538,10 @@ fn make_root_pair(key: &str, value: RtJSONValue, closing_ws: String) -> RtJSONKe
 }
 
 fn make_json5_key(key: &str) -> RtJSONValue {
-    if is_identifier_key(key) {
-        RtJSONValue::Identifier(key.to_string())
-    } else {
-        RtJSONValue::DoubleQuotedString(key.to_string())
-    }
-}
-
-fn is_identifier_key(key: &str) -> bool {
-    let mut chars = key.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-
-    matches!(first, 'a'..='z' | 'A'..='Z' | '_' | '$')
-        && chars.all(|ch| matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '$'))
+    // Always quote keys: a double-quoted string key is valid JSON5 *and*
+    // strict JSON, so files that did not originally contain comments stay
+    // parsable by strict JSON consumers (e.g. aily-cli reading openclaw.json).
+    RtJSONValue::DoubleQuotedString(key.to_string())
 }
 
 fn json5_key_name(key: &RtJSONValue) -> Option<&str> {
@@ -990,8 +979,31 @@ mod tests {
 
             let written = fs::read_to_string(get_openclaw_config_path()).unwrap();
             assert!(written.contains("// top-level comment"));
-            assert!(written.contains("agents: {"));
+            assert!(written.contains("\"agents\": {"));
             assert!(written.contains("provider/model"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn default_model_write_keeps_strict_json_parsable() {
+        // Regression test for #6467: when the source file has no comments,
+        // newly inserted root-level keys must be quoted so the file remains
+        // parsable by strict JSON consumers.
+        let source = "{\n  \"models\": {\n    \"mode\": \"merge\",\n    \"providers\": {}\n  }\n}\n";
+
+        with_test_paths(source, |_| {
+            set_default_model(&OpenClawDefaultModel {
+                primary: "provider/model".to_string(),
+                fallbacks: Vec::new(),
+                extra: HashMap::new(),
+            })
+            .unwrap();
+
+            let written = fs::read_to_string(get_openclaw_config_path()).unwrap();
+            let parsed: Value = serde_json::from_str(&written)
+                .expect("written openclaw.json should stay strict-JSON parsable");
+            assert!(parsed.get("agents").is_some());
         });
     }
 


### PR DESCRIPTION
Fixes #6467

## 问题

cc-switch 通过 round-trip JSON5 编辑写入 `~/.openclaw/openclaw.json` 时，新插入的根级键（如 `models`）以无引号 identifier 形式输出（`make_json5_key` 对合法 JS 标识符走 `RtJSONValue::Identifier` 分支）。该写法是合法 JSON5（OpenClaw 自身可正常读取），但任何严格 JSON 解析器都会解析失败——实测飞书 aily-cli 的 openclaw adapter 因此报 `OpenClaw config ... is not valid JSON` 并判定不可用，且每次在 cc-switch 保存 openclaw provider 配置都会重现。

## 修复

- `make_json5_key` 恒定输出双引号字符串键：双引号键**同时合法于 JSON5 与严格 JSON**，注释保留能力不受影响（已有 `default_model_write_preserves_top_level_comments` 测试覆盖该能力）
- 默认模板 `OPENCLAW_DEFAULT_SOURCE` 同步改为严格 JSON（原为无引号键 + 单引号 + 尾逗号，新建文件同样会破坏严格解析）
- 新增回归测试 `default_model_write_keeps_strict_json_parsable`：无注释的源文件经写入后必须能被 `serde_json` 严格解析

## 说明

- 本机无 Rust 工具链，未能本地运行 `cargo test`，改动依赖 CI 验证；修改模式与既有测试保持一致
- 用户文件中**已经存在**的无引号键会被 round-trip 原样保留（尊重原文件格式），仅保证新插入的键严格兼容
