### PR TITLE
fix(pi): make provider form inputs IME-safe

### DIFF
--- a/src/components/providers/forms/PiProviderForm.tsx
+++ b/src/components/providers/forms/PiProviderForm.tsx
@@ -19,7 +19,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+import { ImeSafeInput } from "@/components/ui/ime-safe-input";
 import { Label } from "@/components/ui/label";
 import {
   Popover,
@@ -167,6 +167,10 @@ function parseJsonObject(value: string): Record<string, unknown> | null {
 
 function optionalText(value: unknown): string {
   return typeof value === "string" ? value : "";
+}
+
+function normalizeProviderKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9-]/g, "");
 }
 
 function optionalNumberText(value: unknown): string {
@@ -1055,11 +1059,6 @@ export function PiProviderForm({
     [updateSettingsConfig],
   );
 
-  const handleProviderKeyChange = useCallback((value: string) => {
-    const normalized = value.toLowerCase().replace(/[^a-z0-9-]/g, "");
-    setProviderKey(normalized);
-  }, []);
-
   const submit = async (identity: ProviderFormData) => {
     onSubmittingChange?.(true);
     setFormError(null);
@@ -1361,12 +1360,11 @@ export function PiProviderForm({
                         *
                       </span>
                     </Label>
-                    <Input
+                    <ImeSafeInput
                       id="pi-provider-key"
                       value={providerKey}
-                      onChange={(event) =>
-                        handleProviderKeyChange(event.target.value)
-                      }
+                      onValueChange={setProviderKey}
+                      normalize={normalizeProviderKey}
                       disabled={isEdit}
                       placeholder="my-provider"
                       autoComplete="off"
@@ -1564,11 +1562,11 @@ export function PiProviderForm({
                             />
                           </Button>
                           <div className="flex min-w-0 flex-1 gap-1">
-                            <Input
+                            <ImeSafeInput
                               id={`pi-model-id-${model.key}`}
                               value={model.id}
-                              onChange={(event) =>
-                                changeModelId(model.key, event.target.value)
+                              onValueChange={(value) =>
+                                changeModelId(model.key, value)
                               }
                               placeholder="model-id"
                               aria-label={t("pi.form.modelId")}
@@ -1582,12 +1580,12 @@ export function PiProviderForm({
                               />
                             )}
                           </div>
-                          <Input
+                          <ImeSafeInput
                             id={`pi-model-name-${model.key}`}
                             value={model.name}
-                            onChange={(event) =>
+                            onValueChange={(value) =>
                               updateModelOverride(model.key, {
-                                name: event.target.value,
+                                name: value,
                                 hasName: true,
                               })
                             }
@@ -1665,7 +1663,7 @@ export function PiProviderForm({
                               }
                               htmlFor={`pi-model-context-window-${model.key}`}
                             >
-                              <Input
+                              <ImeSafeInput
                                 id={`pi-model-context-window-${model.key}`}
                                 aria-label={t("pi.form.contextWindow")}
                                 type="number"
@@ -1674,9 +1672,9 @@ export function PiProviderForm({
                                 inputMode="decimal"
                                 required={!isEdit || model.hasContextWindow}
                                 value={model.contextWindow}
-                                onChange={(event) =>
+                                onValueChange={(value) =>
                                   updateModelOverride(model.key, {
-                                    contextWindow: event.target.value,
+                                    contextWindow: value,
                                     hasContextWindow: true,
                                   })
                                 }
@@ -1697,7 +1695,7 @@ export function PiProviderForm({
                               }
                               htmlFor={`pi-model-max-tokens-${model.key}`}
                             >
-                              <Input
+                              <ImeSafeInput
                                 id={`pi-model-max-tokens-${model.key}`}
                                 aria-label={t("pi.form.maxTokens")}
                                 type="number"
@@ -1706,9 +1704,9 @@ export function PiProviderForm({
                                 inputMode="decimal"
                                 required={!isEdit || model.hasMaxTokens}
                                 value={model.maxTokens}
-                                onChange={(event) =>
+                                onValueChange={(value) =>
                                   updateModelOverride(model.key, {
-                                    maxTokens: event.target.value,
+                                    maxTokens: value,
                                     hasMaxTokens: true,
                                   })
                                 }
@@ -1897,20 +1895,19 @@ export function PiProviderForm({
                                                     "pi.form.thinkingLevelMapTo",
                                                   )}
                                                 </label>
-                                                <Input
+                                                <ImeSafeInput
                                                   value={
                                                     typeof mappedValue ===
                                                     "string"
                                                       ? mappedValue
                                                       : level
                                                   }
-                                                  onChange={(event) =>
+                                                  onValueChange={(value) =>
                                                     updateThinkingLevelMap(
                                                       model.key,
                                                       (map) => ({
                                                         ...map,
-                                                        [level]:
-                                                          event.target.value,
+                                                        [level]: value,
                                                       }),
                                                     )
                                                   }

--- a/tests/components/PiProviderForm.test.tsx
+++ b/tests/components/PiProviderForm.test.tsx
@@ -80,6 +80,83 @@ describe("PiProviderForm", () => {
     expect(screen.queryByText("pi.form.stepModel")).not.toBeInTheDocument();
   });
 
+  it("normalizes the provider key only after Chinese IME composition commits", () => {
+    render(
+      <PiProviderForm
+        appId="pi"
+        submitLabel="Save IME-safe provider key"
+        onSubmit={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "providerPreset.custom" }),
+    );
+    const providerKeyInput = screen.getByPlaceholderText("my-provider");
+
+    fireEvent.compositionStart(providerKeyInput);
+    fireEvent.change(providerKeyInput, {
+      target: { value: "Pi中文-1" },
+    });
+
+    expect(providerKeyInput).toHaveValue("Pi中文-1");
+
+    fireEvent.compositionEnd(providerKeyInput, {
+      data: "Pi中文-1",
+      target: { value: "Pi中文-1" },
+    });
+
+    expect(providerKeyInput).toHaveValue("pi-1");
+  });
+
+  it("keeps model name composition local until the Chinese IME commits", () => {
+    const initialData = {
+      name: "IME provider",
+      settingsConfig: {
+        name: "IME provider",
+        api: "openai-completions",
+        models: [completeModel("ime-model", "Original model")],
+      },
+    };
+    const renderForm = () => (
+      <PiProviderForm
+        appId="pi"
+        providerId="ime-provider"
+        submitLabel="Save IME-safe model"
+        onSubmit={() => {}}
+        onCancel={() => {}}
+        initialData={initialData}
+      />
+    );
+    const { rerender } = render(renderForm());
+
+    const modelNameInput = screen.getByLabelText("pi.form.modelName");
+    const configPreview = screen.getByLabelText(
+      "provider.configJson",
+    ) as HTMLTextAreaElement;
+
+    fireEvent.compositionStart(modelNameInput);
+    fireEvent.change(modelNameInput, {
+      target: { value: "中文模型" },
+    });
+
+    expect(modelNameInput).toHaveValue("中文模型");
+    expect(JSON.parse(configPreview.value).models[0].name).toBe(
+      "Original model",
+    );
+
+    rerender(renderForm());
+    expect(modelNameInput).toHaveValue("中文模型");
+
+    fireEvent.compositionEnd(modelNameInput, {
+      data: "中文模型",
+      target: { value: "中文模型" },
+    });
+
+    expect(JSON.parse(configPreview.value).models[0].name).toBe("中文模型");
+  });
+
   it("uses the OpenCode-style provider hierarchy without per-model endpoints", () => {
     render(
       <PiProviderForm


### PR DESCRIPTION
## Summary / 概述

- Replace the six raw Pi provider form inputs with the existing `ImeSafeInput` component.
- Preserve marked text during IME composition and defer provider-key normalization until composition commits.
- Add Chinese IME regression coverage for provider-key normalization and model-name/config synchronization.

## Related Issue / 关联 Issue

Follow-up to #6064.
Related to #1795.

## Screenshots / 截图

Not applicable. This is an input-behavior fix with no visual changes.

## Validation / 验证

- `vitest run tests/components/PiProviderForm.test.tsx tests/components/ImeSafeInput.test.tsx` (52 tests passed)
- `tsc --noEmit`
- Prettier check for all source files and the updated Pi form test
- `git diff --check`

## Checklist / 检查清单

- [x] TypeScript type check passes / 通过 TypeScript 类型检查
- [x] Format check passes / 通过代码格式检查
- [x] Rust code was not changed / 未修改 Rust 代码
- [x] No user-facing text was added / 未新增用户可见文本