### PR TITLE
fix(openclaw): quote root keys so openclaw.json stays valid JSON

### DIFF
--- a/src-tauri/src/openclaw_config.rs
+++ b/src-tauri/src/openclaw_config.rs
@@ -20,8 +20,12 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
+/// 新建配置文件时的初始内容。
+///
+/// 用严格 JSON 书写：OpenClaw 自己按 JSON5 读取，但该文件同样会被第三方工具
+/// 用严格 JSON 解析器读取，所以不应一上来就写出只有 JSON5 能接受的内容。
 const OPENCLAW_DEFAULT_SOURCE: &str =
-    "{\n  models: {\n    mode: 'merge',\n    providers: {},\n  },\n}\n";
+    "{\n  \"models\": {\n    \"mode\": \"merge\",\n    \"providers\": {}\n  }\n}\n";
 const OPENCLAW_TOOLS_PROFILES: &[&str] = &["minimal", "coding", "messaging", "full"];
 
 // ============================================================================
@@ -293,6 +297,9 @@ impl OpenClawConfigDocument {
             .iter_mut()
             .find(|pair| json5_key_name(&pair.key) == Some(key))
         {
+            // 该 section 本来就要重写，顺带把键名归一为带引号形式，
+            // 让旧版本写出的裸键在下一次保存时自愈。
+            existing.key = make_json5_key(key);
             existing.value = new_value;
             return Ok(());
         }
@@ -537,22 +544,14 @@ fn make_root_pair(key: &str, value: RtJSONValue, closing_ws: String) -> RtJSONKe
     }
 }
 
+/// 新键一律使用带引号的键名。
+///
+/// `openclaw.json` 虽然按 JSON5 解析，但文件名与既有内容都是严格 JSON，
+/// 也会被第三方工具用严格解析器读取。裸标识符键只有 JSON5 接受，一旦写入
+/// 就会让原本合法的文件无法通过 `JSON.parse`。带引号的键在 JSON 与 JSON5
+/// 中都合法，而且与嵌套键保持一致——后者经 `serde_json` 序列化，本就带引号。
 fn make_json5_key(key: &str) -> RtJSONValue {
-    if is_identifier_key(key) {
-        RtJSONValue::Identifier(key.to_string())
-    } else {
-        RtJSONValue::DoubleQuotedString(key.to_string())
-    }
-}
-
-fn is_identifier_key(key: &str) -> bool {
-    let mut chars = key.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-
-    matches!(first, 'a'..='z' | 'A'..='Z' | '_' | '$')
-        && chars.all(|ch| matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '$'))
+    RtJSONValue::DoubleQuotedString(key.to_string())
 }
 
 fn json5_key_name(key: &RtJSONValue) -> Option<&str> {
@@ -990,9 +989,99 @@ mod tests {
 
             let written = fs::read_to_string(get_openclaw_config_path()).unwrap();
             assert!(written.contains("// top-level comment"));
-            assert!(written.contains("agents: {"));
+            assert!(written.contains("\"agents\": {"));
             assert!(written.contains("provider/model"));
         });
