### PR TITLE
fix(codex-oauth): support multiple accounts under same ChatGPT workspace (#5885)

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -283,12 +283,9 @@ impl CodexLiveStateSnapshot {
         if auth.get("auth_mode").and_then(Value::as_str) != Some("chatgpt") {
             return None;
         }
-        let account_id = auth
-            .pointer("/tokens/account_id")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|account_id| !account_id.is_empty())?
-            .to_string();
+        // 必须用 claims 推导的身份：`tokens.account_id` 只是工作区 ID，会把同工作区的
+        // alice / bob 判成同一个账号。
+        let account_id = chatgpt_auth_identity(&auth)?;
         let last_refresh_ms = auth
             .get("last_refresh")
             .and_then(Value::as_str)
@@ -373,12 +370,31 @@ pub(crate) fn codex_managed_oauth_live_auth_marker_exists() -> bool {
     get_codex_managed_oauth_live_auth_marker_path().exists()
 }
 
+/// 从 ChatGPT `auth` 推导账号主键：claims 里的身份优先，完全推不出来才退回
+/// `tokens.account_id`。
+///
+/// 这条 fallback ladder 只能有一份：marker 记录与回滚身份判定若各写一套，改动其中
+/// 一处就会让两边算出不同的 key。
+fn chatgpt_auth_identity(auth: &Value) -> Option<String> {
+    parse_codex_auth_identity(auth)
+        .and_then(|(identity, workspace)| {
+            crate::proxy::providers::codex_oauth_auth::resolve_account_identity_from(
+                &identity, workspace,
+            )
+            .0
+        })
+        .or_else(|| {
+            auth.as_object()
+                .and_then(tokens_account_id)
+                .map(str::to_string)
+        })
+}
+
 /// 从 live/备份的 Codex `auth` 中提取 `account_id`，用于 marker 记录/比对。
 ///
 /// 仅接受 ChatGPT 登录形状（`auth_mode == "chatgpt"`、`OPENAI_API_KEY` 可清空）。
 /// 托管账号写入的完整 bundle 会额外带 `tokens.refresh_token` 与顶层 `last_refresh`，
-/// 这里一并容忍。所有权按 account-scoped 内容判断；Codex CLI 自刷新会轮换
-/// access_token，因此短期 token 指纹不能作为稳定的删除谓词。
+/// 这里一并容忍。
 fn extract_codex_managed_oauth_account_id(auth: &Value) -> Option<String> {
     let auth_obj = auth.as_object()?;
 
@@ -413,18 +429,45 @@ fn extract_codex_managed_oauth_account_id(auth: &Value) -> Option<String> {
         return None;
     }
 
-    let account_id = tokens
-        .get("account_id")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|id| !id.is_empty())?;
     tokens
         .get("access_token")
         .and_then(|value| value.as_str())
         .map(str::trim)
         .filter(|token| !token.is_empty())?;
 
-    Some(account_id.to_string())
+    chatgpt_auth_identity(auth)
+}
+
+/// 解析 ChatGPT `auth` 里的身份 claims，**不做形状白名单检查**。
+///
+/// 归属判定必须与形状解耦：白名单是给「这是不是托管写入的 bundle」用的，Codex CLI
+/// 之后多写一个字段就会让它落空。落空后若退回 `tokens.account_id`（工作区 ID）比对，
+/// 复合键账号会恒判 false，从此认不出自己的 auth.json。
+fn parse_codex_auth_identity(
+    auth: &Value,
+) -> Option<(
+    crate::proxy::providers::codex_oauth_auth::AccountIdentity,
+    Option<String>,
+)> {
+    if auth.get("auth_mode").and_then(Value::as_str) != Some("chatgpt") {
+        return None;
+    }
+    let tokens = auth.get("tokens")?.as_object()?;
+    let parse = |field: &str| {
+        tokens
+            .get(field)
+            .and_then(Value::as_str)
+            .and_then(crate::proxy::providers::codex_oauth_auth::parse_jwt_claims)
+    };
+    let id_claims = parse("id_token");
+    let access_claims = parse("access_token");
+
+    Some(
+        crate::proxy::providers::codex_oauth_auth::resolve_identity_and_workspace(
+            id_claims.as_ref(),
+            access_claims.as_ref(),
+        ),
+    )
 }
 
 /// Build the native-shaped ChatGPT auth bundle shared by cc-switch and Codex CLI.
@@ -447,10 +490,14 @@ pub fn codex_managed_oauth_auth_value(
         "refresh_token".to_string(),
         Value::String(refresh_token.to_string()),
     );
