### PR TITLE
fix(openclaw): keep openclaw.json strict-JSON compatible with quoted root keys

### DIFF
--- a/src-tauri/src/openclaw_config.rs
+++ b/src-tauri/src/openclaw_config.rs
@@ -284,6 +284,16 @@ impl OpenClawConfigDocument {
             });
         }
 
+        // Heal every root key on each write, not just the section being
+        // updated: older versions may have emitted several bare keys, and the
+        // promise is that the next save restores strict JSON for the whole
+        // file. Already-quoted keys are rewritten equivalently.
+        for pair in key_value_pairs.iter_mut() {
+            if let Some(name) = json5_key_name(&pair.key).map(str::to_string) {
+                pair.key = make_json5_key(&name);
+            }
+        }
+
         let leading_ws = context
             .as_ref()
             .map(|ctx| ctx.wsc.0.clone())
@@ -296,9 +306,6 @@ impl OpenClawConfigDocument {
             .iter_mut()
             .find(|pair| json5_key_name(&pair.key) == Some(key))
         {
-            // Re-quote the key so sections written bare by older versions are
-            // healed back to strict JSON on the next write.
-            existing.key = make_json5_key(key);
             existing.value = new_value;
             return Ok(());
         }
@@ -1131,6 +1138,38 @@ mod tests {
                 .expect("rewritten openclaw.json must parse as strict JSON");
             assert!(parsed.get("agents").is_some());
             assert!(written.contains("\"models\": {"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn write_heals_all_bare_root_keys_not_just_the_updated_section() {
+        // Older versions could emit more than one bare root key. Healing only
+        // the section being updated would leave the file rejected by strict
+        // JSON consumers after the promised next save (#6467).
+        let source = r#"{
+  models: {
+    "mode": "merge",
+    "providers": {}
+  },
+  agents: {
+    "defaults": {
+      "model": "p1/x"
+    }
+  }
+}
+"#;
+
+        with_test_paths(source, |_| {
+            let outcome = set_provider("p1", json!({ "api": "anthropic-messages" })).unwrap();
+            assert!(outcome.backup_path.is_some());
+
+            let written = fs::read_to_string(get_openclaw_config_path()).unwrap();
+            let parsed = serde_json::from_str::<Value>(&written)
+                .expect("every bare root key must be healed on save, not just `models`");
+            assert!(parsed.get("agents").is_some());
+            assert!(written.contains("\"models\": {"));
+            assert!(written.contains("\"agents\": {"));
         });
     }
 }

--- a/src-tauri/src/openclaw_config.rs
+++ b/src-tauri/src/openclaw_config.rs
@@ -20,8 +20,11 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
+// Strict JSON on purpose: the file ships a `.json` extension, so third-party
+// consumers parse it with strict JSON readers even though OpenClaw itself
+// tolerates JSON5 (#6467).
 const OPENCLAW_DEFAULT_SOURCE: &str =
-    "{\n  models: {\n    mode: 'merge',\n    providers: {},\n  },\n}\n";
+    "{\n  \"models\": {\n    \"mode\": \"merge\",\n    \"providers\": {}\n  }\n}\n";
 const OPENCLAW_TOOLS_PROFILES: &[&str] = &["minimal", "coding", "messaging", "full"];
 
 // ============================================================================
@@ -293,6 +296,9 @@ impl OpenClawConfigDocument {
             .iter_mut()
             .find(|pair| json5_key_name(&pair.key) == Some(key))
         {
+            // Re-quote the key so sections written bare by older versions are
+            // healed back to strict JSON on the next write.
+            existing.key = make_json5_key(key);
             existing.value = new_value;
             return Ok(());
         }
@@ -538,21 +544,9 @@ fn make_root_pair(key: &str, value: RtJSONValue, closing_ws: String) -> RtJSONKe
 }
 
 fn make_json5_key(key: &str) -> RtJSONValue {
-    if is_identifier_key(key) {
-        RtJSONValue::Identifier(key.to_string())
-    } else {
-        RtJSONValue::DoubleQuotedString(key.to_string())
-    }
-}
-
-fn is_identifier_key(key: &str) -> bool {
-    let mut chars = key.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-
-    matches!(first, 'a'..='z' | 'A'..='Z' | '_' | '$')
-        && chars.all(|ch| matches!(ch, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '$'))
+    // Always emit a double-quoted key: OpenClaw accepts JSON5, but strict JSON
+    // consumers of `openclaw.json` reject bare identifiers (#6467).
+    RtJSONValue::DoubleQuotedString(key.to_string())
 }
 
 fn json5_key_name(key: &RtJSONValue) -> Option<&str> {
@@ -990,7 +984,7 @@ mod tests {
 
             let written = fs::read_to_string(get_openclaw_config_path()).unwrap();
             assert!(written.contains("// top-level comment"));
-            assert!(written.contains("agents: {"));
+            assert!(written.contains("\"agents\": {"));
             assert!(written.contains("provider/model"));
         });
     }
@@ -1084,6 +1078,59 @@ mod tests {
 
             let written = fs::read_to_string(get_openclaw_config_path()).unwrap();
             assert!(written.contains("\"providers\": {}"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn created_config_parses_as_strict_json() {
+        // No existing config file: the document is seeded from
+        // OPENCLAW_DEFAULT_SOURCE, which must stay strict JSON (#6467).
+        with_test_paths("", |config_path| {
+            fs::remove_file(config_path).unwrap();
+
+            let outcome = set_provider("p1", json!({ "api": "anthropic-messages" })).unwrap();
+            assert!(outcome.backup_path.is_none());
+
+            let written = fs::read_to_string(get_openclaw_config_path()).unwrap();
+            let parsed = serde_json::from_str::<Value>(&written)
+                .expect("newly created openclaw.json must parse as strict JSON");
+            assert!(parsed
+                .get("models")
+                .and_then(|m| m.get("providers"))
+                .is_some());
+            assert!(written.contains("\"models\": {"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn write_heals_bare_root_keys_to_strict_json() {
+        // Shape reported in #6467: a strict-JSON config where cc-switch
+        // previously appended/replaced the `models` section with a bare key
+        // (nested values were serialized, so only the root key is bare).
+        let source = r#"{
+  "agents": {
+    "defaults": {
+      "model": "p1/x"
+    }
+  },
+  models: {
+    "mode": "merge",
+    "providers": {}
+  }
+}
+"#;
+
+        with_test_paths(source, |_| {
+            let outcome = set_provider("p1", json!({ "api": "anthropic-messages" })).unwrap();
+            assert!(outcome.backup_path.is_some());
+
+            let written = fs::read_to_string(get_openclaw_config_path()).unwrap();
+            let parsed = serde_json::from_str::<Value>(&written)
+                .expect("rewritten openclaw.json must parse as strict JSON");
+            assert!(parsed.get("agents").is_some());
+            assert!(written.contains("\"models\": {"));
         });
     }
 }


### PR DESCRIPTION
Hi 👋 Another one from the small-fix pile — this addresses #6467.

## Summary / 概述

Fixes #6467

`openclaw.json` ships a `.json` extension, but two spots in the JSON5 round-trip write engine emitted **bare identifiers as root keys**, so after a save the file only parsed as JSON5. OpenClaw itself tolerates that, but strict JSON consumers (in the issue: Feishu aily-cli's openclaw adapter) then fail with `not valid JSON` on every save.

- `OPENCLAW_DEFAULT_SOURCE` — the seed used when the config file doesn't exist yet — was hand-written JSON5 (bare keys, single quotes, trailing commas)
- `make_json5_key()` deliberately emitted bare identifiers for any identifier-shaped key; that's how a bare `models:` ended up appended to otherwise strict-JSON user configs

Changes (all in `src-tauri/src/openclaw_config.rs`):

- the seed template is now strict JSON
- `make_json5_key()` always emits a double-quoted key (double-quoted keys are equally valid JSON5, so OpenClaw's own reader is unaffected)
- when an existing section is replaced, its root key is re-quoted as well — configs already carrying a bare key from earlier versions are healed on the next save, no manual `sed` needed

Reading side is untouched: JSON5 input (bare keys, single quotes, comments) still parses exactly as before, and comment preservation on write is unchanged.

## Screenshots / 截图

Not applicable — behavior-only fix.

## Validation / 验证

- `cargo fmt --check` ✅
- `cargo clippy --lib --tests -- -D warnings` ✅
- `cargo test` ✅ full suite — includes 2 new regression tests: a freshly created config parses as strict JSON, and a config in the shape reported in #6467 (bare `models` root key) is healed to strict JSON on the next write
- Rust-only change; no user-facing text, no frontend/i18n impact

Happy to adjust the approach or wording if you'd like this done differently.