+    }
+
+    // 新增的顶层键必须带引号：openclaw.json 同时会被严格 JSON 解析器读取，
+    // 而嵌套键本就经由 serde_json 序列化（始终带引号），根键不应例外。
+    #[test]
+    #[serial]
+    fn root_section_write_keeps_config_strict_json_parseable() {
+        let source = r#"{
+  "models": {
+    "mode": "merge",
+    "providers": {}
+  }
+}
+"#;
+
+        with_test_paths(source, |_| {
+            serde_json::from_str::<Value>(source).expect("fixture starts as strict JSON");
+
+            set_default_model(&OpenClawDefaultModel {
+                primary: "provider/model".to_string(),
+                fallbacks: Vec::new(),
+                extra: HashMap::new(),
+            })
+            .unwrap();
+
+            let written = fs::read_to_string(get_openclaw_config_path()).unwrap();
+            serde_json::from_str::<Value>(&written).unwrap_or_else(|err| {
+                panic!("written config is no longer strict JSON ({err}):\n{written}")
+            });
+        });
+    }
+
+    // 首次创建的配置文件本身就应当是严格 JSON。
+    #[test]
+    #[serial]
+    fn config_created_from_scratch_is_strict_json() {
+        with_test_paths("{}", |path| {
+            fs::remove_file(path).unwrap();
+
+            set_default_model(&OpenClawDefaultModel {
+                primary: "provider/model".to_string(),
+                fallbacks: Vec::new(),
+                extra: HashMap::new(),
+            })
+            .unwrap();
+
+            let written = fs::read_to_string(get_openclaw_config_path()).unwrap();
+            serde_json::from_str::<Value>(&written).unwrap_or_else(|err| {
+                panic!("freshly created config should be strict JSON ({err}):\n{written}")
+            });
+        });
+    }
+
+    // 旧版本已经写坏的文件，在下一次保存该 section 时应恢复为严格 JSON。
+    #[test]
+    #[serial]
+    fn rewriting_a_section_requotes_a_bare_root_key() {
+        let source = r#"{
+  models: {
+    "mode": "merge",
+    "providers": {
+      "1-copy": {
+        "api": "anthropic-messages"
+      }
+    }
+  }
+}
+"#;
+
+        with_test_paths(source, |_| {
+            assert!(serde_json::from_str::<Value>(source).is_err());
+
+            remove_provider("1-copy").unwrap();
+
+            let written = fs::read_to_string(get_openclaw_config_path()).unwrap();
+            assert!(written.contains("\"models\":"), "got:\n{written}");
+            serde_json::from_str::<Value>(&written).unwrap_or_else(|err| {
+                panic!("rewritten config should be strict JSON ({err}):\n{written}")
+            });
+        });
+    }
+
+    #[test]
+    fn new_root_keys_are_always_quoted() {
+        for key in ["models", "needs-quotes"] {
+            assert!(matches!(
+                make_json5_key(key),
+                RtJSONValue::DoubleQuotedString(_)
+            ));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Refs #6467.

## What happens

`~/.openclaw/openclaw.json` is parsed back with JSON5, but it is named `.json`, it ships as strict JSON, and third-party tools read it with a strict parser. Saving an OpenClaw provider wrote a top-level key as a bare identifier, which only JSON5 accepts, so a previously valid file stopped parsing. The reporter's case is Feishu's aily-cli adapter refusing OpenClaw with `is not valid JSON`.

## Why

The writer was already inconsistent. Nested keys are produced by `serde_json::to_string_pretty` in `value_to_rt_value`, so they are always quoted. Only the root key of a section went through `make_json5_key`:

```rust
fn make_json5_key(key: &str) -> RtJSONValue {
    if is_identifier_key(key) {
        RtJSONValue::Identifier(key.to_string())   // bare -> JSON5 only
    } else {
        RtJSONValue::DoubleQuotedString(key.to_string())
    }
}
```

`models` is a valid identifier, so the output was `models: {` at the root with `"providers": {}` nested underneath — exactly the mixture in the report.

The repo's own test suite already pinned this: `default_model_write_preserves_top_level_comments` asserted `written.contains("agents: {")`. That assertion is updated here.

## Change

Always quote root keys. Quoted keys are valid in both JSON and JSON5, so OpenClaw keeps reading the file and strict parsers stop failing. `is_identifier_key` had no other caller and is removed.

Two adjacent paths needed the same treatment to actually fix the reported symptom:

- **Self-heal.** `set_root_section` previously replaced only `existing.value`, so a file already broken by an earlier version would keep its bare key forever. It now also normalizes the key of the section it is rewriting. Sections that are not touched keep whatever form the user wrote, so hand-maintained JSON5 is not reformatted wholesale.
- **Fresh installs.** `OPENCLAW_DEFAULT_SOURCE` was itself JSON5-only (bare keys, single quotes, trailing commas), so a brand-new config could never be read by a strict parser. It is now strict JSON and matches `default_openclaw_config_value()`.

## Tests

Four tests, all in `openclaw_config`:

- `root_section_write_keeps_config_strict_json_parseable` — strict-JSON fixture stays strict JSON after a section write. This is the regression test for the report.
- `config_created_from_scratch_is_strict_json` — covers the no-file path.
- `rewriting_a_section_requotes_a_bare_root_key` — an already-degraded file recovers on the next save.
- `new_root_keys_are_always_quoted` — unit-level guard on `make_json5_key`.

`default_model_write_preserves_top_level_comments` now expects `"agents": {`; the rest of its assertions (comment preservation, written value) are unchanged. `remove_last_provider_writes_empty_providers_without_panic` already asserted the quoted nested form and is untouched.

## Scope

`openclaw_config.rs` is the only writer of this file; every other reference in `src-tauri` reads it. Comment preservation, backup behaviour and the on-disk conflict check are all unchanged.

One thing worth your call: I kept the normalization limited to the section being written. If you would rather have a single save repair every bare key in the document, that is a small change to `set_root_section` — but it would rewrite keys the user may have deliberately written in JSON5 style, so I did not assume it.