### PR TITLE
fix(ci): run WSL2 contract tests via prebuilt binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,15 +205,37 @@ jobs:
 
       - name: Compile backend tests with native temp
         # link.exe/mt.exe cannot create manifests when TEMP points at a WSL UNC path.
-        run: cargo test --lib --manifest-path src-tauri/Cargo.toml --no-run
+        # Record the built test binary path so the run step below can execute
+        # it directly instead of re-invoking cargo with TEMP on \\wsl.localhost.
+        env:
+          TEMP: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}
+        shell: pwsh
+        run: |
+          $testBinary = cargo test --lib --manifest-path src-tauri/Cargo.toml --no-run --message-format=json |
+            ForEach-Object {
+              if ($_ -match '"reason":"compiler-artifact"') {
+                $artifact = $_ | ConvertFrom-Json
+                if ($artifact.executable -and $artifact.profile.test -and $artifact.target.name -eq 'cc_switch_lib') {
+                  $artifact.executable
+                }
+              }
+            } | Select-Object -First 1
+          if (-not $testBinary) {
+            throw "cc_switch_lib test binary not found in cargo compiler artifacts"
+          }
+          "CC_SWITCH_TEST_EXE=$testBinary" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Run Windows-to-WSL2 filesystem contract
+        # Run the test binary built in the previous step directly. Invoking cargo
+        # here with TEMP pointing at a WSL UNC path can re-link the crate, and
+        # link.exe/mt.exe cannot create manifest temp files on \\wsl.localhost.
         shell: pwsh
         run: |
           $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $testName = "config::tests::atomic_write_replaces_existing_wsl_unc_file"
-          $testList = cargo test --lib --manifest-path src-tauri/Cargo.toml -- --ignored --list
+          $testList = & $env:CC_SWITCH_TEST_EXE --list --ignored
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -221,7 +243,7 @@ jobs:
           if ($testList -notcontains $expected) {
             throw "Expected ignored test was not discovered: $testName"
           }
-          cargo test --lib --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
+          & $env:CC_SWITCH_TEST_EXE $testName --ignored --exact --nocapture
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,10 @@ jobs:
                   $artifact.executable
                 }
               }
-            } | Select-Object -First 1
+            } | Select-Object -First 1 -Wait
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
           if (-not $testBinary) {
             throw "cc_switch_lib test binary not found in cargo compiler artifacts"
           }

--- a/.github/workflows/wsl2-nightly.yml
+++ b/.github/workflows/wsl2-nightly.yml
@@ -60,46 +60,15 @@ jobs:
 
       - name: Compile backend tests with native temp
         # link.exe/mt.exe cannot create manifests when TEMP points at a WSL UNC path.
-        # Record the built test binary paths so the run steps below can execute
-        # them directly instead of re-invoking cargo with TEMP on \\wsl.localhost.
-        env:
-          TEMP: ${{ runner.temp }}
-          TMP: ${{ runner.temp }}
-        shell: pwsh
-        run: |
-          $binariesFile = Join-Path $env:RUNNER_TEMP "cc-switch-test-binaries.txt"
-          "TEST_BINARIES_FILE=$binariesFile" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          cargo test --tests --manifest-path src-tauri/Cargo.toml --no-run --message-format=json |
-            ForEach-Object {
-              if ($_ -match '"reason":"compiler-artifact"') {
-                $artifact = $_ | ConvertFrom-Json
-                if ($artifact.executable -and $artifact.profile.test) {
-                  if ($artifact.target.name -eq 'cc_switch_lib') {
-                    "CC_SWITCH_TEST_EXE=$($artifact.executable)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-                  }
-                  $artifact.executable
-                }
-              }
-            } |
-            Sort-Object -Unique |
-            Set-Content -LiteralPath $binariesFile
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
-          }
+        run: cargo test --tests --manifest-path src-tauri/Cargo.toml --no-run
 
       - name: Run Windows-to-WSL2 filesystem contract
-        # Run the test binary built in the previous step directly. Invoking cargo
-        # here with TEMP pointing at a WSL UNC path can re-link the crate, and
-        # link.exe/mt.exe cannot create manifest temp files on \\wsl.localhost.
         shell: pwsh
         run: |
-          if (-not $env:CC_SWITCH_TEST_EXE) {
-            throw "cc_switch_lib test binary not found in cargo compiler artifacts"
-          }
           $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $testName = "config::tests::atomic_write_replaces_existing_wsl_unc_file"
-          $testList = & $env:CC_SWITCH_TEST_EXE --list --ignored
+          $testList = cargo test --tests --manifest-path src-tauri/Cargo.toml -- --ignored --list
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -107,7 +76,7 @@ jobs:
           if ($testList -notcontains $expected) {
             throw "Expected ignored test was not discovered: $testName"
           }
