### PR TITLE
fix(codex): keep deeplink homepage optional

### DIFF
--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -41,6 +41,9 @@ pub fn import_provider_from_deeplink(
         .clone()
         .ok_or_else(|| AppError::InvalidInput("Missing 'app' field for provider".to_string()))?;
 
+    let app_type = AppType::from_str(&app_str)
+        .map_err(|_| AppError::InvalidInput(format!("Invalid app type: {app_str}")))?;
+
     let api_key = merged_request.api_key.as_ref().ok_or_else(|| {
         AppError::InvalidInput("API key is required (either in URL or config file)".to_string())
     })?;
@@ -67,22 +70,25 @@ pub fn import_provider_from_deeplink(
         .first()
         .ok_or_else(|| AppError::InvalidInput("Endpoint cannot be empty".to_string()))?;
 
-    // Auto-infer homepage from endpoint if not provided
-    if merged_request
-        .homepage
-        .as_ref()
-        .is_none_or(|s| s.is_empty())
+    // Codex profiles do not use the homepage for API requests. Keep it unset
+    // when a deep link only supplies an endpoint instead of inventing a URL.
+    if !matches!(app_type, AppType::Codex)
+        && merged_request
+            .homepage
+            .as_ref()
+            .is_none_or(|s| s.is_empty())
     {
         merged_request.homepage = infer_homepage_from_endpoint(primary_endpoint);
     }
 
-    let homepage = merged_request.homepage.as_ref().ok_or_else(|| {
-        AppError::InvalidInput("Homepage is required (either in URL or config file)".to_string())
-    })?;
-
-    if homepage.is_empty() {
+    if !matches!(app_type, AppType::Codex)
+        && merged_request
+            .homepage
+            .as_ref()
+            .is_none_or(|homepage| homepage.is_empty())
+    {
         return Err(AppError::InvalidInput(
-            "Homepage cannot be empty".to_string(),
+            "Homepage is required (either in URL or config file)".to_string(),
         ));
     }
 
@@ -90,10 +96,6 @@ pub fn import_provider_from_deeplink(
         .name
         .clone()
         .ok_or_else(|| AppError::InvalidInput("Missing 'name' field for provider".to_string()))?;
-
-    // Parse app type
-    let app_type = AppType::from_str(&app_str)
-        .map_err(|_| AppError::InvalidInput(format!("Invalid app type: {app_str}")))?;
 
     // Build provider configuration based on app type
     let mut provider = build_provider_from_request(&app_type, &merged_request)?;

--- a/src-tauri/tests/deeplink_import.rs
+++ b/src-tauri/tests/deeplink_import.rs
@@ -84,3 +84,30 @@ fn deeplink_import_codex_provider_builds_auth_and_config() {
         "config.toml content should contain model setting"
     );
 }
+
+#[test]
+fn deeplink_import_codex_custom_provider_keeps_homepage_empty() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    let _home = ensure_test_home();
+
+    let url = "ccswitch://v1/import?resource=provider&app=codex&name=custom&endpoint=https%3A%2F%2Fapi.tu-zi.com%2Fcoding&apiKey=PASTE_API_KEY_FROM_CLIPBOARD&model=gpt-5.6-sol";
+    let request = parse_deeplink_url(url).expect("parse deeplink url");
+    let db = Arc::new(Database::memory().expect("create memory db"));
+    let state = AppState::new(db.clone());
+
+    let provider_id = import_provider_from_deeplink(&state, request)
+        .expect("import Codex provider without homepage");
+    let providers = db.get_all_providers("codex").expect("get providers");
+    let provider = providers.get(&provider_id).expect("provider created");
+
+    assert!(provider.website_url.is_none());
+    let config = provider
+        .settings_config
+        .get("config")
+        .and_then(serde_json::Value::as_str)
+        .expect("stored Codex config");
+    assert!(config.contains("[model_providers.custom]"));
+    assert!(config.contains("name = \"custom\""));
+    assert!(config.contains("base_url = \"https://api.tu-zi.com/coding\""));
+}


### PR DESCRIPTION
## Summary

- keep `homepage` unset for Codex provider deep links when the link only supplies an API endpoint
- retain homepage inference and validation for every other provider type
- add an integration regression for the `custom` provider imported from `https://api.tu-zi.com/coding`
- matching storefront change: tuziapi/faka#20

## Root cause

The provider importer inferred a homepage for every app. A Codex deep link without `homepage` therefore stored `https://tu-zi.com`, even though that field is optional metadata and is not used for Codex API requests.

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --test deeplink_import` (3 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib deeplink` (42 passed)
- `git diff --check`

The new integration test exercises the actual parser and provider service with the storefront URL shape, then verifies the stored provider has no website and its TOML contains `[model_providers.custom]`, `name = "custom"`, and the expected base URL.

## Rollout

Publish this change in a CC Switch release before rolling out tuziapi/faka#20 for the complete experience. The storefront link itself remains backward compatible, but users will only see an empty website field after installing a release containing this change.

## Rollback

Revert this commit. That restores the previous behavior of deriving and requiring a homepage for Codex imports.
