### PR TITLE
docs: fix grammar in question issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -10,7 +10,7 @@ body:
       label: Self Checks / 自检
       options:
         - label: |
-            I have read the [FAQ](https://github.com/farion1231/cc-switch#faq) section in README.
+            I have read the [FAQ](https://github.com/farion1231/cc-switch#faq) section in the README.
             我已阅读 README 中的[常见问题](https://github.com/farion1231/cc-switch#常见问题)。
           required: true
         - label: |


### PR DESCRIPTION
## Summary

- add the missing definite article to the FAQ self-check text in the question issue template
- keep the Chinese translation and all template behavior unchanged

## Why

The user-facing sentence currently reads “the FAQ section in README.” In this context, “README” should be preceded by “the,” making the sentence read naturally as “the FAQ section in the README.”

## Impact

Documentation text only; there is no runtime or configuration behavior change.

## Validation

- compared the branch against the fork's `main`: exactly one file changed
- confirmed the diff is one added line and one removed line
- re-read the updated YAML and verified indentation and surrounding fields are unchanged

Closes #6469