-          & $env:CC_SWITCH_TEST_EXE $testName --ignored --exact --nocapture
+          cargo test --tests --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -117,13 +86,4 @@ jobs:
         run: |
           $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
-          $binaries = Get-Content -LiteralPath $env:TEST_BINARIES_FILE
-          if ($binaries.Count -eq 0) {
-            throw "No test binaries recorded in $env:TEST_BINARIES_FILE"
-          }
-          foreach ($bin in $binaries) {
-            & $bin --test-threads=1
-            if ($LASTEXITCODE -ne 0) {
-              exit $LASTEXITCODE
-            }
-          }
+          cargo test --tests --manifest-path src-tauri/Cargo.toml -- --test-threads=1

--- a/.github/workflows/wsl2-nightly.yml
+++ b/.github/workflows/wsl2-nightly.yml
@@ -60,15 +60,46 @@ jobs:
 
       - name: Compile backend tests with native temp
         # link.exe/mt.exe cannot create manifests when TEMP points at a WSL UNC path.
-        run: cargo test --tests --manifest-path src-tauri/Cargo.toml --no-run
-
-      - name: Run Windows-to-WSL2 filesystem contract
+        # Record the built test binary paths so the run steps below can execute
+        # them directly instead of re-invoking cargo with TEMP on \\wsl.localhost.
+        env:
+          TEMP: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}
         shell: pwsh
         run: |
+          $binariesFile = Join-Path $env:RUNNER_TEMP "cc-switch-test-binaries.txt"
+          "TEST_BINARIES_FILE=$binariesFile" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          cargo test --tests --manifest-path src-tauri/Cargo.toml --no-run --message-format=json |
+            ForEach-Object {
+              if ($_ -match '"reason":"compiler-artifact"') {
+                $artifact = $_ | ConvertFrom-Json
+                if ($artifact.executable -and $artifact.profile.test) {
+                  if ($artifact.target.name -eq 'cc_switch_lib') {
+                    "CC_SWITCH_TEST_EXE=$($artifact.executable)" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+                  }
+                  $artifact.executable
+                }
+              }
+            } |
+            Sort-Object -Unique |
+            Set-Content -LiteralPath $binariesFile
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+      - name: Run Windows-to-WSL2 filesystem contract
+        # Run the test binary built in the previous step directly. Invoking cargo
+        # here with TEMP pointing at a WSL UNC path can re-link the crate, and
+        # link.exe/mt.exe cannot create manifest temp files on \\wsl.localhost.
+        shell: pwsh
+        run: |
+          if (-not $env:CC_SWITCH_TEST_EXE) {
+            throw "cc_switch_lib test binary not found in cargo compiler artifacts"
+          }
           $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $testName = "config::tests::atomic_write_replaces_existing_wsl_unc_file"
-          $testList = cargo test --tests --manifest-path src-tauri/Cargo.toml -- --ignored --list
+          $testList = & $env:CC_SWITCH_TEST_EXE --list --ignored
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -76,7 +107,7 @@ jobs:
           if ($testList -notcontains $expected) {
             throw "Expected ignored test was not discovered: $testName"
           }
-          cargo test --tests --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
+          & $env:CC_SWITCH_TEST_EXE $testName --ignored --exact --nocapture
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -86,4 +117,13 @@ jobs:
         run: |
           $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
-          cargo test --tests --manifest-path src-tauri/Cargo.toml -- --test-threads=1
+          $binaries = Get-Content -LiteralPath $env:TEST_BINARIES_FILE
+          if ($binaries.Count -eq 0) {
+            throw "No test binaries recorded in $env:TEST_BINARIES_FILE"
+          }
+          foreach ($bin in $binaries) {
+            & $bin --test-threads=1
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
+          }


### PR DESCRIPTION
## Summary

Fixes the intermittent `Backend Checks (Windows + WSL2 home)` failure caused by MSVC `mt.exe` errors `c1010070` / `LNK1327`.

The workflow now:

- compiles the library test binary while `TEMP` and `TMP` point to the Windows runner's native temporary directory;
- reads the executable path from Cargo's JSON artifact output and waits for Cargo to finish;
- propagates Cargo compilation failures;
- runs the prebuilt test binary directly after switching `TEMP` and `TMP` to the WSL2 UNC directory.

This prevents Cargo from relinking under `\\wsl.localhost`, where `link.exe` / `mt.exe` cannot create manifest temporary files.

## Scope

This PR changes only `.github/workflows/ci.yml`. The scheduled full-suite WSL2 workflow is unchanged and can be handled independently.

## Related

Related to #6428.

## Checklist

- [x] Latest head passed the full CI workflow, including the Windows 2025 + WSL2 contract job
- [x] Workflow YAML parses successfully
- [x] Final diff received two independent reviews with no P0, P1, or P2 findings