-    tokens.insert(
-        "account_id".to_string(),
-        Value::String(account_id.to_string()),
-    );
+    // 没有工作区 ID 时整个字段省略：写入空串会让 Codex CLI 发出一个空的
+    // `ChatGPT-Account-Id` header。
+    if !account_id.is_empty() {
+        tokens.insert(
+            "account_id".to_string(),
+            Value::String(account_id.to_string()),
+        );
+    }
     json!({
         "auth_mode": "chatgpt",
         "OPENAI_API_KEY": null,
@@ -483,7 +530,7 @@ pub fn codex_auth_matches_recorded_managed_oauth(
     let Some(auth_account_id) = extract_codex_managed_oauth_account_id(auth) else {
         return Ok(false);
     };
-    if auth_account_id != account_id {
+    if !managed_marker_refers_to_account(&auth_account_id, account_id) {
         return Ok(false);
     }
 
@@ -502,7 +549,32 @@ pub fn codex_auth_matches_recorded_managed_oauth(
     // v1 markers also carry an access-token fingerprint. Serde ignores that
     // legacy extra field, and matching intentionally no longer consults it:
     // the Codex CLI rotates access tokens during normal self-refresh.
-    Ok(matches!(marker.version, 1 | 2) && marker.account_id == account_id)
+    Ok(matches!(marker.version, 1 | 2)
+        && managed_marker_refers_to_account(&marker.account_id, account_id))
+}
+
+/// marker 里记的 key 与请求的 `account_id` 是否指向同一次登录。
+///
+/// marker 一律由 claims 推导，因此是复合键；升级前存下的账号 key 却仍是裸工作区 ID，
+/// 直接字符串比较会恒不相等，导致 marker 既刷不新也清不掉。
+fn managed_marker_refers_to_account(marker_account_id: &str, account_id: &str) -> bool {
+    use crate::proxy::providers::codex_oauth_auth::split_composite_account_id;
+
+    let marker_account_id = marker_account_id.trim();
+    let account_id = account_id.trim();
+    if marker_account_id == account_id {
+        return true;
+    }
+
+    match (
+        split_composite_account_id(marker_account_id),
+        split_composite_account_id(account_id),
+    ) {
+        // 只有「复合键 vs 裸工作区 key」这一种跨形状才等价；两个复合键不相等就是两个人。
+        (Some((_, workspace)), None) => workspace == account_id,
+        (None, Some((_, workspace))) => workspace == marker_account_id,
+        _ => false,
+    }
 }
 
 fn clear_codex_managed_oauth_live_auth_marker_for_account(
@@ -526,7 +598,7 @@ fn clear_codex_managed_oauth_live_auth_marker_for_account(
             return delete_file(&marker_path);
         }
     };
-    if marker.account_id == account_id.trim() {
+    if managed_marker_refers_to_account(&marker.account_id, account_id) {
         delete_file(&marker_path)?;
     }
     Ok(())
@@ -611,9 +683,8 @@ pub fn clear_codex_live_auth_for_managed_account_if_unchanged(
 ///
 /// 托管账号写入的是**完整可刷新 bundle**，与原生浏览器登录形状一致（都含
 /// refresh_token），且 Codex CLI 会轮换 token 使旧的 access_token 指纹失效，因此
-/// 无法再凭形状/哈希区分。这里采用**基于内容的 account_id 判定**：只要是 chatgpt
-/// 模式、且 `tokens.account_id` 命中托管账号，即视为该账号的登录。对同一账号的原生
-/// 登录会被同等处理（同账号，无损）。
+/// 无法再凭形状/哈希区分。判定改为基于 token claims 里的个人身份（细节见下方注释）。
+/// 对同一账号的原生登录会被同等处理（同账号，无损）。
 ///
 /// 用于 Live 备份剥离：避免把托管账号的可刷新 token 持久化进备份配置。
 pub fn codex_live_auth_is_managed_chatgpt_login(auth: &Value, account_id: &str) -> bool {
@@ -633,12 +704,33 @@ pub fn codex_live_auth_is_managed_chatgpt_login(auth: &Value, account_id: &str) 
     if !api_key_clearable {
         return false;
     }
-    obj.get("tokens")
+
+    // 归属只能由 token claims 里的个人身份决定：`tokens.account_id` 只是工作区 ID，
+    // 同工作区另一个成员的登录也会命中它，进而把对方的 live auth 当成自己的，
+    // 采纳或删除掉别人的凭据。
+    //
+    // 升级前存下的账号 key 仍是裸工作区 ID（用户尚未在 UI 重新登录绑定），对这些 key
+    // 只能比到工作区一层——这正是它们在同工作区多成员下会误判的原因，重新登录一次即转为
+    // 复合键。完全解析不出个人 claim 时同样只剩工作区可比。
+    let Some((identity, workspace_id)) = parse_codex_auth_identity(auth) else {
+        return false;
+    };
+
+    crate::proxy::providers::codex_oauth_auth::identity_owns_account_id(
+        &identity,
+        workspace_id.as_deref(),
+        tokens_account_id(obj),
+        account_id,
+    )
+}
+
+fn tokens_account_id(auth: &serde_json::Map<String, Value>) -> Option<&str> {
+    auth.get("tokens")
         .and_then(|tokens| tokens.as_object())
         .and_then(|tokens| tokens.get("account_id"))
         .and_then(|value| value.as_str())
         .map(str::trim)
-        == Some(account_id)
+        .filter(|id| !id.is_empty())
 }
 
 /// 读回 Codex CLI 当前 `~/.codex/auth.json` 中属于 `account_id` 的 refresh_token /
@@ -3464,6 +3556,157 @@ base_url = "https://single.example.com/v1"
         );
     }
 
+    fn unsigned_jwt(payload: &Value) -> String {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+        let encoded = URL_SAFE_NO_PAD.encode(serde_json::to_vec(payload).unwrap());
+        format!("{header}.{encoded}.")
+    }
+
+    fn chatgpt_bundle(id_claims: Value, tokens_account_id: &str, last_refresh: &str) -> Value {
+        chatgpt_bundle_with_access(id_claims, None, tokens_account_id, last_refresh)
+    }
+
+    fn chatgpt_bundle_with_access(
+        id_claims: Value,
+        access_claims: Option<Value>,
+        tokens_account_id: &str,
+        last_refresh: &str,
+    ) -> Value {
+        let access_token = match access_claims {
+            Some(claims) => unsigned_jwt(&claims),
+            None => "access".to_string(),
+        };
+        json!({
+            "auth_mode": "chatgpt",
+            "OPENAI_API_KEY": null,
+            "tokens": {
+                "id_token": unsigned_jwt(&id_claims),
+                "access_token": access_token,
+                "refresh_token": "refresh",
+                "account_id": tokens_account_id
+            },
+            "last_refresh": last_refresh
+        })
+    }
+
+    #[test]
+    fn rollback_does_not_treat_two_members_of_one_workspace_as_the_same_account() {
+        // A -> B 的事务失败回滚时，只有「同一个账号刷新出了更新的 auth」才可以保留
+        // 盘上的现状。`tokens.account_id` 只是工作区 ID，拿它判定会把 bob 的登录
+        // 当成 alice 的新世代保留下来，留下「cc-switch 认为是 alice、盘上却是 bob 凭据」。
+        let alice = chatgpt_auth_identity(&chatgpt_bundle(
+            json!({ "sub": "alice-sub", "chatgpt_account_id": "team-ws" }),
+            "team-ws",
+            "2026-01-02T03:04:05.000000000Z",
+        ));
+        let bob = chatgpt_auth_identity(&chatgpt_bundle(
+            json!({ "sub": "bob-sub", "chatgpt_account_id": "team-ws" }),
+            "team-ws",
+            "2026-01-02T04:04:05.000000000Z",
+        ));
+
+        assert_eq!(alice.as_deref(), Some("alice-sub::team-ws"));
+        assert_ne!(
+            alice, bob,
+            "two members of one workspace must not share a rollback generation identity"
+        );
+    }
+
+    #[test]
+    fn live_auth_ownership_survives_an_unknown_extra_field() {
+        // Codex CLI 之后多写一个字段就会让形状白名单落空。归属判定必须与形状解耦，
+        // 否则落空后退回工作区比对，所有复合键账号同时认不出自己的 auth.json。
+        let mut auth = chatgpt_bundle(
+            json!({ "sub": "alice-sub", "chatgpt_account_id": "team-ws" }),
+            "team-ws",
+            "2026-01-02T03:04:05.000000000Z",
+        );
+        auth.as_object_mut()
+            .unwrap()
+            .insert("some_new_field".to_string(), json!(true));
+
+        assert!(codex_live_auth_is_managed_chatgpt_login(
+            &auth,
+            "alice-sub::team-ws"
+        ));
+        assert!(!codex_live_auth_is_managed_chatgpt_login(
+            &auth,
+            "bob-sub::team-ws"
+        ));
+    }
+
+    #[test]
+    fn live_auth_ownership_survives_a_changed_claim_set() {
+        // 登录时 id_token 只有 sub，主键定为 `alice-sub::team-ws`。之后 CLI 轮换出的
+        // id_token 多带了 user_id，最优 claim 变成 user_id——只比「当前最优 claim」
+        // 就会认不出这是同一个人，凭据从此孤儿化。必须比对全部候选。
+        let rotated = chatgpt_bundle(
+            json!({
+                "sub": "alice-sub",
+                "chatgpt_account_id": "team-ws",
+                "https://api.openai.com/auth": { "user_id": "alice-user-id" }
+            }),
+            "team-ws",
+            "2026-01-02T03:04:05.000000000Z",
+        );
+        assert_eq!(
+            extract_codex_managed_oauth_account_id(&rotated).as_deref(),
+            Some("alice-user-id::team-ws"),
+            "the rotated token must actually rank user_id above sub"
+        );
+
+        assert!(codex_live_auth_is_managed_chatgpt_login(
+            &rotated,
+            "alice-sub::team-ws"
+        ));
+        assert!(
+            !codex_live_auth_is_managed_chatgpt_login(&rotated, "bob-sub::team-ws"),
+            "a claim that never appeared must not match"
+        );
+    }
+
+    #[test]
+    fn a_workspaceless_account_never_leaks_its_key_into_native_auth() {
+        // 没有工作区 claim 的账号，主键就是裸个人身份（可能是 email）。它绝不能出现在
+        // 原生 auth.json 的 tokens.account_id——Codex CLI 会把该字段当
+        // `ChatGPT-Account-Id` 发给 OpenAI。
+        use crate::proxy::providers::codex_oauth_auth::native_tokens_account_id;
+
+        assert_eq!(
+            native_tokens_account_id(Some("team-ws"), "alice::team-ws"),
+            "team-ws"
+        );
+        assert_eq!(
+            native_tokens_account_id(None, "alice@example.com::team-ws"),
+            "",
+            "a composite key must never reach tokens.account_id"
+        );
+        // 裸 key 保持既有行为：它要么就是工作区 ID，要么没有别的值可写
+        assert_eq!(native_tokens_account_id(None, "team-ws"), "team-ws");
+
+        let auth =
+            codex_managed_oauth_auth_value("", "access", None, "refresh", "2026-01-01T00:00:00Z");
+        assert!(
+            auth.pointer("/tokens/account_id").is_none(),
+            "an empty workspace ID must be omitted, not written as an empty string"
+        );
+
+        let with_workspace = codex_managed_oauth_auth_value(
+            "team-ws",
+            "access",
+            None,
+            "refresh",
+            "2026-01-01T00:00:00Z",
+        );
+        assert_eq!(
+            with_workspace
+                .pointer("/tokens/account_id")
+                .and_then(Value::as_str),
+            Some("team-ws")
+        );
+    }
+
     #[test]
     fn managed_chatgpt_login_matched_by_account_id_including_full_refresh_bundle() {
         // ① 之后托管写入的是含 refresh_token 的完整 bundle；备份剥离必须凭 account_id
@@ -3493,6 +3736,56 @@ base_url = "https://single.example.com/v1"
         assert!(!codex_live_auth_is_managed_chatgpt_login(
             &api_key_auth,
             "acct-managed"
+        ));
+
+        // 同 Team 工作区（相同 tokens.account_id）或同 Email 不同工作区能够被精确区分
+        let team_account_1 = chatgpt_bundle(
+            json!({
+                "email": "user1@example.com",
+                "chatgpt_account_id": "team-workspace-uuid"
+            }),
+            "team-workspace-uuid",
+            "2026-01-02T03:04:05.000000000Z",
+        );
+
+        assert_eq!(
+            extract_codex_managed_oauth_account_id(&team_account_1).as_deref(),
+            Some("user1@example.com::team-workspace-uuid")
+        );
+
+        // id_token 只带 sub + 工作区、email 只在 access_token 里时，marker 必须与
+        // 登录路径算出同一个主键，否则 CLI 轮换的 refresh_token 认不回账号
+        let split_claims_account = chatgpt_bundle_with_access(
+            json!({
+                "sub": "auth0|12345",
+                "chatgpt_account_id": "team-workspace-uuid"
+            }),
+            Some(json!({ "email": "user1@example.com" })),
+            "team-workspace-uuid",
+            "2026-01-02T03:04:05.000000000Z",
+        );
+        // 主键只认 id_token 的 claim：access_token 会被 CLI 轮换，让它参与主键
+        // 会在换代后算出另一个 key。
+        assert_eq!(
+            extract_codex_managed_oauth_account_id(&split_claims_account).as_deref(),
+            Some("auth0|12345::team-workspace-uuid")
+        );
+        assert!(codex_live_auth_is_managed_chatgpt_login(
+            &team_account_1,
+            "user1@example.com::team-workspace-uuid"
+        ));
+        assert!(!codex_live_auth_is_managed_chatgpt_login(
+            &team_account_1,
+            "user2@example.com::team-workspace-uuid"
+        ));
+        assert!(!codex_live_auth_is_managed_chatgpt_login(
+            &team_account_1,
+            "user1@example.com::other-workspace-uuid"
+        ));
+        // 兼容旧版仅以 tokens.account_id 绑定的判定
+        assert!(codex_live_auth_is_managed_chatgpt_login(
+            &team_account_1,
+            "team-workspace-uuid"
         ));
     }
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -518,6 +518,11 @@ pub fn record_codex_managed_oauth_live_auth(auth: &Value) -> Result<(), AppError
     crate::config::write_json_file(&get_codex_managed_oauth_live_auth_marker_path(), &marker)
 }
 
+/// live `auth` 与 `account_id` 是否指向 marker 记下的那次托管登录。
+///
+/// marker 里的 key 与 `account_id` 都由 claims 推导，但可能取自不同世代的 claim 集合
+/// （先只有 email、轮换后多了 user_id），直接比字符串会把同一个人判成两个人。改问
+/// 「这份 auth 是否同时拥有两个 key」，经由 auth 传递地判等。
 pub fn codex_auth_matches_recorded_managed_oauth(
     auth: &Value,
     account_id: &str,
@@ -527,10 +532,10 @@ pub fn codex_auth_matches_recorded_managed_oauth(
         return Ok(false);
     }
 
-    let Some(auth_account_id) = extract_codex_managed_oauth_account_id(auth) else {
-        return Ok(false);
-    };
-    if !managed_marker_refers_to_account(&auth_account_id, account_id) {
+    // 形状白名单只回答「这是不是托管写入的 bundle」；归属一律交给 claims 身份判定。
+    if extract_codex_managed_oauth_account_id(auth).is_none()
+        || !codex_live_auth_is_managed_chatgpt_login(auth, account_id)
+    {
         return Ok(false);
     }
 
@@ -550,13 +555,15 @@ pub fn codex_auth_matches_recorded_managed_oauth(
     // legacy extra field, and matching intentionally no longer consults it:
     // the Codex CLI rotates access tokens during normal self-refresh.
     Ok(matches!(marker.version, 1 | 2)
-        && managed_marker_refers_to_account(&marker.account_id, account_id))
+        && codex_live_auth_is_managed_chatgpt_login(auth, &marker.account_id))
 }
 
-/// marker 里记的 key 与请求的 `account_id` 是否指向同一次登录。
+/// marker 里记的 key 与请求的 `account_id` 是否指向同一次登录——**仅供手上没有 live
+/// auth 可据以判定归属的降级路径**（清理 marker 时盘上的 auth 可能已不存在）。
 ///
-/// marker 一律由 claims 推导，因此是复合键；升级前存下的账号 key 却仍是裸工作区 ID，
-/// 直接字符串比较会恒不相等，导致 marker 既刷不新也清不掉。
+/// 有 auth 时一律走 `codex_live_auth_is_managed_chatgpt_login`：两个 key 可能取自不同
+/// 世代的 claim 集合，字符串比较会把同一个人判成两个人。这里只能容忍「claims 复合键 vs
+/// 升级前存下的裸工作区 ID」这一种跨形状，否则 marker 清不掉。
 fn managed_marker_refers_to_account(marker_account_id: &str, account_id: &str) -> bool {
     use crate::proxy::providers::codex_oauth_auth::split_composite_account_id;
 
@@ -3684,6 +3691,76 @@ base_url = "https://single.example.com/v1"
         assert!(
             !codex_live_auth_is_managed_chatgpt_login(&rotated, "other@example.com::team-ws"),
             "the personal claim still has to discriminate members of one workspace"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn marker_still_refers_to_the_account_after_claims_gain_a_user_id() {
+        // 登录当时的 id_token 只有 email，账号 key 因此是 `email::ws`；之后 CLI 轮换
+        // 出的 token 多带了 openai_auth.user_id，marker 便按更高优先级算成
+        // `user_id::ws`。两个复合键不相等，但它们是同一个人。
+        let _home = CodexLiveTestHome::new();
+        let rotated = chatgpt_bundle(
+            json!({
+                "email": "user@example.com",
+                "chatgpt_account_id": "team-ws",
+                "https://api.openai.com/auth": { "user_id": "user-abc" }
+            }),
+            "team-ws",
+            "2026-01-02T03:04:05.000000000Z",
+        );
+        record_codex_managed_oauth_live_auth(&rotated).expect("record marker");
+
+        assert!(
+            codex_auth_matches_recorded_managed_oauth(&rotated, "user@example.com::team-ws")
+                .expect("marker lookup"),
+            "a richer claim set must not orphan the account key stored at login time"
+        );
+        assert!(
+            !codex_auth_matches_recorded_managed_oauth(&rotated, "other@example.com::team-ws")
+                .expect("marker lookup"),
+            "the personal claim still has to discriminate members of one workspace"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn refresh_sync_rerecords_the_marker_when_the_key_generations_differ() {
+        // commit 宣称的可见行为：CLI 自刷新后 marker 仍会被重写。谓词判等只是手段，
+        // 这里锁住的是端到端结果——盘上 marker 从登录世代的 key 更新到刷新世代的 key。
+        let _home = CodexLiveTestHome::new();
+        let claims = json!({
+            "email": "user@example.com",
+            "chatgpt_account_id": "team-ws",
+            "https://api.openai.com/auth": { "user_id": "user-abc" }
+        });
+        let current = chatgpt_bundle(claims.clone(), "team-ws", "2026-01-02T03:04:05Z");
+        crate::config::write_json_file(&get_codex_auth_path(), &current).expect("seed live auth");
+        // 登录当时的 id_token 只有 email，marker 因此记的是 `email::ws`。
+        crate::config::write_json_file(
+            &get_codex_managed_oauth_live_auth_marker_path(),
+            &CodexManagedOAuthLiveAuthMarker {
+                version: 2,
+                account_id: "user@example.com::team-ws".to_string(),
+            },
+        )
+        .expect("seed login-era marker");
+
+        let refreshed = chatgpt_bundle(claims, "team-ws", "2026-01-02T04:05:06Z");
+        assert!(sync_codex_managed_oauth_live_auth_after_refresh(
+            "user@example.com::team-ws",
+            "refresh",
+            &refreshed,
+        )
+        .expect("sync refreshed auth"));
+
+        let marker: CodexManagedOAuthLiveAuthMarker =
+            read_json_file(&get_codex_managed_oauth_live_auth_marker_path())
+                .expect("marker must survive the refresh");
+        assert_eq!(
+            marker.account_id, "user-abc::team-ws",
+            "the marker has to be re-recorded from the refreshed claims"
         );
     }
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -3667,6 +3667,27 @@ base_url = "https://single.example.com/v1"
     }
 
     #[test]
+    fn live_auth_ownership_survives_a_token_that_drops_the_workspace_claim() {
+        // 轮换出的 token 保留个人 claim 但不再带工作区 claim 时，
+        // `synced_chatgpt_account_id()` 会保留已存的工作区并写进 `tokens.account_id`。
+        // 归属判定必须认同一份 auth.json，否则 CLI 轮换采纳、同步与托管清理全部失效。
+        let rotated = chatgpt_bundle(
+            json!({ "email": "user@example.com" }),
+            "team-ws",
+            "2026-01-02T03:04:05.000000000Z",
+        );
+
+        assert!(codex_live_auth_is_managed_chatgpt_login(
+            &rotated,
+            "user@example.com::team-ws"
+        ));
+        assert!(
+            !codex_live_auth_is_managed_chatgpt_login(&rotated, "other@example.com::team-ws"),
+            "the personal claim still has to discriminate members of one workspace"
+        );
+    }
+
+    #[test]
     fn marker_matches_across_key_shapes_but_not_across_people() {
         // marker 一律由 claims 推导（复合键），而升级前存下的账号 key 仍是裸工作区 ID。
         // 这一跨形状必须判定为同一次登录，否则 marker 既刷不新也清不掉。

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -3667,6 +3667,29 @@ base_url = "https://single.example.com/v1"
     }
 
     #[test]
+    fn marker_matches_across_key_shapes_but_not_across_people() {
+        // marker 一律由 claims 推导（复合键），而升级前存下的账号 key 仍是裸工作区 ID。
+        // 这一跨形状必须判定为同一次登录，否则 marker 既刷不新也清不掉。
+        assert!(managed_marker_refers_to_account(
+            "alice-sub::team-ws",
+            "team-ws"
+        ));
+        assert!(managed_marker_refers_to_account(
+            "team-ws",
+            "alice-sub::team-ws"
+        ));
+        // 但同工作区的两个成员是两个人，不能因为工作区相同就互认。
+        assert!(!managed_marker_refers_to_account(
+            "alice-sub::team-ws",
+            "bob-sub::team-ws"
+        ));
+        assert!(!managed_marker_refers_to_account(
+            "alice-sub::team-ws",
+            "other-ws"
+        ));
+    }
+
+    #[test]
     fn a_workspaceless_account_never_leaks_its_key_into_native_auth() {
         // 没有工作区 claim 的账号，主键就是裸个人身份（可能是 email）。它绝不能出现在
         // 原生 auth.json 的 tokens.account_id——Codex CLI 会把该字段当

--- a/src-tauri/src/commands/codex_oauth.rs
+++ b/src-tauri/src/commands/codex_oauth.rs
@@ -52,10 +52,12 @@ pub async fn get_codex_oauth_quota(
         }
     };
 
+    let chatgpt_account_id = manager.get_chatgpt_account_id_for_account(&id).await;
+
     // 瞬时传输失败以 Err 传播（前端 reject → retry + 保留上次成功值）。
     query_codex_quota(
         &token,
-        Some(&id),
+        chatgpt_account_id.as_deref(),
         "codex_oauth",
         "Codex OAuth access token expired or rejected. Please re-login via cc-switch.",
     )
@@ -90,5 +92,11 @@ pub async fn get_codex_oauth_models(
         .await
         .map_err(|e| format!("Codex OAuth token unavailable: {e}"))?;
 
-    crate::services::codex_oauth_models::fetch_models_with_token(&token, &id).await
+    let chatgpt_account_id = manager.get_chatgpt_account_id_for_account(&id).await;
+
+    crate::services::codex_oauth_models::fetch_models_with_token(
+        &token,
+        chatgpt_account_id.as_deref(),
+    )
+    .await
 }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -42,6 +42,7 @@ const PROXY_AUTH_PLACEHOLDER: &str = "PROXY_MANAGED";
 fn validate_codex_official_authorization(
     headers: &http::HeaderMap,
     provider: &Provider,
+    expected_workspace_id: Option<&str>,
 ) -> Result<(), ProxyError> {
     let authorization = headers
         .get(http::header::AUTHORIZATION)
@@ -67,7 +68,14 @@ fn validate_codex_official_authorization(
                     .and_then(|value| value.to_str().ok())
                     .map(str::trim)
                     .filter(|account_id| !account_id.is_empty());
-                if request_account_id != Some(expected_account_id.as_str()) {
+                // 复合键账号送上来的是工作区 UUID（Codex 会话读的是 auth.json 里的
+                // tokens.account_id），与 meta 里的 `user::workspace` 主键不相等，
+                // 因此工作区 ID 必须由 CodexOAuthManager 解析后传进来比对。托管
+                // provider 的存储配置只保留占位 auth，从 settings_config 读不到它。
+                let matches_expected = request_account_id == Some(expected_account_id.as_str())
+                    || (request_account_id.is_some()
+                        && request_account_id == expected_workspace_id);
+                if !matches_expected {
                     return Err(ProxyError::AuthError(
                         "当前 Codex 会话未加载所选 ChatGPT 账号，请重启 Codex 或新建会话后重试"
                             .to_string(),
@@ -1181,8 +1189,30 @@ impl RequestForwarder {
         let codex_official_auth_passthrough = matches!(app_type, AppType::Codex)
             && super::providers::is_codex_official_provider(provider);
 
+        // 同一次请求里 header 校验与 header 注入都要这个工作区 ID，解析一次带下去。
+        let mut codex_workspace_id: Option<String> = None;
         if codex_official_auth_passthrough {
-            validate_codex_official_authorization(headers, provider)?;
+            codex_workspace_id = match (
+                &self.app_handle,
+                provider
+                    .meta
+                    .as_ref()
+                    .and_then(|meta| meta.managed_account_id_for("codex_oauth")),
+            ) {
+                (Some(app_handle), Some(account_id)) => {
+                    app_handle
+                        .state::<CodexOAuthState>()
+                        .0
+                        .get_chatgpt_account_id_for_account(&account_id)
+                        .await
+                }
+                _ => None,
+            };
+            validate_codex_official_authorization(
+                headers,
+                provider,
+                codex_workspace_id.as_deref(),
+            )?;
         }
 
         // 应用模型映射（独立于格式转换）
@@ -1718,25 +1748,41 @@ impl RequestForwarder {
                         .as_ref()
                         .and_then(|m| m.managed_account_id_for("codex_oauth"));
 
-                    let token_result = match &account_id {
+                    // 未绑定账号时先把默认账号定下来，后面的 token 与
+                    // `ChatGPT-Account-Id` 都用同一个 ID 取：分两次各自解析默认账号，
+                    // 中间一次 `set_default_account` 就会拼出 A 的 token 配 B 的工作区。
+                    let account_id = match account_id {
                         Some(id) => {
                             log::debug!("[CodexOAuth] 使用指定账号 {id} 获取 token");
-                            codex_auth.get_valid_token_for_account(id).await
+                            Some(id)
                         }
                         None => {
                             log::debug!("[CodexOAuth] 使用默认账号获取 token");
-                            codex_auth.get_valid_token().await
+                            codex_auth.default_account_id().await
                         }
+                    };
+
+                    let token_result = match &account_id {
+                        Some(id) => codex_auth.get_valid_token_for_account(id).await,
+                        None => Err(
+                            crate::proxy::providers::codex_oauth_auth::CodexOAuthError::AccountNotFound(
+                                "无可用的 ChatGPT 账号".to_string(),
+                            ),
+                        ),
                     };
 
                     match token_result {
                         Ok(token) => {
                             auth = AuthInfo::new(token, AuthStrategy::CodexOAuth);
                             should_send_codex_oauth_session_headers = true;
-                            // 解析使用的 account_id（用于注入 ChatGPT-Account-Id header）
-                            codex_oauth_account_id = match account_id {
-                                Some(id) => Some(id),
-                                None => codex_auth.default_account_id().await,
+                            // 解析使用的 chatgpt_account_id（用于注入 ChatGPT-Account-Id header，仅组织/Team 账号需要）
+                            codex_oauth_account_id = match (&codex_workspace_id, &account_id) {
+                                // official passthrough 上面已经解析过同一个账号
+                                (Some(workspace), Some(_)) => Some(workspace.clone()),
+                                (_, Some(aid)) => {
+                                    codex_auth.get_chatgpt_account_id_for_account(aid).await
+                                }
+                                (_, None) => None,
                             };
                             log::debug!(
                                 "[CodexOAuth] 成功获取 access_token (account={})",
@@ -4544,7 +4590,7 @@ mod tests {
         let mut provider = test_provider_with_type(None);
         provider.id = "codex-official".to_string();
         provider.category = Some("official".to_string());
-        let error = validate_codex_official_authorization(&headers, &provider)
+        let error = validate_codex_official_authorization(&headers, &provider, None)
             .expect_err("stale placeholder must be rejected");
         assert!(matches!(error, ProxyError::AuthError(message) if message.contains("重启 Codex")));
     }
@@ -4566,13 +4612,48 @@ mod tests {
             HeaderValue::from_static("Bearer account-a-token"),
         );
         headers.insert("chatgpt-account-id", HeaderValue::from_static("account-a"));
-        let error = validate_codex_official_authorization(&headers, &provider)
+        let error = validate_codex_official_authorization(&headers, &provider, None)
             .expect_err("a stale Codex session must not cross the account boundary");
         assert!(matches!(error, ProxyError::AuthError(message) if message.contains("重启 Codex")));
 
         headers.insert("chatgpt-account-id", HeaderValue::from_static("account-b"));
-        validate_codex_official_authorization(&headers, &provider)
+        validate_codex_official_authorization(&headers, &provider, None)
             .expect("the selected account may pass through");
+    }
+
+    #[test]
+    fn managed_codex_official_accepts_the_resolved_workspace_id() {
+        let mut provider = test_provider_with_type(Some("codex_oauth"));
+        provider.category = Some("official".to_string());
+        provider.meta.as_mut().expect("provider meta").auth_binding =
+            Some(crate::provider::AuthBinding {
+                source: crate::provider::AuthBindingSource::ManagedAccount,
+                auth_provider: Some("codex_oauth".to_string()),
+                account_id: Some("user@example.com::team-workspace-uuid".to_string()),
+            });
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer account-token"),
+        );
+        // Codex 会话送的是 auth.json 里的工作区 UUID，不是复合主键
+        headers.insert(
+            "chatgpt-account-id",
+            HeaderValue::from_static("team-workspace-uuid"),
+        );
+
+        let error = validate_codex_official_authorization(&headers, &provider, None)
+            .expect_err("without the resolved workspace the composite key cannot match");
+        assert!(matches!(error, ProxyError::AuthError(message) if message.contains("重启 Codex")));
+
+        validate_codex_official_authorization(&headers, &provider, Some("team-workspace-uuid"))
+            .expect("the workspace resolved from CodexOAuthManager may pass through");
+
+        let error =
+            validate_codex_official_authorization(&headers, &provider, Some("other-workspace"))
+                .expect_err("another workspace must not pass through");
+        assert!(matches!(error, ProxyError::AuthError(message) if message.contains("重启 Codex")));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -137,13 +137,15 @@ struct OAuthTokenResponse {
     expires_in: Option<i64>,
 }
 
-/// 解析后的 JWT claims（仅关心 chatgpt_account_id 等字段）
+/// 解析后的 JWT claims（仅关心 chatgpt_account_id、email、user_id、sub 等字段）
 #[derive(Debug, Clone, Default, Deserialize)]
-struct IdTokenClaims {
+pub(crate) struct IdTokenClaims {
     #[serde(default)]
     chatgpt_account_id: Option<String>,
     #[serde(default)]
     email: Option<String>,
+    #[serde(default)]
+    sub: Option<String>,
     #[serde(default)]
     organizations: Vec<OrgClaim>,
     #[serde(default, rename = "https://api.openai.com/auth")]
@@ -151,15 +153,193 @@ struct IdTokenClaims {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
-struct OrgClaim {
+pub(crate) struct OrgClaim {
     #[serde(default)]
     id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
-struct OpenAiAuthClaim {
+pub(crate) struct OpenAiAuthClaim {
     #[serde(default)]
     chatgpt_account_id: Option<String>,
+    #[serde(default)]
+    user_id: Option<String>,
+}
+
+impl IdTokenClaims {
+    fn extract_chatgpt_account_id(&self) -> Option<String> {
+        self.chatgpt_account_id
+            .as_deref()
+            .or_else(|| {
+                self.openai_auth
+                    .as_ref()
+                    .and_then(|a| a.chatgpt_account_id.as_deref())
+            })
+            .or_else(|| self.organizations.first().and_then(|o| o.id.as_deref()))
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+    }
+
+    fn email_claim(&self) -> Option<&str> {
+        non_empty(self.email.as_deref())
+    }
+
+    fn user_id_claim(&self) -> Option<&str> {
+        non_empty(
+            self.openai_auth
+                .as_ref()
+                .and_then(|auth| auth.user_id.as_deref()),
+        )
+    }
+
+    fn sub_claim(&self) -> Option<&str> {
+        non_empty(self.sub.as_deref())
+    }
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+/// 一个账号从 token claims 里能拿到的全部身份信息。
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct AccountIdentity {
+    /// 账号主键使用的个人身份。
+    ///
+    /// 只有 id_token 完全没有个人 claim 时才退到 access_token：access_token 会被
+    /// Codex CLI 自刷新轮换，拿它参与主键会让同一个账号在换代后算出不同的 key，
+    /// 于是 `~/.codex/auth.json` 再也认不回账号、CLI 轮换出的 refresh_token 被孤儿化。
+    primary: Option<String>,
+    /// 两个 token 里出现过的全部个人标识，用于「是否同一个人」的宽容比对。
+    candidates: Vec<String>,
+    /// 展示用 email，跨两个 token 收集（主键不一定用它）。
+    email: Option<String>,
+}
+
+impl AccountIdentity {
+    pub(crate) fn from_claims(
+        id_claims: Option<&IdTokenClaims>,
+        access_claims: Option<&IdTokenClaims>,
+    ) -> Self {
+        let mut candidates = Vec::new();
+        let mut collect = |claims: Option<&IdTokenClaims>| -> Option<String> {
+            let claims = claims?;
+            // 优先级 user_id > sub > email：前两者是 OpenAI 侧不可变的不透明标识，
+            // email 可以被用户改掉，用它当主键会让同一个账号改名后变成两条记录。
+            let mut best = None;
+            for value in [
+                claims.user_id_claim().map(str::to_string),
+                claims.sub_claim().map(str::to_string),
+                claims.email_claim().map(normalize_email),
+            ] {
+                let Some(value) = value else { continue };
+                if !candidates.contains(&value) {
+                    candidates.push(value.clone());
+                }
+                best.get_or_insert(value);
+            }
+            best
+        };
+
+        // 两个 token 都要走一遍，否则 access_token 的候选不会被收集。
+        let from_id_token = collect(id_claims);
+        let from_access_token = collect(access_claims);
+        let email = id_claims
+            .and_then(IdTokenClaims::email_claim)
+            .or_else(|| access_claims.and_then(IdTokenClaims::email_claim))
+            .map(str::to_string);
+
+        Self {
+            primary: from_id_token.or(from_access_token),
+            candidates,
+            email,
+        }
+    }
+
+    /// `user` 是否是这份 claims 描述的同一个人。
+    ///
+    /// 比对全部候选而不是只比 `primary()`：token 换代后 claim 集合可能变化
+    /// （例如新 id_token 不再带 `user_id`），只要原来那个标识仍在就应当认得出来。
+    fn matches_user(&self, user: &str) -> bool {
+        self.candidates.iter().any(|candidate| candidate == user)
+    }
+}
+
+/// email 统一小写：同一个账号在不同登录里回传 `Alice@x` / `alice@x` 时不能变成两条记录。
+fn normalize_email(email: &str) -> String {
+    email.to_lowercase()
+}
+
+/// 账号主键 `用户身份::工作区` 的分隔符。`::` 不会出现在 email / OpenAI 的
+/// user_id / sub 里，因此可用它判断一个 key 是否已是复合键。
+pub(crate) const ACCOUNT_ID_SEPARATOR: &str = "::";
+
+/// 拆开复合主键。返回 `None` 表示这是升级前存下的裸工作区 key。
+pub(crate) fn split_composite_account_id(account_id: &str) -> Option<(&str, &str)> {
+    account_id.split_once(ACCOUNT_ID_SEPARATOR)
+}
+
+/// 这份 claims 是否属于 `account_id` 指向的账号。
+///
+/// 复合键必须个人身份与工作区都命中；裸工作区 key（升级前存量，用户尚未在 UI
+/// 重新绑定）只能比到工作区一层——这正是它在同工作区多成员下会误判的原因。
+pub(crate) fn identity_owns_account_id(
+    identity: &AccountIdentity,
+    claims_workspace_id: Option<&str>,
+    tokens_account_id: Option<&str>,
+    account_id: &str,
+) -> bool {
+    match split_composite_account_id(account_id) {
+        Some((user, workspace)) => {
+            identity.matches_user(user) && claims_workspace_id == Some(workspace)
+        }
+        // 裸 key 有两种：升级前存下的工作区 ID，以及没有工作区 claim 的个人账号。
+        // 字符串本身分不出来，两种都要试。
+        None => {
+            claims_workspace_id == Some(account_id)
+                || (claims_workspace_id.is_none()
+                    && (identity.matches_user(account_id) || tokens_account_id == Some(account_id)))
+        }
+    }
+}
+
+/// 写进原生 `~/.codex/auth.json` 的 `tokens.account_id`。
+///
+/// 复合主键绝不能写出去：它含个人身份（可能是 email），而 Codex CLI 会把这个字段当
+/// `ChatGPT-Account-Id` 发给 OpenAI。裸 key 则保持既有行为原样写入——它要么就是工作区
+/// ID，要么是没有工作区的个人账号，后者本来就没有别的值可写。
+pub(crate) fn native_tokens_account_id<'a>(
+    chatgpt_account_id: Option<&'a str>,
+    account_id: &'a str,
+) -> &'a str {
+    chatgpt_account_id.unwrap_or(match split_composite_account_id(account_id) {
+        Some(_) => "",
+        None => account_id,
+    })
+}
+
+/// 由已解析的 identity 组合出 (account_id, email, workspace)。
+pub(crate) fn resolve_account_identity_from(
+    identity: &AccountIdentity,
+    chatgpt_account_id: Option<String>,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let account_id =
+        compose_primary_account_id(identity.primary.clone(), chatgpt_account_id.clone());
+
+    (account_id, identity.email.clone(), chatgpt_account_id)
+}
+
+pub(crate) fn resolve_identity_and_workspace(
+    id_claims: Option<&IdTokenClaims>,
+    access_claims: Option<&IdTokenClaims>,
+) -> (AccountIdentity, Option<String>) {
+    let identity = AccountIdentity::from_claims(id_claims, access_claims);
+    let chatgpt_account_id = id_claims
+        .and_then(IdTokenClaims::extract_chatgpt_account_id)
+        .or_else(|| access_claims.and_then(IdTokenClaims::extract_chatgpt_account_id));
+
+    (identity, chatgpt_account_id)
 }
 
 /// 缓存的 access_token（含过期时间）
@@ -231,11 +411,14 @@ struct PendingDeviceCode {
 /// 持久化的账号数据
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CodexAccountData {
-    /// chatgpt_account_id（同时作为 HashMap 的 key）
+    /// 账号唯一标识（同时作为 HashMap 的 key，优先使用 email / user_id / sub）
     pub account_id: String,
     /// 账号邮箱（如果可获取）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
+    /// OpenAI chatgpt_account_id / workspace ID（如果可获取）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chatgpt_account_id: Option<String>,
     /// Refresh Token（持久化）
     pub refresh_token: String,
     /// 认证时间戳（秒）
@@ -250,16 +433,55 @@ struct CodexAccountData {
     pub token_updated_at_ms: i64,
 }
 
+impl CodexAccountData {
+    /// 已存下的工作区 ID。
+    fn stored_workspace_id(&self) -> Option<String> {
+        non_empty(self.chatgpt_account_id.as_deref()).map(str::to_string)
+    }
+
+    /// 当前 id_token claims 里的工作区 ID。
+    fn claimed_workspace_id(&self) -> Option<String> {
+        self.id_token
+            .as_deref()
+            .and_then(parse_jwt_claims)
+            .and_then(|c| c.extract_chatgpt_account_id())
+    }
+
+    /// 日常读取：已存的字段优先，存量账号没有该字段时才回落到 claims。
+    pub fn effective_chatgpt_account_id(&self) -> Option<String> {
+        self.stored_workspace_id()
+            .or_else(|| self.claimed_workspace_id())
+    }
+
+    /// 刷新 / 采纳新 token 后重新解析工作区 ID。
+    ///
+    /// 与 `effective_chatgpt_account_id()` 的取值顺序相反：先认 claims，工作区变更时
+    /// 才比对得出差异。否则陈旧的工作区会继续被注入 `chatgpt-account-id` 和托管
+    /// auth.json。新 token 不带工作区 claim 时保留旧值。
+    pub fn synced_chatgpt_account_id(&self) -> Option<String> {
+        self.claimed_workspace_id()
+            .or_else(|| self.stored_workspace_id())
+    }
+}
+
 /// 公开的账号信息（返回给前端，复用 GitHubAccount 结构）
 impl From<&CodexAccountData> for GitHubAccount {
     fn from(data: &CodexAccountData) -> Self {
+        let login = match (&data.email, &data.chatgpt_account_id) {
+            (Some(email), Some(ws)) if !ws.trim().is_empty() => {
+                // 按字符截断：workspace ID 来自 JWT claim，不保证是 ASCII UUID，
+                // 按字节切片会在多字节字符中间 panic（这里在 list_accounts 热路径上）。
+                let short_ws: String = ws.trim().chars().take(8).collect();
+                format!("{email} ({short_ws})")
+            }
+            (Some(email), _) => email.clone(),
+            (None, Some(ws)) => format!("ChatGPT ({ws})"),
+            (None, None) => format!("ChatGPT ({})", data.account_id),
+        };
+
         GitHubAccount {
             id: data.account_id.clone(),
-            // 用 email 作为显示名（若无则用 account_id）
-            login: data
-                .email
-                .clone()
-                .unwrap_or_else(|| format!("ChatGPT ({})", &data.account_id)),
+            login,
             avatar_url: None,
             authenticated_at: data.authenticated_at,
             github_domain: "github.com".to_string(),
@@ -286,6 +508,8 @@ pub(crate) struct ManagedTokenBundle {
     pub access_token: String,
     pub id_token: Option<String>,
     pub refresh_token: String,
+    /// OpenAI Workspace / Team ID（chatgpt_account_id，写入 auth.json 里的 tokens.account_id）
+    pub chatgpt_account_id: Option<String>,
     /// access_token 的真实获取时间，RFC3339 纳秒精度 + `Z`（与原生 auth.json 的
     /// `last_refresh` 形状一致）。反映 token 何时真正刷新，而非写盘时刻。
     pub last_refresh: String,
@@ -495,7 +719,7 @@ impl CodexOAuthManager {
             CodexOAuthError::TokenFetchFailed("响应缺少 refresh_token".to_string())
         })?;
 
-        let (account_id, email) = extract_identity_from_tokens(&tokens);
+        let (account_id, email, chatgpt_account_id) = extract_identity_from_tokens(&tokens);
         let account_id = account_id.ok_or_else(|| {
             CodexOAuthError::ParseError("无法从 token 中提取 account_id".to_string())
         })?;
@@ -508,6 +732,7 @@ impl CodexOAuthManager {
                 account_id.clone(),
                 refresh_token,
                 email,
+                chatgpt_account_id,
                 // 空字符串视为缺失，避免写出空的 id_token
                 tokens.id_token.clone().filter(|t| !t.trim().is_empty()),
                 Some(CachedAccessToken {
@@ -727,7 +952,7 @@ impl CodexOAuthManager {
 
         // 如果服务端返回了新的 refresh_token 或 id_token，更新存储
         let mut needs_save = false;
-        let (stored_refresh_token, stored_id_token) = {
+        let (stored_refresh_token, stored_id_token, stored_chatgpt_account_id) = {
             let mut accounts = self.accounts.write().await;
             let account = accounts
                 .get_mut(account_id)
@@ -762,11 +987,21 @@ impl CodexOAuthManager {
                     needs_save = true;
                 }
             }
+            // 同步更新或回填 chatgpt_account_id
+            let effective_chatgpt_id = account.synced_chatgpt_account_id();
+            if account.chatgpt_account_id != effective_chatgpt_id {
+                account.chatgpt_account_id = effective_chatgpt_id.clone();
+                needs_save = true;
+            }
             if account.token_updated_at_ms != obtained_at_ms {
                 account.token_updated_at_ms = obtained_at_ms;
                 needs_save = true;
             }
-            (account.refresh_token.clone(), account.id_token.clone())
+            (
+                account.refresh_token.clone(),
+                account.id_token.clone(),
+                effective_chatgpt_id,
+            )
         };
         if needs_save {
             self.save_to_disk().await?;
@@ -781,8 +1016,10 @@ impl CodexOAuthManager {
         let last_refresh = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(obtained_at_ms)
             .unwrap_or_else(chrono::Utc::now)
             .to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
+        let live_tokens_account_id =
+            native_tokens_account_id(stored_chatgpt_account_id.as_deref(), account_id);
         let refreshed_auth = crate::codex_config::codex_managed_oauth_auth_value(
-            account_id,
+            live_tokens_account_id,
             &cached.token,
             stored_id_token.as_deref(),
             &stored_refresh_token,
@@ -886,17 +1123,22 @@ impl CodexOAuthManager {
             chrono::DateTime::<chrono::Utc>::from_timestamp_millis(cached.obtained_at_ms)
                 .unwrap_or_else(chrono::Utc::now)
                 .to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
-        let (id_token, refresh_token) = {
+        let (id_token, refresh_token, chatgpt_account_id) = {
             let accounts = self.accounts.read().await;
             let account = accounts
                 .get(account_id)
                 .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
-            (account.id_token.clone(), account.refresh_token.clone())
+            (
+                account.id_token.clone(),
+                account.refresh_token.clone(),
+                account.effective_chatgpt_account_id(),
+            )
         };
         Ok(ManagedTokenBundle {
             access_token: cached.token,
             id_token,
             refresh_token,
+            chatgpt_account_id,
             last_refresh,
         })
     }
@@ -1099,10 +1341,14 @@ impl CodexOAuthManager {
                     }
                 }
             }
-            // 采纳了 CLI 轮换后的 refresh_token：与之配套的旧 access_token 可能已被
-            // 服务端提前失效。在同一 accounts 写锁内（accounts -> access_tokens 顺序）
-            // 清缓存，避免释放锁后被快路径读到旧 token；下次按新 refresh_token 重取。
+            // 采纳了 CLI 轮换后的 refresh_token / id_token：同步更新 chatgpt_account_id
+            // 并清理舊 access_token 缓存
             if material_replaced {
+                let effective_chatgpt_id = account.synced_chatgpt_account_id();
+                if account.chatgpt_account_id != effective_chatgpt_id {
+                    account.chatgpt_account_id = effective_chatgpt_id;
+                    changed = true;
+                }
                 self.access_tokens.write().await.remove(account_id);
             }
 
@@ -1131,6 +1377,14 @@ impl CodexOAuthManager {
     /// 获取默认账号 ID（热路径使用，避免克隆整个账号 HashMap）
     pub async fn default_account_id(&self) -> Option<String> {
         self.resolve_default_account_id().await
+    }
+
+    /// 获取指定账号关联的 OpenAI Workspace / Team ID（chatgpt_account_id）
+    pub async fn get_chatgpt_account_id_for_account(&self, account_id: &str) -> Option<String> {
+        let accounts = self.accounts.read().await;
+        accounts
+            .get(account_id)
+            .and_then(|a| a.effective_chatgpt_account_id())
     }
 
     // ==================== 多账号管理 ====================
@@ -1294,6 +1548,7 @@ impl CodexOAuthManager {
             account_id.to_string(),
             "test-refresh-token".to_string(),
             Some(format!("{account_id}@example.test")),
+            None,
             id_token.map(|token| token.to_string()),
             Some(CachedAccessToken {
                 token: access_token.to_string(),
@@ -1332,11 +1587,15 @@ impl CodexOAuthManager {
 
     // ==================== 内部方法 ====================
 
+    // 账号身份（account_id / email / workspace）与凭据必须一起原子写入，拆成
+    // 中间结构只会把同一次登录的字段分散到两处。
+    #[allow(clippy::too_many_arguments)]
     async fn add_account_internal(
         &self,
         account_id: String,
         refresh_token: String,
         email: Option<String>,
+        chatgpt_account_id: Option<String>,
         id_token: Option<String>,
         initial_access_token: Option<CachedAccessToken>,
         pending_device_code: Option<&str>,
@@ -1364,6 +1623,7 @@ impl CodexOAuthManager {
         let data = CodexAccountData {
             account_id: account_id.clone(),
             email,
+            chatgpt_account_id,
             refresh_token,
             authenticated_at: now,
             id_token,
@@ -1601,7 +1861,7 @@ fn extract_refresh_error_code(body: &str) -> Option<String> {
 }
 
 /// 解析 JWT 中的 claims
-fn parse_jwt_claims(token: &str) -> Option<IdTokenClaims> {
+pub(crate) fn parse_jwt_claims(token: &str) -> Option<IdTokenClaims> {
     let parts: Vec<&str> = token.split('.').collect();
     if parts.len() != 3 {
         return None;
@@ -1610,46 +1870,37 @@ fn parse_jwt_claims(token: &str) -> Option<IdTokenClaims> {
     serde_json::from_slice(&decoded).ok()
 }
 
-/// 从 token 响应中提取 (account_id, email)
-fn extract_identity_from_tokens(tokens: &OAuthTokenResponse) -> (Option<String>, Option<String>) {
-    let mut account_id: Option<String> = None;
-    let mut email: Option<String> = None;
-
-    if let Some(id_token) = tokens.id_token.as_deref() {
-        if let Some(claims) = parse_jwt_claims(id_token) {
-            account_id = claims
-                .chatgpt_account_id
-                .clone()
-                .or_else(|| {
-                    claims
-                        .openai_auth
-                        .as_ref()
-                        .and_then(|a| a.chatgpt_account_id.clone())
-                })
-                .or_else(|| claims.organizations.first().and_then(|o| o.id.clone()));
-            email = claims.email.clone();
-        }
+/// 组合账号主键：有个人身份且有工作区时用 `user_identity::workspace_id`，
+/// 使同一工作区的多个成员、以及同一成员的多个工作区都不会互相覆盖。
+fn compose_primary_account_id(
+    user_identity: Option<String>,
+    chatgpt_account_id: Option<String>,
+) -> Option<String> {
+    match (user_identity, chatgpt_account_id) {
+        (Some(user), Some(workspace)) => Some(format!("{user}{ACCOUNT_ID_SEPARATOR}{workspace}")),
+        (Some(user), None) => Some(user),
+        (None, Some(workspace)) => Some(workspace),
+        (None, None) => None,
     }
+}
 
-    if account_id.is_none() {
-        if let Some(claims) = parse_jwt_claims(&tokens.access_token) {
-            account_id = claims
-                .chatgpt_account_id
-                .clone()
-                .or_else(|| {
-                    claims
-                        .openai_auth
-                        .as_ref()
-                        .and_then(|a| a.chatgpt_account_id.clone())
-                })
-                .or_else(|| claims.organizations.first().and_then(|o| o.id.clone()));
-            if email.is_none() {
-                email = claims.email.clone();
-            }
-        }
-    }
+/// 从 token 响应中提取 (account_id, email, chatgpt_account_id)
+///
+/// `account_id` 为区分不同个人的唯一标识（Primary Key）：
+/// 个人身份优先级 email > openai_auth.user_id > sub，再拼接工作区 ID；
+/// 完全没有个人 claim 时退化为工作区 ID。
+///
+/// `chatgpt_account_id` 为 OpenAI Workspace/Team ID
+fn extract_identity_from_tokens(
+    tokens: &OAuthTokenResponse,
+) -> (Option<String>, Option<String>, Option<String>) {
+    let id_claims = tokens.id_token.as_deref().and_then(parse_jwt_claims);
+    let access_claims = parse_jwt_claims(&tokens.access_token);
 
-    (account_id, email)
+    let (identity, chatgpt_account_id) =
+        resolve_identity_and_workspace(id_claims.as_ref(), access_claims.as_ref());
+
+    resolve_account_identity_from(&identity, chatgpt_account_id)
 }
 
 #[cfg(test)]
@@ -1776,6 +2027,7 @@ mod tests {
                     None,
                     None,
                     None,
+                    None,
                 )
                 .await
                 .unwrap();
@@ -1801,6 +2053,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -1809,6 +2062,7 @@ mod tests {
                 "acc-456".to_string(),
                 "rt2".to_string(),
                 Some("b@example.com".to_string()),
+                None,
                 None,
                 None,
                 None,
@@ -2125,6 +2379,7 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
                 Some("device-auth-id"),
             )
             .await;
@@ -2152,6 +2407,464 @@ mod tests {
 
         assert!(matches!(result, Err(CodexOAuthError::ExpiredToken)));
         assert!(manager.pending_device_codes.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn same_team_multiple_accounts_coexist_without_overwrite() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+
+        // 两个属于同一 Team 工作区（相同 chatgpt_account_id）但不同邮箱的账号
+        let team_workspace_id = "e7a7bd67-d460-48dd-b066-0a550abd3778";
+        let acct_1 = format!("user1@example.com::{team_workspace_id}");
+        let acct_2 = format!("user2@example.com::{team_workspace_id}");
+
+        manager
+            .add_account_internal(
+                acct_1.clone(),
+                "rt-user1".to_string(),
+                Some("user1@example.com".to_string()),
+                Some(team_workspace_id.to_string()),
+                Some("id-token-1".to_string()),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        manager
+            .add_account_internal(
+                acct_2.clone(),
+                "rt-user2".to_string(),
+                Some("user2@example.com".to_string()),
+                Some(team_workspace_id.to_string()),
+                Some("id-token-2".to_string()),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let accounts = manager.list_accounts().await;
+        assert_eq!(accounts.len(), 2, "两个同 Team 账号必须独立并存");
+        assert!(accounts
+            .iter()
+            .any(|a| a.id == acct_1 && a.login == "user1@example.com (e7a7bd67)"));
+        assert!(accounts
+            .iter()
+            .any(|a| a.id == acct_2 && a.login == "user2@example.com (e7a7bd67)"));
+
+        assert_eq!(
+            manager
+                .get_chatgpt_account_id_for_account(&acct_1)
+                .await
+                .as_deref(),
+            Some(team_workspace_id)
+        );
+        assert_eq!(
+            manager
+                .get_chatgpt_account_id_for_account(&acct_2)
+                .await
+                .as_deref(),
+            Some(team_workspace_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn same_user_multiple_teams_coexist_without_overwrite() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+
+        // 同一个邮箱加入两个不同的 Team 以及一个 Personal 空间
+        let team_1 = "e7a7bd67-d460-48dd-b066-0a550abd3778";
+        let team_2 = "9b32f10a-81c2-48dd-b066-0a550abd9999";
+        let acct_team_1 = format!("user@example.com::{team_1}");
+        let acct_team_2 = format!("user@example.com::{team_2}");
+        let acct_personal = "user@example.com".to_string();
+
+        manager
+            .add_account_internal(
+                acct_team_1.clone(),
+                "rt-team1".to_string(),
+                Some("user@example.com".to_string()),
+                Some(team_1.to_string()),
+                Some("id-team-1".to_string()),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        manager
+            .add_account_internal(
+                acct_team_2.clone(),
+                "rt-team2".to_string(),
+                Some("user@example.com".to_string()),
+                Some(team_2.to_string()),
+                Some("id-team-2".to_string()),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        manager
+            .add_account_internal(
+                acct_personal.clone(),
+                "rt-personal".to_string(),
+                Some("user@example.com".to_string()),
+                None,
+                Some("id-personal".to_string()),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let accounts = manager.list_accounts().await;
+        assert_eq!(
+            accounts.len(),
+            3,
+            "同一用户的多个工作区账号必须全部独立并存"
+        );
+        assert!(accounts
+            .iter()
+            .any(|a| a.id == acct_team_1 && a.login == "user@example.com (e7a7bd67)"));
+        assert!(accounts
+            .iter()
+            .any(|a| a.id == acct_team_2 && a.login == "user@example.com (9b32f10a)"));
+        assert!(accounts
+            .iter()
+            .any(|a| a.id == acct_personal && a.login == "user@example.com"));
+
+        assert_eq!(
+            manager
+                .get_chatgpt_account_id_for_account(&acct_team_1)
+                .await
+                .as_deref(),
+            Some(team_1)
+        );
+        assert_eq!(
+            manager
+                .get_chatgpt_account_id_for_account(&acct_team_2)
+                .await
+                .as_deref(),
+            Some(team_2)
+        );
+        assert_eq!(
+            manager
+                .get_chatgpt_account_id_for_account(&acct_personal)
+                .await
+                .as_deref(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_identity_from_tokens_priority() {
+        // 1. 同时有 user_id / sub / email 时用 user_id::workspace_id：
+        //    user_id 与 sub 是不可变的不透明标识，email 可以被用户改掉
+        let payload1 = serde_json::json!({
+            "email": "user@example.com",
+            "sub": "auth0|12345",
+            "chatgpt_account_id": "team-workspace-uuid",
+            "https://api.openai.com/auth": {
+                "user_id": "user-abcdef",
+                "chatgpt_account_id": "team-workspace-uuid"
+            }
+        });
+        let tokens = OAuthTokenResponse {
+            access_token: "access".to_string(),
+            refresh_token: Some("refresh".to_string()),
+            id_token: Some(unsigned_jwt(payload1)),
+            expires_in: Some(3600),
+        };
+        let (account_id, email, chatgpt_account_id) = extract_identity_from_tokens(&tokens);
+        assert_eq!(
+            account_id.as_deref(),
+            Some("user-abcdef::team-workspace-uuid")
+        );
+        // email 仍然照常解析出来，只是不参与主键
+        assert_eq!(email.as_deref(), Some("user@example.com"));
+        assert_eq!(chatgpt_account_id.as_deref(), Some("team-workspace-uuid"));
+
+        // 2. 缺失 email 时降级使用 user_id::workspace_id
+        let payload2 = serde_json::json!({
+            "sub": "auth0|12345",
+            "https://api.openai.com/auth": {
+                "user_id": "user-abcdef",
+                "chatgpt_account_id": "team-workspace-uuid"
+            }
+        });
+        let tokens2 = OAuthTokenResponse {
+            access_token: "access".to_string(),
+            refresh_token: Some("refresh".to_string()),
+            id_token: Some(unsigned_jwt(payload2)),
+            expires_in: Some(3600),
+        };
+        let (account_id2, email2, chatgpt_account_id2) = extract_identity_from_tokens(&tokens2);
+        assert_eq!(
+            account_id2.as_deref(),
+            Some("user-abcdef::team-workspace-uuid")
+        );
+        assert_eq!(email2, None);
+        assert_eq!(chatgpt_account_id2.as_deref(), Some("team-workspace-uuid"));
+    }
+
+    fn unsigned_jwt(payload: serde_json::Value) -> String {
+        let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+        let encoded = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        format!("{header}.{encoded}.")
+    }
+
+    #[test]
+    fn identity_falls_back_to_access_token_personal_claims_before_workspace() {
+        // id_token 只带工作区 claim，个人身份只在 access_token 里
+        let id_token = unsigned_jwt(serde_json::json!({
+            "https://api.openai.com/auth": { "chatgpt_account_id": "team-workspace-uuid" }
+        }));
+        let access_token = unsigned_jwt(serde_json::json!({ "email": "user@example.com" }));
+        let tokens = OAuthTokenResponse {
+            access_token,
+            refresh_token: Some("refresh".to_string()),
+            id_token: Some(id_token),
+            expires_in: Some(3600),
+        };
+
+        let (account_id, email, chatgpt_account_id) = extract_identity_from_tokens(&tokens);
+        assert_eq!(
+            account_id.as_deref(),
+            Some("user@example.com::team-workspace-uuid")
+        );
+        assert_eq!(email.as_deref(), Some("user@example.com"));
+        assert_eq!(chatgpt_account_id.as_deref(), Some("team-workspace-uuid"));
+    }
+
+    #[test]
+    fn synced_workspace_id_replaces_a_stale_stored_value() {
+        let account = CodexAccountData {
+            account_id: "user@example.com::old-workspace".to_string(),
+            email: Some("user@example.com".to_string()),
+            chatgpt_account_id: Some("old-workspace".to_string()),
+            refresh_token: "refresh".to_string(),
+            authenticated_at: 0,
+            id_token: Some(unsigned_jwt(serde_json::json!({
+                "email": "user@example.com",
+                "chatgpt_account_id": "new-workspace"
+            }))),
+            token_updated_at_ms: 0,
+        };
+
+        // 存量字段非空时 effective_* 永远返回旧值，同步必须读新 token 的 claims
+        assert_eq!(
+            account.effective_chatgpt_account_id().as_deref(),
+            Some("old-workspace")
+        );
+        assert_eq!(
+            account.synced_chatgpt_account_id().as_deref(),
+            Some("new-workspace")
+        );
+    }
+
+    #[test]
+    fn synced_workspace_id_keeps_stored_value_when_new_token_has_no_claim() {
+        let account = CodexAccountData {
+            account_id: "user@example.com::workspace".to_string(),
+            email: Some("user@example.com".to_string()),
+            chatgpt_account_id: Some("workspace".to_string()),
+            refresh_token: "refresh".to_string(),
+            authenticated_at: 0,
+            id_token: Some(unsigned_jwt(
+                serde_json::json!({ "email": "user@example.com" }),
+            )),
+            token_updated_at_ms: 0,
+        };
+
+        assert_eq!(
+            account.synced_chatgpt_account_id().as_deref(),
+            Some("workspace")
+        );
+    }
+
+    /// v3.20.0 及更早版本存下来的形状：key 是工作区 ID，个人身份只体现在
+    /// email / id_token claims 里。
+    async fn seed_legacy_workspace_account(
+        manager: &CodexOAuthManager,
+        workspace: &str,
+        email: Option<&str>,
+    ) {
+        let id_token = email.map(|email| {
+            unsigned_jwt(serde_json::json!({
+                "email": email,
+                "chatgpt_account_id": workspace,
+            }))
+        });
+        manager
+            .add_account_internal(
+                workspace.to_string(),
+                "rt-legacy".to_string(),
+                email.map(str::to_string),
+                Some(workspace.to_string()),
+                id_token,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn relogin_writes_a_composite_key_and_leaves_the_legacy_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        let workspace = "team-workspace-uuid";
+        seed_legacy_workspace_account(&manager, workspace, Some("alice@example.com")).await;
+
+        // 登录一律写入复合键，不去改写升级前存下的裸工作区 key：那个 key 无法证明
+        // 属于谁（同工作区另一个成员的重新登录长得一模一样），沿用它就可能静默覆盖
+        // 别人的凭据。旧条目原样保留，用户在 UI 重新选一次账号即完成绑定。
+        manager
+            .add_account_internal(
+                format!("alice@example.com::{workspace}"),
+                "rt-alice-new".to_string(),
+                Some("alice@example.com".to_string()),
+                Some(workspace.to_string()),
+                Some(unsigned_jwt(serde_json::json!({
+                    "email": "alice@example.com",
+                    "chatgpt_account_id": workspace,
+                }))),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let accounts = manager.accounts.read().await;
+        assert_eq!(accounts.len(), 2);
+        assert_eq!(
+            accounts.get(workspace).map(|a| a.refresh_token.as_str()),
+            Some("rt-legacy")
+        );
+        assert_eq!(
+            accounts
+                .get(&format!("alice@example.com::{workspace}"))
+                .map(|a| a.refresh_token.as_str()),
+            Some("rt-alice-new")
+        );
+    }
+
+    #[tokio::test]
+    async fn another_member_of_the_same_workspace_gets_its_own_key() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        let workspace = "team-workspace-uuid";
+        seed_legacy_workspace_account(&manager, workspace, Some("alice@example.com")).await;
+
+        manager
+            .add_account_internal(
+                format!("bob@example.com::{workspace}"),
+                "rt-bob".to_string(),
+                Some("bob@example.com".to_string()),
+                Some(workspace.to_string()),
+                Some(unsigned_jwt(serde_json::json!({
+                    "email": "bob@example.com",
+                    "chatgpt_account_id": workspace,
+                }))),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let accounts = manager.accounts.read().await;
+        assert_eq!(accounts.len(), 2);
+        assert_eq!(
+            accounts.get(workspace).map(|a| a.refresh_token.as_str()),
+            Some("rt-legacy")
+        );
+        assert!(accounts.contains_key(&format!("bob@example.com::{workspace}")));
+    }
+
+    #[tokio::test]
+    async fn the_same_user_in_another_workspace_gets_its_own_key() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        seed_legacy_workspace_account(&manager, "workspace-a", Some("alice@example.com")).await;
+
+        manager
+            .add_account_internal(
+                "alice@example.com::workspace-b".to_string(),
+                "rt-alice-b".to_string(),
+                Some("alice@example.com".to_string()),
+                Some("workspace-b".to_string()),
+                Some(unsigned_jwt(serde_json::json!({
+                    "email": "alice@example.com",
+                    "chatgpt_account_id": "workspace-b",
+                }))),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let accounts = manager.accounts.read().await;
+        assert_eq!(accounts.len(), 2);
+        assert!(accounts.contains_key("workspace-a"));
+        assert!(accounts.contains_key("alice@example.com::workspace-b"));
+    }
+
+    #[test]
+    fn email_case_does_not_split_one_account_into_two_keys() {
+        // 同一个账号在不同次登录里可能回传不同大小写的 email，主键必须归一化，
+        // 否则会长出两条互不认识的记录。user_id / sub 是不透明标识，不能动。
+        let make = |email: &str| {
+            extract_identity_from_tokens(&OAuthTokenResponse {
+                access_token: unsigned_jwt(serde_json::json!({
+                    "email": email,
+                    "chatgpt_account_id": "workspace",
+                })),
+                refresh_token: Some("refresh".to_string()),
+                id_token: None,
+                expires_in: Some(3600),
+            })
+            .0
+        };
+
+        assert_eq!(
+            make("Alice@Example.com").as_deref(),
+            make("alice@example.com").as_deref()
+        );
+        assert_eq!(
+            make("Alice@Example.com").as_deref(),
+            Some("alice@example.com::workspace")
+        );
+    }
+
+    #[test]
+    fn the_primary_key_ignores_access_token_only_claims() {
+        // id_token 带 sub、email 只在 access_token 里：主键必须取 id_token 的 sub。
+        // access_token 会被 Codex CLI 自刷新轮换，让它参与主键，就会在换代后算出
+        // 另一个 key，auth.json 从此认不回账号、CLI 轮换的 refresh_token 被孤儿化。
+        let id_token = unsigned_jwt(serde_json::json!({
+            "sub": "auth0|12345",
+            "chatgpt_account_id": "team-workspace-uuid"
+        }));
+        let access_token = unsigned_jwt(serde_json::json!({ "email": "alice@example.com" }));
+        let tokens = OAuthTokenResponse {
+            access_token,
+            refresh_token: Some("refresh".to_string()),
+            id_token: Some(id_token),
+            expires_in: Some(3600),
+        };
+
+        let (account_id, email, chatgpt_account_id) = extract_identity_from_tokens(&tokens);
+        assert_eq!(
+            account_id.as_deref(),
+            Some("auth0|12345::team-workspace-uuid")
+        );
+        // email 只用于展示，仍然跨两个 token 收集
+        assert_eq!(email.as_deref(), Some("alice@example.com"));
+        assert_eq!(chatgpt_account_id.as_deref(), Some("team-workspace-uuid"));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -1887,7 +1887,7 @@ fn compose_primary_account_id(
 /// 从 token 响应中提取 (account_id, email, chatgpt_account_id)
 ///
 /// `account_id` 为区分不同个人的唯一标识（Primary Key）：
-/// 个人身份优先级 email > openai_auth.user_id > sub，再拼接工作区 ID；
+/// 个人身份优先级 openai_auth.user_id > sub > email，再拼接工作区 ID；
 /// 完全没有个人 claim 时退化为工作区 ID。
 ///
 /// `chatgpt_account_id` 为 OpenAI Workspace/Team ID

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -2420,7 +2420,7 @@ mod tests {
         let manager = CodexOAuthManager::new(temp.path().to_path_buf());
 
         // 两个属于同一 Team 工作区（相同 chatgpt_account_id）但不同邮箱的账号
-        let team_workspace_id = "e7a7bd67-d460-48dd-b066-0a550abd3778";
+        let team_workspace_id = "11111111-1111-4111-8111-111111111111";
         let acct_1 = format!("user1@example.com::{team_workspace_id}");
         let acct_2 = format!("user2@example.com::{team_workspace_id}");
 
@@ -2454,10 +2454,10 @@ mod tests {
         assert_eq!(accounts.len(), 2, "两个同 Team 账号必须独立并存");
         assert!(accounts
             .iter()
-            .any(|a| a.id == acct_1 && a.login == "user1@example.com (e7a7bd67)"));
+            .any(|a| a.id == acct_1 && a.login == "user1@example.com (11111111)"));
         assert!(accounts
             .iter()
-            .any(|a| a.id == acct_2 && a.login == "user2@example.com (e7a7bd67)"));
+            .any(|a| a.id == acct_2 && a.login == "user2@example.com (11111111)"));
 
         assert_eq!(
             manager
@@ -2481,8 +2481,8 @@ mod tests {
         let manager = CodexOAuthManager::new(temp.path().to_path_buf());
 
         // 同一个邮箱加入两个不同的 Team 以及一个 Personal 空间
-        let team_1 = "e7a7bd67-d460-48dd-b066-0a550abd3778";
-        let team_2 = "9b32f10a-81c2-48dd-b066-0a550abd9999";
+        let team_1 = "11111111-1111-4111-8111-111111111111";
+        let team_2 = "22222222-2222-4222-8222-222222222222";
         let acct_team_1 = format!("user@example.com::{team_1}");
         let acct_team_2 = format!("user@example.com::{team_2}");
         let acct_personal = "user@example.com".to_string();
@@ -2534,10 +2534,10 @@ mod tests {
         );
         assert!(accounts
             .iter()
-            .any(|a| a.id == acct_team_1 && a.login == "user@example.com (e7a7bd67)"));
+            .any(|a| a.id == acct_team_1 && a.login == "user@example.com (11111111)"));
         assert!(accounts
             .iter()
-            .any(|a| a.id == acct_team_2 && a.login == "user@example.com (9b32f10a)"));
+            .any(|a| a.id == acct_team_2 && a.login == "user@example.com (22222222)"));
         assert!(accounts
             .iter()
             .any(|a| a.id == acct_personal && a.login == "user@example.com"));

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -291,8 +291,13 @@ pub(crate) fn identity_owns_account_id(
     account_id: &str,
 ) -> bool {
     match split_composite_account_id(account_id) {
+        // 工作区先认 claims，claims 没有时回落到 `tokens.account_id`：轮换出的 token
+        // 可能保留个人 claim 却不再带工作区 claim，而写盘时 `synced_chatgpt_account_id()`
+        // 会保留已存的工作区。只比 claims 会让账号认不回自己的 auth.json。回落不会让同
+        // 工作区的两个成员互认——个人身份那一半仍然要命中。
         Some((user, workspace)) => {
-            identity.matches_user(user) && claims_workspace_id == Some(workspace)
+            identity.matches_user(user)
+                && claims_workspace_id.or(tokens_account_id) == Some(workspace)
         }
         // 裸 key 有两种：升级前存下的工作区 ID，以及没有工作区 claim 的个人账号。
         // 字符串本身分不出来，两种都要试。

--- a/src-tauri/src/services/codex_oauth_models.rs
+++ b/src-tauri/src/services/codex_oauth_models.rs
@@ -14,16 +14,21 @@ const CODEX_OAUTH_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub async fn fetch_models_with_token(
     token: &str,
-    account_id: &str,
+    account_id: Option<&str>,
 ) -> Result<Vec<FetchedModel>, String> {
     let client = crate::proxy::http_client::get();
-    let response = client
+    let mut req = client
         .get(CODEX_OAUTH_MODELS_URL)
         .query(&[("client_version", CODEX_OAUTH_CLIENT_VERSION)])
         .header("Authorization", format!("Bearer {token}"))
         .header("originator", "cc-switch")
-        .header("chatgpt-account-id", account_id)
-        .timeout(Duration::from_secs(CODEX_OAUTH_FETCH_TIMEOUT_SECS))
+        .timeout(Duration::from_secs(CODEX_OAUTH_FETCH_TIMEOUT_SECS));
+
+    if let Some(id) = account_id.map(str::trim).filter(|s| !s.is_empty()) {
+        req = req.header("chatgpt-account-id", id);
+    }
+
+    let response = req
         .send()
         .await
         .map_err(|e| format!("Request failed: {e}"))?;

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -852,8 +852,14 @@ fn get_codex_managed_oauth_live_auth_value(
                     )
                 })?;
 
+            let auth_account_id =
+                crate::proxy::providers::codex_oauth_auth::native_tokens_account_id(
+                    bundle.chatgpt_account_id.as_deref(),
+                    &account_id,
+                );
+
             Ok::<Value, String>(codex_managed_oauth_live_auth(
-                &account_id,
+                auth_account_id,
                 &bundle.access_token,
                 Some(id_token),
                 &bundle.refresh_token,


### PR DESCRIPTION
## Summary / 概述

Fixes #5885. Resolves an issue where multiple ChatGPT accounts overwrite each other in CC Switch by adopting a composite natural key (`user_identity::workspace_id`).

Before this change the stored account key was the workspace ID itself (`chatgpt_account_id`, falling back to the first `organizations[].id`), so two collision scenarios were indistinguishable:

1. **Multiple users in the same Team/Enterprise workspace** (sharing the same `chatgpt_account_id`).
2. **The same user account subscribed across multiple workspaces** (e.g. personal space + company team).

### Key Changes

- **Composite Primary Key (`user_identity::workspace_id`)**: `account_id` resolves to `format!("{user}::{workspace}")` (or `user` for personal workspaces without a workspace UUID). User identity is ranked `openai_auth.user_id` > `sub` > `email` and is taken **from the `id_token` only**; the `access_token` is a fallback used only when the `id_token` carries no personal claim at all. Both choices exist for stability: `user_id`/`sub` are opaque and immutable while an email can be changed, and the Codex CLI rotates the access token during self-refresh — letting it decide the key would compute a *different* key after a rotation, at which point `~/.codex/auth.json` no longer maps back to the account and the CLI-rotated `refresh_token` is orphaned.
- **Separate Workspace UUID**: The upstream `chatgpt_account_id` is preserved independently for HTTP headers (`chatgpt-account-id` on `/wham/usage` & `/codex/models`) and for writing into the native `~/.codex/auth.json` (`tokens.account_id`).
- **Case-insensitive email**: When email *is* the key (no `user_id`/`sub` available), it is lower-cased so `Alice@example.com` and `alice@example.com` cannot split one account into two entries. `user_id` / `sub` are opaque identifiers and are kept verbatim.
- **Pre-upgrade keys are never reused**: A login always writes the composite key. It deliberately does *not* adopt the pre-upgrade workspace-ID entry, because a re-login by member B of a shared workspace is byte-for-byte indistinguishable from a re-login by member A — adopting that key could silently overwrite someone else's credentials. The old entry is left untouched (the UI already shows it as needing re-login) and the user re-binds it by picking the account once. As a result the storage key is always identical to the identity in the claims, which is what makes every ownership check below decidable.
- **Shared identity resolution**: The login path and the managed live-auth marker in `codex_config.rs` now go through the same resolver, so the same account can no longer be assigned two different keys (which would make a CLI-rotated `refresh_token` unrecognizable).
- **Workspace resync**: A refreshed or adopted token re-derives the workspace ID from the new `id_token` claims rather than short-circuiting on the stored non-empty field, so a changed workspace actually replaces the stale one instead of being re-emitted in `chatgpt-account-id` and in the native `auth.json`.
- **Managed Official session validation**: The expected workspace ID is now resolved from `CodexOAuthManager`. A managed provider only persists placeholder auth, so reading it from `settings_config` would reject every request from the Team/Enterprise accounts this change is meant to support.
- **Display Name with Workspace Tag**: Formats `account.login` as `email (short_workspace_uuid)` (e.g. `user@example.com (e7a7bd67)`) so users can distinguish multiple workspace cards.
- **Claims-first live-auth ownership**: `codex_live_auth_is_managed_chatgpt_login` now matches `~/.codex/auth.json` against the identity derived from its own token claims. `tokens.account_id` only holds the workspace UUID, so matching on it alone would let one member adopt or delete another member's live credentials. Workspace-level matching is kept only for keys without `::` (pre-upgrade entries) and for logins whose claims cannot be parsed at all. Ownership is also **decoupled from the managed-bundle shape whitelist** — an unknown field added by a future Codex CLI would otherwise make the whitelist fall through and every composite-key account fail to recognize its own `auth.json` — and it compares against **every** identity claim present in the tokens rather than only the highest-ranked one, so a rotation that changes which claims are present still resolves to the same account.
- **Rollback no longer conflates two members of one workspace**: `restore_preserving_newer_same_account_auth` keeps the on-disk auth only when the *same* account demonstrably refreshed it. That check used `tokens.account_id`, i.e. the workspace, so a failed `alice -> bob` transaction would treat bob's newer `auth.json` as "the same account, newer generation" and leave bob's credentials on disk while cc-switch considers alice active. It now uses the claims identity.
- **`tokens.account_id` never receives a composite key**: writing the native `auth.json` previously fell back to `account_id` when no workspace was known, which would put an email into the field the Codex CLI sends as `ChatGPT-Account-Id`. The field is now omitted instead; the fallback is limited to pre-upgrade bare-workspace keys.
- **One default-account resolution per request**: the forwarder resolved the default account twice (once inside `get_valid_token()`, once for the header), so a concurrent `set_default_account` between them could pair account A's bearer token with account B's workspace header.
- **Unit Tests**: Same-workspace multi-user coexistence, same-user multi-workspace coexistence, a re-login leaving the pre-upgrade entry untouched, email case normalization, the key ignoring access-token-only claims, ownership surviving both an unknown extra field and a changed claim set, rollback keeping two workspace members apart, a workspace-less key never leaking into the native `auth.json`, and workspace resync on refresh.

### Known limitations / 已知限制

- **The official passthrough still cannot tell two members of one workspace apart.** A Codex session only ever sends the workspace UUID in `chatgpt-account-id`, so `validate_codex_official_authorization` can confirm the workspace but not which member's session it is. This is pre-existing behavior (the previous code compared against the workspace too) and is not made worse here; distinguishing members would require validating bearer-token ownership, which is out of scope for this PR.
- **Accounts stored before the upgrade need one re-login.** They keep their workspace-ID key until the user picks the account again; see above for why auto-migration is unsafe.
- **Until that re-login, a pre-upgrade account's live-auth ownership check is workspace-level.** If a second member of the same workspace logs in on the same machine before the old entry is re-bound, that check can still misjudge. Re-logging in resolves it permanently.
- **The on-disk store is still `version: 1` while the key semantics changed.** Downgrading to an older build is not handled: it would read a composite `account_id` as if it were a workspace UUID. Happy to bump the version if you prefer that.

## Related Issue / 关联 Issue

Fixes #5885

## Screenshots / 截图

<!-- N/A: Backend auth keying fix -->

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
