### PR TITLE
fix(grokbuild): stop showing Codex-specific copy in the Grok Build form

### DIFF
--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -450,6 +450,10 @@ export function CodexFormFields({
   //（填了才生成 catalog）。两者都已与「路由接管」概念解耦。
   const isChatFormat = apiFormat === "openai_chat";
   const isAnthropicFormat = apiFormat === "anthropic";
+  // Grok Build 复用本表单，但语义与 Codex 有差异（无模型映射、协议由 TOML 的
+  // api_backend 声明、请求体也不是 Codex 发出的）——提示文案按 appId 分流，
+  // 对应词条在 grokBuild.* 下。
+  const isGrokBuild = appId === "grokbuild";
   const canEditCatalog = Boolean(onCatalogModelsChange);
   const canEditReasoning = Boolean(onCodexChatReasoningChange);
   const supportsThinking =
@@ -799,9 +803,15 @@ export function CodexFormFields({
               id="codexDefaultModel"
               value={codexModel}
               onChange={(event) => onModelChange(event.target.value)}
-              placeholder={t("codexConfig.defaultModelPlaceholder", {
-                defaultValue: "例如: gpt-5.6",
-              })}
+              placeholder={
+                isGrokBuild
+                  ? t("grokBuild.defaultModelPlaceholder", {
+                      defaultValue: "例如: grok-4.5",
+                    })
+                  : t("codexConfig.defaultModelPlaceholder", {
+                      defaultValue: "例如: gpt-5.6",
+                    })
+              }
               className="flex-1"
             />
             <Button
@@ -827,10 +837,15 @@ export function CodexFormFields({
             )}
           </div>
           <p className="text-xs leading-relaxed text-muted-foreground">
-            {t("codexConfig.defaultModelHint", {
-              defaultValue:
-                "Codex 默认请求的模型，随时可改，无需等待预设更新。留空且配置了模型映射时，默认使用映射第一行。",
-            })}
+            {isGrokBuild
+              ? t("grokBuild.defaultModelHint", {
+                  defaultValue:
+                    "Grok Build 默认请求的模型，随时可改，无需等待预设更新。",
+                })
+              : t("codexConfig.defaultModelHint", {
+                  defaultValue:
+                    "Codex 默认请求的模型，随时可改，无需等待预设更新。留空且配置了模型映射时，默认使用映射第一行。",
+                })}
           </p>
           {isDefaultModelOutsideCatalog && (
             <p className="flex flex-wrap items-center gap-x-2 text-xs leading-relaxed text-muted-foreground">
@@ -880,10 +895,15 @@ export function CodexFormFields({
           </CollapsibleTrigger>
           {!advancedExpanded && (
             <p className="mt-1 ml-1 text-xs text-muted-foreground">
-              {t("codexConfig.advancedSectionHint", {
-                defaultValue:
-                  "包含上游格式、模型映射、思考能力与自定义 User-Agent。使用 Chat Completions 协议的供应商需开启路由接管才能使用。",
-              })}
+              {isGrokBuild
+                ? t("grokBuild.advancedSectionHint", {
+                    defaultValue:
+                      "包含上游格式、思考能力与自定义 User-Agent。使用 Chat Completions / Anthropic Messages 协议的供应商需开启路由接管才能使用。",
+                  })
+                : t("codexConfig.advancedSectionHint", {
+                    defaultValue:
+                      "包含上游格式、模型映射、思考能力与自定义 User-Agent。使用 Chat Completions 协议的供应商需开启路由接管才能使用。",
+                  })}
             </p>
           )}
           <CollapsibleContent className="space-y-3 pt-3">
@@ -1026,10 +1046,15 @@ export function CodexFormFields({
                       })}
                     />
                     <p className="text-xs leading-relaxed text-muted-foreground">
-                      {t("codexConfig.maxOutputTokensHint", {
-                        defaultValue:
-                          "Codex 不会把 model_max_output_tokens 写进请求体，默认上限 8192 容易在长回答或深度思考时被截断（stop_reason=max_tokens）。此处设置会作为 Anthropic 的 max_tokens 覆盖请求值。请勿超过该模型/网关的真实输出上限，否则可能 400。留空使用默认 8192。",
-                      })}
+                      {isGrokBuild
+                        ? t("grokBuild.maxOutputTokensHint", {
+                            defaultValue:
+                              "默认上限 8192 容易在长回答或深度思考时被截断（stop_reason=max_tokens）。此处设置会作为 Anthropic 的 max_tokens 覆盖请求值。请勿超过该模型/网关的真实输出上限，否则可能 400。留空使用默认 8192。",
+                          })
+                        : t("codexConfig.maxOutputTokensHint", {
+                            defaultValue:
+                              "Codex 不会把 model_max_output_tokens 写进请求体，默认上限 8192 容易在长回答或深度思考时被截断（stop_reason=max_tokens）。此处设置会作为 Anthropic 的 max_tokens 覆盖请求值。请勿超过该模型/网关的真实输出上限，否则可能 400。留空使用默认 8192。",
+                          })}
                     </p>
                   </div>
                 )}
@@ -1131,10 +1156,15 @@ export function CodexFormFields({
                       })}
                     </FormLabel>
                     <p className="text-xs leading-relaxed text-muted-foreground">
-                      {t("codexConfig.reasoningEffortHint", {
-                        defaultValue:
-                          "上游支持 low/high/max 等思考深度控制时启用。启用后会自动启用思考模式，并把 Codex 的 reasoning.effort 转成上游 Chat 参数。",
-                      })}
+                      {isGrokBuild
+                        ? t("grokBuild.reasoningEffortHint", {
+                            defaultValue:
+                              "上游支持 low/high/max 等思考深度控制时启用。启用后会自动启用思考模式，并把请求中的 reasoning effort 转成上游 Chat 参数。",
+                          })
+                        : t("codexConfig.reasoningEffortHint", {
+                            defaultValue:
+                              "上游支持 low/high/max 等思考深度控制时启用。启用后会自动启用思考模式，并把 Codex 的 reasoning.effort 转成上游 Chat 参数。",
+                          })}
                     </p>
                   </div>
                   <Switch

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1061,7 +1061,12 @@
     "contextWindowInvalid": "Context window must be a positive integer",
     "profile": "Client model profile",
     "rawConfig": "config.toml",
-    "invalidToml": "Invalid config.toml: {{error}}"
+    "invalidToml": "Invalid config.toml: {{error}}",
+    "defaultModelPlaceholder": "e.g. grok-4.5",
+    "defaultModelHint": "The model Grok Build requests by default; change it anytime without waiting for a preset update.",
+    "advancedSectionHint": "Includes upstream format, reasoning overrides and custom User-Agent. Providers using the Chat Completions or Anthropic Messages protocol require routing takeover to be enabled.",
+    "reasoningEffortHint": "Enable when the upstream supports thinking-depth control such as low/high/max. Enabling this also turns on thinking mode and converts the request's reasoning effort into the upstream Chat parameter.",
+    "maxOutputTokensHint": "The default 8192 ceiling can truncate long or thinking-heavy responses (stop_reason=max_tokens). This value overrides the request's max_tokens on the Anthropic path. Do not exceed the real output ceiling of the model/gateway or it may 400. Leave empty to use the default 8192."
   },
   "sessionManager": {
     "title": "Session Manager",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1061,7 +1061,12 @@
     "contextWindowInvalid": "コンテキストウィンドウは正の整数で指定してください",
     "profile": "クライアントモデルプロファイル",
     "rawConfig": "config.toml",
-    "invalidToml": "config.toml の形式が不正です: {{error}}"
+    "invalidToml": "config.toml の形式が不正です: {{error}}",
+    "defaultModelPlaceholder": "例: grok-4.5",
+    "defaultModelHint": "Grok Build がデフォルトでリクエストするモデルです。プリセットの更新を待たずにいつでも変更できます。",
+    "advancedSectionHint": "上流フォーマット、思考機能、カスタム User-Agent の設定を含みます。Chat Completions / Anthropic Messages プロトコルを使用するプロバイダーはルーティング引き継ぎの有効化が必要です。",
+    "reasoningEffortHint": "上流が low/high/max などの思考の深さの制御に対応している場合に有効化します。有効にすると思考モードも自動的にオンになり、リクエストの reasoning effort を上流の Chat パラメータに変換します。",
+    "maxOutputTokensHint": "デフォルト上限 8192 では長い回答や深い思考時に切り詰められることがあります（stop_reason=max_tokens）。この値は Anthropic 経路で max_tokens を上書きします。モデル／ゲートウェイの実際の出力上限を超えると 400 になる場合があります。空欄でデフォルトの 8192 を使用します。"
   },
   "sessionManager": {
     "title": "セッション管理",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1062,7 +1062,12 @@
     "contextWindowInvalid": "上下文視窗必須是正整數",
     "profile": "用戶端模型檔位",
     "rawConfig": "config.toml",
-    "invalidToml": "config.toml 格式錯誤：{{error}}"
+    "invalidToml": "config.toml 格式錯誤：{{error}}",
+    "defaultModelPlaceholder": "例如: grok-4.5",
+    "defaultModelHint": "Grok Build 預設請求的模型，隨時可改，無需等待軟體更新供應商範本。",
+    "advancedSectionHint": "包含上游格式、思考能力與自訂 User-Agent。使用 Chat Completions / Anthropic Messages 協定的供應商需開啟路由接管才能使用。",
+    "reasoningEffortHint": "上游支援 low/high/max 等思考深度控制時啟用。啟用後會自動啟用思考模式，並把請求中的 reasoning effort 轉成上游 Chat 參數。",
+    "maxOutputTokensHint": "預設上限 8192 容易在長回答或深度思考時被截斷（stop_reason=max_tokens）。此處設定會作為 Anthropic 的 max_tokens 覆蓋請求值。請勿超過該模型／閘道的真實輸出上限，否則可能 400。留空使用預設 8192。"
   },
   "sessionManager": {
     "title": "工作階段管理",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1061,7 +1061,12 @@
     "contextWindowInvalid": "上下文窗口必须是正整数",
     "profile": "客户端模型档位",
     "rawConfig": "config.toml",
-    "invalidToml": "config.toml 格式错误：{{error}}"
+    "invalidToml": "config.toml 格式错误：{{error}}",
+    "defaultModelPlaceholder": "例如: grok-4.5",
+    "defaultModelHint": "Grok Build 默认请求的模型，随时可改，无需等待预设更新。",
+    "advancedSectionHint": "包含上游格式、思考能力与自定义 User-Agent。使用 Chat Completions / Anthropic Messages 协议的供应商需开启路由接管才能使用。",
+    "reasoningEffortHint": "上游支持 low/high/max 等思考深度控制时启用。启用后会自动启用思考模式，并把请求中的 reasoning effort 转成上游 Chat 参数。",
+    "maxOutputTokensHint": "默认上限 8192 容易在长回答或深度思考时被截断（stop_reason=max_tokens）。此处设置会作为 Anthropic 的 max_tokens 覆盖请求值。请勿超过该模型/网关的真实输出上限，否则可能 400。留空使用默认 8192。"
   },
   "sessionManager": {
     "title": "会话管理",

--- a/tests/components/GrokBuildProviderForm.test.tsx
+++ b/tests/components/GrokBuildProviderForm.test.tsx
@@ -215,4 +215,88 @@ context_window = 250000
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit.mock.calls[0][0].meta.custom_endpoints).toBeUndefined();
   });
+
+  // #6427 复用 Codex 表单时把 Codex 专属文案原样带进了 Grok Build 表单。
+  // 按 appId 分流后，Grok 表单不得再出现 Codex 字样或不适用条款（模型映射）。
+  it("uses Grok-specific copy for the model field and collapsed advanced section", async () => {
+    const user = userEvent.setup();
+    const configToml = `[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "grok-4.5"
+base_url = "https://relay.example.com/v1"
+name = "Chat Relay"
+api_key = "secret-key"
+api_backend = "chat_completions"
+context_window = 500000
+`;
+    const { container } = render(
+      <GrokBuildProviderForm
+        providerId="chat-relay"
+        submitLabel="Save"
+        onSubmit={() => {}}
+        onCancel={() => {}}
+        initialData={{
+          name: "Chat Relay",
+          category: "custom",
+          settingsConfig: { config: configToml },
+          meta: { apiFormat: "openai_chat" },
+        }}
+      />,
+    );
+
+    const modelInput =
+      container.querySelector<HTMLInputElement>("#codexDefaultModel");
+    expect(modelInput?.placeholder).toBe("例如: grok-4.5");
+    expect(screen.getByText(/Grok Build 默认请求的模型/)).toBeInTheDocument();
+    expect(screen.queryByText(/Codex 默认请求的模型/)).toBeNull();
+    // Grok 没有模型映射目录，不应出现"映射第一行"条款
+    expect(screen.queryByText(/映射第一行/)).toBeNull();
+
+    // Chat 格式且无已配置高级值时高级区默认折叠，折叠提示也应是 Grok 版本
+    expect(
+      screen.getByText(/Anthropic Messages 协议的供应商需开启路由接管/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/模型映射、思考能力/)).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: /高级选项/ }));
+    expect(
+      screen.getByText(/把请求中的 reasoning effort 转成上游 Chat 参数/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Codex 的 reasoning\.effort/)).toBeNull();
+  });
+
+  it("uses Grok-specific copy for the max output tokens hint", () => {
+    const configToml = `[models]
+default = "grok-4.5"
+
+[model."grok-4.5"]
+model = "grok-4.5"
+base_url = "https://relay.example.com/v1"
+name = "Anthropic Relay"
+api_key = "secret-key"
+api_backend = "messages"
+context_window = 500000
+`;
+    render(
+      <GrokBuildProviderForm
+        providerId="anthropic-relay"
+        submitLabel="Save"
+        onSubmit={() => {}}
+        onCancel={() => {}}
+        initialData={{
+          name: "Anthropic Relay",
+          category: "custom",
+          settingsConfig: { config: configToml },
+          meta: { apiFormat: "anthropic" },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/^默认上限 8192 容易在长回答/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Codex 不会把 model_max_output_tokens/),
+    ).toBeNull();
+  });
 });


