### PR TITLE
fix(codex): keep Codex Desktop's [desktop] table across provider switches

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -3775,6 +3775,70 @@ pub fn preflight_codex_live_write(
     .map(|_| ())
 }
 
+/// Codex Desktop owns the `[desktop]` table in `config.toml`: it is the app's
+/// own UI state (`mac-menu-bar-enabled`, …), not provider configuration.
+/// Switching providers replaces the live file with the stored provider TOML,
+/// which silently drops whatever the desktop app had written there (#6400) —
+/// and a dropped key reads as "back to default", so turning a setting off does
+/// not survive a switch.
+///
+/// Keys the provider config sets itself win; only keys it does not mention are
+/// carried over. A live file we cannot parse is left alone rather than blocking
+/// the switch.
+fn merge_codex_desktop_table(live_text: &str, config_text: &str) -> String {
+    let Ok(live_doc) = live_text.parse::<DocumentMut>() else {
+        return config_text.to_string();
+    };
+    let Some(live_desktop) = live_doc.get("desktop").and_then(|item| item.as_table()) else {
+        return config_text.to_string();
+    };
+    if live_desktop.is_empty() {
+        return config_text.to_string();
+    }
+    let Ok(mut target_doc) = config_text.parse::<DocumentMut>() else {
+        return config_text.to_string();
+    };
+
+    if target_doc
+        .get("desktop")
+        .and_then(|item| item.as_table())
+        .is_none()
+    {
+        let mut table = toml_edit::Table::new();
+        table.set_implicit(false);
+        target_doc["desktop"] = toml_edit::Item::Table(table);
+    }
+    let Some(target_desktop) = target_doc
+        .get_mut("desktop")
+        .and_then(|item| item.as_table_mut())
+    else {
+        return config_text.to_string();
+    };
+
+    let mut carried = false;
+    for (key, value) in live_desktop.iter() {
+        if target_desktop.get(key).is_none() {
+            target_desktop[key] = value.clone();
+            carried = true;
+        }
+    }
+    if !carried {
+        return config_text.to_string();
+    }
+
+    target_doc.to_string()
+}
+
+/// Read the live `config.toml` and carry its `[desktop]` table into the config
+/// about to be written. Missing or unreadable live files are not an error.
+fn carry_over_codex_desktop_table(config_text: &str) -> String {
+    let live_path = get_codex_config_path();
+    match fs::read_to_string(&live_path) {
+        Ok(live_text) => merge_codex_desktop_table(&live_text, config_text),
+        Err(_) => config_text.to_string(),
+    }
+}
+
 pub fn write_codex_live_for_provider(
     category: Option<&str>,
     auth: &Value,
@@ -3786,10 +3850,20 @@ pub fn write_codex_live_for_provider(
         config_text,
         crate::settings::preserve_codex_official_auth_on_switch(),
     )?;
+    // #6400: carry Codex Desktop's own [desktop] table into what is about to
+    // be written. Deliberately here and not inside plan_codex_live_write:
+    // that builder is also run as a preflight and discarded, and a preflight
+    // has no business reading the live file.
+    let config_text = plan
+        .config_text
+        .as_deref()
+        .map(carry_over_codex_desktop_table);
+    let config_text = config_text.as_deref();
+
     if plan.write_full_auth {
-        return write_codex_live_atomic(auth, plan.config_text.as_deref());
+        return write_codex_live_atomic(auth, config_text);
     }
-    write_codex_live_config_atomic(plan.config_text.as_deref())?;
+    write_codex_live_config_atomic(config_text)?;
     // Config is already committed at this point, so a cleanup failure
     // degrades to a warning instead of reporting an unswitched state.
     if plan.remove_auth_file {
@@ -7797,5 +7871,86 @@ model_catalog_json = "cc-switch-model-catalog.json"
             result.is_err(),
             "file larger than MAX_CODEX_CATALOG_BYTES must be rejected"
         );
+    }
+
+    // #6400: `[desktop]` is Codex Desktop's own UI state. A provider switch
+    // rewrites config.toml from the stored provider TOML, so without this the
+    // app's settings silently revert to their defaults.
+    #[test]
+    fn desktop_table_survives_a_provider_switch() {
+        let live = r#"model_provider = "old_vendor"
+
+[desktop]
+followUpQueueMode = "queue"
+mac-menu-bar-enabled = false
+"#;
+        let incoming = r#"model_provider = "new_vendor"
+model = "gpt-5"
+"#;
+
+        let merged = merge_codex_desktop_table(live, incoming);
+        let parsed: toml::Value = toml::from_str(&merged).expect("merged config parses");
+        let desktop = parsed.get("desktop").expect("desktop table carried over");
+
+        assert_eq!(
+            desktop
+                .get("mac-menu-bar-enabled")
+                .and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert_eq!(
+            desktop.get("followUpQueueMode").and_then(|v| v.as_str()),
+            Some("queue")
+        );
+        assert_eq!(
+            parsed.get("model_provider").and_then(|v| v.as_str()),
+            Some("new_vendor"),
+            "provider fields must not be affected"
+        );
+    }
+
+    #[test]
+    fn desktop_table_does_not_override_the_incoming_config() {
+        let live = r#"[desktop]
+mac-menu-bar-enabled = false
+followUpQueueMode = "queue"
+"#;
+        let incoming = r#"[desktop]
+mac-menu-bar-enabled = true
+"#;
+
+        let merged = merge_codex_desktop_table(live, incoming);
+        let parsed: toml::Value = toml::from_str(&merged).expect("merged config parses");
+        let desktop = parsed.get("desktop").expect("desktop table");
+
+        assert_eq!(
+            desktop
+                .get("mac-menu-bar-enabled")
+                .and_then(|v| v.as_bool()),
+            Some(true),
+            "a value the provider config sets itself wins"
+        );
+        assert_eq!(
+            desktop.get("followUpQueueMode").and_then(|v| v.as_str()),
+            Some("queue"),
+            "keys it does not mention are still carried over"
+        );
+    }
+
+    #[test]
+    fn desktop_merge_is_a_noop_without_anything_to_carry() {
+        let incoming = "model_provider = \"vendor\"\n";
+
+        for live in [
+            "model_provider = \"old\"\n",
+            "[desktop]\n",
+            "this is not = = toml",
+        ] {
+            assert_eq!(
+                merge_codex_desktop_table(live, incoming),
+                incoming,
+                "live config {live:?} should leave the incoming config untouched"
+            );
+        }
     }
 }

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2788,14 +2788,6 @@ pub fn strip_codex_mcp_servers_from_settings(settings: &mut Value) -> Result<(),
     Ok(())
 }
 
