### PR TITLE
fix(usage): key trend chart x-axis on raw dates across year boundaries

### DIFF
--- a/src/components/usage/UsageTrendChart.tsx
+++ b/src/components/usage/UsageTrendChart.tsx
@@ -59,24 +59,30 @@ export function UsageTrendChart({
   const isHourly = durationSeconds <= 24 * 60 * 60;
   const language = i18n.resolvedLanguage || i18n.language || "en";
   const dateLocale = getLocaleFromLanguage(language);
+
+  // X 轴必须用原始日期做 key：跨年区间里不同年份的相同 MM/DD 会生成重复
+  // label，recharts 按类别匹配时 tooltip 和高亮点会命中前一年的数据点。
+  // 显示用的 label 由 formatTrendLabel 统一格式化。
+  const formatTrendLabel = (rawDate: string) => {
+    const pointDate = new Date(rawDate);
+    return isHourly
+      ? pointDate.toLocaleString(dateLocale, {
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+        })
+      : pointDate.toLocaleDateString(dateLocale, {
+          month: "2-digit",
+          day: "2-digit",
+        });
+  };
+
   const chartData =
     trends?.map((stat) => {
-      const pointDate = new Date(stat.date);
       const cost = parseFiniteNumber(stat.totalCost);
       return {
         rawDate: stat.date,
-        label: isHourly
-          ? pointDate.toLocaleString(dateLocale, {
-              month: "2-digit",
-              day: "2-digit",
-              hour: "2-digit",
-              minute: "2-digit",
-            })
-          : pointDate.toLocaleDateString(dateLocale, {
-              month: "2-digit",
-              day: "2-digit",
-            }),
-        hour: pointDate.getHours(),
         inputTokens: stat.totalInputTokens,
         outputTokens: stat.totalOutputTokens,
         cacheCreationTokens: stat.totalCacheCreationTokens,
@@ -91,7 +97,7 @@ export function UsageTrendChart({
     if (active && payload && payload.length) {
       return (
         <div className="rounded-lg border bg-background/95 p-3 shadow-lg backdrop-blur-md">
-          <p className="mb-2 font-medium">{label}</p>
+          <p className="mb-2 font-medium">{formatTrendLabel(String(label))}</p>
           {payload.map((entry: any, index: number) => (
             <div
               key={index}
@@ -162,10 +168,11 @@ export function UsageTrendChart({
               opacity={0.4}
             />
             <XAxis
-              dataKey="label"
+              dataKey="rawDate"
               axisLine={false}
               tickLine={false}
               tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
+              tickFormatter={(value: string) => formatTrendLabel(value)}
               dy={10}
             />
             <YAxis


### PR DESCRIPTION
Hi — second of the two small fixes I mentioned in #6482. This one addresses #6302.

## Summary / 概述

Fixes #6302

The usage trend chart keyed its x-axis on the **formatted** `MM/DD` label. When a custom range spans more than a year, two different buckets can produce the same label string; recharts then collapses them into a single category position (default `allowDuplicatedCategory` behavior), so hovering a later-year point highlights the dots near the same month/day in the earlier year.

- key the x-axis on `rawDate` — the backend bucket value (`YYYY-MM-DD` for daily buckets, RFC 3339 for hourly), which is unique per point
- move label formatting into a single `formatTrendLabel` helper used by both axis ticks and the tooltip header, so the cursor line, tooltip, and active dots always resolve to the same data point
- displayed formats are unchanged for single-year ranges; hourly ranges are unaffected since each `MM/DD HH:mm` label appears at most once in a ≤24h window

## Screenshots / 截图

Not applicable — behavior-only fix; single-year ranges render exactly as before. Happy to record a multi-year before/after if useful.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `pnpm test:unit` — one note: `tests/components/PiProviderForm.test.tsx` flakes intermittently on my machine under parallel load regardless of this change (passes 46/46 in isolation; this PR doesn't touch anything it imports). Everything else passes.
- [x] No user-facing text changed, no i18n updates needed

Happy to adjust the approach or wording if you'd like this done differently.
