### PR TITLE
fix(proxy): fall back to buffered deltas when Read tool done event carries empty arguments

### DIFF
--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -879,6 +879,7 @@ pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 
                                             .get("arguments")
                                             .or_else(|| data.pointer("/item/arguments"))
                                             .and_then(|v| v.as_str())
+                                            .filter(|value| !value.is_empty())
                                             .map(str::to_string)
                                             .unwrap_or_else(|| {
                                                 tool_args_by_index
@@ -1799,6 +1800,35 @@ mod tests {
         assert!(merged.contains("\"name\":\"Read\""));
         assert!(merged.contains("\"partial_json\":\"{\\\"file_path\\\":\\\"/tmp/demo.py\\\",\\\"limit\\\":2000,\\\"offset\\\":0}"));
         assert!(!merged.contains("\\\"pages\\\":\\\"\\\""));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_read_tool_empty_arguments_on_done_falls_back_to_buffered_deltas() {
+        // 某些网关（如新版 claude-code-router 容器）在 function_call_arguments.done 事件里
+        // 返回空字符串 arguments，完整参数只出现在后续 output_item.done 中。
+        // Read 的分片被缓冲等待 done 归并，此时必须回退到已缓冲分片，否则 tool_use 参数丢失。
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_read\",\"model\":\"gpt-5.5\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_read\",\"type\":\"function_call\",\"call_id\":\"call_read\",\"name\":\"Read\"}}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_read\",\"delta\":\"{\\\"file_path\\\":\"}\n\n",
+            "event: response.function_call_arguments.delta\n",
+            "data: {\"type\":\"response.function_call_arguments.delta\",\"item_id\":\"fc_read\",\"delta\":\"\\\"/tmp/demo.py\\\"}\"}\n\n",
+            "event: response.function_call_arguments.done\n",
+            "data: {\"type\":\"response.function_call_arguments.done\",\"item_id\":\"fc_read\",\"arguments\":\"\"}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_read\",\"type\":\"function_call\",\"call_id\":\"call_read\",\"name\":\"Read\",\"arguments\":\"{\\\"file_path\\\":\\\"/tmp/demo.py\\\"}\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+
+        let merged = convert_stream_text(input).await;
+
+        assert!(merged.contains("\"name\":\"Read\""));
+        assert!(merged.contains("\"partial_json\":\"{\\\"file_path\\\":\\\"/tmp/demo.py\\\"}\""));
+        assert!(merged.contains("event: content_block_stop"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary / 概述

The streaming Responses bridge buffers `function_call_arguments.delta` chunks for tools named `Read` (for `pages` sanitization) and emits them at the `done` event. Some OpenAI-Responses-compatible gateways (e.g. recent claude-code-router builds) send `response.function_call_arguments.done` with an **empty-string** `arguments` field while the complete arguments only exist in the deltas and the later `output_item.done` item.

The `done` handler only fell back to the buffered chunks when the `arguments` field was **missing** — not when present-but-empty. Result: every `Read` tool_use reached the Anthropic client with empty `input`, permanently breaking the tool on that route (tools with other names stream through unaffected).

Fix: treat empty-string `arguments` on the done event as absent (one-line `.filter`), mirroring the existing `output_item.done` handler which already filters empty strings. Added a regression test reproducing the exact event sequence captured from such a gateway.

## Related Issue / 关联 Issue

Related (same bridge, different symptom): #6473

## Steps to verify / 验证方式

Captured from a live claude-code-router container (podman, `/v1/responses`, GLM-5.3):

| Probe | Result before | Result after |
|---|---|---|
| CC Switch 15721 → openai_responses → CCR, `Read` tool call | tool_use `input: {}` | parameters intact |
| Same route, other tool names | unaffected | unaffected |
| `apiFormat=anthropic` pass-through | working | working |

```bash
cd src-tauri && cargo test --lib streaming_responses
# 22 passed; 0 failed (includes new regression test)
```

## Screenshots / 截图

N/A (protocol-level fix, covered by unit test)

## Checklist / 检查清单

- [x] `cargo clippy --lib -- -D warnings` passes / 通过 Clippy 检查
- [x] Rust unit tests pass (`cargo test --lib streaming_responses` — 22/22) / 单测通过
- [ ] `pnpm typecheck` / `pnpm format:check` — no TS/frontend change / 未改动前端代码