### PR TITLE
fix(ui): key the live-config snapshot to the provider being edited

### DIFF
--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -56,35 +56,45 @@ export function EditProviderDialog({
   );
 
   // 默认使用传入的 provider.settingsConfig，若当前编辑对象是"当前生效供应商"，则尝试读取实时配置替换初始值
-  const [liveSettings, setLiveSettings] = useState<Record<
-    string,
-    unknown
-  > | null>(null);
+  //
+  // #6445: App.tsx derives `open` from Boolean(editingProvider), so choosing a
+  // different provider swaps `provider` while the panel stays open. Keying the
+  // snapshot by (appId, provider.id) — the same shape as formReadyToken above —
+  // means a stale snapshot can never be shown for another provider: the derived
+  // `liveSettings` falls back to the SSOT config until the new load settles.
+  const liveLoadKey = open && provider ? `${appId}::${provider.id}` : null;
 
-  // 使用 ref 标记是否已经加载过，防止重复读取覆盖用户编辑
-  const [hasLoadedLive, setHasLoadedLive] = useState(false);
+  const [loadedLive, setLoadedLive] = useState<{
+    key: string | null;
+    settings: Record<string, unknown> | null;
+  }>({ key: null, settings: null });
+
+  const liveSettings =
+    loadedLive.key === liveLoadKey ? loadedLive.settings : null;
 
   useEffect(() => {
     let cancelled = false;
+    // 记录该 (app, provider) 的加载结果，防止重复读取覆盖用户编辑
+    const settle = (settings: Record<string, unknown> | null) => {
+      if (!cancelled) {
+        setLoadedLive({ key: liveLoadKey, settings });
+      }
+    };
     const load = async () => {
       if (!open || !provider) {
-        setLiveSettings(null);
-        setHasLoadedLive(false);
+        settle(null);
         return;
       }
 
-      // 关键修复：只在首次打开时加载一次
-      if (hasLoadedLive) {
+      // 关键修复：每个 (app, provider) 只加载一次
+      if (loadedLive.key === liveLoadKey) {
         return;
       }
 
       // 代理接管模式：Live 配置已被代理改写，读取 live 会导致编辑界面展示代理地址/占位符等内容
       // 因此直接回退到 SSOT（数据库）配置，避免用户困惑与误保存
       if (isProxyTakeover) {
-        if (!cancelled) {
-          setLiveSettings(null);
-          setHasLoadedLive(true);
-        }
+        settle(null);
         return;
       }
 
@@ -92,29 +102,16 @@ export function EditProviderDialog({
       // the catalog coordinator. Neither has a per-provider generic live
       // snapshot that may replace the DB aggregate in this form.
       if (appId === "opencode" || appId === "pi") {
-        if (!cancelled) {
-          setLiveSettings(null);
-          setHasLoadedLive(true);
-        }
+        settle(null);
         return;
       }
 
       if (appId === "openclaw") {
         try {
           const live = await openclawApi.getLiveProvider(provider.id);
-          if (!cancelled && live && typeof live === "object") {
-            setLiveSettings(live);
-          } else if (!cancelled) {
-            setLiveSettings(null);
-          }
+          settle(live && typeof live === "object" ? live : null);
         } catch {
-          if (!cancelled) {
-            setLiveSettings(null);
-          }
-        } finally {
-          if (!cancelled) {
-            setHasLoadedLive(true);
-          }
+          settle(null);
         }
         return;
       }
@@ -126,32 +123,24 @@ export function EditProviderDialog({
             const live = (await vscodeApi.getLiveProviderSettings(
               appId,
             )) as Record<string, unknown>;
-            if (!cancelled && live && typeof live === "object") {
-              setLiveSettings(live);
-              setHasLoadedLive(true);
-            }
+            settle(live && typeof live === "object" ? live : null);
           } catch {
             // 读取实时配置失败则回退到 SSOT（不打断编辑流程）
-            if (!cancelled) {
-              setLiveSettings(null);
-              setHasLoadedLive(true);
-            }
+            settle(null);
           }
         } else {
-          if (!cancelled) {
-            setLiveSettings(null);
-            setHasLoadedLive(true);
-          }
+          settle(null);
         }
-      } finally {
-        // no-op
+      } catch {
+        // 查询当前供应商失败同样回退到 SSOT
+        settle(null);
       }
     };
     void load();
     return () => {
       cancelled = true;
     };
-  }, [open, provider?.id, appId, hasLoadedLive, isProxyTakeover]); // 只依赖 provider.id，不依赖整个 provider 对象
+  }, [open, provider, liveLoadKey, loadedLive.key, appId, isProxyTakeover]);
 
   const initialSettingsConfig = useMemo(() => {
     const base = (liveSettings ?? provider?.settingsConfig ?? {}) as Record<

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -299,4 +299,64 @@ describe("EditProviderDialog", () => {
     act(() => staleCallback?.(true));
     expect(reopenedButton).toBeDisabled();
   });
+
+  // #6445: App.tsx derives `open` from Boolean(editingProvider), so picking a
+  // different provider swaps `provider` while `open` stays true. The live-config
+  // load must re-run for the new provider instead of reusing the previous one's.
+  it("does not show the previous provider's live settings after switching providers while open", async () => {
+    const active: Provider = {
+      id: "relay",
+      name: "Relay",
+      category: "aggregator",
+      settingsConfig: { auth: { OPENAI_API_KEY: "relay-db-key" } },
+    };
+    const other: Provider = {
+      id: "deepseek",
+      name: "DeepSeek",
+      category: "custom",
+      settingsConfig: { auth: { OPENAI_API_KEY: "deepseek-db-key" } },
+    };
+
+    // "relay" is the provider currently written to the live config.
+    apiMocks.getCurrent.mockResolvedValue("relay");
+    apiMocks.getLiveProviderSettings.mockResolvedValue({
+      auth: { OPENAI_API_KEY: "relay-live-key" },
+    });
+
+    const { rerender } = render(
+      <EditProviderDialog
+        open
+        provider={active}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-config").textContent).toContain(
+        "relay-live-key",
+      );
+    });
+
+    // Switch to a provider that is not the active one, without closing first.
+    rerender(
+      <EditProviderDialog
+        open
+        provider={other}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("settings-config").textContent).toContain(
+        "deepseek-db-key",
+      );
+    });
+    expect(screen.getByTestId("settings-config").textContent).not.toContain(
+      "relay-live-key",
+    );
+  });
 });


