### PR TITLE
ci: retain release transfer artifacts for one day

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -557,6 +557,7 @@ jobs:
           name: release-assets-${{ runner.os }}-${{ matrix.arch || runner.arch }}
           path: release-assets/*
           if-no-files-found: error
+          retention-days: 1
 
       - name: List generated bundles (debug)
         if: always()


### PR DESCRIPTION
## Summary

Adds `retention-days: 1` only to the `release-assets-*` `actions/upload-artifact@v7` transfer step in the release workflow.

This controls the temporary GitHub Actions transfer artifact lifetime. It does not change GitHub Release assets, cache retention, download steps, or publishing behavior.

## Validation

- `git diff --check`
- Manual diff review: one file and one added YAML key only.
- `pnpm.cmd exec prettier --check .github/workflows/release.yml` was also evaluated with the repository's Prettier version. It reports a pre-existing formatting failure for the unchanged upstream workflow; the same baseline file at `40cac1a6` fails the identical check, so this PR intentionally does not reformat unrelated YAML.
