### PR TITLE
feat(codex): map fixed reasoning levels to provider values

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -548,9 +548,9 @@ fn codex_catalog_input_modalities(
     modalities.iter().map(|item| (*item).to_string()).collect()
 }
 
-/// Stable reasoning levels currently rendered by Codex Desktop for custom
-/// catalog entries. Provider-native values are kept in CC Switch settings and
-/// are never written into `supported_reasoning_levels`.
+/// Codex-facing reasoning levels exposed by default for custom catalog entries.
+/// Provider-native values are kept in CC Switch settings and are never written
+/// into `supported_reasoning_levels`.
 const CODEX_REASONING_LEVEL_DESCRIPTIONS: &[(&str, &str)] = &[
     ("low", "Fast responses with lighter reasoning"),
     (
@@ -559,6 +559,8 @@ const CODEX_REASONING_LEVEL_DESCRIPTIONS: &[(&str, &str)] = &[
     ),
     ("high", "Greater reasoning depth for complex problems"),
     ("xhigh", "Extra high reasoning depth for complex problems"),
+    ("max", "Maximum reasoning depth for the hardest problems"),
+    ("ultra", "Ultra reasoning depth"),
 ];
 
 fn codex_reasoning_level_description(effort: &str) -> Option<&'static str> {
@@ -3539,6 +3541,8 @@ base_url = "https://production.api/v1"
                             { "level": "xhigh", "upstreamValue": "max", "description": "Maximum provider reasoning" },
                             { "level": "low", "upstreamValue": "light", "description": "Fast provider reasoning" },
                             { "level": "medium" },
+                            { "level": "max", "upstreamValue": "maximum" },
+                            { "level": "ultra", "description": "Unlimited provider reasoning" },
                             { "level": "bogus", "upstreamValue": "turbo" }
                         ],
                         "defaultReasoningLevel": "xhigh"
@@ -3568,7 +3572,7 @@ base_url = "https://production.api/v1"
                 .filter_map(|level| level.get("effort").and_then(Value::as_str))
                 .collect()
         };
-        assert_eq!(efforts(0), vec!["low", "medium", "xhigh"]);
+        assert_eq!(efforts(0), vec!["low", "medium", "xhigh", "max", "ultra"]);
         assert_eq!(
             models[0]["supported_reasoning_levels"][0]["description"],
             "Fast provider reasoning"
@@ -3581,6 +3585,14 @@ base_url = "https://production.api/v1"
             models[0]["supported_reasoning_levels"][2]["description"],
             "Maximum provider reasoning"
         );
+        assert_eq!(
+            models[0]["supported_reasoning_levels"][3]["description"],
+            "Maximum reasoning depth for the hardest problems"
+        );
+        assert_eq!(
+            models[0]["supported_reasoning_levels"][4]["description"],
+            "Unlimited provider reasoning"
+        );
         assert_eq!(models[0]["default_reasoning_level"], "xhigh");
         for entry in models[0]["supported_reasoning_levels"]
             .as_array()
@@ -3589,12 +3601,11 @@ base_url = "https://production.api/v1"
             assert!(entry.get("upstreamValue").is_none());
             assert!(entry.get("upstream_value").is_none());
             assert_ne!(entry.get("effort").and_then(Value::as_str), Some("light"));
-            assert_ne!(entry.get("effort").and_then(Value::as_str), Some("max"));
         }
 
-        // Existing #6228 data migrates to the stable levels that Codex Desktop
-        // actually renders for custom models.
-        assert_eq!(efforts(1), vec!["low", "high"]);
+        // Existing #6228 data keeps every configured supported level while
+        // dropping none/minimal, which are intentionally not exposed by default.
+        assert_eq!(efforts(1), vec!["low", "high", "max"]);
         assert_eq!(models[1]["default_reasoning_level"], "high");
     }
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -548,11 +548,10 @@ fn codex_catalog_input_modalities(
     modalities.iter().map(|item| (*item).to_string()).collect()
 }
 
-/// Canonical reasoning effort levels Codex understands, with the same
-/// descriptions the official gpt-5.5 template uses. `none` disables thinking.
+/// Stable reasoning levels currently rendered by Codex Desktop for custom
+/// catalog entries. Provider-native values are kept in CC Switch settings and
+/// are never written into `supported_reasoning_levels`.
 const CODEX_REASONING_LEVEL_DESCRIPTIONS: &[(&str, &str)] = &[
-    ("none", "Disable Thinking"),
-    ("minimal", "Minimal reasoning"),
     ("low", "Fast responses with lighter reasoning"),
     (
         "medium",
@@ -560,8 +559,6 @@ const CODEX_REASONING_LEVEL_DESCRIPTIONS: &[(&str, &str)] = &[
     ),
     ("high", "Greater reasoning depth for complex problems"),
     ("xhigh", "Extra high reasoning depth for complex problems"),
-    ("max", "Maximum reasoning depth for the hardest problems"),
-    ("ultra", "Ultra reasoning depth"),
 ];
 
 fn codex_reasoning_level_description(effort: &str) -> Option<&'static str> {
@@ -571,61 +568,64 @@ fn codex_reasoning_level_description(effort: &str) -> Option<&'static str> {
         .map(|(_, description)| *description)
 }
 
