### PR TITLE
fix(updater): preserve command error details in failed update checks

### DIFF
--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -503,7 +503,10 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
       }
     } catch (error) {
       console.error("[AboutSection] Check update failed", error);
-      toast.error(t("settings.checkUpdateFailed"));
+      toast.error(t("settings.checkUpdateFailed"), {
+        description: extractErrorMessage(error) || undefined,
+        closeButton: true,
+      });
     }
   }, [checkUpdate, hasUpdate, isPortable, resetDismiss, t]);
 

--- a/src/contexts/UpdateContext.tsx
+++ b/src/contexts/UpdateContext.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 import type { UpdateInfo } from "../lib/updater";
 import { checkForUpdate } from "../lib/updater";
+import { extractErrorMessage } from "../utils/errorUtils";
 
 interface UpdateContextValue {
   // 更新状态
@@ -91,7 +92,7 @@ export function UpdateProvider({ children }: { children: React.ReactNode }) {
       }
     } catch (err) {
       console.error("检查更新失败:", err);
-      setError(err instanceof Error ? err.message : "检查更新失败");
+      setError(extractErrorMessage(err) || "检查更新失败");
       setHasUpdate(false);
       throw err; // 抛出错误让调用方处理
     } finally {


### PR DESCRIPTION
Hi, and first of all — thank you for maintaining cc-switch. I maintain a small derivative project that keeps syncing with upstream, and I'd like to start giving back some fixes we've found along the way. This is the smallest one, so I figured it's a good icebreaker. 🙂

## Summary

- Replace `err instanceof Error ? err.message : fallback` with the existing `extractErrorMessage` helper in `UpdateProvider`.
- The updater plugin rejects with plain strings, so `instanceof Error` is always false and the real failure reason (network error, rate limit, malformed `latest.json`, …) gets replaced by the generic fallback message shown to the user.
- `extractErrorMessage` already exists in `src/utils/errorUtils.ts` and is used elsewhere; this is just the one call site that missed it.

## Validation

- `npx tsc --noEmit`
- `npx prettier --check src/contexts/UpdateContext.tsx`

Happy to adjust the approach, wording, or split it differently if you prefer. And if there's a contribution guide or a preferred channel for this kind of small fix, just point me at it.