-/// Route a Codex live write between full auth+config or config-only.
-///
-/// Official providers with usable login material own `auth.json`. Third-party
-/// providers only touch `config.toml` when the compatibility setting is enabled
-/// so the user's ChatGPT login cache survives provider switches.
-///
-/// 统一会话开关开启时，官方配置在落盘前注入共享的 `custom` 路由
-/// （见 `inject_codex_unified_session_bucket`）。
 /// Codex Desktop owns the `[desktop]` table in `config.toml`: it is the app's
 /// own UI state (`mac-menu-bar-enabled`, …), not provider configuration.
 /// Switching providers replaces the live file with the stored provider TOML,
@@ -2810,7 +2802,13 @@ fn merge_codex_desktop_table(live_text: &str, config_text: &str) -> String {
     let Ok(live_doc) = live_text.parse::<DocumentMut>() else {
         return config_text.to_string();
     };
-    let Some(live_desktop) = live_doc.get("desktop").and_then(|item| item.as_table()) else {
+    // `as_table_like`, not `as_table`: `desktop = { mac-menu-bar-enabled = false }`
+    // is an inline table and perfectly valid TOML, but `as_table` returns none
+    // for it — same trap `update_codex_toml_field` documents for `model_providers`.
+    let Some(live_desktop) = live_doc
+        .get("desktop")
+        .and_then(|item| item.as_table_like())
+    else {
         return config_text.to_string();
     };
     if live_desktop.is_empty() {
@@ -2820,18 +2818,22 @@ fn merge_codex_desktop_table(live_text: &str, config_text: &str) -> String {
         return config_text.to_string();
     };
 
-    if target_doc
-        .get("desktop")
-        .and_then(|item| item.as_table())
-        .is_none()
-    {
-        let mut table = toml_edit::Table::new();
-        table.set_implicit(false);
-        target_doc["desktop"] = toml_edit::Item::Table(table);
+    match target_doc.get("desktop") {
+        // Nothing to merge into yet, so give the carried keys a home.
+        None => {
+            let mut table = toml_edit::Table::new();
+            table.set_implicit(false);
+            target_doc["desktop"] = toml_edit::Item::Table(table);
+        }
+        // The incoming config wins, and that has to hold for shapes we cannot
+        // merge into as well (`desktop = 42`). Replacing it here would discard a
+        // value the provider config states outright, so leave the text alone.
+        Some(item) if item.as_table_like().is_none() => return config_text.to_string(),
+        Some(_) => {}
     }
     let Some(target_desktop) = target_doc
         .get_mut("desktop")
-        .and_then(|item| item.as_table_mut())
+        .and_then(|item| item.as_table_like_mut())
     else {
         return config_text.to_string();
     };
@@ -2839,7 +2841,7 @@ fn merge_codex_desktop_table(live_text: &str, config_text: &str) -> String {
     let mut carried = false;
     for (key, value) in live_desktop.iter() {
         if target_desktop.get(key).is_none() {
-            target_desktop[key] = value.clone();
+            target_desktop.insert(key, value.clone());
             carried = true;
         }
     }
@@ -2860,13 +2862,61 @@ fn carry_over_codex_desktop_table(config_text: &str) -> String {
     }
 }
 
+/// `[desktop]` belongs to live for the same reason `[mcp_servers]` does, so it
+/// gets the same treatment on the way out: strip it when backfilling a provider.
+///
+/// Leaving it in makes the snapshot taken at switch-out time the provider's own
+/// value. Switch away, change a Desktop setting, switch back, and that stale
+/// snapshot wins over the newer live value — the carry-over above deliberately
+/// yields to keys the provider config sets, and it cannot tell a backfilled key
+/// from one the user meant.
+pub fn strip_codex_desktop_from_settings(settings: &mut Value) -> Result<(), AppError> {
+    let Some(config_text) = settings
+        .get("config")
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+    else {
+        return Ok(());
+    };
+    if !config_text.contains("desktop") {
+        return Ok(());
+    }
+    let mut doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+    if doc.as_table_mut().remove("desktop").is_some() {
+        if let Some(obj) = settings.as_object_mut() {
+            obj.insert("config".to_string(), Value::String(doc.to_string()));
+        }
+    }
+    Ok(())
+}
+
+/// Route a Codex live write between full auth+config or config-only.
+///
+/// Official providers with usable login material own `auth.json`. Third-party
+/// providers only touch `config.toml` when the compatibility setting is enabled
+/// so the user's ChatGPT login cache survives provider switches.
+///
+/// 统一会话开关开启时，官方配置在落盘前注入共享的 `custom` 路由
+/// （见 `inject_codex_unified_session_bucket`）。
 pub fn write_codex_live_for_provider(
     category: Option<&str>,
     auth: &Value,
     config_text: Option<&str>,
 ) -> Result<(), AppError> {
-    let desktop_preserved = config_text.map(carry_over_codex_desktop_table);
-    let config_text = desktop_preserved.as_deref().or(config_text);
+    // A Codex provider may legitimately carry no `config` at all, and every
+    // branch below then writes an empty `config.toml` — which drops `[desktop]`
+    // exactly as an overwrite would. Merge against the empty string so that case
+    // is covered too, and keep the result only when something was actually
+    // carried, so a provider with no config and no live desktop state still
+    // writes nothing.
+    let desktop_preserved = carry_over_codex_desktop_table(config_text.unwrap_or(""));
+    let config_text = match config_text {
+        Some(_) => Some(desktop_preserved.as_str()),
+        None if !desktop_preserved.trim().is_empty() => Some(desktop_preserved.as_str()),
+        None => None,
+    };
 
     let unified_official_config =
         if category == Some("official") && crate::settings::unify_codex_session_history() {
@@ -3599,6 +3649,100 @@ mac-menu-bar-enabled = true
                 "live config {live:?} should leave the incoming config untouched"
             );
         }
+    }
+
+    // Both sides of the merge may be written as inline tables, which is valid
+    // TOML the `as_table` accessor silently reports as "not a table".
+    #[test]
+    fn desktop_merge_handles_inline_tables_on_both_sides() {
+        let live = r#"desktop = { mac-menu-bar-enabled = false, followUpQueueMode = "queue" }
+"#;
+        let incoming = r#"desktop = { mac-menu-bar-enabled = true }
+"#;
+
+        let merged = merge_codex_desktop_table(live, incoming);
+        let parsed: toml::Value = toml::from_str(&merged).expect("merged config parses");
+        let desktop = parsed.get("desktop").expect("desktop table");
+
+        assert_eq!(
+            desktop
+                .get("mac-menu-bar-enabled")
+                .and_then(|v| v.as_bool()),
+            Some(true),
+            "an inline table the provider config sets must not be replaced"
+        );
+        assert_eq!(
+            desktop.get("followUpQueueMode").and_then(|v| v.as_str()),
+            Some("queue"),
+            "keys carried out of an inline live table"
+        );
+    }
+
+    // "Incoming wins" has to hold for shapes there is no way to merge into,
+    // rather than degrading into "incoming gets replaced".
+    #[test]
+    fn desktop_merge_leaves_a_non_table_incoming_value_alone() {
+        let live = "[desktop]\nmac-menu-bar-enabled = false\n";
+        let incoming = "desktop = 42\n";
+
+        assert_eq!(merge_codex_desktop_table(live, incoming), incoming);
+    }
+
+    // Codex providers may legitimately store no `config` at all, and the live
+    // write then produces an empty config.toml — dropping `[desktop]` just as an
+    // overwrite does. This has to go through `write_codex_live_for_provider`:
+    // the merge helper is not where that case is decided.
+    #[test]
+    #[serial_test::serial]
+    fn live_write_without_a_provider_config_keeps_the_desktop_table() {
+        let temp_home = tempfile::tempdir().expect("create temp home");
+        let previous_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp_home.path());
+
+        let outcome = (|| {
+            let config_path = get_codex_config_path();
+            if !config_path.starts_with(temp_home.path()) {
+                return Err(format!(
+                    "live config resolved outside the isolated home: {}",
+                    config_path.display()
+                ));
+            }
+            std::fs::create_dir_all(config_path.parent().expect("codex dir"))
+                .map_err(|e| e.to_string())?;
+            std::fs::write(&config_path, "[desktop]\nmac-menu-bar-enabled = false\n")
+                .map_err(|e| e.to_string())?;
+
+            write_codex_live_for_provider(Some("custom"), &json!({}), None)
+                .map_err(|e| e.to_string())?;
+
+            std::fs::read_to_string(&config_path).map_err(|e| e.to_string())
+        })();
+
+        match previous_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+
+        let written = outcome.expect("live write");
+        assert!(
+            written.contains("mac-menu-bar-enabled"),
+            "a provider with no stored config must not wipe Desktop's own state, got: {written:?}"
+        );
+    }
+
+    // The stripping itself is covered end-to-end at the backfill entry point in
+    // `services::provider::live`; this pins the no-op path.
+    #[test]
+    fn backfill_strip_leaves_a_config_without_desktop_untouched() {
+        let original = "model_provider = \"vendor\"\n";
+        let mut settings = json!({ "config": original });
+
+        strip_codex_desktop_from_settings(&mut settings).expect("strip succeeds");
+
+        assert_eq!(
+            settings.get("config").and_then(|v| v.as_str()),
+            Some(original)
+        );
     }
 
     #[test]

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2796,11 +2796,78 @@ pub fn strip_codex_mcp_servers_from_settings(settings: &mut Value) -> Result<(),
 ///
 /// 统一会话开关开启时，官方配置在落盘前注入共享的 `custom` 路由
 /// （见 `inject_codex_unified_session_bucket`）。
+/// Codex Desktop owns the `[desktop]` table in `config.toml`: it is the app's
+/// own UI state (`mac-menu-bar-enabled`, …), not provider configuration.
+/// Switching providers replaces the live file with the stored provider TOML,
+/// which silently drops whatever the desktop app had written there (#6400) —
+/// and a dropped key reads as "back to default", so turning a setting off does
+/// not survive a switch.
+///
+/// Keys the provider config sets itself win; only keys it does not mention are
+/// carried over. A live file we cannot parse is left alone rather than blocking
+/// the switch.
+fn merge_codex_desktop_table(live_text: &str, config_text: &str) -> String {
+    let Ok(live_doc) = live_text.parse::<DocumentMut>() else {
+        return config_text.to_string();
+    };
+    let Some(live_desktop) = live_doc.get("desktop").and_then(|item| item.as_table()) else {
+        return config_text.to_string();
+    };
+    if live_desktop.is_empty() {
+        return config_text.to_string();
+    }
+    let Ok(mut target_doc) = config_text.parse::<DocumentMut>() else {
+        return config_text.to_string();
+    };
+
+    if target_doc
+        .get("desktop")
+        .and_then(|item| item.as_table())
+        .is_none()
+    {
+        let mut table = toml_edit::Table::new();
+        table.set_implicit(false);
+        target_doc["desktop"] = toml_edit::Item::Table(table);
+    }
+    let Some(target_desktop) = target_doc
+        .get_mut("desktop")
+        .and_then(|item| item.as_table_mut())
+    else {
+        return config_text.to_string();
+    };
+
+    let mut carried = false;
+    for (key, value) in live_desktop.iter() {
+        if target_desktop.get(key).is_none() {
+            target_desktop[key] = value.clone();
+            carried = true;
+        }
+    }
+    if !carried {
+        return config_text.to_string();
+    }
+
+    target_doc.to_string()
+}
+
+/// Read the live `config.toml` and carry its `[desktop]` table into the config
+/// about to be written. Missing or unreadable live files are not an error.
+fn carry_over_codex_desktop_table(config_text: &str) -> String {
+    let live_path = get_codex_config_path();
+    match fs::read_to_string(&live_path) {
+        Ok(live_text) => merge_codex_desktop_table(&live_text, config_text),
+        Err(_) => config_text.to_string(),
+    }
+}
+
 pub fn write_codex_live_for_provider(
     category: Option<&str>,
     auth: &Value,
     config_text: Option<&str>,
 ) -> Result<(), AppError> {
+    let desktop_preserved = config_text.map(carry_over_codex_desktop_table);
+    let config_text = desktop_preserved.as_deref().or(config_text);
+
     let unified_official_config =
         if category == Some("official") && crate::settings::unify_codex_session_history() {
             Some(inject_codex_unified_session_bucket(
@@ -3451,6 +3518,87 @@ base_url = "https://leftover.example.com/v1"
 base_url = "https://single.example.com/v1"
 "#;
         assert_eq!(extract_codex_base_url(no_active), None);
+    }
+
+    // #6400: `[desktop]` is Codex Desktop's own UI state. A provider switch
+    // rewrites config.toml from the stored provider TOML, so without this the
+    // app's settings silently revert to their defaults.
+    #[test]
+    fn desktop_table_survives_a_provider_switch() {
+        let live = r#"model_provider = "old_vendor"
+
+[desktop]
+followUpQueueMode = "queue"
+mac-menu-bar-enabled = false
+"#;
+        let incoming = r#"model_provider = "new_vendor"
+model = "gpt-5"
+"#;
+
+        let merged = merge_codex_desktop_table(live, incoming);
+        let parsed: toml::Value = toml::from_str(&merged).expect("merged config parses");
+        let desktop = parsed.get("desktop").expect("desktop table carried over");
+
+        assert_eq!(
+            desktop
+                .get("mac-menu-bar-enabled")
+                .and_then(|v| v.as_bool()),
+            Some(false)
+        );
+        assert_eq!(
+            desktop.get("followUpQueueMode").and_then(|v| v.as_str()),
+            Some("queue")
+        );
+        assert_eq!(
+            parsed.get("model_provider").and_then(|v| v.as_str()),
+            Some("new_vendor"),
+            "provider fields must not be affected"
+        );
+    }
+
+    #[test]
+    fn desktop_table_does_not_override_the_incoming_config() {
+        let live = r#"[desktop]
+mac-menu-bar-enabled = false
+followUpQueueMode = "queue"
+"#;
+        let incoming = r#"[desktop]
+mac-menu-bar-enabled = true
+"#;
+
+        let merged = merge_codex_desktop_table(live, incoming);
+        let parsed: toml::Value = toml::from_str(&merged).expect("merged config parses");
+        let desktop = parsed.get("desktop").expect("desktop table");
+
+        assert_eq!(
+            desktop
+                .get("mac-menu-bar-enabled")
+                .and_then(|v| v.as_bool()),
+            Some(true),
+            "a value the provider config sets itself wins"
+        );
+        assert_eq!(
+            desktop.get("followUpQueueMode").and_then(|v| v.as_str()),
+            Some("queue"),
+            "keys it does not mention are still carried over"
+        );
+    }
+
+    #[test]
+    fn desktop_merge_is_a_noop_without_anything_to_carry() {
+        let incoming = "model_provider = \"vendor\"\n";
+
+        for live in [
+            "model_provider = \"old\"\n",
+            "[desktop]\n",
+            "this is not = = toml",
+        ] {
+            assert_eq!(
+                merge_codex_desktop_table(live, incoming),
+                incoming,
+                "live config {live:?} should leave the incoming config untouched"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -1053,6 +1053,16 @@ fn restore_live_settings_for_provider_backfill(
         );
     }
 
+    // `[desktop]` 是 Codex Desktop 自己的界面状态，live 才是唯一来源；回填时
+    // 剥掉，否则切走那一刻的快照会变成供应商「自己的值」，切回来时压过用户
+    // 期间在桌面端改的设置（#6400）。
+    if let Err(err) = crate::codex_config::strip_codex_desktop_from_settings(&mut settings) {
+        log::warn!(
+            "Failed to strip [desktop] while backfilling '{}': {err}",
+            provider.id
+        );
+    }
+
     // 统一会话开关注入的共享 `custom` 路由只属于 live 配置；切换回填时
     // 必须剥掉，否则官方供应商的存储配置被污染，关闭开关后无法还原。
     if provider.category.as_deref() == Some("official") {
@@ -3077,6 +3087,42 @@ base_url = "https://a.example/v1"
         assert!(
             config_text.contains("model = \"gpt-5.5\""),
             "non-MCP content must survive the strip"
+        );
+    }
+
+    #[test]
+    fn codex_switch_backfill_strips_the_desktop_table() {
+        // [desktop] 是 Codex Desktop 自己的界面状态，live 是唯一来源。回填留下
+        // 快照，切回来时它会以「供应商自己的值」的身份压过用户期间改的设置。
+        let provider = Provider::with_id(
+            "prov".to_string(),
+            "Prov".to_string(),
+            json!({
+                "auth": { "OPENAI_API_KEY": "sk-test" },
+                "config": "model = \"gpt-5.5\"\n"
+            }),
+            None,
+        );
+
+        let live_settings = json!({
+            "auth": { "OPENAI_API_KEY": "sk-test" },
+            "config": "model = \"gpt-5.5\"\n\n[desktop]\nmac-menu-bar-enabled = false\n"
+        });
+
+        let result =
+            restore_live_settings_for_provider_backfill(&AppType::Codex, &provider, live_settings);
+
+        let config_text = result
+            .get("config")
+            .and_then(|v| v.as_str())
+            .expect("config text");
+        assert!(
+            !config_text.contains("desktop"),
+            "backfill must strip [desktop] from the stored provider config, got: {config_text}"
+        );
+        assert!(
+            config_text.contains("model = \"gpt-5.5\""),
+            "non-desktop content must survive the strip"
         );
     }
 


### PR DESCRIPTION
Refs #6400.

## What happens

`[desktop]` in `~/.codex/config.toml` is written by the Codex/ChatGPT desktop app and holds its own UI state — `mac-menu-bar-enabled`, `followUpQueueMode`, `conversationDetailMode`. None of it describes the selected provider.

Switching providers rewrites the live config from the stored provider TOML, so the whole table disappears:

```diff
 [desktop]
 followUpQueueMode = "queue"
-mac-menu-bar-enabled = false
 conversationDetailMode = "STEPS_COMMANDS"
```

The desktop bundle defaults `mac-menu-bar-enabled` to `true`, so dropping the key is observably the same as switching "Show in menu bar" back on. The user gets no indication that a provider switch did it.

## Why

`write_live_snapshot` → `write_codex_provider_live_with_catalog` → `write_codex_live_for_provider` builds the live file from the provider's stored `config` text. `prepare_codex_provider_live_config` only injects the bearer token on top of that text — nothing reads the file being replaced, so anything present only in the live config is lost. Grepping `src-tauri` for a `desktop` TOML table turns up nothing, so this is not a case of the table being handled somewhere else.

The stored Common Config snippet does carry the key, but it is only overlaid for providers whose `meta.commonConfigEnabled` resolves to true, which is why the issue shows up when switching to or from a third-party provider that has it off.

## Change

`write_codex_live_for_provider` now merges the live `[desktop]` table into the config it is about to write.

- Keys the provider config sets itself win. Only keys it does not mention are copied, so an intentional provider-side value is never overridden.
- If the live file has no `[desktop]` table, or nothing is left to carry, the incoming text is returned unchanged — no reformatting of configs this does not need to touch.
- A live file that fails to parse is left alone rather than failing the switch.

The merge lives in a pure function, `merge_codex_desktop_table(live_text, config_text)`, with a thin I/O wrapper that reads the live path.

## Scope

`write_codex_live_for_provider` has exactly one caller, `write_codex_provider_live_with_catalog`, which is the provider-switch path. The identically named method in `services/proxy.rs` is a different function on the proxy service; proxy takeover writes through its own path and is untouched.

## Tests

Three tests on the merge itself:

- `desktop_table_survives_a_provider_switch` — keys carried over, provider fields unaffected
- `desktop_table_does_not_override_the_incoming_config` — provider-set value wins, unmentioned key still carried
- `desktop_merge_is_a_noop_without_anything_to_carry` — live config with no `[desktop]`, with an empty one, and one that is not valid TOML

`cargo test --lib`: 2477 passed, 2 failed. Both failures are `codex_config::tests::resolve_catalog_rejects_symlink_escaping_config_dir` and `services::session_usage_grokbuild::tests::symlink_cycle_does_not_cause_stack_overflow`, which panic with `Os { code: 1314, "A required privilege is not held by the client." }` — Windows refuses symlink creation without elevation. They fail identically on the base commit with this branch stashed. `cargo fmt --check` and `cargo clippy --lib --all-features -- -D warnings` are clean.

One thing I deliberately did not add: an end-to-end test through `write_codex_live_for_provider`. It would have to set `CC_SWITCH_TEST_HOME` process-wide, and `codex_config`'s test module has no `serial_test` harness, so it risked making a 2400-test suite flaky for one wiring assertion. The wiring is a single call at the top of that function. If you would rather have it covered, I am happy to add it with `#[serial]`.