### PR TITLE
fix(zhipu): read the quota response when it has no data envelope

### DIFF
--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -252,13 +252,25 @@ fn classify_zhipu_window(item: &serde_json::Value) -> Option<ZhipuWindow> {
 ///
 /// 老套餐（2026-02-12 前订阅）只回 1 条
 /// `TOKENS_LIMIT`，自然降级为仅展示 `five_hour`；新套餐回 2 条。
+/// 定位配额条目数组。
+///
+/// 该端点的外层结构不止一种：历史上是 `{ "data": { "limits": [...] } }`，
+/// 线上也出现过直接返回顶层数组、完全没有外层包裹的情况（issue #6402）。
+/// 与其钉死一种形状，不如按已知的几种位置依次查找。
+fn zhipu_limit_entries(value: &serde_json::Value) -> Option<&Vec<serde_json::Value>> {
+    if let Some(entries) = value.as_array() {
+        return Some(entries);
+    }
+    value.get("limits").and_then(|v| v.as_array())
+}
+
 fn parse_zhipu_token_tiers(data: &serde_json::Value) -> Vec<QuotaTier> {
     type Entry = (Option<i64>, f64, Option<String>);
     let mut five_hour: Option<Entry> = None;
     let mut weekly: Option<Entry> = None;
     let mut unclassified: Vec<Entry> = Vec::new();
 
-    if let Some(limits) = data.get("limits").and_then(|v| v.as_array()) {
+    if let Some(limits) = zhipu_limit_entries(data) {
         for limit_item in limits {
             let limit_type = limit_item
                 .get("type")
@@ -395,6 +407,9 @@ fn zhipu_quota_from_body(body: &serde_json::Value) -> SubscriptionQuota {
 
     let data = match body.get("data") {
         Some(d) => d,
+        // 没有 `data` 外层时，配额数组可能就在顶层（issue #6402）。
+        // 只有连条目都找不到才算响应异常。
+        None if zhipu_limit_entries(body).is_some() => body,
         None => return make_error("Missing 'data' field in response".to_string()),
     };
 
@@ -1474,10 +1489,54 @@ mod tests {
         detect_provider, parse_afp_tiers, parse_coding_plan_tiers, parse_minimax_tiers,
         parse_opencode_go_tiers, parse_zhipu_token_tiers, query_zhipu_team_at,
         volcengine_canonical_query, volcengine_is_auth_error_code, volcengine_region,
-        volcengine_response_error, volcengine_sign, zhipu_quota_base, CodingPlanProvider,
-        TIER_FIVE_HOUR, TIER_MONTHLY, TIER_WEEKLY_LIMIT,
+        volcengine_response_error, volcengine_sign, zhipu_quota_base, zhipu_quota_from_body,
+        CodingPlanProvider, TIER_FIVE_HOUR, TIER_MONTHLY, TIER_WEEKLY_LIMIT,
     };
     use serde_json::json;
+
+    // #6402: 线上返回的是顶层数组，没有 `data` / `limits` 外层。
+    // 数值取自 issue 里 dump 的真实响应。
+    #[test]
+    fn zhipu_quota_reads_a_top_level_limit_array() {
+        let body = json!([
+            { "type": "CREDIT_LIMIT", "unit": 3, "percentage": 9.0,
+              "nextResetTime": 1_786_592_963_348_i64 },
+            { "type": "CREDIT_LIMIT", "unit": 6, "percentage": 41.0,
+              "nextResetTime": 1_786_692_650_981_i64 },
+        ]);
+
+        let quota = zhipu_quota_from_body(&body);
+
+        assert!(quota.error.is_none(), "quota: {quota:?}");
+        assert_eq!(quota.tiers.len(), 2, "quota: {quota:?}");
+        assert_eq!(quota.tiers[0].name, TIER_FIVE_HOUR);
+        assert_eq!(quota.tiers[0].utilization, 9.0);
+        assert_eq!(quota.tiers[1].name, TIER_WEEKLY_LIMIT);
+        assert_eq!(quota.tiers[1].utilization, 41.0);
+    }
+
+    #[test]
+    fn zhipu_quota_reads_limits_without_a_data_envelope() {
+        let body = json!({
+            "limits": [
+                { "type": "CREDIT_LIMIT", "unit": 3, "percentage": 12.0 },
+            ]
+        });
+
+        let quota = zhipu_quota_from_body(&body);
+
+        assert!(quota.error.is_none(), "quota: {quota:?}");
+        assert_eq!(quota.tiers.len(), 1);
+        assert_eq!(quota.tiers[0].name, TIER_FIVE_HOUR);
+        assert_eq!(quota.tiers[0].utilization, 12.0);
+    }
+
+    #[test]
+    fn zhipu_quota_still_reports_a_body_with_no_limits_anywhere() {
+        let quota = zhipu_quota_from_body(&json!({ "unexpected": true }));
+        assert!(!quota.success);
+        assert!(quota.error.is_some());
+    }
 
     #[test]
     fn opencode_go_detects_both_base_variants_but_not_zen() {

--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -244,13 +244,25 @@ fn classify_zhipu_window(item: &serde_json::Value) -> Option<ZhipuWindow> {
 ///
 /// 老套餐（2026-02-12 前订阅）只回 1 条
 /// `TOKENS_LIMIT`，自然降级为仅展示 `five_hour`；新套餐回 2 条。
+/// 定位配额条目数组。
+///
+/// 该端点的外层结构不止一种：历史上是 `{ "data": { "limits": [...] } }`，
+/// 线上也出现过直接返回顶层数组、完全没有外层包裹的情况（issue #6402）。
+/// 与其钉死一种形状，不如按已知的几种位置依次查找。
+fn zhipu_limit_entries(value: &serde_json::Value) -> Option<&Vec<serde_json::Value>> {
+    if let Some(entries) = value.as_array() {
+        return Some(entries);
+    }
+    value.get("limits").and_then(|v| v.as_array())
+}
+
 fn parse_zhipu_token_tiers(data: &serde_json::Value) -> Vec<QuotaTier> {
     type Entry = (Option<i64>, f64, Option<String>);
     let mut five_hour: Option<Entry> = None;
     let mut weekly: Option<Entry> = None;
     let mut unclassified: Vec<Entry> = Vec::new();
 
-    if let Some(limits) = data.get("limits").and_then(|v| v.as_array()) {
+    if let Some(limits) = zhipu_limit_entries(data) {
         for limit_item in limits {
             let limit_type = limit_item
                 .get("type")
@@ -387,6 +399,9 @@ fn zhipu_quota_from_body(body: &serde_json::Value) -> SubscriptionQuota {
 
     let data = match body.get("data") {
         Some(d) => d,
+        // 没有 `data` 外层时，配额数组可能就在顶层（issue #6402）。
+        // 只有连条目都找不到才算响应异常。
+        None if zhipu_limit_entries(body).is_some() => body,
         None => return make_error("Missing 'data' field in response".to_string()),
     };
 
@@ -1345,9 +1360,53 @@ mod tests {
         parse_afp_tiers, parse_coding_plan_tiers, parse_minimax_tiers, parse_zhipu_token_tiers,
         query_zhipu_team_at, volcengine_canonical_query, volcengine_is_auth_error_code,
         volcengine_region, volcengine_response_error, volcengine_sign, zhipu_quota_base,
-        TIER_FIVE_HOUR, TIER_MONTHLY, TIER_WEEKLY_LIMIT,
+        zhipu_quota_from_body, TIER_FIVE_HOUR, TIER_MONTHLY, TIER_WEEKLY_LIMIT,
     };
     use serde_json::json;
+
+    // #6402: 线上返回的是顶层数组，没有 `data` / `limits` 外层。
+    // 数值取自 issue 里 dump 的真实响应。
+    #[test]
+    fn zhipu_quota_reads_a_top_level_limit_array() {
+        let body = json!([
+            { "type": "CREDIT_LIMIT", "unit": 3, "percentage": 9.0,
+              "nextResetTime": 1_786_592_963_348_i64 },
+            { "type": "CREDIT_LIMIT", "unit": 6, "percentage": 41.0,
+              "nextResetTime": 1_786_692_650_981_i64 },
+        ]);
+
+        let quota = zhipu_quota_from_body(&body);
+
+        assert!(quota.error.is_none(), "quota: {quota:?}");
+        assert_eq!(quota.tiers.len(), 2, "quota: {quota:?}");
+        assert_eq!(quota.tiers[0].name, TIER_FIVE_HOUR);
+        assert_eq!(quota.tiers[0].utilization, 9.0);
+        assert_eq!(quota.tiers[1].name, TIER_WEEKLY_LIMIT);
+        assert_eq!(quota.tiers[1].utilization, 41.0);
+    }
+
+    #[test]
+    fn zhipu_quota_reads_limits_without_a_data_envelope() {
+        let body = json!({
+            "limits": [
+                { "type": "CREDIT_LIMIT", "unit": 3, "percentage": 12.0 },
+            ]
+        });
+
+        let quota = zhipu_quota_from_body(&body);
+
+        assert!(quota.error.is_none(), "quota: {quota:?}");
+        assert_eq!(quota.tiers.len(), 1);
+        assert_eq!(quota.tiers[0].name, TIER_FIVE_HOUR);
+        assert_eq!(quota.tiers[0].utilization, 12.0);
+    }
+
+    #[test]
+    fn zhipu_quota_still_reports_a_body_with_no_limits_anywhere() {
+        let quota = zhipu_quota_from_body(&json!({ "unexpected": true }));
+        assert!(!quota.success);
+        assert!(quota.error.is_some());
+    }
 
     #[test]
     fn zhipu_new_plan_two_tiers_sorted_by_reset_time() {


### PR DESCRIPTION
Refs #6402.

## What happens

The GLM Coding Plan card renders no tiers at all for some accounts, while the request itself succeeds — pointing a custom extractor script at the same endpoint shows the quota fine. So the transport is healthy; the built-in parser is what drops the data.

## Why

`zhipu_quota_from_body` requires `body.data`:

```rust
let data = match body.get("data") {
    Some(d) => d,
    None => return make_error("Missing 'data' field in response".to_string()),
};
```

and `parse_zhipu_token_tiers` then requires `data.limits`.

`GET /api/monitor/usage/quota/limit` has also been observed returning the limit list as a bare top-level array, with no envelope at all. From the dump in the issue:

```json
[
  {"type":"CREDIT_LIMIT","unit":3,"number":5,"usage":28000,"currentValue":2585,"remaining":25414,"percentage":9,"nextResetTime":1786592963348},
  {"type":"CREDIT_LIMIT","unit":6,"number":1,"usage":140000,"currentValue":58386,"remaining":81613,"percentage":41,"nextResetTime":1786692650981}
]
```

Against that body `body.get("data")` is `None`, so the parser returns `Missing 'data' field in response` before it ever looks at the entries.

## Scope note

The issue titles the `CREDIT_LIMIT` type filter, but that half is **already fixed** on `main` — the filter accepts `CREDIT_LIMIT` alongside `TOKENS_LIMIT`, case-insensitively. The part that still reproduces is the envelope, which the reporter flagged separately at the end of the report. This PR covers only that, hence `Refs` rather than `Fixes`.

## Change

Find the limit array where it actually is, rather than pinning one envelope shape — the bare array, or a `limits` array on whatever object we were handed. `unit`-based window classification and every other behaviour is untouched.

A body with no limits anywhere still returns an error, so a genuinely broken response is not silently converted into an empty-but-successful quota.

## Tests

Three added:

- `zhipu_quota_reads_a_top_level_limit_array` — the reporter's real response verbatim, asserting both tiers and their percentages
- `zhipu_quota_reads_limits_without_a_data_envelope` — `{ "limits": [...] }` with no `data`
- `zhipu_quota_still_reports_a_body_with_no_limits_anywhere` — an unrecognised body must still surface an error

Reverting the two source hunks and leaving the tests in place fails both new envelope tests with `error: Some("Missing 'data' field in response")` — the exact symptom from the report.

All 20 pre-existing `zhipu*` tests still pass unchanged.

`cargo test --lib`: 2480 passed, 2 failed. Both failures are `codex_config::tests::resolve_catalog_rejects_symlink_escaping_config_dir` and `services::session_usage_grokbuild::tests::symlink_cycle_does_not_cause_stack_overflow`, which panic with `Os { code: 1314, "A required privilege is not held by the client." }` — Windows refuses symlink creation without elevation, and they fail identically on the base commit. `cargo fmt --check` and `cargo clippy --lib --all-features -- -D warnings` are clean.