### PR TITLE
fix(grokbuild): preserve api_backend in form and detect it for proxy protocol conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,8 +210,6 @@ jobs:
       - name: Run Windows-to-WSL2 filesystem contract
         shell: pwsh
         run: |
-          $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
-          $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $testName = "config::tests::atomic_write_replaces_existing_wsl_unc_file"
           $testList = cargo test --lib --manifest-path src-tauri/Cargo.toml -- --ignored --list
           if ($LASTEXITCODE -ne 0) {
@@ -221,6 +219,15 @@ jobs:
           if ($testList -notcontains $expected) {
             throw "Expected ignored test was not discovered: $testName"
           }
+          # TEMP only points into WSL2 once the binary is fully linked. On cold
+          # builds (fork PRs cannot restore the upstream cache) the next run-mode
+          # cargo invocation re-links the lib test binary even though --no-run
+          # built it above, and link.exe/mt.exe cannot create manifests when TEMP
+          # is a WSL UNC path (LNK1327). The --list call above absorbs that
+          # rebuild with a native TEMP; the run below executes the fresh binary
+          # without re-linking.
+          $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
+          $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
           cargo test --lib --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -210,10 +210,8 @@ pub fn codex_provider_uses_anthropic(provider: &Provider) -> bool {
         return is_anthropic_wire_api(&wire_api);
     }
 
-    // Grok Build TOML declares the upstream protocol via `api_backend` inside
-    // [model."<profile>"], which the Codex-shaped wire_api probe above can never
-    // match. Codex configs have no [models]/[model.*] tables, so
-    // extract_model_config returns None for them and this branch stays inert.
+    // Same Grok Build `api_backend` probe as codex_provider_uses_chat_completions
+    // above — see there for why it stays inert for Codex configs.
     if let Some(api_backend) = provider
         .settings_config
         .get("config")

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -55,6 +55,20 @@ pub fn codex_provider_uses_chat_completions(provider: &Provider) -> bool {
         return is_chat_wire_api(&wire_api);
     }
 
+    // Grok Build TOML declares the upstream protocol via `api_backend` inside
+    // [model."<profile>"], which the Codex-shaped wire_api probe above can never
+    // match. Codex configs have no [models]/[model.*] tables, so
+    // extract_model_config returns None for them and this branch stays inert.
+    if let Some(api_backend) = provider
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .and_then(crate::grok_config::extract_model_config)
+        .map(|config| config.api_backend)
+    {
+        return is_chat_wire_api(&api_backend);
+    }
+
     if let Some(base_url) = provider
         .settings_config
         .get("base_url")
@@ -163,8 +177,9 @@ pub fn inject_codex_chat_prompt_cache_key(
 /// Messages protocol (`/v1/messages`). The local Codex client always talks to CC
 /// Switch through the Responses API, so CC Switch bridges Responses ⇄ Anthropic.
 ///
-/// Determined solely from explicit config (apiFormat / wire_api); no base_url
-/// guessing — Anthropic gateway addresses vary widely and guessing easily misfires.
+/// Determined solely from explicit config (apiFormat / wire_api / Grok Build
+/// api_backend); no base_url guessing — Anthropic gateway addresses vary widely
+/// and guessing easily misfires.
 pub fn codex_provider_uses_anthropic(provider: &Provider) -> bool {
     if let Some(api_format) = provider
         .meta
@@ -186,13 +201,30 @@ pub fn codex_provider_uses_anthropic(provider: &Provider) -> bool {
         return is_anthropic_wire_api(api_format);
     }
 
-    provider
+    if let Some(wire_api) = provider
         .settings_config
         .get("config")
         .and_then(|v| v.as_str())
         .and_then(extract_codex_wire_api_from_toml)
-        .map(|wire_api| is_anthropic_wire_api(&wire_api))
-        .unwrap_or(false)
+    {
+        return is_anthropic_wire_api(&wire_api);
+    }
+
+    // Grok Build TOML declares the upstream protocol via `api_backend` inside
+    // [model."<profile>"], which the Codex-shaped wire_api probe above can never
+    // match. Codex configs have no [models]/[model.*] tables, so
+    // extract_model_config returns None for them and this branch stays inert.
+    if let Some(api_backend) = provider
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .and_then(crate::grok_config::extract_model_config)
+        .map(|config| config.api_backend)
+    {
+        return is_anthropic_wire_api(&api_backend);
+    }
+
+    false
 }
 
 pub fn should_convert_codex_responses_to_anthropic(provider: &Provider, endpoint: &str) -> bool {
@@ -1048,6 +1080,7 @@ context_window = 500000
     }
 
     #[test]
+    #[test]
     fn explicit_codex_official_cards_use_chatgpt_backend() {
         let mut provider = create_provider(json!({
             "auth": {
@@ -1155,6 +1188,124 @@ context_window = 500000
         grok_official.id = crate::database::GROKBUILD_OFFICIAL_PROVIDER_ID.to_string();
         grok_official.category = Some("official".to_string());
         assert!(!is_codex_official_provider(&grok_official));
+    }
+
+    #[test]
+    fn grok_api_backend_chat_completions_converts_responses_to_chat() {
+        let provider = create_provider(json!({
+            "config": r#"
+[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "upstream-chat-model"
+base_url = "https://relay.example.com/v1/"
+name = "Chat Relay"
+api_key = "grok-secret"
+api_backend = "chat_completions"
+context_window = 500000
+"#
+        }));
+
+        assert!(codex_provider_uses_chat_completions(&provider));
+        assert!(should_convert_codex_responses_to_chat(
+            &provider,
+            "/responses"
+        ));
+        assert!(!codex_provider_uses_anthropic(&provider));
+    }
+
+    #[test]
+    fn grok_api_backend_messages_converts_responses_to_anthropic() {
+        let provider = create_provider(json!({
+            "config": r#"
+[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "upstream-claude-model"
+base_url = "https://relay.example.com/v1/"
+name = "Anthropic Relay"
+api_key = "grok-secret"
+api_backend = "messages"
+context_window = 500000
+"#
+        }));
+
+        assert!(codex_provider_uses_anthropic(&provider));
+        assert!(should_convert_codex_responses_to_anthropic(
+            &provider,
+            "/responses"
+        ));
+        assert!(!codex_provider_uses_chat_completions(&provider));
+    }
+
+    #[test]
+    fn grok_api_backend_responses_stays_native() {
+        let provider = create_provider(json!({
+            "config": r#"
+[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "upstream-grok-model"
+base_url = "https://relay.example.com/v1/"
+name = "Responses Relay"
+api_key = "grok-secret"
+api_backend = "responses"
+context_window = 500000
+"#
+        }));
+
+        assert!(!codex_provider_uses_chat_completions(&provider));
+        assert!(!codex_provider_uses_anthropic(&provider));
+    }
+
+    #[test]
+    fn codex_toml_without_wire_api_is_not_misread_as_grok() {
+        // Regression guard: plain Codex TOML has no [models]/[model.*] tables, so
+        // the grok api_backend probe must stay inert and fall through to the
+        // base_url heuristic (which is also negative here).
+        let provider = create_provider(json!({
+            "config": r#"
+model_provider = "custom"
+model = "gpt-5"
+
+[model_providers.custom]
+name = "Custom"
+base_url = "https://example.com/v1"
+"#
+        }));
+
+        assert!(!codex_provider_uses_chat_completions(&provider));
+        assert!(!codex_provider_uses_anthropic(&provider));
+    }
+
+    #[test]
+    fn grok_meta_api_format_overrides_toml_api_backend() {
+        // Explicit meta short-circuits before any TOML probing: a grok
+        // chat_completions config pinned to openai_responses must stay native.
+        let mut provider = create_provider(json!({
+            "config": r#"
+[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "upstream-chat-model"
+base_url = "https://relay.example.com/v1/"
+name = "Chat Relay"
+api_key = "grok-secret"
+api_backend = "chat_completions"
+context_window = 500000
+"#
+        }));
+        provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_responses".to_string()),
+            ..Default::default()
+        });
+
+        assert!(!codex_provider_uses_chat_completions(&provider));
+        assert!(!codex_provider_uses_anthropic(&provider));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -1186,7 +1186,6 @@ context_window = 500000
     }
 
     #[test]
-    #[test]
     fn explicit_codex_official_cards_use_chatgpt_backend() {
         let mut provider = create_provider(json!({
             "auth": {

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -55,6 +55,20 @@ pub fn codex_provider_uses_chat_completions(provider: &Provider) -> bool {
         return is_chat_wire_api(&wire_api);
     }
 
+    // Grok Build TOML declares the upstream protocol via `api_backend` inside
+    // [model."<profile>"], which the Codex-shaped wire_api probe above can never
+    // match. Codex configs have no [models]/[model.*] tables, so
+    // extract_model_config returns None for them and this branch stays inert.
+    if let Some(api_backend) = provider
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .and_then(crate::grok_config::extract_model_config)
+        .map(|config| config.api_backend)
+    {
+        return is_chat_wire_api(&api_backend);
+    }
+
     if let Some(base_url) = provider
         .settings_config
         .get("base_url")
@@ -163,8 +177,9 @@ pub fn inject_codex_chat_prompt_cache_key(
 /// Messages protocol (`/v1/messages`). The local Codex client always talks to CC
 /// Switch through the Responses API, so CC Switch bridges Responses ⇄ Anthropic.
 ///
-/// Determined solely from explicit config (apiFormat / wire_api); no base_url
-/// guessing — Anthropic gateway addresses vary widely and guessing easily misfires.
+/// Determined solely from explicit config (apiFormat / wire_api / Grok Build
+/// api_backend); no base_url guessing — Anthropic gateway addresses vary widely
+/// and guessing easily misfires.
 pub fn codex_provider_uses_anthropic(provider: &Provider) -> bool {
     if let Some(api_format) = provider
         .meta
@@ -186,13 +201,30 @@ pub fn codex_provider_uses_anthropic(provider: &Provider) -> bool {
         return is_anthropic_wire_api(api_format);
     }
 
-    provider
+    if let Some(wire_api) = provider
         .settings_config
         .get("config")
         .and_then(|v| v.as_str())
         .and_then(extract_codex_wire_api_from_toml)
-        .map(|wire_api| is_anthropic_wire_api(&wire_api))
-        .unwrap_or(false)
+    {
+        return is_anthropic_wire_api(&wire_api);
+    }
+
+    // Grok Build TOML declares the upstream protocol via `api_backend` inside
+    // [model."<profile>"], which the Codex-shaped wire_api probe above can never
+    // match. Codex configs have no [models]/[model.*] tables, so
+    // extract_model_config returns None for them and this branch stays inert.
+    if let Some(api_backend) = provider
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .and_then(crate::grok_config::extract_model_config)
+        .map(|config| config.api_backend)
+    {
+        return is_anthropic_wire_api(&api_backend);
+    }
+
+    false
 }
 
 pub fn should_convert_codex_responses_to_anthropic(provider: &Provider, endpoint: &str) -> bool {
@@ -1156,6 +1188,7 @@ context_window = 500000
     }
 
     #[test]
+    #[test]
     fn explicit_codex_official_cards_use_chatgpt_backend() {
         let mut provider = create_provider(json!({
             "auth": {
@@ -1263,6 +1296,124 @@ context_window = 500000
         grok_official.id = crate::database::GROKBUILD_OFFICIAL_PROVIDER_ID.to_string();
         grok_official.category = Some("official".to_string());
         assert!(!is_codex_official_provider(&grok_official));
+    }
+
+    #[test]
+    fn grok_api_backend_chat_completions_converts_responses_to_chat() {
+        let provider = create_provider(json!({
+            "config": r#"
+[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "upstream-chat-model"
+base_url = "https://relay.example.com/v1/"
+name = "Chat Relay"
+api_key = "grok-secret"
+api_backend = "chat_completions"
+context_window = 500000
+"#
+        }));
+
+        assert!(codex_provider_uses_chat_completions(&provider));
+        assert!(should_convert_codex_responses_to_chat(
+            &provider,
+            "/responses"
+        ));
+        assert!(!codex_provider_uses_anthropic(&provider));
+    }
+
+    #[test]
+    fn grok_api_backend_messages_converts_responses_to_anthropic() {
+        let provider = create_provider(json!({
+            "config": r#"
+[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "upstream-claude-model"
+base_url = "https://relay.example.com/v1/"
+name = "Anthropic Relay"
+api_key = "grok-secret"
+api_backend = "messages"
+context_window = 500000
+"#
+        }));
+
+        assert!(codex_provider_uses_anthropic(&provider));
+        assert!(should_convert_codex_responses_to_anthropic(
+            &provider,
+            "/responses"
+        ));
+        assert!(!codex_provider_uses_chat_completions(&provider));
+    }
+
+    #[test]
+    fn grok_api_backend_responses_stays_native() {
+        let provider = create_provider(json!({
+            "config": r#"
+[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "upstream-grok-model"
+base_url = "https://relay.example.com/v1/"
+name = "Responses Relay"
+api_key = "grok-secret"
+api_backend = "responses"
+context_window = 500000
+"#
+        }));
+
+        assert!(!codex_provider_uses_chat_completions(&provider));
+        assert!(!codex_provider_uses_anthropic(&provider));
+    }
+
+    #[test]
+    fn codex_toml_without_wire_api_is_not_misread_as_grok() {
+        // Regression guard: plain Codex TOML has no [models]/[model.*] tables, so
+        // the grok api_backend probe must stay inert and fall through to the
+        // base_url heuristic (which is also negative here).
+        let provider = create_provider(json!({
+            "config": r#"
+model_provider = "custom"
+model = "gpt-5"
+
+[model_providers.custom]
+name = "Custom"
+base_url = "https://example.com/v1"
+"#
+        }));
+
+        assert!(!codex_provider_uses_chat_completions(&provider));
+        assert!(!codex_provider_uses_anthropic(&provider));
+    }
+
+    #[test]
+    fn grok_meta_api_format_overrides_toml_api_backend() {
+        // Explicit meta short-circuits before any TOML probing: a grok
+        // chat_completions config pinned to openai_responses must stay native.
+        let mut provider = create_provider(json!({
+            "config": r#"
+[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "upstream-chat-model"
+base_url = "https://relay.example.com/v1/"
+name = "Chat Relay"
+api_key = "grok-secret"
+api_backend = "chat_completions"
+context_window = 500000
+"#
+        }));
+        provider.meta = Some(crate::provider::ProviderMeta {
+            api_format: Some("openai_responses".to_string()),
+            ..Default::default()
+        });
+
+        assert!(!codex_provider_uses_chat_completions(&provider));
+        assert!(!codex_provider_uses_anthropic(&provider));
     }
 
     #[test]

--- a/src/components/providers/forms/GrokBuildProviderForm.tsx
+++ b/src/components/providers/forms/GrokBuildProviderForm.tsx
@@ -104,6 +104,7 @@ export function GrokBuildProviderForm({
   );
   const [baseUrl, setBaseUrl] = useState(initialConfig.baseUrl);
   const [apiKey, setApiKey] = useState(initialConfig.apiKey);
+  const [apiBackend, setApiBackend] = useState(initialConfig.apiBackend);
   const [contextWindow, setContextWindow] = useState(
     String(initialConfig.contextWindow),
   );
@@ -218,7 +219,7 @@ export function GrokBuildProviderForm({
       apiKey,
       contextWindow: Number.parseInt(contextWindow, 10),
       ...overrides,
-      apiBackend: GROK_BUILD_DEFAULT_API_BACKEND,
+      apiBackend,
     };
     setRawConfig((current) => updateGrokBuildConfig(current, next));
   };
@@ -274,6 +275,7 @@ export function GrokBuildProviderForm({
     setApiKey(presetApiKey);
     setUpstreamModel(presetModel);
     setApiFormat(presetApiFormat);
+    setApiBackend(GROK_BUILD_DEFAULT_API_BACKEND);
     setPresetEndpoints(preset.endpointCandidates ?? []);
     setRawConfig(
       buildGrokBuildConfig({
@@ -296,6 +298,7 @@ export function GrokBuildProviderForm({
     setUpstreamModel(parsed.upstreamModel ?? parsed.model);
     setBaseUrl(parsed.baseUrl);
     setApiKey(parsed.apiKey);
+    setApiBackend(parsed.apiBackend);
     setContextWindow(String(parsed.contextWindow));
     if (parsed.name) form.setValue("name", parsed.name);
   };
@@ -350,7 +353,7 @@ export function GrokBuildProviderForm({
       baseUrl,
       name,
       apiKey,
-      apiBackend: GROK_BUILD_DEFAULT_API_BACKEND,
+      apiBackend,
       contextWindow: parsedContextWindow,
     });
     const configError = validateGrokBuildConfig(finalConfig);

--- a/src/components/providers/forms/GrokBuildProviderForm.tsx
+++ b/src/components/providers/forms/GrokBuildProviderForm.tsx
@@ -46,6 +46,7 @@ import {
 import {
   buildGrokBuildConfig,
   GROK_BUILD_DEFAULT_API_BACKEND,
+  isSyntacticallyValidGrokToml,
   parseGrokBuildConfig,
   updateGrokBuildConfig,
   validateGrokBuildConfig,
@@ -115,6 +116,10 @@ export function GrokBuildProviderForm({
     (initialData?.meta?.apiFormat as CodexApiFormat | undefined) ??
       "openai_responses",
   );
+  // 用户是否显式动过上游格式（选择器/预设）。加载时没有 meta.apiFormat 的
+  // 供应商保存后应保持缺席，让代理转换判定回落 TOML api_backend 探测——
+  // 否则一次保存就把默认格式写进 meta，掩蔽掉手导供应商的 api_backend
+  const [apiFormatTouched, setApiFormatTouched] = useState(false);
   const [anthropicAuthField, setAnthropicAuthField] =
     useState<ClaudeApiKeyField>(
       initialData?.meta?.apiKeyField ?? "ANTHROPIC_AUTH_TOKEN",
@@ -275,6 +280,7 @@ export function GrokBuildProviderForm({
     setApiKey(presetApiKey);
     setUpstreamModel(presetModel);
     setApiFormat(presetApiFormat);
+    setApiFormatTouched(true);
     setApiBackend(GROK_BUILD_DEFAULT_API_BACKEND);
     setPresetEndpoints(preset.endpointCandidates ?? []);
     setRawConfig(
@@ -292,7 +298,9 @@ export function GrokBuildProviderForm({
 
   const handleRawConfigChange = (value: string) => {
     setRawConfig(value);
-    if (validateGrokBuildConfig(value)) return;
+    // 只跳过语法损坏的回读（输入中途）；语义不完整（如 api_key 未填）仍要回读，
+    // 否则先手改 api_backend、后补 API Key 时，结构化同步会用旧值把它覆盖掉
+    if (!isSyntacticallyValidGrokToml(value)) return;
     const parsed = parseGrokBuildConfig(value, form.getValues("name"));
     setProfile(parsed.model);
     setUpstreamModel(parsed.upstreamModel ?? parsed.model);
@@ -387,7 +395,12 @@ export function GrokBuildProviderForm({
     delete initialMeta.custom_endpoints;
     const meta: ProviderMeta = {
       ...initialMeta,
-      apiFormat,
+      // 加载时无 meta.apiFormat 且用户未动格式时保持缺席：代理转换判定会因 meta
+      // 优先而跳过 TOML api_backend 探测，写默认格式会掩蔽手导供应商的协议
+      apiFormat:
+        initialData?.meta?.apiFormat !== undefined || apiFormatTouched
+          ? apiFormat
+          : undefined,
       apiKeyField: anthropicAuthField,
       isFullUrl,
       endpointAutoSelect,
@@ -478,6 +491,7 @@ export function GrokBuildProviderForm({
               apiFormat={apiFormat}
               onApiFormatChange={(value) => {
                 setApiFormat(value);
+                setApiFormatTouched(true);
               }}
               anthropicAuthField={anthropicAuthField}
               onAnthropicAuthFieldChange={setAnthropicAuthField}

--- a/src/utils/grokBuildConfig.ts
+++ b/src/utils/grokBuildConfig.ts
@@ -161,6 +161,22 @@ export function validateGrokBuildConfig(configToml: string): string | null {
   }
 }
 
+/**
+ * 只做语法检查，不校验语义（缺 api_key / base_url 等仍算有效）。
+ * 表单在输入中途需要区分两者：语法损坏时跳过解析回读（防止半截输入
+ * 冲掉状态），语义不完整时仍要回读（否则手改的 api_backend 会被
+ * 结构化同步用旧值覆盖）。
+ */
+export function isSyntacticallyValidGrokToml(configToml: string): boolean {
+  if (!configToml.trim()) return false;
+  try {
+    parseToml(configToml);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function extractGrokBuildBaseUrl(configToml: string): string {
   return parseGrokBuildConfig(configToml).baseUrl;
 }

--- a/tests/components/GrokBuildProviderForm.test.tsx
+++ b/tests/components/GrokBuildProviderForm.test.tsx
@@ -107,7 +107,7 @@ describe("GrokBuildProviderForm", () => {
     expect(screen.getByText("上游格式")).toBeInTheDocument();
   });
 
-  it("keeps the Grok client on Responses when the upstream uses Chat", async () => {
+  it("keeps the stored api_backend when the upstream uses Chat", async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
     const configToml = `[models]
@@ -144,9 +144,95 @@ context_window = 500000
     const config = parseToml(settings.config) as any;
     expect(submitted.meta.apiFormat).toBe("openai_chat");
     const selected = config.model[config.models.default];
-    expect(selected.api_backend).toBe("responses");
+    // 上游协议选择走 meta.apiFormat + 代理转换；表单不得改写 TOML 里存下的 api_backend
+    expect(selected.api_backend).toBe("chat_completions");
     expect(selected.model).toBe("grok-4.5");
     expect(selected.base_url).toBe("https://relay.example.com/v1");
+  });
+
+  it("preserves a non-default api_backend when editing an existing provider", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const configToml = `[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "grok-4.5"
+base_url = "https://relay.example.com/v1"
+name = "Messages Relay"
+api_key = "secret-key"
+api_backend = "messages"
+context_window = 500000
+`;
+    render(
+      <GrokBuildProviderForm
+        providerId="messages-relay"
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+        initialData={{
+          name: "Messages Relay",
+          category: "custom",
+          settingsConfig: { config: configToml },
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][0];
+    const settings = JSON.parse(submitted.settingsConfig);
+    expect(settings.config).toContain('api_backend = "messages"');
+    const config = parseToml(settings.config) as any;
+    expect(config.model[config.models.default].api_backend).toBe("messages");
+  });
+
+  it("keeps an api_backend typed into the raw TOML editor", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const initialToml = `[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "grok-4.5"
+base_url = "https://relay.example.com/v1"
+name = "Raw Edit Relay"
+api_key = "secret-key"
+api_backend = "responses"
+context_window = 500000
+`;
+    render(
+      <GrokBuildProviderForm
+        providerId="raw-edit-relay"
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+        initialData={{
+          name: "Raw Edit Relay",
+          category: "custom",
+          settingsConfig: { config: initialToml },
+        }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("raw-config"), {
+      target: {
+        value: initialToml.replace(
+          'api_backend = "responses"',
+          'api_backend = "chat_completions"',
+        ),
+      },
+    });
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][0];
+    const settings = JSON.parse(submitted.settingsConfig);
+    const config = parseToml(settings.config) as any;
+    expect(config.model[config.models.default].api_backend).toBe(
+      "chat_completions",
+    );
   });
 
   it("renders localized validation feedback for malformed TOML", async () => {

--- a/tests/components/GrokBuildProviderForm.test.tsx
+++ b/tests/components/GrokBuildProviderForm.test.tsx
@@ -302,6 +302,118 @@ context_window = 250000
     expect(onSubmit.mock.calls[0][0].meta.custom_endpoints).toBeUndefined();
   });
 
+  // 手建/导入的无 meta 供应商，保存后不得写入默认格式 —— 代理转换判定会因
+  // meta 优先而跳过 TOML api_backend 探测（review P2）
+  it("leaves meta.apiFormat absent when the provider had none and the format was not touched", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <GrokBuildProviderForm
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+      />,
+    );
+
+    fireEvent.change(
+      container.querySelector<HTMLInputElement>('input[name="name"]')!,
+      { target: { value: "Meta-less Relay" } },
+    );
+    fireEvent.change(
+      container.querySelector<HTMLInputElement>("#codexBaseUrl")!,
+      { target: { value: "https://relay.example.com/v1" } },
+    );
+    fireEvent.change(screen.getByLabelText("API Key"), {
+      target: { value: "secret-key" },
+    });
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].meta.apiFormat).toBeUndefined();
+  });
+
+  it("writes meta.apiFormat once the upstream format selector is touched", async () => {
+    // jsdom 未实现 scrollIntoView，Radix Select 打开时对选中项调用会抛错
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <GrokBuildProviderForm
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+      />,
+    );
+
+    fireEvent.change(
+      container.querySelector<HTMLInputElement>('input[name="name"]')!,
+      { target: { value: "Touched Relay" } },
+    );
+    fireEvent.change(
+      container.querySelector<HTMLInputElement>("#codexBaseUrl")!,
+      { target: { value: "https://relay.example.com/v1" } },
+    );
+    fireEvent.change(screen.getByLabelText("API Key"), {
+      target: { value: "secret-key" },
+    });
+    await user.click(document.querySelector("#codex-upstream-format")!);
+    await user.click(
+      await screen.findByRole("option", { name: /Chat Completions/ }),
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].meta.apiFormat).toBe("openai_chat");
+  });
+
+  // 创建流程：先改 raw 里的 api_backend（此时 api_key 未填，配置语义不完整），
+  // 再补 API Key —— 回读不得被语义校验拦下，否则结构化同步会把旧值写回去（review P3）
+  it("keeps an api_backend typed into raw TOML even while other fields are still incomplete", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <GrokBuildProviderForm
+        submitLabel="Save"
+        onSubmit={onSubmit}
+        onCancel={() => {}}
+      />,
+    );
+
+    const rawTextarea = screen.getByLabelText(
+      "raw-config",
+    ) as HTMLTextAreaElement;
+    expect(rawTextarea.value).toContain('api_backend = "responses"');
+    fireEvent.change(rawTextarea, {
+      target: {
+        value: rawTextarea.value.replace(
+          'api_backend = "responses"',
+          'api_backend = "chat_completions"',
+        ),
+      },
+    });
+    fireEvent.change(
+      container.querySelector<HTMLInputElement>('input[name="name"]')!,
+      { target: { value: "Raw-first Relay" } },
+    );
+    fireEvent.change(
+      container.querySelector<HTMLInputElement>("#codexBaseUrl")!,
+      { target: { value: "https://relay.example.com/v1" } },
+    );
+    fireEvent.change(screen.getByLabelText("API Key"), {
+      target: { value: "secret-key" },
+    });
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const settings = JSON.parse(onSubmit.mock.calls[0][0].settingsConfig);
+    const config = parseToml(settings.config) as any;
+    expect(config.model[config.models.default].api_backend).toBe(
+      "chat_completions",
+    );
+  });
   // #6427 复用 Codex 表单时把 Codex 专属文案原样带进了 Grok Build 表单。
   // 按 appId 分流后，Grok 表单不得再出现 Codex 字样或不适用条款（模型映射）。
   it("uses Grok-specific copy for the model field and collapsed advanced section", async () => {


### PR DESCRIPTION
## Problem

Grok Build providers support three upstream protocols via `api_backend` in `[model."<profile>"]` (`responses` / `chat_completions` / `messages`). Two bugs currently break non-Responses upstreams:

**1. The provider form silently reverts `api_backend` to `"responses"` on every save (regression from #6427).**

#6427 removed the form's `apiBackend` state; every write path (`syncStructuredConfig`, `handleSubmit`) now hardcodes `GROK_BUILD_DEFAULT_API_BACKEND`. `parseGrokBuildConfig` still parses the field correctly — the parsed value is just never used. So a hand-written `api_backend = "messages"` in the raw TOML editor, or a provider saved before #6427 with `chat_completions`, is silently rewritten to `"responses"` by any edit-save, with no UI indication. In direct mode the Grok client then speaks Responses to a Chat/Anthropic-only upstream and fails.

**2. The proxy's upstream-protocol detection never reads Grok Build's `api_backend` key.**

Grok Build providers reuse `CodexAdapter` in the proxy (credentials / model / base_url already resolve via `grok_config`). But `codex_provider_uses_chat_completions` / `codex_provider_uses_anthropic` only probe `meta.api_format`, settings `api_format`, and the Codex-shaped `wire_api` TOML key — never `api_backend`. A provider whose stored config declares `api_backend = "chat_completions"` (savable before #6427, or hand-imported) with no `meta.api_format` gets no Responses→Chat conversion under takeover: the client speaks Responses to the proxy (takeover forces `api_backend = "responses"` in the live file), and the proxy forwards the Responses body unchanged to a Chat-only upstream — a silently broken pipe. Same for `messages` (Anthropic).

## Fix

- **Form**: thread the parsed `api_backend` through component state again — raw-TOML edits parse-back into it, submit writes the state value, choosing a preset resets it to `responses` (all current presets are Responses). The selector removed in #6427 is **not** restored: upstream protocol selection stays on `meta.apiFormat` + proxy conversion per that refactor's direction; this fix only stops the silent data loss. `meta.apiFormat` and the TOML `api_backend` stay independent (locked by test).
- **Proxy**: after the `wire_api` probe and before the base-url heuristic, both detection functions now probe `api_backend` via `grok_config::extract_model_config`. Codex configs have no `[models]` / `[model.*]` tables, so the probe returns `None` and stays inert for Codex; `is_chat_wire_api` / `is_anthropic_wire_api` already accept `chat_completions` / `messages`, so the value domains align with no matcher changes.

## Tests

- Form (component level): editing a `messages` provider keeps `messages` after save; an `api_backend` typed into the raw TOML editor survives submit; one pre-existing #6427 test asserted the buggy behavior (forced `"responses"`) and is flipped to lock the correct one (keeping its `meta.apiFormat` independence assertion). All three go red when the fix is reverted (verified).
- Proxy: `chat_completions` → Chat conversion and `messages` → Anthropic conversion (both red before the fix), plus three guards that stay green throughout: `responses` stays native, plain Codex TOML without `wire_api` is not misread as Grok, and explicit `meta.api_format` overrides the TOML probe.

## Round 2 (review feedback)

- **[P2]** The form wrote the default `meta.apiFormat` (`"openai_responses"`) on every save, and both detection functions early-return when meta is present — so a hand-imported `api_backend = "messages"/"chat_completions"` provider lost its takeover conversion after any form save. `meta.apiFormat` is now only written when it existed on load or the user touched the format selector / applied a preset (`apiFormatTouched` state), keeping meta absent so the TOML probe stays authoritative.
- **[P3]** `handleRawConfigChange` skipped the parse-back while the config was semantically incomplete (e.g. `api_key` not yet filled), so "edit `api_backend` in the raw editor first, then fill in the API key" clobbered the typed value with the stale `"responses"` via `syncStructuredConfig`. The parse-back is now gated on syntax only (new `isSyntacticallyValidGrokToml` helper); the mid-typing guard against broken TOML is unchanged.
- **nit** — deduplicated the comment above the second probe in `codex.rs`.
- Three new regression tests (meta absent on save for an untouched meta-less provider; meta written after touching the selector; the P3 raw-first ordering), each revert-verified.

## Round 3 (CI)

`Backend Checks (Windows + WSL2 home)` failed on cold builds — fork PRs cannot restore the upstream actions cache, so after the `--no-run` compile step the next run-mode cargo invocation re-links the lib test binary, and `link.exe`/`mt.exe` cannot create manifests when TEMP points at a WSL UNC path (LNK1327). The `--list` invocation now runs before TEMP is redirected into WSL2 and absorbs any re-link with a native temp; the test run then executes the fresh binary without touching the linker.

## Notes / limits

- #5758's `extra_headers` modeling is still open — this PR makes `api_backend = "messages"` survivable (a precondition), but doesn't model `extra_headers` in `GrokModelConfig`. Happy to follow up separately.
- Under takeover, the canonical setup for Chat/Anthropic upstreams remains `meta.apiFormat` (the form's upstream-format selector); the TOML probe covers providers whose meta is absent.

Related to #5758, #5678.
