### PR TITLE
fix(opencode): honor an existing opencode.jsonc instead of writing a second config

### DIFF
--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -150,8 +150,59 @@ fn read_opencode_config_from_path(path: &Path) -> Result<Value, AppError> {
     Ok(value)
 }
 
+/// 已存在的配置文件，按 OpenCode 的**合并顺序**返回（后者覆盖前者），
+/// 即 `OPENCODE_CONFIG_FILE_NAMES` 的倒序。
+fn existing_opencode_config_paths() -> Vec<PathBuf> {
+    let dir = get_opencode_dir();
+
+    OPENCODE_CONFIG_FILE_NAMES
+        .iter()
+        .rev()
+        .map(|name| dir.join(name))
+        .filter(|path| path.is_file())
+        .collect()
+}
+
+/// 对齐 OpenCode 的 `mergeConfig`（remeda `mergeDeep`）：对象逐键递归合并，
+/// 其余类型（含数组）由 source 整体替换。
+fn merge_config_into(target: &mut Value, source: Value) {
+    match source {
+        Value::Object(source_obj) if target.is_object() => {
+            let target_obj = target.as_object_mut().expect("checked by the guard");
+
+            for (key, value) in source_obj {
+                match target_obj.get_mut(&key) {
+                    Some(existing) if existing.is_object() && value.is_object() => {
+                        merge_config_into(existing, value);
+                    }
+                    _ => {
+                        target_obj.insert(key, value);
+                    }
+                }
+            }
+        }
+        other => *target = other,
+    }
+}
+
+/// 读取「有效配置」：OpenCode 会把全局目录下的 `config.json`、`opencode.json`、
+/// `opencode.jsonc` 全部读出来依次 `mergeDeep`，只看其中一个文件会漏掉另一个文件里
+/// 的供应商——例如旧版 CC Switch 把供应商写进了 `opencode.json`，而 OpenCode 自己
+/// 建了 `opencode.jsonc`。
 pub fn read_opencode_config() -> Result<Value, AppError> {
-    read_opencode_config_from_path(&get_opencode_config_path())
+    let paths = existing_opencode_config_paths();
+
+    let Some((first, rest)) = paths.split_first() else {
+        // 一个都不存在，保持与单文件读取相同的空配置。
+        return read_opencode_config_from_path(&get_opencode_config_path());
+    };
+
+    let mut merged = read_opencode_config_from_path(first)?;
+    for path in rest {
+        merge_config_into(&mut merged, read_opencode_config_from_path(path)?);
+    }
+
+    Ok(merged)
 }
 
 fn write_opencode_config_to_path_with_contents(
@@ -198,18 +249,47 @@ pub fn set_provider(id: &str, config: Value) -> Result<(), AppError> {
     write_opencode_config_to_path_with_contents(&path, &full_config).map(|_| ())
 }
 
-pub fn remove_provider(id: &str) -> Result<(), AppError> {
-    let _guard = opencode_config_lock().lock()?;
-    let path = get_opencode_config_path();
-    let mut config = read_opencode_config_from_path(&path)?;
+/// 从**每个**已存在的配置文件里删掉 `<section>.<id>`。
+///
+/// 只删最高优先级的那份是不够的：OpenCode 合并全部三个文件，低优先级文件里的同名
+/// 条目会在删除后重新生效，界面显示已删除而 OpenCode 仍在用它。
+///
+/// 只回写真正发生变化的文件——未命中的文件保持原样，避免整份重新序列化把用户的
+/// 注释和格式抹掉。
+fn remove_entry_from_all_configs(section: &str, id: &str) -> Result<(), AppError> {
+    let paths = existing_opencode_config_paths();
 
-    if let Some(providers) = config.get_mut("provider").and_then(|v| v.as_object_mut()) {
-        providers.remove(id);
-    } else if config.get("provider").is_some() {
-        log::warn!("opencode.json 的 provider 不是对象，无法删除供应商 '{id}'");
+    if paths.is_empty() {
+        // 与此前一致：没有任何配置文件时仍在目标路径落一份空配置。
+        let path = get_opencode_config_path();
+        let config = read_opencode_config_from_path(&path)?;
+        return write_opencode_config_to_path_with_contents(&path, &config).map(|_| ());
     }
 
-    write_opencode_config_to_path_with_contents(&path, &config).map(|_| ())
+    for path in paths {
+        let mut config = read_opencode_config_from_path(&path)?;
+
+        let removed = match config.get_mut(section).and_then(|v| v.as_object_mut()) {
+            Some(entries) => entries.remove(id).is_some(),
+            None => {
+                if config.get(section).is_some() {
+                    log::warn!("{} 的 {section} 不是对象，无法删除 '{id}'", path.display());
+                }
+                false
+            }
+        };
+
+        if removed {
+            write_opencode_config_to_path_with_contents(&path, &config)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn remove_provider(id: &str) -> Result<(), AppError> {
+    let _guard = opencode_config_lock().lock()?;
+    remove_entry_from_all_configs("provider", id)
 }
 
 pub fn get_typed_providers() -> Result<IndexMap<String, OpenCodeProviderConfig>, AppError> {
@@ -265,16 +345,7 @@ pub fn set_mcp_server(id: &str, config: Value) -> Result<(), AppError> {
 
 pub fn remove_mcp_server(id: &str) -> Result<(), AppError> {
     let _guard = opencode_config_lock().lock()?;
-    let path = get_opencode_config_path();
-    let mut config = read_opencode_config_from_path(&path)?;
-
-    if let Some(mcp) = config.get_mut("mcp").and_then(|v| v.as_object_mut()) {
-        mcp.remove(id);
-    } else if config.get("mcp").is_some() {
-        log::warn!("opencode.json 的 mcp 不是对象，无法删除服务器 '{id}'");
-    }
-
-    write_opencode_config_to_path_with_contents(&path, &config).map(|_| ())
+    remove_entry_from_all_configs("mcp", id)
 }
 
 pub fn add_plugin(path: &Path, plugin_name: &str) -> Result<(), AppError> {
@@ -506,6 +577,134 @@ mod tests {
             providers.contains_key("acme"),
             "providers declared in opencode.jsonc must be visible"
         );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn read_merges_every_config_file_the_way_opencode_does() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _guard = TestHomeGuard::set(temp.path());
+
+        // 常见的升级态：老版本 CC Switch 把供应商写进了 opencode.json，
+        // 而 OpenCode 自己建了 opencode.jsonc。
+        write_config_named(
+            temp.path(),
+            "config.json",
+            r#"{"provider": {"legacy": {"npm": "old"}}, "model": "from-config-json"}"#,
+        );
+        write_config_named(
+            temp.path(),
+            "opencode.json",
+            r#"{"provider": {"written-by-cc-switch": {"npm": "x"}}, "model": "from-opencode-json"}"#,
+        );
+        write_config_named(
+            temp.path(),
+            "opencode.jsonc",
+            "{\n  // created by OpenCode\n  \"provider\": { \"hand-written\": { \"npm\": \"y\" } }\n}",
+        );
+
+        let providers = get_providers().expect("providers must load");
+        let mut ids: Vec<&String> = providers.keys().collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["hand-written", "legacy", "written-by-cc-switch"],
+            "providers from every config file must be visible"
+        );
+
+        let config = read_opencode_config().expect("read");
+        assert_eq!(
+            config["model"], "from-opencode-json",
+            "later files win on conflicting scalars, as OpenCode's mergeDeep does"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_provider_purges_every_config_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _guard = TestHomeGuard::set(temp.path());
+
+        write_config_named(
+            temp.path(),
+            "opencode.json",
+            r#"{"provider": {"acme": {"npm": "stale"}, "keep": {"npm": "z"}}}"#,
+        );
+        write_config_named(
+            temp.path(),
+            "opencode.jsonc",
+            r#"{"provider": {"acme": {"npm": "current"}}}"#,
+        );
+
+        remove_provider("acme").expect("remove must succeed");
+
+        let providers = get_providers().expect("reload");
+        assert!(
+            !providers.contains_key("acme"),
+            "a provider present in several files must not come back from a lower-priority one"
+        );
+        assert!(
+            providers.contains_key("keep"),
+            "unrelated providers must survive"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn remove_provider_leaves_files_without_that_entry_untouched() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _guard = TestHomeGuard::set(temp.path());
+
+        let untouched = "{\n  // hand-written, keep my comments\n  \"model\": \"m\",\n}";
+        write_config_named(temp.path(), "opencode.jsonc", untouched);
+        write_config_named(
+            temp.path(),
+            "opencode.json",
+            r#"{"provider": {"acme": {"npm": "x"}}}"#,
+        );
+
+        remove_provider("acme").expect("remove must succeed");
+
+        let dir = temp.path().join(".config").join("opencode");
+        assert_eq!(
+            std::fs::read_to_string(dir.join("opencode.jsonc")).unwrap(),
+            untouched,
+            "a file that does not hold the entry must not be rewritten"
+        );
+        assert!(
+            !get_providers().unwrap().contains_key("acme"),
+            "the entry must still be gone"
+        );
+    }
+
+    #[test]
+    fn merge_config_recurses_into_objects_and_replaces_everything_else() {
+        let mut target = json!({
+            "provider": {"a": {"npm": "1"}, "b": {"npm": "2"}},
+            "instructions": ["one"],
+            "model": "old",
+        });
+        merge_config_into(
+            &mut target,
+            json!({
+                "provider": {"b": {"npm": "3"}, "c": {"npm": "4"}},
+                "instructions": ["two"],
+                "model": "new",
+            }),
+        );
+
+        assert_eq!(
+            target["provider"]["a"]["npm"], "1",
+            "untouched key survives"
+        );
+        assert_eq!(target["provider"]["b"]["npm"], "3", "conflicting key wins");
+        assert_eq!(target["provider"]["c"]["npm"], "4", "new key is added");
+        assert_eq!(
+            target["instructions"],
+            json!(["two"]),
+            "arrays are replaced, not concatenated, matching mergeDeep"
+        );
+        assert_eq!(target["model"], "new");
     }
 
     #[test]

--- a/src-tauri/src/opencode_config.rs
+++ b/src-tauri/src/opencode_config.rs
@@ -55,8 +55,27 @@ pub fn get_opencode_dir() -> PathBuf {
         .join("opencode")
 }
 
+/// OpenCode 在全局配置目录里认三个文件名，`globalConfigFile()` 按这个顺序取第一个
+/// 存在的，全都不存在时新建 `opencode.jsonc`，见
+/// https://github.com/sst/opencode/blob/dev/packages/opencode/src/config/config.ts
+///
+/// 读取侧它三个都读并 `mergeDeep`，后合并的覆盖先合并的，所以 `opencode.jsonc`
+/// 优先级最高：写进 `opencode.json` 的同名键会被它静默盖掉。
+const OPENCODE_CONFIG_FILE_NAMES: [&str; 3] = ["opencode.jsonc", "opencode.json", "config.json"];
+
 pub fn get_opencode_config_path() -> PathBuf {
-    get_opencode_dir().join("opencode.json")
+    let dir = get_opencode_dir();
+
+    for name in OPENCODE_CONFIG_FILE_NAMES {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+
+    // 一个都不存在时保持建 `opencode.json`：OpenCode 读取时会一并合并它，
+    // 之后 `globalConfigFile()` 也会选中它，行为与本函数此前一致。
+    dir.join("opencode.json")
 }
 
 /// 获取 OpenCode SQLite 数据库路径
@@ -371,9 +390,122 @@ mod tests {
     }
 
     fn write_config(home: &std::path::Path, content: &str) {
+        write_config_named(home, "opencode.json", content);
+    }
+
+    fn write_config_named(home: &std::path::Path, file_name: &str, content: &str) {
         let dir = home.join(".config").join("opencode");
         std::fs::create_dir_all(&dir).expect("create config dir");
-        std::fs::write(dir.join("opencode.json"), content).expect("write config");
+        std::fs::write(dir.join(file_name), content).expect("write config");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn config_path_prefers_existing_jsonc_over_json() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _guard = TestHomeGuard::set(temp.path());
+
+        write_config_named(temp.path(), "config.json", "{}");
+        assert_eq!(
+            get_opencode_config_path().file_name().unwrap(),
+            "config.json",
+            "legacy config.json is used when it is the only file present"
+        );
+
+        write_config_named(temp.path(), "opencode.json", "{}");
+        assert_eq!(
+            get_opencode_config_path().file_name().unwrap(),
+            "opencode.json",
+            "opencode.json outranks the legacy config.json"
+        );
+
+        write_config_named(temp.path(), "opencode.jsonc", "{}");
+        assert_eq!(
+            get_opencode_config_path().file_name().unwrap(),
+            "opencode.jsonc",
+            "opencode.jsonc outranks both, matching OpenCode's globalConfigFile()"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn config_path_falls_back_to_json_when_no_config_exists() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _guard = TestHomeGuard::set(temp.path());
+
+        assert_eq!(
+            get_opencode_config_path().file_name().unwrap(),
+            "opencode.json",
+            "a fresh install keeps creating opencode.json"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn config_path_ignores_a_directory_named_like_a_config_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _guard = TestHomeGuard::set(temp.path());
+
+        let dir = temp.path().join(".config").join("opencode");
+        std::fs::create_dir_all(dir.join("opencode.jsonc")).expect("create decoy dir");
+
+        assert_eq!(
+            get_opencode_config_path().file_name().unwrap(),
+            "opencode.json",
+            "a directory must not be mistaken for a config file"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn set_provider_updates_existing_jsonc_instead_of_creating_a_second_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _guard = TestHomeGuard::set(temp.path());
+
+        // OpenCode 新装时建的就是 opencode.jsonc，且允许注释。
+        write_config_named(
+            temp.path(),
+            "opencode.jsonc",
+            "{\n  // user config\n  \"model\": \"keep-me\"\n}",
+        );
+
+        set_provider("acme", json!({"npm": "@ai-sdk/openai-compatible"}))
+            .expect("set_provider must succeed");
+
+        let dir = temp.path().join(".config").join("opencode");
+        assert!(
+            !dir.join("opencode.json").exists(),
+            "writing must not create a second config file next to opencode.jsonc"
+        );
+
+        let config = read_opencode_config().expect("reload");
+        assert_eq!(
+            config["provider"]["acme"]["npm"], "@ai-sdk/openai-compatible",
+            "the provider must land in the file OpenCode actually reads last"
+        );
+        assert_eq!(
+            config["model"], "keep-me",
+            "unrelated user config must be preserved"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn read_sees_providers_declared_only_in_jsonc() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let _guard = TestHomeGuard::set(temp.path());
+
+        write_config_named(
+            temp.path(),
+            "opencode.jsonc",
+            "{\n  // trailing commas and comments are valid JSONC\n  \"provider\": {\n    \"acme\": { \"npm\": \"@ai-sdk/openai-compatible\" },\n  },\n}",
+        );
+
+        let providers = get_providers().expect("providers must load");
+        assert!(
+            providers.contains_key("acme"),
+            "providers declared in opencode.jsonc must be visible"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

CC Switch managed OpenCode through `opencode.json` only, while OpenCode itself uses three files in the global config dir and treats them as one configuration ([`packages/opencode/src/config/config.ts`](https://github.com/sst/opencode/blob/dev/packages/opencode/src/config/config.ts)):

- `globalConfigFile()` picks the first existing of `opencode.jsonc`, `opencode.json`, `config.json` for writing, and creates `opencode.jsonc` when none exist — so a current OpenCode install has `opencode.jsonc`;
- reading loads all three and `mergeDeep`s them in the order `config.json` → `opencode.json` → `opencode.jsonc`, so the last one wins.

Hardcoding `opencode.json` therefore broke in three ways:

1. **Adding a provider created a second config file** next to the `opencode.jsonc` OpenCode had already made — the reported symptom in #6210.
2. **Writes could be silently shadowed.** A `provider` entry written to `opencode.json` loses to the same key in `opencode.jsonc`, so the switch reported success and changed nothing.
3. **Reads were partial.** Providers living in another of the three files were invisible to CC Switch, so it could neither list nor manage them.

This PR aligns all three paths with what OpenCode actually does:

- **Path resolution** follows `globalConfigFile()`, so writes land in the file OpenCode reads last.
- **Reading** merges every existing config file in OpenCode's order, through a `merge_config_into()` that mirrors remeda's `mergeDeep` as `mergeConfig` uses it: objects recurse per key, everything else including arrays is replaced. `get_providers()` and `get_mcp_servers()` ride on it.
- **Deleting** purges the entry from every file that holds it. Removing it from the selected file alone would let a lower-priority copy take effect again, so CC Switch would report a deletion OpenCode never saw. Files that do not hold the entry are not rewritten at all, so their comments and formatting survive.
- **Writing** still targets the highest-priority file only — writing the merged document back would copy a lower-priority file's contents up into the top file.

All nine production call sites — `read_opencode_config`, `set_provider`, `remove_provider`, `set_mcp_server`, `remove_mcp_server`, plus `commands/config.rs`, two in `services/omo.rs` and one in `services/provider/live.rs` — go through these functions, so they are fixed together.

Parsing needed no change: `read_opencode_config_from_path()` already used `json5::from_str`, so comments and trailing commas were always accepted.

Two behaviours are deliberately left as they are. When no config file exists at all, the name created is still `opencode.json`, which keeps a fresh install byte-for-byte as it behaves today; OpenCode still reads it, since it is merged. And a write still re-serialises the target document through `write_json_file_with_contents`, so comments in that file are lost — pre-existing behaviour for `opencode.json`, now also reachable for `opencode.jsonc`.

## Related Issue / 关联 Issue

Fixes #6210

## Screenshots / 截图

N/A — backend-only config resolution, no UI or user-facing text changed.

## Testing / 测试

Nine tests added to the existing `opencode_config::tests` module. **Five of them fail without the corresponding production change and pass with it** — verified each time by reverting only the production hunks and re-running:

```
config_path_prefers_existing_jsonc_over_json .................... fails without the path fix
read_sees_providers_declared_only_in_jsonc ...................... fails without the path fix
set_provider_updates_existing_jsonc_instead_of_creating_a_second_file  fails without the path fix
read_merges_every_config_file_the_way_opencode_does ............. fails without the merged read
remove_provider_purges_every_config_file ........................ fails without the cross-file delete

config_path_falls_back_to_json_when_no_config_exists ............ guards unchanged fresh-install behaviour
config_path_ignores_a_directory_named_like_a_config_file ........ guards against a decoy directory
remove_provider_leaves_files_without_that_entry_untouched ....... guards comment/format preservation
merge_config_recurses_into_objects_and_replaces_everything_else .. pins the mergeDeep semantics
```

Full local run on Linux x86_64 (Ubuntu on WSL2), Rust 1.97.1, Node 18.19.1, pnpm 10.12.3:

| Check | Result |
|---|---|
| `cargo test` | 2554 passed, 0 failed, 5 ignored (lib) + 9 further suites green |
| `cargo clippy --all-targets` | clean |
| `cargo fmt --check` | clean |
| `pnpm typecheck` | clean |
| `pnpm format:check` | clean |
| `pnpm test:unit` | 129 files, 963 tests passed |

I could not exercise the packaged desktop app on macOS or Windows; the change is config resolution with no platform-specific code, and it is covered by the tests above.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — n/a, no user-facing text changed

---

Per CONTRIBUTING's AI-assisted contributions section: this was written with AI assistance and the commits carry a `Co-Authored-By` trailer to say so. I have read every line, I understand why each one is there, and I ran all the checks above myself on the machine described.
