### PR TITLE
fix(provider): harden IME-safe provider fields

### DIFF
--- a/src/components/providers/forms/BasicFormFields.tsx
+++ b/src/components/providers/forms/BasicFormFields.tsx
@@ -8,7 +8,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+import { ImeSafeInput } from "@/components/ui/ime-safe-input";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft } from "lucide-react";
 import {
@@ -130,7 +130,15 @@ export function BasicFormFields({
             <FormItem>
               <FormLabel>{t("provider.name")}</FormLabel>
               <FormControl>
-                <Input {...field} placeholder={t("provider.namePlaceholder")} />
+                <ImeSafeInput
+                  ref={field.ref}
+                  name={field.name}
+                  value={field.value ?? ""}
+                  onValueChange={field.onChange}
+                  onBlur={field.onBlur}
+                  disabled={field.disabled}
+                  placeholder={t("provider.namePlaceholder")}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -144,8 +152,13 @@ export function BasicFormFields({
             <FormItem>
               <FormLabel>{t("provider.notes")}</FormLabel>
               <FormControl>
-                <Input
-                  {...field}
+                <ImeSafeInput
+                  ref={field.ref}
+                  name={field.name}
+                  value={field.value ?? ""}
+                  onValueChange={field.onChange}
+                  onBlur={field.onBlur}
+                  disabled={field.disabled}
                   placeholder={t("provider.notesPlaceholder")}
                 />
               </FormControl>
@@ -162,8 +175,13 @@ export function BasicFormFields({
           <FormItem>
             <FormLabel>{t("provider.websiteUrl")}</FormLabel>
             <FormControl>
-              <Input
-                {...field}
+              <ImeSafeInput
+                ref={field.ref}
+                name={field.name}
+                value={field.value ?? ""}
+                onValueChange={field.onChange}
+                onBlur={field.onBlur}
+                disabled={field.disabled}
                 placeholder={t("providerForm.websiteUrlPlaceholder")}
               />
             </FormControl>

--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -55,9 +55,10 @@ function ModelIdInput({
     <ImeSafeInput
       value={localValue}
       onValueChange={setLocalValue}
-      onBlur={() => {
-        if (localValue !== modelId && localValue.trim()) {
-          onChange(localValue);
+      onBlur={(event) => {
+        const nextValue = event.currentTarget.value;
+        if (nextValue !== modelId && nextValue.trim()) {
+          onChange(nextValue);
         }
       }}
       placeholder={placeholder}
@@ -97,8 +98,8 @@ function ExtraOptionKeyInput({
     <ImeSafeInput
       value={localValue}
       onValueChange={setLocalValue}
-      onBlur={() => {
-        const trimmed = localValue.trim();
+      onBlur={(event) => {
+        const trimmed = event.currentTarget.value.trim();
         if (trimmed && trimmed !== optionKey) {
           const accepted = onChange(trimmed);
           if (accepted === false) {
@@ -136,8 +137,8 @@ function ModelOptionKeyInput({
     <ImeSafeInput
       value={localValue}
       onValueChange={setLocalValue}
-      onBlur={() => {
-        const trimmed = localValue.trim();
+      onBlur={(event) => {
+        const trimmed = event.currentTarget.value.trim();
         if (trimmed && trimmed !== optionKey) {
           onChange(trimmed);
         }

--- a/src/components/ui/ime-safe-input.tsx
+++ b/src/components/ui/ime-safe-input.tsx
@@ -18,6 +18,7 @@ const ImeSafeInput = React.forwardRef<HTMLInputElement, ImeSafeInputProps>(
       value,
       onValueChange,
       normalize,
+      onBlur,
       onCompositionStart,
       onCompositionEnd,
       ...props
@@ -62,6 +63,23 @@ const ImeSafeInput = React.forwardRef<HTMLInputElement, ImeSafeInputProps>(
             return;
           }
           commit(nextValue);
+        }}
+        onBlur={(event) => {
+          if (composingRef.current) {
+            // Some WebKit window-switch paths blur the input without first
+            // delivering compositionend. Commit the marked text once and
+            // leave the duplicate-event guard armed for a late event.
+            composingRef.current = false;
+            commit(event.currentTarget.value);
+          } else {
+            // The parent may parse and stringify a committed value back to the
+            // same prop it already held. In that case the value effect cannot
+            // observe a dependency change, so blur is the idle reconciliation
+            // point for both the visible draft and duplicate-event baseline.
+            externalValueRef.current = value;
+            setDraft(value);
+          }
+          onBlur?.(event);
         }}
         onCompositionStart={(event) => {
           composingRef.current = true;

--- a/tests/components/BasicFormFields.test.tsx
+++ b/tests/components/BasicFormFields.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useForm, type FieldPath, type UseFormReturn } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import { BasicFormFields } from "@/components/providers/forms/BasicFormFields";
+import { Form } from "@/components/ui/form";
+import type { ProviderFormData } from "@/lib/schemas/provider";
+
+vi.mock("@/components/ProviderIcon", () => ({
+  ProviderIcon: () => <div data-testid="provider-icon" />,
+}));
+
+vi.mock("@/components/IconPicker", () => ({
+  IconPicker: () => <div data-testid="icon-picker" />,
+}));
+
+const defaultValues: Partial<ProviderFormData> = {
+  name: "原供应商",
+  notes: "原备注",
+  websiteUrl: "https://example.com",
+  icon: "",
+  iconColor: "",
+};
+
+function renderBasicForm() {
+  let formApi!: UseFormReturn<ProviderFormData>;
+
+  function TestForm() {
+    const form = useForm<ProviderFormData>({ defaultValues });
+    formApi = form;
+    return (
+      <Form {...form}>
+        <BasicFormFields form={form} />
+      </Form>
+    );
+  }
+
+  const rendered = render(<TestForm />);
+  return { ...rendered, getForm: () => formApi, TestForm };
+}
+
+describe("BasicFormFields", () => {
+  it.each([
+    ["provider.name", "name", "原供应商"],
+    ["provider.notes", "notes", "原备注"],
+    ["provider.websiteUrl", "websiteUrl", "https://example.com"],
+  ] as const)(
+    "keeps %s composition local until the IME commits",
+    (label, fieldName, initialValue) => {
+      const { getForm, rerender, TestForm } = renderBasicForm();
+      const input = screen.getByLabelText(label);
+
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: "中文输入" } });
+
+      expect(input).toHaveValue("中文输入");
+      expect(
+        getForm().getValues(fieldName as FieldPath<ProviderFormData>),
+      ).toBe(initialValue);
+
+      // An unrelated parent render must not replace the browser-owned marked
+      // text with React Hook Form's last committed value.
+      rerender(<TestForm />);
+      expect(input).toHaveValue("中文输入");
+
+      fireEvent.compositionEnd(input, {
+        data: "中文输入",
+        target: { value: "中文输入" },
+      });
+
+      expect(
+        getForm().getValues(fieldName as FieldPath<ProviderFormData>),
+      ).toBe("中文输入");
+    },
+  );
+
+  it.each([
+    ["provider.name", "name", "原供应商"],
+    ["provider.notes", "notes", "原备注"],
+    ["provider.websiteUrl", "websiteUrl", "https://example.com"],
+  ] as const)(
+    "force-commits unfinished %s composition on blur",
+    (label, fieldName, initialValue) => {
+      const { getForm } = renderBasicForm();
+      const input = screen.getByLabelText(label);
+
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: "失焦提交" } });
+
+      expect(
+        getForm().getValues(fieldName as FieldPath<ProviderFormData>),
+      ).toBe(initialValue);
+
+      fireEvent.blur(input);
+
+      expect(
+        getForm().getValues(fieldName as FieldPath<ProviderFormData>),
+      ).toBe("失焦提交");
+    },
+  );
+});

--- a/tests/components/ImeSafeInput.test.tsx
+++ b/tests/components/ImeSafeInput.test.tsx
@@ -81,4 +81,60 @@ describe("ImeSafeInput", () => {
 
     expect(screen.getByRole("textbox")).toHaveValue("second");
   });
+
+  it("force-commits an unfinished composition on blur", () => {
+    const onValueChange = vi.fn();
+    const onBlur = vi.fn();
+    render(
+      <ImeSafeInput value="" onValueChange={onValueChange} onBlur={onBlur} />,
+    );
+    const input = screen.getByRole("textbox");
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: "未完成" } });
+    fireEvent.blur(input);
+
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+    expect(onValueChange).toHaveBeenCalledWith("未完成");
+    expect(onBlur).toHaveBeenCalledTimes(1);
+
+    // A late compositionend must not duplicate the blur commit.
+    fireEvent.compositionEnd(input, {
+      data: "未完成",
+      target: { value: "未完成" },
+    });
+    expect(onValueChange).toHaveBeenCalledTimes(1);
+
+    // The blur path must also clear the composing state for future input.
+    fireEvent.change(input, { target: { value: "下一次" } });
+    expect(onValueChange).toHaveBeenCalledTimes(2);
+    expect(onValueChange).toHaveBeenLastCalledWith("下一次");
+  });
+
+  it("reconciles an idle draft when the parent canonicalizes to the same prop", () => {
+    const onValueChange = vi.fn();
+    const canonicalValue = '{"enabled":true}';
+    const { rerender } = render(
+      <ImeSafeInput value={canonicalValue} onValueChange={onValueChange} />,
+    );
+    const input = screen.getByRole("textbox");
+
+    fireEvent.change(input, { target: { value: '{ "enabled": true }' } });
+    expect(onValueChange).toHaveBeenCalledWith('{ "enabled": true }');
+
+    // The parent parse/stringify result is identical to its previous prop, so
+    // the value effect has no dependency change to observe.
+    rerender(
+      <ImeSafeInput value={canonicalValue} onValueChange={onValueChange} />,
+    );
+    expect(input).toHaveValue('{ "enabled": true }');
+
+    fireEvent.blur(input);
+    expect(input).toHaveValue(canonicalValue);
+
+    // Resetting the duplicate-event baseline ensures the same textual edit is
+    // not incorrectly suppressed after reconciliation.
+    fireEvent.change(input, { target: { value: '{ "enabled": true }' } });
+    expect(onValueChange).toHaveBeenCalledTimes(2);
+  });
 });

--- a/tests/components/OpenCodeFormFields.test.tsx
+++ b/tests/components/OpenCodeFormFields.test.tsx
@@ -235,6 +235,81 @@ describe("OpenCodeFormFields", () => {
     });
   });
 
+  it("commits an unfinished model ID composition on its first blur", () => {
+    const onModelsChange = vi.fn();
+    renderOpenCodeForm({ onModelsChange });
+    const modelIdInput = screen.getByDisplayValue("kimi-k2");
+
+    fireEvent.compositionStart(modelIdInput);
+    fireEvent.change(modelIdInput, { target: { value: "中文模型" } });
+    fireEvent.blur(modelIdInput);
+
+    expect(onModelsChange).toHaveBeenCalledTimes(1);
+    expect(onModelsChange).toHaveBeenCalledWith({
+      中文模型: {
+        name: "Kimi K2",
+        limit: { context: 1048576, output: 131072 },
+      },
+    });
+  });
+
+  it("commits an unfinished model option key composition on its first blur", () => {
+    const onModelsChange = vi.fn();
+    renderOpenCodeForm({
+      models: {
+        "kimi-k2": {
+          name: "Kimi K2",
+          options: { provider: "baseten" },
+        },
+      },
+      onModelsChange,
+    });
+    expandFirstModel();
+    const optionKeyInput = screen.getByDisplayValue("provider");
+
+    fireEvent.compositionStart(optionKeyInput);
+    fireEvent.change(optionKeyInput, { target: { value: "路由" } });
+    fireEvent.blur(optionKeyInput);
+
+    expect(onModelsChange).toHaveBeenCalledTimes(1);
+    expect(onModelsChange).toHaveBeenCalledWith({
+      "kimi-k2": {
+        name: "Kimi K2",
+        options: { 路由: "baseten" },
+      },
+    });
+  });
+
+  it("reconciles a model option draft after JSON canonicalization", () => {
+    const onModelsChange = vi.fn();
+    const models = {
+      "kimi-k2": {
+        name: "Kimi K2",
+        options: { provider: { order: ["baseten"] } },
+      },
+    };
+    const { rerender, props } = renderOpenCodeForm({ models, onModelsChange });
+    expandFirstModel();
+    const optionValueInput = screen.getByDisplayValue('{"order":["baseten"]}');
+
+    fireEvent.change(optionValueInput, {
+      target: { value: '{ "order": ["baseten"] }' },
+    });
+    expect(onModelsChange).toHaveBeenCalledWith(models);
+
+    // Parsing the edit and stringifying it again produces the same prop value
+    // as before, so only the idle blur reconciliation can reset the draft.
+    rerender(
+      <FormShell>
+        <OpenCodeFormFields {...props} models={models} />
+      </FormShell>,
+    );
+    expect(optionValueInput).toHaveValue('{ "order": ["baseten"] }');
+
+    fireEvent.blur(optionValueInput);
+    expect(optionValueInput).toHaveValue('{"order":["baseten"]}');
+  });
+
   it("updates model token limits as structured numbers", () => {
     const onModelsChange = vi.fn();
     renderOpenCodeForm({ onModelsChange });


### PR DESCRIPTION
## Summary

- adopt ImeSafeInput for the shared provider name, notes, and website URL fields
- force-commit interrupted IME compositions on blur and reconcile idle drafts with the external value
- commit OpenCode model and option key edits from the blur event value instead of stale local React state
- add component and form-level regression coverage for the follow-up paths

## Review follow-up

This is a follow-up to PR #6333 based on the maintainer review comment:
https://github.com/farion1231/cc-switch/pull/6333#issuecomment-5289108906

It addresses both non-blocking follow-ups from that review. The underlying bug is the macOS IME issue tracked in #6308, where parent re-renders during marked-text composition could produce duplicated or reordered characters. The blur hardening also covers the window-switch path where compositionend may not arrive, and the OpenCode JSON option path where parse/stringify can leave the prop textually unchanged while the local draft diverges.

## Validation

- focused IME/provider tests: 5 files, 34 tests passed
- pnpm test:unit: 130 test files, 980 tests passed
- pnpm typecheck
- Prettier check on all changed files
- git diff --check

Related to #6308 and follow-up to #6333.