### PR TITLE
fix(codex): cancel stale device login after clear

### DIFF
--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -22,7 +22,10 @@ use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
 
@@ -302,6 +305,8 @@ pub struct CodexOAuthManager {
     /// 进行中的 Device Code 流程：device_auth_id -> {user_code, expires_at_ms}
     /// 过期条目会在 start_device_flow 时被清理，防止放弃的登录流程导致无界增长
     pending_device_codes: Arc<RwLock<HashMap<String, PendingDeviceCode>>>,
+    /// 清除全部认证时递增，使已经在网络请求中的登录流程无法重新登记。
+    login_epoch: AtomicU64,
     storage_path: PathBuf,
     /// 持久化串行锁：`save_to_disk` 与 `clear_auth` 的「快照+写盘/删文件」都在此锁内
     /// 完成。此前由外层 `RwLock<CodexOAuthManager>` 的写锁隐式串行化；去掉外层锁后
@@ -320,6 +325,7 @@ impl CodexOAuthManager {
             refresh_locks: Arc::new(RwLock::new(HashMap::new())),
             lifecycle_lock: Arc::new(RwLock::new(())),
             pending_device_codes: Arc::new(RwLock::new(HashMap::new())),
+            login_epoch: AtomicU64::new(0),
             storage_path,
             storage_lock: Arc::new(Mutex::new(())),
         };
@@ -341,6 +347,7 @@ impl CodexOAuthManager {
     /// - verification_uri = https://auth.openai.com/codex/device
     pub async fn start_device_flow(&self) -> Result<GitHubDeviceCodeResponse, CodexOAuthError> {
         log::info!("[CodexOAuth] 启动 Device Code 流程");
+        let login_epoch = self.login_epoch.load(Ordering::Acquire);
 
         let response = crate::proxy::http_client::get()
             .post(DEVICE_AUTH_USERCODE_URL)
@@ -368,20 +375,13 @@ impl CodexOAuthManager {
         let expires_in = device.expires_in.unwrap_or(DEVICE_CODE_DEFAULT_EXPIRES_IN);
         let expires_at_ms = chrono::Utc::now().timestamp_millis() + (expires_in as i64) * 1000;
 
-        // 记录 device_auth_id -> 用户码映射；同时清理所有已过期的条目，
-        // 避免用户放弃登录流程导致 HashMap 无界增长
-        {
-            let mut pending = self.pending_device_codes.write().await;
-            let now_ms = chrono::Utc::now().timestamp_millis();
-            pending.retain(|_, entry| entry.expires_at_ms > now_ms);
-            pending.insert(
-                device.device_auth_id.clone(),
-                PendingDeviceCode {
-                    user_code: device.user_code.clone(),
-                    expires_at_ms,
-                },
-            );
-        }
+        self.register_pending_device_code(
+            device.device_auth_id.clone(),
+            device.user_code.clone(),
+            expires_at_ms,
+            login_epoch,
+        )
+        .await?;
 
         log::info!(
             "[CodexOAuth] 获取 Device Code 成功，user_code: {}",
@@ -395,6 +395,30 @@ impl CodexOAuthManager {
             expires_in,
             interval,
         })
+    }
+
+    async fn register_pending_device_code(
+        &self,
+        device_auth_id: String,
+        user_code: String,
+        expires_at_ms: i64,
+        login_epoch: u64,
+    ) -> Result<(), CodexOAuthError> {
+        let mut pending = self.pending_device_codes.write().await;
+        if self.login_epoch.load(Ordering::Acquire) != login_epoch {
+            return Err(CodexOAuthError::ExpiredToken);
+        }
+
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        pending.retain(|_, entry| entry.expires_at_ms > now_ms);
+        pending.insert(
+            device_auth_id,
+            PendingDeviceCode {
+                user_code,
+                expires_at_ms,
+            },
+        );
+        Ok(())
     }
 
     /// 轮询 Device Code 状态
@@ -1222,6 +1246,7 @@ impl CodexOAuthManager {
         }
         {
             let mut pending = self.pending_device_codes.write().await;
+            self.login_epoch.fetch_add(1, Ordering::AcqRel);
             pending.clear();
         }
 
@@ -2107,6 +2132,26 @@ mod tests {
         assert!(matches!(result, Err(CodexOAuthError::ExpiredToken)));
         assert!(manager.list_accounts().await.is_empty());
         assert!(!manager.storage_path.exists());
+    }
+
+    #[tokio::test]
+    async fn device_start_rejects_flow_cleared_during_network_request() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        let login_epoch = manager.login_epoch.load(Ordering::Acquire);
+
+        manager.clear_auth().await.unwrap();
+        let result = manager
+            .register_pending_device_code(
+                "stale-device-auth-id".to_string(),
+                "ABCD-EFGH".to_string(),
+                chrono::Utc::now().timestamp_millis() + 60_000,
+                login_epoch,
+            )
+            .await;
+
+        assert!(matches!(result, Err(CodexOAuthError::ExpiredToken)));
+        assert!(manager.pending_device_codes.read().await.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix a race between starting Codex Device Code login and clearing all Codex auth.

A response started before the clear can no longer add a pending login afterward.

Follow-up to #3879.

## Tests

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --tests -- -D warnings`