### PR DESCRIPTION
## Summary / 概述

Editing a provider could show another provider's API key. `EditProviderDialog` loads the live config for whichever provider is currently applied, and guarded that load with a plain `hasLoadedLive` boolean. The flag records *that* a snapshot was loaded but not *which provider* it belongs to.

`App.tsx` derives the panel's open state from the selection itself:

```tsx
open={Boolean(editingProvider)}
```

So picking a different provider swaps `provider` while `open` stays `true`. The effect re-runs, hits `if (hasLoadedLive) return`, and the previous provider's live snapshot stays in state — `initialSettingsConfig` prefers `liveSettings` over `provider.settingsConfig`, so the form renders the wrong key.

The fix keys the snapshot by `(appId, provider.id)` and derives `liveSettings` from it:

```ts
const liveLoadKey = open && provider ? `${appId}::${provider.id}` : null;
const liveSettings = loadedLive.key === liveLoadKey ? loadedLive.settings : null;
```

A stale key now yields `null`, so the form falls back to the SSOT config until the new load settles — there is no frame where one provider's live config is shown under another's name. This is the same shape as `formReadyToken` twenty lines above in the same file, which already keys its state on `[appId, open, provider?.id]`.

While collapsing the four `setLiveSettings`/`setHasLoadedLive` pairs into one `settle()` helper, the outer `try` around `providersApi.getCurrent` turned out to have a `finally` but no `catch`, so a failure there left the previous snapshot in place and never settled. It now falls back to SSOT like the inner handler already did.

## Related Issue / 关联 Issue

Refs #6445 — partially.

#6445 reports two symptoms and this only accounts for the second one:

- *"启用另外一个供应商后，点击编辑，其 api key 显示的也不对"* — covered, and reproduced in a test below.
- *"启用 deepseek 的时候，点击其编辑 显示的是中转站的 api key"* — **not** covered. If deepseek is the applied provider, the live read is supposed to return deepseek's own config, so why the relay's key ends up there is a separate question I could not settle from the renderer. I have deliberately not written `Fixes` so the issue stays open for that half.

## Verification

Added a regression test that renders the active provider, waits for its live snapshot, then swaps in a different provider without closing — exactly what `Boolean(editingProvider)` produces.

```
without the fix:  × does not show the previous provider's live settings after switching providers while open
                    expected '{"auth":{"OPENAI_API_KEY":"relay-live…' to contain 'deepseek-db-key'
with the fix:     Test Files 122 passed (122)
                  Tests      877 passed (877)
```

One note on the numbers: an earlier baseline run on a clean checkout showed 2 unrelated failures that did not reproduce on re-run, so the suite looks mildly flaky somewhere. Without this change the only failure is the new test; with it the full run is green.

## Unrelated observation, not changed here

`isProxyTakeover` is passed to this dialog without the `isProxyRunning` conjunct that every other call site uses:

```tsx
// App.tsx:1109 — ProviderList
isProxyTakeover={isProxyRunning && isCurrentAppTakeoverActive}
// App.tsx:1326
active={isProxyRunning && isCurrentAppTakeoverActive}
// App.tsx:1771 — EditProviderDialog
isProxyTakeover={isCurrentAppTakeoverActive}
```

With the proxy stopped but a takeover still recorded, the dialog therefore skips the live read and shows the SSOT config, which is the opposite of what the comment on that branch intends. It fails safe rather than showing a wrong key, so it is not the cause of either symptom above — flagging it rather than folding it into this PR. Happy to send it separately if you agree it is wrong.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) — no Rust changed
- [ ] Updated i18n files if user-facing text changed — no user-facing text changed
