### PR TITLE
fix(deeplink): support Claude Desktop provider imports

### DIFF
--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -81,7 +81,14 @@ fn parse_provider_deeplink(
     // Validate app type
     if !matches!(
         app.as_str(),
-        "claude" | "codex" | "gemini" | "grokbuild" | "opencode" | "openclaw" | "hermes"
+        "claude"
+            | "claude-desktop"
+            | "codex"
+            | "gemini"
+            | "grokbuild"
+            | "opencode"
+            | "openclaw"
+            | "hermes"
     ) {
         return Err(AppError::InvalidInput(format!(
             "Invalid provider app type: '{app}'"

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -646,7 +646,7 @@ pub fn parse_and_merge_config(
     }
 
     match request.app.as_deref().unwrap_or("") {
-        "claude" => merge_claude_config(&mut merged, &config_value)?,
+        "claude" | "claude-desktop" => merge_claude_config(&mut merged, &config_value)?,
         "codex" => merge_codex_config(&mut merged, &config_value)?,
         "gemini" => merge_gemini_config(&mut merged, &config_value)?,
         "grokbuild" => merge_grokbuild_config(&mut merged, &config_value)?,

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -79,6 +79,21 @@ fn test_parse_valid_claude_deeplink() {
 }
 
 #[test]
+fn test_parse_valid_claude_desktop_deeplink() {
+    let url = "ccswitch://v1/import?resource=provider&app=claude-desktop&name=Claude%20Desktop&homepage=https%3A%2F%2Fexample.com&endpoint=https%3A%2F%2Fapi.example.com&apiKey=test-api-key&model=claude-fable-5&haikuModel=claude-haiku-4&sonnetModel=claude-sonnet-5&opusModel=claude-opus-4-8&enabled=true";
+
+    let request = parse_deeplink_url(url).unwrap();
+
+    assert_eq!(request.app.as_deref(), Some("claude-desktop"));
+    assert_eq!(request.name.as_deref(), Some("Claude Desktop"));
+    assert_eq!(request.model.as_deref(), Some("claude-fable-5"));
+    assert_eq!(request.haiku_model.as_deref(), Some("claude-haiku-4"));
+    assert_eq!(request.sonnet_model.as_deref(), Some("claude-sonnet-5"));
+    assert_eq!(request.opus_model.as_deref(), Some("claude-opus-4-8"));
+    assert_eq!(request.enabled, Some(true));
+}
+
+#[test]
 fn test_parse_deeplink_with_notes() {
     let url = "ccswitch://v1/import?resource=provider&app=codex&name=Codex&homepage=https%3A%2F%2Fcodex.com&endpoint=https%3A%2F%2Fapi.codex.com&apiKey=key123&notes=Test%20notes";
 
@@ -577,6 +592,30 @@ fn test_parse_and_merge_config_claude() {
     );
     assert_eq!(merged.homepage, Some("https://anthropic.com".to_string()));
     assert_eq!(merged.model, Some("claude-sonnet-4.5".to_string()));
+}
+
+#[test]
+fn test_parse_and_merge_config_claude_desktop() {
+    let config_json = r#"{"env":{"ANTHROPIC_AUTH_TOKEN":"sk-ant-xxx","ANTHROPIC_BASE_URL":"https://api.anthropic.com/v1","ANTHROPIC_MODEL":"claude-sonnet-4.5"}}"#;
+    let request = DeepLinkImportRequest {
+        version: "v1".to_string(),
+        resource: "provider".to_string(),
+        app: Some("claude-desktop".to_string()),
+        name: Some("Claude Desktop".to_string()),
+        config: Some(BASE64_STANDARD.encode(config_json.as_bytes())),
+        config_format: Some("json".to_string()),
+        ..Default::default()
+    };
+
+    let merged = parse_and_merge_config(&request).unwrap();
+
+    assert_eq!(merged.app.as_deref(), Some("claude-desktop"));
+    assert_eq!(merged.api_key.as_deref(), Some("sk-ant-xxx"));
+    assert_eq!(
+        merged.endpoint.as_deref(),
+        Some("https://api.anthropic.com/v1")
+    );
+    assert_eq!(merged.model.as_deref(), Some("claude-sonnet-4.5"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary / 概述

Support provider deep links targeting `claude-desktop` on current `main`.

- Accept `claude-desktop` in the provider deep-link parser.
- Reuse Claude config merging for embedded Claude Desktop configurations.
- Add regression tests for URL parsing, model fields, enabled state, and embedded config merging.

This rebases and extends #6369, which is currently conflicting and does not cover the embedded `config=` merge path.

## Related Issue / 关联 Issue

Fixes #6368

## Screenshots / 截图

Not applicable; this changes backend parsing and config merging only.

## Verification / 验证

- `pnpm typecheck`
- Locked Prettier check equivalent to `pnpm format:check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test test_parse_valid_claude_desktop_deeplink --lib --quiet`
- `cargo test test_parse_and_merge_config_claude_desktop --lib --quiet`
- Tauri debug `.app` and `.dmg` build on macOS

A broader local `claude_desktop` test filter passed 44 tests; one unrelated proxy test could not bind because the installed CC Switch app was already using the proxy port. Repository CI can run the full isolated test matrix.

## Checklist / 检查清单

- [x] TypeScript type checking passes
- [x] Formatting checks pass
- [x] Clippy passes
- [x] No i18n update is required because no user-facing text changed