-/// User-declared levels reduced to the canonical efforts Codex understands,
-/// in canonical (lowest → highest) order regardless of declaration order.
-/// Unknown efforts are dropped so a typo can never produce an entry Codex
-/// would reject.
-fn codex_canonical_efforts(levels: &[String]) -> Vec<&str> {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CodexReasoningEffortMappingSpec {
+    level: String,
+    upstream_value: Option<String>,
+    description: Option<String>,
+}
+
+fn codex_canonical_reasoning_mappings(
+    mappings: &[CodexReasoningEffortMappingSpec],
+) -> Vec<&CodexReasoningEffortMappingSpec> {
     CODEX_REASONING_LEVEL_DESCRIPTIONS
         .iter()
-        .filter(|(effort, _)| levels.iter().any(|candidate| candidate == effort))
-        .map(|(effort, _)| *effort)
+        .filter_map(|(level, _)| mappings.iter().find(|mapping| mapping.level == *level))
         .collect()
 }
 
-/// Build a `supported_reasoning_levels` array from user-declared effort values.
-fn codex_supported_reasoning_levels(levels: &[String]) -> Value {
-    let entries: Vec<Value> = codex_canonical_efforts(levels)
+fn codex_supported_reasoning_levels(mappings: &[CodexReasoningEffortMappingSpec]) -> Value {
+    let entries: Vec<Value> = codex_canonical_reasoning_mappings(mappings)
         .into_iter()
-        .map(|effort| {
-            let description = codex_reasoning_level_description(effort)
-                .expect("canonical effort always has a description");
-            json!({ "effort": effort, "description": description })
+        .map(|mapping| {
+            let description = mapping.description.as_deref().unwrap_or_else(|| {
+                codex_reasoning_level_description(&mapping.level)
+                    .expect("canonical effort always has a description")
+            });
+            json!({ "effort": mapping.level, "description": description })
         })
         .collect();
     json!(entries)
 }
 
-/// Apply a per-model reasoning-level override onto a catalog entry. Returns
-/// true when the override was applied (so callers can skip further work).
-/// `template_default` is the base entry's `default_reasoning_level` (from the
-/// profile template or an official vendor entry) used as the fallback when the
-/// user did not declare one explicitly.
+/// Apply a per-model reasoning-level override onto a catalog entry. The catalog
+/// exposes only Codex's stable picker levels. Provider-native values are applied
+/// separately by the local proxy and deliberately do not leak into this file.
 fn apply_codex_reasoning_level_override(
     entry_obj: &mut serde_json::Map<String, Value>,
     template_default: Option<&str>,
     spec: &CodexCatalogModelSpec,
 ) -> bool {
-    let Some(levels) = spec.reasoning_levels.as_deref() else {
+    let Some(mappings) = spec.reasoning_effort_mappings.as_deref() else {
         return false;
     };
-    let canonical = codex_canonical_efforts(levels);
+    let canonical = codex_canonical_reasoning_mappings(mappings);
     if canonical.is_empty() {
         return false;
     }
-    let supported = codex_supported_reasoning_levels(levels);
-    entry_obj.insert("supported_reasoning_levels".to_string(), supported);
+    entry_obj.insert(
+        "supported_reasoning_levels".to_string(),
+        codex_supported_reasoning_levels(mappings),
+    );
 
-    // Default: explicit user value wins; otherwise keep the base default when
-    // it is still supported; otherwise fall back to the highest supported
-    // level in canonical order. All candidates are validated against the
-    // canonical set so the default can never reference a dropped effort.
     let default_level = spec
         .default_reasoning_level
         .as_deref()
-        .filter(|level| canonical.contains(level))
-        .or_else(|| template_default.filter(|level| canonical.contains(level)))
-        .or_else(|| canonical.last().copied());
+        .filter(|level| canonical.iter().any(|mapping| mapping.level == **level))
+        .or_else(|| {
+            template_default.filter(|level| canonical.iter().any(|mapping| mapping.level == *level))
+        })
+        .or_else(|| canonical.last().map(|mapping| mapping.level.as_str()));
     if let Some(default_level) = default_level {
         entry_obj.insert("default_reasoning_level".to_string(), json!(default_level));
     }
@@ -737,14 +737,12 @@ struct CodexCatalogModelSpec {
     /// back to the template default when absent. Only consulted for
     /// `NativeResponses`.
     base_instructions: Option<String>,
-    /// Per-row override for the generated catalog's `supported_reasoning_levels`
-    /// (e.g. ["none", "low", "medium", "high", "xhigh", "max"]). When omitted
-    /// the template's conservative default (none/high) is kept. Consulted for
-    /// every profile; the vendor-catalog path applies it on top of the
-    /// official entry.
-    reasoning_levels: Option<Vec<String>>,
+    /// Per-row Codex-level declarations plus optional provider-native values
+    /// and user-authored descriptions. Only the stable Codex `level` and
+    /// description are written to the generated catalog.
+    reasoning_effort_mappings: Option<Vec<CodexReasoningEffortMappingSpec>>,
     /// Per-row override for the generated catalog's `default_reasoning_level`.
-    /// Only meaningful together with `reasoning_levels`; when absent the
+    /// Only meaningful together with `reasoning_effort_mappings`; when absent the
     /// template default is kept if it is still in the list, otherwise the last
     /// (highest) declared level wins.
     default_reasoning_level: Option<String>,
@@ -814,20 +812,66 @@ fn codex_catalog_model_specs(settings: &Value) -> Vec<CodexCatalogModelSpec> {
             .filter(|text| !text.is_empty())
             .map(str::to_string);
 
-        let reasoning_levels = model_config
-            .get("reasoningLevels")
-            .or_else(|| model_config.get("reasoning_levels"))
+        let reasoning_effort_mappings = model_config
+            .get("reasoningEffortMappings")
+            .or_else(|| model_config.get("reasoning_effort_mappings"))
             .and_then(|value| value.as_array())
             .map(|items| {
                 items
                     .iter()
-                    .filter_map(|item| item.as_str())
-                    .map(str::trim)
-                    .filter(|level| !level.is_empty())
-                    .map(str::to_string)
+                    .filter_map(|item| {
+                        let level = item
+                            .get("level")
+                            .and_then(Value::as_str)?
+                            .trim()
+                            .to_ascii_lowercase();
+                        if codex_reasoning_level_description(&level).is_none() {
+                            return None;
+                        }
+                        let upstream_value = item
+                            .get("upstreamValue")
+                            .or_else(|| item.get("upstream_value"))
+                            .and_then(Value::as_str)
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())
+                            .map(str::to_string);
+                        let description = item
+                            .get("description")
+                            .and_then(Value::as_str)
+                            .map(str::trim)
+                            .filter(|value| !value.is_empty())
+                            .map(str::to_string);
+                        Some(CodexReasoningEffortMappingSpec {
+                            level,
+                            upstream_value,
+                            description,
+                        })
+                    })
                     .collect::<Vec<_>>()
             })
-            .filter(|levels| !levels.is_empty());
+            .filter(|mappings| !mappings.is_empty())
+            .or_else(|| {
+                // Backward-compatible migration for providers saved by #6228.
+                model_config
+                    .get("reasoningLevels")
+                    .or_else(|| model_config.get("reasoning_levels"))
+                    .and_then(Value::as_array)
+                    .map(|items| {
+                        items
+                            .iter()
+                            .filter_map(Value::as_str)
+                            .map(str::trim)
+                            .map(str::to_ascii_lowercase)
+                            .filter(|level| codex_reasoning_level_description(level).is_some())
+                            .map(|level| CodexReasoningEffortMappingSpec {
+                                level,
+                                upstream_value: None,
+                                description: None,
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .filter(|mappings| !mappings.is_empty())
+            });
         let default_reasoning_level = model_config
             .get("defaultReasoningLevel")
             .or_else(|| model_config.get("default_reasoning_level"))
@@ -843,7 +887,7 @@ fn codex_catalog_model_specs(settings: &Value) -> Vec<CodexCatalogModelSpec> {
             supports_parallel_tool_calls,
             input_modalities,
             base_instructions,
-            reasoning_levels,
+            reasoning_effort_mappings,
             default_reasoning_level,
         });
     }
@@ -3363,7 +3407,7 @@ base_url = "https://production.api/v1"
             supports_parallel_tool_calls: None,
             input_modalities: None,
             base_instructions: None,
-            reasoning_levels: None,
+            reasoning_effort_mappings: None,
             default_reasoning_level: None,
         }];
         let catalog = codex_model_catalog_from_specs(
@@ -3485,34 +3529,23 @@ base_url = "https://production.api/v1"
     }
 
     #[test]
-    fn native_responses_catalog_honors_per_model_reasoning_levels() {
-        // The native template only declares none/high. A per-model
-        // reasoningLevels override must replace supported_reasoning_levels and
-        // pick a sensible default_reasoning_level.
+    fn native_responses_catalog_honors_reasoning_effort_mappings_and_descriptions() {
         let settings = json!({
             "modelCatalog": {
                 "models": [
                     {
                         "model": "deepseek-v4-flash",
-                        "reasoningLevels": ["none", "low", "medium", "high", "xhigh", "max"],
+                        "reasoningEffortMappings": [
+                            { "level": "xhigh", "upstreamValue": "max", "description": "Maximum provider reasoning" },
+                            { "level": "low", "upstreamValue": "light", "description": "Fast provider reasoning" },
+                            { "level": "medium" },
+                            { "level": "bogus", "upstreamValue": "turbo" }
+                        ],
                         "defaultReasoningLevel": "xhigh"
                     },
                     {
-                        "model": "no-default-model",
-                        "reasoningLevels": ["low", "medium", "high"]
-                    },
-                    {
-                        "model": "template-default-model",
-                        "reasoningLevels": ["none", "high", "xhigh"]
-                    },
-                    {
-                        "model": "dirty-levels",
-                        "reasoningLevels": ["none", "bogus", "high", ""]
-                    },
-                    {
-                        "model": "unordered-model",
-                        "reasoningLevels": ["xhigh", "low", "bogus", "low"],
-                        "defaultReasoningLevel": "bogus"
+                        "model": "legacy-model",
+                        "reasoningLevels": ["none", "low", "high", "max"]
                     }
                 ]
             }
@@ -3527,80 +3560,56 @@ base_url = "https://production.api/v1"
         .expect("non-empty modelCatalog must yield a catalog");
 
         let models = catalog["models"].as_array().expect("models array");
-        let efforts = |index: usize| -> Vec<String> {
+        let efforts = |index: usize| -> Vec<&str> {
             models[index]["supported_reasoning_levels"]
                 .as_array()
                 .expect("supported_reasoning_levels array")
                 .iter()
-                .filter_map(|level| level.get("effort").and_then(|v| v.as_str()))
-                .map(str::to_string)
+                .filter_map(|level| level.get("effort").and_then(Value::as_str))
                 .collect()
         };
+        assert_eq!(efforts(0), vec!["low", "medium", "xhigh"]);
+        assert_eq!(
+            models[0]["supported_reasoning_levels"][0]["description"],
+            "Fast provider reasoning"
+        );
+        assert_eq!(
+            models[0]["supported_reasoning_levels"][1]["description"],
+            "Balances speed and reasoning depth for everyday tasks"
+        );
+        assert_eq!(
+            models[0]["supported_reasoning_levels"][2]["description"],
+            "Maximum provider reasoning"
+        );
+        assert_eq!(models[0]["default_reasoning_level"], "xhigh");
+        for entry in models[0]["supported_reasoning_levels"]
+            .as_array()
+            .expect("supported reasoning entries")
+        {
+            assert!(entry.get("upstreamValue").is_none());
+            assert!(entry.get("upstream_value").is_none());
+            assert_ne!(entry.get("effort").and_then(Value::as_str), Some("light"));
+            assert_ne!(entry.get("effort").and_then(Value::as_str), Some("max"));
+        }
 
-        // Explicit default wins.
-        assert_eq!(
-            efforts(0),
-            vec!["none", "low", "medium", "high", "xhigh", "max"]
-        );
-        assert_eq!(
-            models[0]
-                .get("default_reasoning_level")
-                .and_then(|v| v.as_str()),
-            Some("xhigh")
-        );
-
-        // No explicit default: falls back to the last (highest) declared level.
-        assert_eq!(efforts(1), vec!["low", "medium", "high"]);
-        assert_eq!(
-            models[1]
-                .get("default_reasoning_level")
-                .and_then(|v| v.as_str()),
-            Some("high")
-        );
-
-        // Template default ("high") is kept when it is still in the list.
-        assert_eq!(efforts(2), vec!["none", "high", "xhigh"]);
-        assert_eq!(
-            models[2]
-                .get("default_reasoning_level")
-                .and_then(|v| v.as_str()),
-            Some("high")
-        );
-
-        // Unknown / empty efforts are dropped; the default still resolves to
-        // a supported level (the template default, "high").
-        assert_eq!(efforts(3), vec!["none", "high"]);
-        assert_eq!(
-            models[3]
-                .get("default_reasoning_level")
-                .and_then(|v| v.as_str()),
-            Some("high")
-        );
-
-        // Declaration order is normalized to canonical order, duplicates and
-        // an unknown explicit default are dropped, and the fallback picks the
-        // highest supported level in canonical order (not the last declared
-        // one, and never an unknown effort).
-        assert_eq!(efforts(4), vec!["low", "xhigh"]);
-        assert_eq!(
-            models[4]
-                .get("default_reasoning_level")
-                .and_then(|v| v.as_str()),
-            Some("xhigh")
-        );
+        // Existing #6228 data migrates to the stable levels that Codex Desktop
+        // actually renders for custom models.
+        assert_eq!(efforts(1), vec!["low", "high"]);
+        assert_eq!(models[1]["default_reasoning_level"], "high");
     }
 
     #[test]
-    fn vendor_catalog_honors_per_model_reasoning_levels() {
-        // The DeepSeek official catalog declares low/high/max; a per-model
-        // override must win over the official entry.
+    fn vendor_catalog_honors_reasoning_effort_mappings() {
         let settings = json!({
             "modelCatalog": {
                 "models": [
                     {
                         "model": "deepseek-v4-flash",
-                        "reasoningLevels": ["none", "low", "medium", "high", "xhigh", "max"],
-                        "defaultReasoningLevel": "xhigh"
+                        "reasoningEffortMappings": [
+                            { "level": "low", "upstreamValue": "minimal", "description": "Quick" },
+                            { "level": "high", "upstreamValue": "max", "description": "Deep" }
+                        ],
+                        "defaultReasoningLevel": "high"
                     }
                 ]
             }
@@ -3619,18 +3628,18 @@ base_url = "https://production.api/v1"
             .as_array()
             .expect("supported_reasoning_levels array")
             .iter()
-            .filter_map(|level| level.get("effort").and_then(|v| v.as_str()))
+            .filter_map(|level| level.get("effort").and_then(Value::as_str))
             .collect();
+        assert_eq!(efforts, vec!["low", "high"]);
         assert_eq!(
-            efforts,
-            vec!["none", "low", "medium", "high", "xhigh", "max"]
+            entry["supported_reasoning_levels"][0]["description"],
+            "Quick"
         );
         assert_eq!(
-            entry
-                .get("default_reasoning_level")
-                .and_then(|v| v.as_str()),
-            Some("xhigh")
+            entry["supported_reasoning_levels"][1]["description"],
+            "Deep"
         );
+        assert_eq!(entry["default_reasoning_level"], "high");
     }
 
     #[test]
@@ -3720,7 +3729,7 @@ base_url = "https://production.api/v1"
                 supports_parallel_tool_calls: None,
                 input_modalities: None,
                 base_instructions: None,
-                reasoning_levels: None,
+                reasoning_effort_mappings: None,
                 default_reasoning_level: None,
             },
             CodexCatalogModelSpec {
@@ -3730,7 +3739,7 @@ base_url = "https://production.api/v1"
                 supports_parallel_tool_calls: None,
                 input_modalities: None,
                 base_instructions: None,
-                reasoning_levels: None,
+                reasoning_effort_mappings: None,
                 default_reasoning_level: None,
             },
             CodexCatalogModelSpec {
@@ -3740,7 +3749,7 @@ base_url = "https://production.api/v1"
                 supports_parallel_tool_calls: None,
                 input_modalities: None,
                 base_instructions: None,
-                reasoning_levels: None,
+                reasoning_effort_mappings: None,
                 default_reasoning_level: None,
             },
             CodexCatalogModelSpec {
@@ -3750,7 +3759,7 @@ base_url = "https://production.api/v1"
                 supports_parallel_tool_calls: None,
                 input_modalities: Some(vec!["text".to_string(), "image".to_string()]),
                 base_instructions: None,
-                reasoning_levels: None,
+                reasoning_effort_mappings: None,
                 default_reasoning_level: None,
             },
             CodexCatalogModelSpec {
@@ -3760,7 +3769,7 @@ base_url = "https://production.api/v1"
                 supports_parallel_tool_calls: None,
                 input_modalities: Some(vec!["text".to_string()]),
                 base_instructions: None,
-                reasoning_levels: None,
+                reasoning_effort_mappings: None,
                 default_reasoning_level: None,
             },
         ];
@@ -4032,7 +4041,7 @@ wire_api = "responses"
             supports_parallel_tool_calls: None,
             input_modalities: None,
             base_instructions: None,
-            reasoning_levels: None,
+            reasoning_effort_mappings: None,
             default_reasoning_level: None,
         }];
         // Using a gpt-5.5-shaped template under ProxyChat must NOT strip

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1177,6 +1177,16 @@ impl RequestForwarder {
         // 与 CCH 对齐：请求前不做 thinking 主动改写（仅保留兼容入口）
         let mut mapped_body = normalize_thinking_type(mapped_body);
 
+        // Map Codex's stable picker effort to a provider-native value for
+        // native Responses passthrough and the Anthropic bridge. Chat conversion
+        // applies the mapping after it has selected the provider's parameter shape.
+        if matches!(app_type, AppType::Codex | AppType::GrokBuild)
+            && !codex_responses_to_chat
+            && !codex_responses_to_anthropic
+        {
+            super::providers::apply_codex_reasoning_effort_mapping(provider, &mut mapped_body);
+        }
+
         // Grok Build exposes a stable client-side model profile in config.toml.
         // Route requests to the provider's real upstream model before applying
         // the optional Responses -> Chat/Anthropic bridge.
@@ -1448,10 +1458,17 @@ impl RequestForwarder {
             super::providers::apply_codex_chat_upstream_model(provider, &mut mapped_body);
             let reasoning_config =
                 super::providers::resolve_codex_chat_reasoning_config(provider, &mapped_body);
+            let source_body = mapped_body.clone();
             let mut chat_body = super::providers::transform_codex_chat::responses_to_chat_completions_with_reasoning(
                 mapped_body,
                 reasoning_config.as_ref(),
             )?;
+            super::providers::apply_codex_chat_reasoning_effort_mapping(
+                provider,
+                &source_body,
+                &mut chat_body,
+                reasoning_config.as_ref(),
+            );
             super::providers::inject_codex_chat_prompt_cache_key(
                 provider,
                 &mut chat_body,
@@ -1486,11 +1503,17 @@ impl RequestForwarder {
             // accepted by every current Claude model and virtually all gateways. The
             // transform clamps any thinking budget below this value.
             const DEFAULT_CODEX_ANTHROPIC_MAX_TOKENS: u64 = 8192;
+            let source_body = mapped_body.clone();
             let mut anthropic_body =
                 super::providers::transform_codex_anthropic::responses_request_to_anthropic(
                     mapped_body,
                     DEFAULT_CODEX_ANTHROPIC_MAX_TOKENS,
                 )?;
+            super::providers::apply_codex_anthropic_reasoning_effort_mapping(
+                provider,
+                &source_body,
+                &mut anthropic_body,
+            );
             // Handle the 1M-context marker [1m]: strip the model-name suffix (the
             // gateway doesn't recognize it) and set the flag so the beta header is
             // added. apply_codex_upstream_model may have just written back a model

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -327,19 +327,151 @@ pub fn apply_codex_upstream_model(provider: &Provider, body: &mut JsonValue) -> 
     Some(upstream_model)
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CodexReasoningEffortMapping {
+    upstream_value: Option<String>,
+}
+
+fn codex_reasoning_effort_mapping_for_request(
+    provider: &Provider,
+    body: &JsonValue,
+) -> Option<CodexReasoningEffortMapping> {
+    let model = body.get("model")?.as_str()?.trim();
+    let level = body.pointer("/reasoning/effort")?.as_str()?.trim();
+    let models = provider
+        .settings_config
+        .get("modelCatalog")?
+        .get("models")?
+        .as_array()?;
+    let model_config = models.iter().find(|item| {
+        item.get("model")
+            .and_then(JsonValue::as_str)
+            .is_some_and(|candidate| candidate.trim() == model)
+    })?;
+    let mappings = model_config
+        .get("reasoningEffortMappings")
+        .or_else(|| model_config.get("reasoning_effort_mappings"))?
+        .as_array()?;
+    let mapping = mappings.iter().find(|item| {
+        item.get("level")
+            .and_then(JsonValue::as_str)
+            .is_some_and(|candidate| candidate.trim().eq_ignore_ascii_case(level))
+    })?;
+    let upstream_value = mapping
+        .get("upstreamValue")
+        .or_else(|| mapping.get("upstream_value"))
+        .and_then(JsonValue::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    Some(CodexReasoningEffortMapping { upstream_value })
+}
+
+/// Apply a model-specific Codex-level -> provider-native effort mapping before
+/// native Responses passthrough or Responses -> Anthropic conversion.
+pub fn apply_codex_reasoning_effort_mapping(
+    provider: &Provider,
+    body: &mut JsonValue,
+) -> Option<String> {
+    let mapping = codex_reasoning_effort_mapping_for_request(provider, body)?;
+    let upstream_value = mapping.upstream_value?;
+    let reasoning = body.get_mut("reasoning")?.as_object_mut()?;
+    reasoning.insert(
+        "effort".to_string(),
+        JsonValue::String(upstream_value.clone()),
+    );
+    Some(upstream_value)
+}
+
+/// Override the converted Anthropic payload with a provider-native effort
+/// value after the Responses -> Messages bridge has derived its thinking mode.
+pub fn apply_codex_anthropic_reasoning_effort_mapping(
+    provider: &Provider,
+    source_body: &JsonValue,
+    result: &mut JsonValue,
+) -> Option<String> {
+    let upstream_value =
+        codex_reasoning_effort_mapping_for_request(provider, source_body)?.upstream_value?;
+    if !result
+        .get("output_config")
+        .is_some_and(JsonValue::is_object)
+    {
+        result["output_config"] = serde_json::json!({});
+    }
+    result["output_config"]["effort"] = JsonValue::String(upstream_value.clone());
+    Some(upstream_value)
+}
+
+/// Override the converted Chat payload with a provider-native effort value.
+/// The configured Chat effort parameter decides whether the value is written as
+/// top-level `reasoning_effort` or OpenRouter-style `reasoning.effort`.
+pub fn apply_codex_chat_reasoning_effort_mapping(
+    provider: &Provider,
+    source_body: &JsonValue,
+    result: &mut JsonValue,
+    config: Option<&CodexChatReasoningConfig>,
+) -> Option<String> {
+    let upstream_value =
+        codex_reasoning_effort_mapping_for_request(provider, source_body)?.upstream_value?;
+    let effort_param = config
+        .and_then(|value| value.effort_param.as_deref())
+        .unwrap_or("reasoning_effort")
+        .trim()
+        .to_ascii_lowercase();
+    match effort_param.as_str() {
+        "reasoning.effort" => {
+            if !result.get("reasoning").is_some_and(JsonValue::is_object) {
+                result["reasoning"] = serde_json::json!({});
+            }
+            result["reasoning"]["effort"] = JsonValue::String(upstream_value.clone());
+            if let Some(object) = result.as_object_mut() {
+                object.remove("reasoning_effort");
+            }
+        }
+        "none" => return None,
+        _ => {
+            result["reasoning_effort"] = JsonValue::String(upstream_value.clone());
+        }
+    }
+    Some(upstream_value)
+}
+
 pub fn resolve_codex_chat_reasoning_config(
     provider: &Provider,
     body: &JsonValue,
 ) -> Option<CodexChatReasoningConfig> {
-    if let Some(config) = provider
+    let mut config = provider
         .meta
         .as_ref()
         .and_then(|meta| meta.codex_chat_reasoning.clone())
-    {
-        return Some(normalize_codex_chat_reasoning_config(config));
+        .or_else(|| infer_codex_chat_reasoning_config(provider, body));
+    let had_reasoning_config = config.is_some();
+
+    // A per-model mapping is itself an explicit effort-capability declaration.
+    // Keep a platform-specific parameter shape when inference found one;
+    // otherwise use the common OpenAI-compatible top-level field.
+    if codex_reasoning_effort_mapping_for_request(provider, body).is_some() {
+        let value = config.get_or_insert_with(CodexChatReasoningConfig::default);
+        value.supports_effort = Some(true);
+        if !had_reasoning_config {
+            // Generic OpenAI-compatible Chat providers commonly support only
+            // `reasoning_effort`; do not invent a separate `thinking` object.
+            value.supports_thinking = Some(false);
+            value.thinking_param = Some("none".to_string());
+        }
+        if value
+            .effort_param
+            .as_deref()
+            .is_none_or(|param| param.trim().is_empty() || param == "none")
+        {
+            value.effort_param = Some("reasoning_effort".to_string());
+        }
+        if value.effort_value_mode.is_none() {
+            value.effort_value_mode = Some("passthrough".to_string());
+        }
     }
 
-    infer_codex_chat_reasoning_config(provider, body)
+    config.map(normalize_codex_chat_reasoning_config)
 }
 
 fn normalize_codex_chat_reasoning_config(
@@ -837,6 +969,119 @@ mod tests {
             icon_color: None,
             in_failover_queue: false,
         }
+    }
+
+    #[test]
+    fn applies_model_specific_reasoning_mapping_to_native_responses() {
+        let provider = create_provider(json!({
+            "modelCatalog": {
+                "models": [{
+                    "model": "provider-model",
+                    "reasoningEffortMappings": [
+                        { "level": "low", "upstreamValue": "light" },
+                        { "level": "xhigh", "upstreamValue": "adaptive" }
+                    ]
+                }]
+            }
+        }));
+        let mut body = json!({
+            "model": "provider-model",
+            "reasoning": { "effort": "xhigh" }
+        });
+
+        assert_eq!(
+            apply_codex_reasoning_effort_mapping(&provider, &mut body).as_deref(),
+            Some("adaptive")
+        );
+        assert_eq!(body["reasoning"]["effort"], "adaptive");
+    }
+
+    #[test]
+    fn applies_model_specific_reasoning_mapping_after_anthropic_conversion() {
+        let provider = create_provider(json!({
+            "modelCatalog": {
+                "models": [{
+                    "model": "provider-model",
+                    "reasoningEffortMappings": [
+                        { "level": "xhigh", "upstreamValue": "max" }
+                    ]
+                }]
+            }
+        }));
+        let source = json!({
+            "model": "provider-model",
+            "reasoning": { "effort": "xhigh" }
+        });
+        let mut result = json!({
+            "model": "provider-model",
+            "thinking": { "type": "adaptive" },
+            "output_config": { "effort": "high" }
+        });
+
+        assert_eq!(
+            apply_codex_anthropic_reasoning_effort_mapping(&provider, &source, &mut result,)
+                .as_deref(),
+            Some("max")
+        );
+        assert_eq!(result["output_config"]["effort"], "max");
+    }
+
+    #[test]
+    fn applies_model_specific_reasoning_mapping_to_chat_parameter_shape() {
+        let provider = create_provider(json!({
+            "modelCatalog": {
+                "models": [{
+                    "model": "provider-model",
+                    "reasoningEffortMappings": [
+                        { "level": "high", "upstreamValue": "deep" }
+                    ]
+                }]
+            }
+        }));
+        let source = json!({
+            "model": "provider-model",
+            "reasoning": { "effort": "high" }
+        });
+        let config = CodexChatReasoningConfig {
+            supports_effort: Some(true),
+            effort_param: Some("reasoning.effort".to_string()),
+            ..Default::default()
+        };
+        let mut result = json!({ "model": "provider-model" });
+
+        assert_eq!(
+            apply_codex_chat_reasoning_effort_mapping(
+                &provider,
+                &source,
+                &mut result,
+                Some(&config),
+            )
+            .as_deref(),
+            Some("deep")
+        );
+        assert_eq!(result["reasoning"]["effort"], "deep");
+        assert!(result.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn ignores_reasoning_mapping_for_a_different_model() {
+        let provider = create_provider(json!({
+            "modelCatalog": {
+                "models": [{
+                    "model": "model-a",
+                    "reasoningEffortMappings": [
+                        { "level": "high", "upstreamValue": "deep" }
+                    ]
+                }]
+            }
+        }));
+        let mut body = json!({
+            "model": "model-b",
+            "reasoning": { "effort": "high" }
+        });
+
+        assert!(apply_codex_reasoning_effort_mapping(&provider, &mut body).is_none());
+        assert_eq!(body["reasoning"]["effort"], "high");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -57,11 +57,12 @@ pub use claude::{
 };
 pub use codex::CodexAdapter;
 pub use codex::{
-    apply_codex_chat_upstream_model, apply_codex_upstream_model, codex_provider_upstream_model,
-    inject_codex_chat_prompt_cache_key, is_codex_official_provider,
-    provider_needs_responses_namespace_flatten, resolve_codex_catalog_tool_profile,
-    resolve_codex_chat_reasoning_config, should_convert_codex_responses_to_anthropic,
-    should_convert_codex_responses_to_chat,
+    apply_codex_anthropic_reasoning_effort_mapping, apply_codex_chat_reasoning_effort_mapping,
+    apply_codex_chat_upstream_model, apply_codex_reasoning_effort_mapping,
+    apply_codex_upstream_model, codex_provider_upstream_model, inject_codex_chat_prompt_cache_key,
+    is_codex_official_provider, provider_needs_responses_namespace_flatten,
+    resolve_codex_catalog_tool_profile, resolve_codex_chat_reasoning_config,
+    should_convert_codex_responses_to_anthropic, should_convert_codex_responses_to_chat,
 };
 pub use gemini::GeminiAdapter;
 

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -137,6 +137,21 @@ interface CodexFormFieldsProps {
 
 type CodexCatalogRow = CodexCatalogModel & { rowId: string };
 
+// Codex-facing levels exposed by default for every custom catalog model.
+// Provider-native values are configured independently in the mapping editor.
+const CODEX_REASONING_LEVELS: readonly CodexReasoningLevel[] = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "ultra",
+];
+
+const createDefaultReasoningEffortMappings =
+  (): CodexReasoningEffortMapping[] =>
+    CODEX_REASONING_LEVELS.map((level) => ({ level }));
+
 function createCatalogRow(seed?: Partial<CodexCatalogModel>): CodexCatalogRow {
   return {
     rowId: crypto.randomUUID(),
@@ -152,9 +167,10 @@ function createCatalogRow(seed?: Partial<CodexCatalogModel>): CodexCatalogRow {
     ...(seed?.baseInstructions
       ? { baseInstructions: seed.baseInstructions }
       : {}),
-    ...(seed?.reasoningEffortMappings && seed.reasoningEffortMappings.length > 0
-      ? { reasoningEffortMappings: seed.reasoningEffortMappings }
-      : {}),
+    reasoningEffortMappings:
+      seed?.reasoningEffortMappings !== undefined
+        ? seed.reasoningEffortMappings
+        : createDefaultReasoningEffortMappings(),
     ...(seed?.defaultReasoningLevel
       ? { defaultReasoningLevel: seed.defaultReasoningLevel }
       : {}),
@@ -190,15 +206,6 @@ function catalogRowsMatchModels(
   });
 }
 
-// Codex Desktop currently renders these catalog efforts as Light, Medium, High,
-// and Extra High. Provider-native values are configured separately below.
-const CODEX_REASONING_LEVELS: readonly CodexReasoningLevel[] = [
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-];
-
 // Sentinel for the default-level Select: Radix Select forbids empty item
 // values, so "back to Auto" needs a non-empty value mapped to undefined.
 const AUTO_DEFAULT_REASONING_LEVEL = "__auto__";
@@ -232,7 +239,7 @@ function ReasoningLevelsEditor({
       const mapping = nextByLevel.get(level);
       return mapping ? [mapping] : [];
     });
-    onMappingsChange(next.length > 0 ? next : undefined);
+    onMappingsChange(next);
     if (defaultLevel && !nextByLevel.has(defaultLevel)) {
       onDefaultLevelChange(undefined);
     }

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -57,6 +57,8 @@ import type {
   CodexApiFormat,
   CodexCatalogModel,
   CodexChatReasoning,
+  CodexReasoningEffortMapping,
+  CodexReasoningLevel,
   PromptCacheRoutingMode,
   ProviderCategory,
 } from "@/types";
@@ -150,8 +152,8 @@ function createCatalogRow(seed?: Partial<CodexCatalogModel>): CodexCatalogRow {
     ...(seed?.baseInstructions
       ? { baseInstructions: seed.baseInstructions }
       : {}),
-    ...(seed?.reasoningLevels && seed.reasoningLevels.length > 0
-      ? { reasoningLevels: seed.reasoningLevels }
+    ...(seed?.reasoningEffortMappings && seed.reasoningEffortMappings.length > 0
+      ? { reasoningEffortMappings: seed.reasoningEffortMappings }
       : {}),
     ...(seed?.defaultReasoningLevel
       ? { defaultReasoningLevel: seed.defaultReasoningLevel }
@@ -180,61 +182,79 @@ function catalogRowsMatchModels(
       (row.baseInstructions ?? "") === (incoming.baseInstructions ?? "") &&
       JSON.stringify(row.inputModalities ?? []) ===
         JSON.stringify(incoming.inputModalities ?? []) &&
-      JSON.stringify(row.reasoningLevels ?? []) ===
-        JSON.stringify(incoming.reasoningLevels ?? []) &&
+      JSON.stringify(row.reasoningEffortMappings ?? []) ===
+        JSON.stringify(incoming.reasoningEffortMappings ?? []) &&
       (row.defaultReasoningLevel ?? "") ===
         (incoming.defaultReasoningLevel ?? "")
     );
   });
 }
 
-// Reasoning effort levels Codex understands, in ascending depth order. The
-// backend drops unknown values, so the UI only offers canonical ones.
-const CODEX_REASONING_LEVELS = [
-  "none",
-  "minimal",
+// Codex Desktop currently renders these catalog efforts as Light, Medium, High,
+// and Extra High. Provider-native values are configured separately below.
+const CODEX_REASONING_LEVELS: readonly CodexReasoningLevel[] = [
   "low",
   "medium",
   "high",
   "xhigh",
-  "max",
-  "ultra",
-] as const;
+];
 
 // Sentinel for the default-level Select: Radix Select forbids empty item
 // values, so "back to Auto" needs a non-empty value mapped to undefined.
 const AUTO_DEFAULT_REASONING_LEVEL = "__auto__";
 
 function ReasoningLevelsEditor({
-  levels,
+  mappings,
   defaultLevel,
-  onLevelsChange,
+  onMappingsChange,
   onDefaultLevelChange,
 }: {
-  levels?: string[];
-  defaultLevel?: string;
-  onLevelsChange: (levels: string[] | undefined) => void;
-  onDefaultLevelChange: (level: string | undefined) => void;
+  mappings?: CodexReasoningEffortMapping[];
+  defaultLevel?: CodexReasoningLevel;
+  onMappingsChange: (
+    mappings: CodexReasoningEffortMapping[] | undefined,
+  ) => void;
+  onDefaultLevelChange: (level: CodexReasoningLevel | undefined) => void;
 }) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
-  const selected = (levels ?? []).filter((level) =>
-    (CODEX_REASONING_LEVELS as readonly string[]).includes(level),
+  const byLevel = new Map(
+    (mappings ?? [])
+      .filter((mapping) => CODEX_REASONING_LEVELS.includes(mapping.level))
+      .map((mapping) => [mapping.level, mapping]),
   );
+  const selected = CODEX_REASONING_LEVELS.filter((level) => byLevel.has(level));
 
-  const toggleLevel = (level: string) => {
-    const picked = selected.includes(level)
-      ? selected.filter((item) => item !== level)
-      : [...selected, level];
-    // Store in canonical ascending-depth order (not click order): the Codex
-    // picker and the generated catalog both follow array order.
-    const next = (CODEX_REASONING_LEVELS as readonly string[]).filter((item) =>
-      picked.includes(item),
-    );
-    onLevelsChange(next.length > 0 ? next : undefined);
-    if (defaultLevel && !next.includes(defaultLevel)) {
+  const commit = (
+    nextByLevel: Map<CodexReasoningLevel, CodexReasoningEffortMapping>,
+  ) => {
+    const next = CODEX_REASONING_LEVELS.flatMap((level) => {
+      const mapping = nextByLevel.get(level);
+      return mapping ? [mapping] : [];
+    });
+    onMappingsChange(next.length > 0 ? next : undefined);
+    if (defaultLevel && !nextByLevel.has(defaultLevel)) {
       onDefaultLevelChange(undefined);
     }
+  };
+
+  const toggleLevel = (level: CodexReasoningLevel) => {
+    const next = new Map(byLevel);
+    if (next.has(level)) {
+      next.delete(level);
+    } else {
+      next.set(level, { level });
+    }
+    commit(next);
+  };
+
+  const updateMapping = (
+    level: CodexReasoningLevel,
+    patch: Partial<CodexReasoningEffortMapping>,
+  ) => {
+    const next = new Map(byLevel);
+    next.set(level, { ...(next.get(level) ?? { level }), ...patch, level });
+    commit(next);
   };
 
   const triggerLabel =
@@ -266,11 +286,11 @@ function ReasoningLevelsEditor({
       </PopoverTrigger>
       <PopoverContent
         side="bottom"
-        align="start"
+        align="end"
         sideOffset={6}
         avoidCollisions
         collisionPadding={8}
-        className="z-[1000] w-[var(--radix-popover-trigger-width)] p-0 border-border-default"
+        className="z-[1000] w-[min(620px,calc(100vw-24px))] p-0 border-border-default"
       >
         <Command>
           <CommandInput
@@ -305,6 +325,85 @@ function ReasoningLevelsEditor({
         </Command>
         {selected.length > 0 && (
           <div className="border-t border-border-default p-2">
+            <div className="mb-1 grid grid-cols-[64px_minmax(0,0.8fr)_minmax(0,1.2fr)] gap-1.5 px-1 text-[10px] text-muted-foreground">
+              <span>
+                {t("codexConfig.reasoningMappingLevel", {
+                  defaultValue: "Codex",
+                })}
+              </span>
+              <span>
+                {t("codexConfig.reasoningMappingUpstream", {
+                  defaultValue: "Upstream value",
+                })}
+              </span>
+              <span>
+                {t("codexConfig.reasoningMappingDescription", {
+                  defaultValue: "Description",
+                })}
+              </span>
+            </div>
+            <div className="space-y-1.5">
+              {selected.map((level) => {
+                const mapping = byLevel.get(level)!;
+                return (
+                  <div
+                    key={level}
+                    className="grid grid-cols-[64px_minmax(0,0.8fr)_minmax(0,1.2fr)] items-center gap-1.5"
+                  >
+                    <span className="px-1 font-mono text-xs">{level}</span>
+                    <Input
+                      value={mapping.upstreamValue ?? ""}
+                      onChange={(event) =>
+                        updateMapping(level, {
+                          upstreamValue: event.target.value,
+                        })
+                      }
+                      placeholder={level}
+                      className="h-8 font-mono text-xs"
+                      aria-label={t(
+                        "codexConfig.reasoningMappingUpstreamAria",
+                        {
+                          defaultValue: `${level} upstream value`,
+                          level,
+                        },
+                      )}
+                    />
+                    <Input
+                      value={mapping.description ?? ""}
+                      onChange={(event) =>
+                        updateMapping(level, {
+                          description: event.target.value,
+                        })
+                      }
+                      placeholder={t(
+                        "codexConfig.reasoningMappingDescriptionPlaceholder",
+                        {
+                          defaultValue: "Use Codex default",
+                        },
+                      )}
+                      className="h-8 text-xs"
+                      aria-label={t(
+                        "codexConfig.reasoningMappingDescriptionAria",
+                        {
+                          defaultValue: `${level} description`,
+                          level,
+                        },
+                      )}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+            <p className="mt-1.5 text-[10px] leading-snug text-muted-foreground">
+              {t("codexConfig.reasoningMappingHint", {
+                defaultValue:
+                  "Codex shows the fixed levels above. Upstream values are applied only when requests pass through CC Switch routing; leave blank to forward the same value.",
+              })}
+            </p>
+          </div>
+        )}
+        {selected.length > 0 && (
+          <div className="border-t border-border-default p-2">
             <span className="text-xs text-muted-foreground">
               {t("codexConfig.defaultReasoningLevelLabel", {
                 defaultValue: "Default level",
@@ -314,7 +413,9 @@ function ReasoningLevelsEditor({
               value={defaultLevel ?? AUTO_DEFAULT_REASONING_LEVEL}
               onValueChange={(value) =>
                 onDefaultLevelChange(
-                  value === AUTO_DEFAULT_REASONING_LEVEL ? undefined : value,
+                  value === AUTO_DEFAULT_REASONING_LEVEL
+                    ? undefined
+                    : (value as CodexReasoningLevel),
                 )
               }
             >
@@ -326,9 +427,6 @@ function ReasoningLevelsEditor({
                   )}
                 />
               </SelectTrigger>
-              {/* Must render above the enclosing z-[1000] popover: the
-                  default SelectContent z-[100] would hide the menu behind
-                  the panel when it flips upward. */}
               <SelectContent className="z-[1100]">
                 <SelectItem value={AUTO_DEFAULT_REASONING_LEVEL}>
                   {t("codexConfig.defaultReasoningLevelPlaceholder", {
@@ -1234,11 +1332,11 @@ export function CodexFormFields({
                           })}
                         />
                         <ReasoningLevelsEditor
-                          levels={row.reasoningLevels}
+                          mappings={row.reasoningEffortMappings}
                           defaultLevel={row.defaultReasoningLevel}
-                          onLevelsChange={(levels) =>
+                          onMappingsChange={(mappings) =>
                             handleUpdateCatalogRow(index, {
-                              reasoningLevels: levels,
+                              reasoningEffortMappings: mappings,
                             })
                           }
                           onDefaultLevelChange={(level) =>

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -168,6 +168,8 @@ export const normalizeCodexCatalogModelsForSave = (
       "medium",
       "high",
       "xhigh",
+      "max",
+      "ultra",
     ];
     const rawMappings: Array<{
       level: unknown;
@@ -226,7 +228,8 @@ export const normalizeCodexCatalogModelsForSave = (
         ? { inputModalities }
         : {}),
       ...(baseInstructions ? { baseInstructions } : {}),
-      ...(reasoningEffortMappings.length > 0
+      ...(item.reasoningEffortMappings !== undefined ||
+      item.reasoningLevels !== undefined
         ? { reasoningEffortMappings }
         : {}),
       ...(normalizedDefaultReasoningLevel

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -21,6 +21,8 @@ import type {
   CodexApiFormat,
   CodexCatalogModel,
   CodexChatReasoning,
+  CodexReasoningEffortMapping,
+  CodexReasoningLevel,
   PromptCacheRoutingMode,
   ClaudeApiKeyField,
 } from "@/types";
@@ -161,10 +163,56 @@ export const normalizeCodexCatalogModelsForSave = (
     );
 
     const baseInstructions = item.baseInstructions?.trim();
-    const reasoningLevels = item.reasoningLevels?.filter(
-      (level) => typeof level === "string" && level.trim(),
+    const canonicalReasoningLevels: readonly CodexReasoningLevel[] = [
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+    ];
+    const rawMappings: Array<{
+      level: unknown;
+      upstreamValue?: unknown;
+      description?: unknown;
+    }> = item.reasoningEffortMappings
+      ? item.reasoningEffortMappings
+      : (item.reasoningLevels ?? []).map((level) => ({ level }));
+    const mappingByLevel = new Map<
+      CodexReasoningLevel,
+      CodexReasoningEffortMapping
+    >();
+    for (const mapping of rawMappings) {
+      const level = String(mapping.level).trim().toLowerCase();
+      if (!(canonicalReasoningLevels as readonly string[]).includes(level)) {
+        continue;
+      }
+      const upstreamValue =
+        typeof mapping.upstreamValue === "string"
+          ? mapping.upstreamValue.trim()
+          : undefined;
+      const description =
+        typeof mapping.description === "string"
+          ? mapping.description.trim()
+          : undefined;
+      mappingByLevel.set(level as CodexReasoningLevel, {
+        level: level as CodexReasoningLevel,
+        ...(upstreamValue ? { upstreamValue } : {}),
+        ...(description ? { description } : {}),
+      });
+    }
+    const reasoningEffortMappings = canonicalReasoningLevels.flatMap(
+      (level) => {
+        const mapping = mappingByLevel.get(level);
+        return mapping ? [mapping] : [];
+      },
     );
-    const defaultReasoningLevel = item.defaultReasoningLevel?.trim();
+    const defaultReasoningLevel = String(item.defaultReasoningLevel ?? "")
+      .trim()
+      .toLowerCase();
+    const normalizedDefaultReasoningLevel = mappingByLevel.has(
+      defaultReasoningLevel as CodexReasoningLevel,
+    )
+      ? (defaultReasoningLevel as CodexReasoningLevel)
+      : undefined;
 
     normalized.push({
       model,
@@ -178,10 +226,12 @@ export const normalizeCodexCatalogModelsForSave = (
         ? { inputModalities }
         : {}),
       ...(baseInstructions ? { baseInstructions } : {}),
-      ...(reasoningLevels && reasoningLevels.length > 0
-        ? { reasoningLevels }
+      ...(reasoningEffortMappings.length > 0
+        ? { reasoningEffortMappings }
         : {}),
-      ...(defaultReasoningLevel ? { defaultReasoningLevel } : {}),
+      ...(normalizedDefaultReasoningLevel
+        ? { defaultReasoningLevel: normalizedDefaultReasoningLevel }
+        : {}),
     });
   }
 

--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -108,7 +108,7 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
               ? rawReasoningMappings
               : legacyReasoningLevels
                   ?.filter((level: unknown) =>
-                    ["low", "medium", "high", "xhigh"].includes(
+                    ["low", "medium", "high", "xhigh", "max", "ultra"].includes(
                       String(level).trim().toLowerCase(),
                     ),
                   )
@@ -142,11 +142,11 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
                 : {}),
               ...(inputModalities ? { inputModalities } : {}),
               ...(baseInstructions ? { baseInstructions } : {}),
-              ...(reasoningEffortMappings && reasoningEffortMappings.length > 0
+              ...(reasoningEffortMappings !== undefined
                 ? { reasoningEffortMappings }
                 : {}),
               ...(defaultReasoningLevel &&
-              ["low", "medium", "high", "xhigh"].includes(
+              ["low", "medium", "high", "xhigh", "max", "ultra"].includes(
                 defaultReasoningLevel.trim().toLowerCase(),
               )
                 ? {

--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -92,11 +92,29 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
                 : typeof item?.base_instructions === "string"
                   ? item.base_instructions
                   : undefined;
-            const reasoningLevels = Array.isArray(item?.reasoningLevels)
+            const rawReasoningMappings = Array.isArray(
+              item?.reasoningEffortMappings,
+            )
+              ? item.reasoningEffortMappings
+              : Array.isArray(item?.reasoning_effort_mappings)
+                ? item.reasoning_effort_mappings
+                : undefined;
+            const legacyReasoningLevels = Array.isArray(item?.reasoningLevels)
               ? item.reasoningLevels
               : Array.isArray(item?.reasoning_levels)
                 ? item.reasoning_levels
                 : undefined;
+            const reasoningEffortMappings = rawReasoningMappings
+              ? rawReasoningMappings
+              : legacyReasoningLevels
+                  ?.filter((level: unknown) =>
+                    ["low", "medium", "high", "xhigh"].includes(
+                      String(level).trim().toLowerCase(),
+                    ),
+                  )
+                  .map((level: unknown) => ({
+                    level: String(level).trim().toLowerCase(),
+                  }));
             const defaultReasoningLevel =
               typeof item?.defaultReasoningLevel === "string"
                 ? item.defaultReasoningLevel
@@ -124,10 +142,19 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
                 : {}),
               ...(inputModalities ? { inputModalities } : {}),
               ...(baseInstructions ? { baseInstructions } : {}),
-              ...(reasoningLevels && reasoningLevels.length > 0
-                ? { reasoningLevels }
+              ...(reasoningEffortMappings && reasoningEffortMappings.length > 0
+                ? { reasoningEffortMappings }
                 : {}),
-              ...(defaultReasoningLevel ? { defaultReasoningLevel } : {}),
+              ...(defaultReasoningLevel &&
+              ["low", "medium", "high", "xhigh"].includes(
+                defaultReasoningLevel.trim().toLowerCase(),
+              )
+                ? {
+                    defaultReasoningLevel: defaultReasoningLevel
+                      .trim()
+                      .toLowerCase(),
+                  }
+                : {}),
             };
           })
           .filter((item: CodexCatalogModel) => item.model.trim()),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1547,7 +1547,7 @@
     "reasoningMappingDescriptionPlaceholder": "Use Codex default",
     "reasoningMappingUpstreamAria": "{{level}} upstream value",
     "reasoningMappingDescriptionAria": "{{level}} description",
-    "reasoningMappingHint": "Codex shows the fixed levels above. Upstream values are applied only when requests pass through CC Switch routing; leave blank to forward the same value."
+    "reasoningMappingHint": "Low through Ultra are enabled by default. Upstream values are applied only when requests pass through CC Switch routing; leave blank to forward the same value."
   },
   "geminiConfig": {
     "envFile": "Environment Variables (.env)",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1540,7 +1540,14 @@
     "reasoningGroupTitle": "Reasoning Capability",
     "reasoningSectionHint": "Preset providers are configured automatically; custom providers are inferred from name/URL. Override manually only when auto-detection is wrong.",
     "advancedSectionHint": "Includes upstream format, model mapping, reasoning overrides and custom User-Agent. Providers using the Chat Completions protocol require routing takeover to be enabled.",
-    "noCommonConfigToApply": "The common config snippet is empty or contains nothing to write"
+    "noCommonConfigToApply": "The common config snippet is empty or contains nothing to write",
+    "reasoningMappingLevel": "Codex",
+    "reasoningMappingUpstream": "Upstream value",
+    "reasoningMappingDescription": "Description",
+    "reasoningMappingDescriptionPlaceholder": "Use Codex default",
+    "reasoningMappingUpstreamAria": "{{level}} upstream value",
+    "reasoningMappingDescriptionAria": "{{level}} description",
+    "reasoningMappingHint": "Codex shows the fixed levels above. Upstream values are applied only when requests pass through CC Switch routing; leave blank to forward the same value."
   },
   "geminiConfig": {
     "envFile": "Environment Variables (.env)",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1540,7 +1540,14 @@
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "プリセットの供給元は自動的に設定され、カスタム供給元は名前/URL から自動推論されます。自動識別が正しくない場合のみ手動で上書きしてください。",
     "advancedSectionHint": "上流フォーマット、モデルマッピング、思考能力、カスタム User-Agent の設定を含みます。Chat Completions プロトコルを使用するプロバイダーはルーティング引き継ぎの有効化が必要です。",
-    "noCommonConfigToApply": "共通設定スニペットが空か、書き込む内容がありません"
+    "noCommonConfigToApply": "共通設定スニペットが空か、書き込む内容がありません",
+    "reasoningMappingLevel": "Codex レベル",
+    "reasoningMappingUpstream": "上流の値",
+    "reasoningMappingDescription": "説明",
+    "reasoningMappingDescriptionPlaceholder": "Codex の既定説明を使用",
+    "reasoningMappingUpstreamAria": "{{level}} の上流値",
+    "reasoningMappingDescriptionAria": "{{level}} の説明",
+    "reasoningMappingHint": "Codex には上記の固定レベルが表示されます。上流値はリクエストが CC Switch ルーティングを通る場合のみ適用され、空欄の場合は Codex の値をそのまま転送します。"
   },
   "geminiConfig": {
     "envFile": "環境変数 (.env)",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1547,7 +1547,7 @@
     "reasoningMappingDescriptionPlaceholder": "Codex の既定説明を使用",
     "reasoningMappingUpstreamAria": "{{level}} の上流値",
     "reasoningMappingDescriptionAria": "{{level}} の説明",
-    "reasoningMappingHint": "Codex には上記の固定レベルが表示されます。上流値はリクエストが CC Switch ルーティングを通る場合のみ適用され、空欄の場合は Codex の値をそのまま転送します。"
+    "reasoningMappingHint": "low から ultra までの6段階がデフォルトで有効です。上流値はリクエストが CC Switch ルーティングを通る場合のみ適用され、空欄の場合は Codex の値をそのまま転送します。"
   },
   "geminiConfig": {
     "envFile": "環境変数 (.env)",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1541,7 +1541,14 @@
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "預設供應商已自動設定；自訂供應商會按名稱/位址自動推斷。僅當自動識別不準時才需手動覆寫。",
     "advancedSectionHint": "包含上游格式、模型映射、思考能力與自訂 User-Agent。使用 Chat Completions 協定的供應商需開啟路由接管才能使用。",
-    "noCommonConfigToApply": "通用設定片段為空或沒有可寫入的內容"
+    "noCommonConfigToApply": "通用設定片段為空或沒有可寫入的內容",
+    "reasoningMappingLevel": "Codex 檔位",
+    "reasoningMappingUpstream": "上游值",
+    "reasoningMappingDescription": "描述",
+    "reasoningMappingDescriptionPlaceholder": "使用 Codex 預設描述",
+    "reasoningMappingUpstreamAria": "{{level}} 上游值",
+    "reasoningMappingDescriptionAria": "{{level}} 描述",
+    "reasoningMappingHint": "Codex 固定顯示以上檔位。請求經過 CC Switch 路由時才會套用上游值；留空則原樣傳遞 Codex 檔位。"
   },
   "geminiConfig": {
     "envFile": "環境變數 (.env)",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1548,7 +1548,7 @@
     "reasoningMappingDescriptionPlaceholder": "使用 Codex 預設描述",
     "reasoningMappingUpstreamAria": "{{level}} 上游值",
     "reasoningMappingDescriptionAria": "{{level}} 描述",
-    "reasoningMappingHint": "Codex 固定顯示以上檔位。請求經過 CC Switch 路由時才會套用上游值；留空則原樣傳遞 Codex 檔位。"
+    "reasoningMappingHint": "預設啟用 low 到 ultra 六個檔位。請求經過 CC Switch 路由時才會套用上游值；留空則原樣傳遞 Codex 檔位。"
   },
   "geminiConfig": {
     "envFile": "環境變數 (.env)",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1540,7 +1540,14 @@
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "预设供应商已自动配置；自定义供应商会按名称/地址自动推断。仅当自动识别不准时才需手动覆盖。",
     "advancedSectionHint": "包含上游格式、模型映射、思考能力与自定义 User-Agent。使用 Chat Completions 协议的供应商需开启路由接管才能使用。",
-    "noCommonConfigToApply": "通用配置片段为空或没有可写入的内容"
+    "noCommonConfigToApply": "通用配置片段为空或没有可写入的内容",
+    "reasoningMappingLevel": "Codex 档位",
+    "reasoningMappingUpstream": "上游值",
+    "reasoningMappingDescription": "描述",
+    "reasoningMappingDescriptionPlaceholder": "使用 Codex 默认描述",
+    "reasoningMappingUpstreamAria": "{{level}} 上游值",
+    "reasoningMappingDescriptionAria": "{{level}} 描述",
+    "reasoningMappingHint": "Codex 固定显示以上档位。请求经过 CC Switch 路由时才会应用上游值；留空则原样传递 Codex 档位。"
   },
   "geminiConfig": {
     "envFile": "环境变量 (.env)",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1547,7 +1547,7 @@
     "reasoningMappingDescriptionPlaceholder": "使用 Codex 默认描述",
     "reasoningMappingUpstreamAria": "{{level}} 上游值",
     "reasoningMappingDescriptionAria": "{{level}} 描述",
-    "reasoningMappingHint": "Codex 固定显示以上档位。请求经过 CC Switch 路由时才会应用上游值；留空则原样传递 Codex 档位。"
+    "reasoningMappingHint": "默认启用 low 到 ultra 六个档位。请求经过 CC Switch 路由时才会应用上游值；留空则原样传递 Codex 档位。"
   },
   "geminiConfig": {
     "envFile": "环境变量 (.env)",

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,7 +258,13 @@ export type ClaudeApiFormat =
 // - "anthropic": native Anthropic Messages format, needs local routing to convert to Responses
 export type CodexApiFormat = "openai_responses" | "openai_chat" | "anthropic";
 
-export type CodexReasoningLevel = "low" | "medium" | "high" | "xhigh";
+export type CodexReasoningLevel =
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | "ultra";
 
 export interface CodexReasoningEffortMapping {
   // Stable effort exposed by the Codex model picker.

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,6 +258,18 @@ export type ClaudeApiFormat =
 // - "anthropic": native Anthropic Messages format, needs local routing to convert to Responses
 export type CodexApiFormat = "openai_responses" | "openai_chat" | "anthropic";
 
+export type CodexReasoningLevel = "low" | "medium" | "high" | "xhigh";
+
+export interface CodexReasoningEffortMapping {
+  // Stable effort exposed by the Codex model picker.
+  level: CodexReasoningLevel;
+  // Optional provider-native value written by CC Switch while proxying. When
+  // omitted, the Codex level is forwarded unchanged.
+  upstreamValue?: string;
+  // Optional catalog description shown by Codex surfaces that render it.
+  description?: string;
+}
+
 export interface CodexCatalogModel {
   model: string;
   displayName?: string;
@@ -271,14 +283,17 @@ export interface CodexCatalogModel {
   // Codex requires this field in every catalog entry; when omitted the backend
   // falls back to a neutral default. e.g. MiMo "developed by Xiaomi".
   baseInstructions?: string;
-  // Per-model reasoning effort levels exposed in the generated Codex catalog
-  // (e.g. ["none", "low", "medium", "high", "xhigh", "max"]). When omitted the
-  // backend keeps the template's conservative none/high default.
+  // Per-model mappings from Codex's stable picker levels to provider-native
+  // values. The catalog always exposes the Codex `level`; `upstreamValue` is
+  // applied only while requests pass through CC Switch's local routing.
+  reasoningEffortMappings?: CodexReasoningEffortMapping[];
+  // Legacy field written by CC Switch 3.19.2 / PR #6228. It remains readable so
+  // existing providers can migrate without data loss, but new saves use
+  // reasoningEffortMappings.
   reasoningLevels?: string[];
-  // Per-model default reasoning effort. Only meaningful together with
-  // reasoningLevels; when omitted the backend keeps the template default if it
-  // is still in the list, otherwise the highest declared level.
-  defaultReasoningLevel?: string;
+  // Per-model default Codex reasoning level. Only meaningful together with the
+  // configured mappings.
+  defaultReasoningLevel?: CodexReasoningLevel;
 }
 
 // Claude 认证字段类型

--- a/tests/components/ProviderForm.codexCatalog.test.ts
+++ b/tests/components/ProviderForm.codexCatalog.test.ts
@@ -60,6 +60,7 @@ describe("ProviderForm Codex catalog helpers", () => {
             { level: "xhigh", upstreamValue: " max ", description: " Deep " },
             { level: "low", upstreamValue: " light " },
             { level: "medium", description: " Balanced " },
+            { level: "ultra", upstreamValue: " unlimited " },
             { level: "low", upstreamValue: "duplicate" },
           ],
           defaultReasoningLevel: "xhigh",
@@ -78,12 +79,17 @@ describe("ProviderForm Codex catalog helpers", () => {
           { level: "low", upstreamValue: "duplicate" },
           { level: "medium", description: "Balanced" },
           { level: "xhigh", upstreamValue: "max", description: "Deep" },
+          { level: "ultra", upstreamValue: "unlimited" },
         ],
         defaultReasoningLevel: "xhigh",
       },
       {
         model: "legacy-model",
-        reasoningEffortMappings: [{ level: "low" }, { level: "high" }],
+        reasoningEffortMappings: [
+          { level: "low" },
+          { level: "high" },
+          { level: "max" },
+        ],
         defaultReasoningLevel: "high",
       },
     ]);

--- a/tests/components/ProviderForm.codexCatalog.test.ts
+++ b/tests/components/ProviderForm.codexCatalog.test.ts
@@ -50,30 +50,42 @@ describe("ProviderForm Codex catalog helpers", () => {
     ]);
   });
 
-  it("preserves per-model reasoning levels and default level", () => {
+  it("normalizes Codex effort mappings, descriptions, and defaults", () => {
     expect(
       normalizeCodexCatalogModelsForSave([
         {
           model: "deepseek-v4-flash",
           displayName: "DeepSeek V4 Flash",
-          reasoningLevels: ["none", "low", "medium", "high", "xhigh", "max"],
-          defaultReasoningLevel: " xhigh ",
+          reasoningEffortMappings: [
+            { level: "xhigh", upstreamValue: " max ", description: " Deep " },
+            { level: "low", upstreamValue: " light " },
+            { level: "medium", description: " Balanced " },
+            { level: "low", upstreamValue: "duplicate" },
+          ],
+          defaultReasoningLevel: "xhigh",
         },
-        // empty levels / whitespace default are dropped
         {
-          model: "plain-model",
-          reasoningLevels: [],
-          defaultReasoningLevel: "   ",
+          model: "legacy-model",
+          reasoningLevels: ["none", "low", "high", "max"],
+          defaultReasoningLevel: "high",
         },
       ]),
     ).toEqual([
       {
         model: "deepseek-v4-flash",
         displayName: "DeepSeek V4 Flash",
-        reasoningLevels: ["none", "low", "medium", "high", "xhigh", "max"],
+        reasoningEffortMappings: [
+          { level: "low", upstreamValue: "duplicate" },
+          { level: "medium", description: "Balanced" },
+          { level: "xhigh", upstreamValue: "max", description: "Deep" },
+        ],
         defaultReasoningLevel: "xhigh",
       },
-      { model: "plain-model" },
+      {
+        model: "legacy-model",
+        reasoningEffortMappings: [{ level: "low" }, { level: "high" }],
+        defaultReasoningLevel: "high",
+      },
     ]);
   });
 });


### PR DESCRIPTION
## Background

PR #6228 added per-model Reasoning Effort declarations to the generated Codex model catalog. A follow-up experiment in #6483 allowed arbitrary catalog effort strings, but end-to-end testing with Codex Desktop showed an important limitation: the Desktop picker filters catalog values through a built-in Codex effort vocabulary instead of rendering arbitrary provider-native strings.

This PR takes a different approach and is intentionally independent from #6483:

- expose a stable set of Codex-facing levels in the generated catalog;
- let users map each Codex level to the value required by the upstream provider;
- let users customize the catalog description for every level.

#6483 is left unchanged so the two designs can be reviewed independently.

## Design

### 1. Six Codex-facing levels enabled by default

Every new custom catalog model starts with these six levels selected:

- `low` — shown as **Light** by Codex Desktop
- `medium` — **Medium**
- `high` — **High**
- `xhigh` — **Extra High**
- `max` — **Max**
- `ultra` — **Ultra**

These canonical values are written into `supported_reasoning_levels` in ascending order. Existing configurations may still select a subset.

Codex Desktop contains labels for all six values, but the final visibility of `max` and `ultra` can still depend on the installed Codex version, account feature flags, and Desktop settings. CC Switch's responsibility is to declare them in the catalog by default rather than silently discarding them.

`none` and `minimal` are intentionally not enabled by this UI because this design focuses on the six user-requested reasoning-depth levels.

### 2. Per-level provider mapping

Each selected Codex-facing level stores an optional provider-native value:

```json
{
  "reasoningEffortMappings": [
    {
      "level": "low",
      "upstreamValue": "light",
      "description": "Fast provider reasoning"
    },
    {
      "level": "xhigh",
      "upstreamValue": "max",
      "description": "Maximum provider reasoning"
    },
    {
      "level": "ultra",
      "upstreamValue": "unlimited"
    }
  ],
  "defaultReasoningLevel": "xhigh"
}
```

The generated Codex catalog exposes the canonical values (`low`, `xhigh`, `ultra` in this example). It never exposes `light` or `unlimited` as picker values.

When a request passes through CC Switch local routing, the selected Codex level is replaced with its model-specific `upstreamValue`. Leaving `upstreamValue` blank preserves the original Codex value.

This separation is important because provider vocabularies are not uniform and may evolve independently from Codex's picker vocabulary.

### 3. User-authored descriptions

Every selected level has an optional description input. When blank, CC Switch writes its maintained default description. When provided, the custom description is written into the model catalog beside the canonical Codex effort.

Provider-native values are deliberately never written into the generated catalog description or effort field unless the user explicitly enters them as description text.

### 4. Protocol coverage

Mappings are model-specific and cover every Codex routing path:

- native Responses passthrough: rewrites `reasoning.effort`;
- Responses -> Chat Completions: writes the mapped value using the configured parameter shape (`reasoning_effort` or `reasoning.effort`);
- Responses -> Anthropic Messages: applies the mapped value after conversion, writing `output_config.effort` without changing `thinking.type`.

Applying the mapping at the protocol boundary prevents provider-native values from being passed through converters that only understand canonical Codex levels.

## UI

The existing model row stays compact. Its Reasoning Levels field opens a popover containing:

1. the six Codex-facing levels, selected by default for a new model;
2. one compact row per selected level with:
   - Codex level;
   - editable upstream value;
   - editable description;
3. the default-level selector.

No separate large settings section is added to the provider form.

An explicit empty selection remains distinguishable from a model that has never configured mappings, so reopening the form does not unexpectedly re-enable levels the user removed.

## Catalog and routing boundaries

The two value domains remain separate throughout the implementation:

```text
Codex picker level
        ↓
cc-switch-model-catalog.json: supported_reasoning_levels[].effort
        ↓ request enters CC Switch routing
model-specific reasoningEffortMappings lookup
        ↓
provider-native request value
```

For example:

```text
Codex xhigh → catalog xhigh → route mapping → Anthropic output_config.effort=max
```

Without routing takeover, CC Switch cannot rewrite the outgoing request, so `upstreamValue` mappings are not applied. Catalog levels and custom descriptions still work without routing.

## Compatibility and migration

- Existing `reasoningLevels` arrays from #6228 remain readable.
- On load/save they migrate to `reasoningEffortMappings`.
- Legacy `max` values are now retained instead of being discarded.
- Unknown values remain filtered out of the Codex-facing catalog.
- Providers without an explicit saved mapping receive the six default rows when edited as a custom catalog model.
- Explicit mapping subsets and explicit empty mappings are preserved by the frontend state/normalization path.
- Upstream mapping only takes effect when requests pass through CC Switch routing.

## Validation

Completed locally on August 16, 2026:

```bash
pnpm typecheck
pnpm test:unit
pnpm format:check
pnpm build:renderer
cargo test --manifest-path src-tauri/Cargo.toml codex_config::tests:: --lib
cargo test --manifest-path src-tauri/Cargo.toml proxy::providers::codex::tests:: --lib
rustfmt --edition 2021 src-tauri/src/codex_config.rs
git diff --check
```

Results:

- frontend tests: **122 files / 876 tests passed**;
- Codex catalog/config tests: **82 passed**;
- Codex provider/routing tests: **45 passed**;
- TypeScript, Prettier, renderer production build, Rust formatting, and diff checks passed.

## Reviewer test plan

1. Add or edit a custom Codex provider with a model catalog.
2. Add a model and open its Reasoning Levels popover.
3. Confirm `low`, `medium`, `high`, `xhigh`, `max`, and `ultra` are selected by default.
4. Remove one level, save, reopen the provider, and confirm the subset is preserved.
5. Enter an upstream value and a custom description for one or more levels.
6. Select a default and save.
7. Confirm the provider stores `reasoningEffortMappings`.
8. Confirm the generated catalog contains the canonical Codex levels and supplied descriptions, not provider-native values.
9. With local routing enabled, send a request using a mapped level and confirm the upstream request carries its configured provider-native value.
10. If testing `max` or `ultra` in Codex Desktop, account for the Desktop build/settings/feature-gate visibility rules described above.