### PR DESCRIPTION
## Problem

#6427 aligned the Grok Build provider form with Codex by reusing `CodexFormFields`, but five Codex-facing strings render unchanged in the Grok Build form:

1. **Default-model hint** — "The model Codex requests by default … If left empty while model mapping is configured, the first mapping row is used." Grok Build has no model-mapping catalog, so both the app name and the fallback clause are wrong here.
2. **Default-model placeholder** — suggests a GPT model (`e.g. gpt-5.6-sol`).
3. **Advanced-section hint** — lists model mapping as contained, which the Grok form doesn't offer.
4. **Reasoning-effort hint** — references Codex's `reasoning.effort`.
5. **Max-output-tokens hint** — describes Codex's request body ("Codex does not forward model_max_output_tokens …").

## Fix

- Branch those five strings on `appId === "grokbuild"` inside `CodexFormFields` and add matching `grokBuild.*` entries to all four locales (en/zh/ja/zh-TW), worded for Grok Build semantics (e.g. no mapping clause, "the request's reasoning effort" instead of "Codex's reasoning.effort").
- Codex rendering is unchanged — same keys, same text.

The catalog-gated strings (`defaultModelNotInCatalog`, `addToModelMapping`, …) were checked and are safe: they require `catalogRows.length > 0`, which never happens for Grok Build since the catalog section isn't rendered.

## Tests

- Two new regression tests in `GrokBuildProviderForm.test.tsx` assert the Grok copy renders and the Codex text never appears (model field + collapsed advanced hint + reasoning hint on the Chat format; max-tokens hint on the Anthropic format).
- Revert-verified: forcing the appId branch off makes exactly the two new tests fail; the six pre-existing tests stay green either way.
- `pnpm typecheck`, `pnpm format:check` and the full `pnpm test:unit` pass.

## Note

`grokBuild.apiBackend` / `grokBuild.profile` became orphaned locale keys when #6427 removed those controls. Left in place intentionally since pruning is unrelated to this fix — happy to remove them here if you'd rather.
