### PR TITLE
feat: support DeepSeek Harness

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -826,6 +826,7 @@ dependencies = [
  "webpki-roots 0.26.11",
  "windows-sys 0.61.2",
  "winreg 0.52.0",
+ "yaml-rust",
  "zip 2.4.2",
  "zstd",
 ]
@@ -2924,6 +2925,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4687,7 +4694,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7743,6 +7750,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,6 +69,7 @@ anyhow = "1.0"
 zip = "2.2"
 serde_yaml = "0.9"
 tempfile = "3"
+yaml-rust = { version = "0.3", features = ["preserve_order"] }
 url = "2.5"
 auto-launch = "0.5"
 once_cell = "1.21.3"

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -34,6 +34,7 @@ impl McpApps {
             AppType::Hermes => self.hermes,
             AppType::Pi => false, // Pi core has no native MCP registry.
             AppType::ClaudeDesktop => false,
+            AppType::DeepSeekHarness => false,
         }
     }
 
@@ -49,6 +50,7 @@ impl McpApps {
             AppType::Hermes => self.hermes = enabled,
             AppType::Pi => {}            // Pi core has no native MCP registry.
             AppType::ClaudeDesktop => {} // Claude Desktop 3P provider config doesn't support MCP here
+            AppType::DeepSeekHarness => {}
         }
     }
 
@@ -119,6 +121,7 @@ impl SkillApps {
             AppType::Pi => self.pi,
             AppType::OpenClaw => false, // OpenClaw doesn't support Skills
             AppType::ClaudeDesktop => false,
+            AppType::DeepSeekHarness => false,
         }
     }
 
@@ -134,6 +137,7 @@ impl SkillApps {
             AppType::Pi => self.pi = enabled,
             AppType::OpenClaw => {} // OpenClaw doesn't support Skills, ignore
             AppType::ClaudeDesktop => {} // Claude Desktop 3P profiles don't use CC Switch skill sync
+            AppType::DeepSeekHarness => {}
         }
     }
 
@@ -392,6 +396,7 @@ pub enum AppType {
     OpenClaw,
     Hermes,
     Pi,
+    DeepSeekHarness,
 }
 
 impl AppType {
@@ -406,6 +411,7 @@ impl AppType {
             AppType::OpenClaw => "openclaw",
             AppType::Hermes => "hermes",
             AppType::Pi => "pi",
+            AppType::DeepSeekHarness => "deepseek-harness",
         }
     }
 
@@ -417,7 +423,11 @@ impl AppType {
     pub fn is_additive_mode(&self) -> bool {
         matches!(
             self,
-            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Pi
+            AppType::OpenCode
+                | AppType::OpenClaw
+                | AppType::Hermes
+                | AppType::Pi
+                | AppType::DeepSeekHarness
         )
     }
 
@@ -440,6 +450,7 @@ impl AppType {
             AppType::OpenClaw,
             AppType::Hermes,
             AppType::Pi,
+            AppType::DeepSeekHarness,
         ]
         .into_iter()
     }
@@ -460,6 +471,9 @@ impl FromStr for AppType {
             "openclaw" => Ok(AppType::OpenClaw),
             "hermes" => Ok(AppType::Hermes),
             "pi" => Ok(AppType::Pi),
+            "deepseek-harness" | "deepseek_harness" | "deepseekharness" | "dsh" => {
+                Ok(AppType::DeepSeekHarness)
+            }
             other => Err(AppError::localized(
                 "unsupported_app",
                 format!("不支持的应用标识: '{other}'。可选值: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, pi。"),
@@ -504,6 +518,7 @@ impl CommonConfigSnippets {
             AppType::OpenClaw => self.openclaw.as_ref(),
             AppType::Hermes => self.hermes.as_ref(),
             AppType::Pi => None,
+            AppType::DeepSeekHarness => None,
         }
     }
 
@@ -519,6 +534,7 @@ impl CommonConfigSnippets {
             AppType::OpenClaw => self.openclaw = snippet,
             AppType::Hermes => self.hermes = snippet,
             AppType::Pi => {}
+            AppType::DeepSeekHarness => {}
         }
     }
 }
@@ -844,7 +860,7 @@ impl MultiAppConfig {
             AppType::Hermes => &mut config.prompts.hermes.prompts,
             // Pi was added after prompts moved to SQLite. Keeping it out of
             // this legacy config avoids a second, unused prompt state.
-            AppType::Pi => return Ok(false),
+            AppType::Pi | AppType::DeepSeekHarness => return Ok(false),
         };
 
         prompts.insert(id, prompt);
@@ -889,6 +905,7 @@ impl MultiAppConfig {
                 AppType::OpenClaw => continue, // OpenClaw MCP is still in development, skip
                 AppType::Hermes => continue,   // Hermes didn't exist in v3.6.x, skip
                 AppType::Pi => continue,       // Pi didn't exist in v3.6.x, skip
+                AppType::DeepSeekHarness => continue,
             };
 
             for (id, entry) in old_servers {

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -423,11 +423,7 @@ impl AppType {
     pub fn is_additive_mode(&self) -> bool {
         matches!(
             self,
-            AppType::OpenCode
-                | AppType::OpenClaw
-                | AppType::Hermes
-                | AppType::Pi
-                | AppType::DeepSeekHarness
+            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Pi
         )
     }
 

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -146,6 +146,15 @@ pub async fn get_config_status(
                 path,
             })
         }
+        AppType::DeepSeekHarness => {
+            let config_path = crate::deepseek_harness_config::get_settings_path();
+            Ok(ConfigStatus {
+                exists: config_path.exists(),
+                path: crate::deepseek_harness_config::get_dsh_home()
+                    .to_string_lossy()
+                    .to_string(),
+            })
+        }
     }
 }
 
@@ -168,6 +177,7 @@ pub async fn get_config_dir(app: String) -> Result<String, String> {
         AppType::OpenClaw => crate::openclaw_config::get_openclaw_dir(),
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
         AppType::Pi => crate::pi_config::get_pi_agent_dir().map_err(|e| e.to_string())?,
+        AppType::DeepSeekHarness => crate::deepseek_harness_config::get_dsh_home(),
     };
 
     Ok(dir.to_string_lossy().to_string())
@@ -187,6 +197,7 @@ pub async fn open_config_folder(handle: AppHandle, app: String) -> Result<bool, 
         AppType::OpenClaw => crate::openclaw_config::get_openclaw_dir(),
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
         AppType::Pi => crate::pi_config::get_pi_agent_dir().map_err(|e| e.to_string())?,
+        AppType::DeepSeekHarness => crate::deepseek_harness_config::get_dsh_home(),
     };
 
     if !config_dir.exists() {

--- a/src-tauri/src/database/dao/mcp.rs
+++ b/src-tauri/src/database/dao/mcp.rs
@@ -91,7 +91,9 @@ impl Database {
             AppType::OpenCode => Some("enabled_opencode"),
             AppType::Hermes => Some("enabled_hermes"),
             // These applications intentionally have no MCP flag in the SSOT.
-            AppType::ClaudeDesktop | AppType::OpenClaw | AppType::Pi => None,
+            AppType::ClaudeDesktop | AppType::OpenClaw | AppType::Pi | AppType::DeepSeekHarness => {
+                None
+            }
         };
 
         if let Some(column) = column {

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -152,9 +152,9 @@ pub(crate) fn build_provider_from_request(
         AppType::OpenCode => build_opencode_settings(request),
         AppType::OpenClaw => build_additive_app_settings(request),
         AppType::Hermes => build_hermes_settings(request),
-        AppType::Pi => {
+        AppType::Pi | AppType::DeepSeekHarness => {
             return Err(AppError::InvalidInput(
-                "Pi providers must be added from the Pi provider page".to_string(),
+                "These providers must be added from their provider page".to_string(),
             ));
         }
     };

--- a/src-tauri/src/deepseek_harness_config.rs
+++ b/src-tauri/src/deepseek_harness_config.rs
@@ -107,6 +107,15 @@ pub fn set_provider(
     {
         config.profile = Some(DESKTOP_PROFILE_NAME.to_string());
     }
+    if config
+        .base_url
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("")
+        .is_empty()
+    {
+        config.base_url = None;
+    }
     let config_value = serde_json::to_value(&config)
         .map_err(|error| AppError::Config(format!("Serialize DeepSeek Harness config: {error}")))?;
     let object = config_value.as_object().ok_or_else(|| {
@@ -356,6 +365,7 @@ mod tests {
                 "official",
                 &DeepSeekHarnessProviderConfig {
                     api_key: Some("rotated".to_string()),
+                    base_url: Some("https://api.deepseek.com/v1".to_string()),
                     ..Default::default()
                 },
             )
@@ -368,6 +378,29 @@ mod tests {
             assert!(error
                 .to_string()
                 .contains("Invalid DeepSeek Harness profile"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn accepts_missing_base_url_for_official_runtime_fallback() {
+        with_temp_home(|home| {
+            for base_url in [None, Some(""), Some("   ")] {
+                let base_url = base_url.map(ToOwned::to_owned);
+                set_provider(
+                    "official",
+                    &DeepSeekHarnessProviderConfig {
+                        api_key: Some("sk-test".to_string()),
+                        base_url,
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+
+                let settings = std::fs::read_to_string(home.join("settings.yaml")).unwrap();
+                assert!(settings.contains("llm-deepseek"));
+                assert!(!settings.contains("baseURL"));
+            }
         });
     }
 

--- a/src-tauri/src/deepseek_harness_config.rs
+++ b/src-tauri/src/deepseek_harness_config.rs
@@ -383,6 +383,42 @@ mod tests {
 
     #[test]
     #[serial]
+    fn preserves_custom_providers_when_switching_managed_route() {
+        with_temp_home(|home| {
+            std::fs::write(
+                home.join("settings.yaml"),
+                "llm-pi-ai:\n  providers:\n    k3:\n      displayName: K3\nother-plugin: keep\n",
+            )
+            .unwrap();
+            std::fs::write(home.join(".credentials.yaml"), "K3_API_KEY: keep\n").unwrap();
+
+            set_provider(
+                "official",
+                &DeepSeekHarnessProviderConfig {
+                    api_key: Some("sk-test".to_string()),
+                    base_url: Some("https://api.deepseek.com".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+            let settings = std::fs::read_to_string(home.join("settings.yaml")).unwrap();
+            assert!(settings.contains("llm-pi-ai"));
+            assert!(settings.contains("displayName: K3"));
+            assert!(settings.contains("llm-deepseek"));
+            let credentials = std::fs::read_to_string(home.join(".credentials.yaml")).unwrap();
+            assert!(credentials.contains("K3_API_KEY: keep"));
+
+            remove_provider().unwrap();
+
+            let settings = std::fs::read_to_string(home.join("settings.yaml")).unwrap();
+            assert!(!settings.contains("llm-deepseek"));
+            assert!(settings.contains("displayName: K3"));
+        });
+    }
+
+    #[test]
+    #[serial]
     fn accepts_missing_base_url_for_official_runtime_fallback() {
         with_temp_home(|home| {
             for base_url in [None, Some(""), Some("   ")] {

--- a/src-tauri/src/deepseek_harness_config.rs
+++ b/src-tauri/src/deepseek_harness_config.rs
@@ -1,0 +1,399 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use yaml_rust::yaml::{Hash as YamlHash, Yaml};
+use yaml_rust::{YamlEmitter, YamlLoader};
+
+use crate::config::{atomic_write_private, get_home_dir};
+use crate::error::AppError;
+
+pub const DEFAULT_PROFILE_NAME: &str = "default";
+pub const DESKTOP_PROFILE_NAME: &str = "desktop";
+const API_KEY_FIELD: &str = "apiKey";
+const SETTINGS_NAMESPACE: &str = "llm-deepseek";
+const API_KEY_REF: &str = "DEEPSEEK_API_KEY";
+const PROFILE_PATCH_TEMPLATE: &str = "\
+# Your patch layer for this dsh profile, applied after every bundle layer:
+# a top-level YAML array of loader patch entries (id-targeted config
+# overrides, disables, and insert lists; `!!js` expressions allowed).
+[]
+";
+const PROFILE_PNPM_WORKSPACE: &str = "\
+packages:
+  - .
+
+nodeLinker: hoisted
+autoInstallPeers: false
+";
+
+/// A DeepSeek Harness provider profile stored by CC Switch.
+///
+/// `apiKey` is intentionally excluded from live settings: official Harness keeps secrets in
+/// `$DSH_HOME/.credentials.yaml`, not in `settings.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct DeepSeekHarnessProviderConfig {
+    #[serde(rename = "apiKey", default, skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    #[serde(rename = "baseURL", default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<String>,
+    #[serde(
+        rename = "reasoningEffort",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub reasoning_effort: Option<String>,
+    #[serde(rename = "maxTokens", default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub models: Option<Value>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, Value>,
+}
+
+pub fn get_dsh_home() -> PathBuf {
+    std::env::var_os("DSH_HOME")
+        .filter(|value| !value.to_string_lossy().trim().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| get_home_dir().join(".dsh"))
+}
+
+pub fn get_settings_path() -> PathBuf {
+    get_dsh_home().join("settings.yaml")
+}
+
+pub fn get_credentials_path() -> PathBuf {
+    get_dsh_home().join(".credentials.yaml")
+}
+
+pub fn get_profile_dir(profile: Option<&str>) -> Result<PathBuf, AppError> {
+    let name = normalize_profile_name(profile)?;
+    Ok(get_dsh_home().join("profiles").join(name))
+}
+
+fn normalize_profile_name(profile: Option<&str>) -> Result<String, AppError> {
+    let name = profile.unwrap_or(DEFAULT_PROFILE_NAME).trim();
+    if name.is_empty() {
+        return Ok(DEFAULT_PROFILE_NAME.to_string());
+    }
+    if name == "." || name == ".." || name == "node_modules" || name.contains(['/', '\\']) {
+        return Err(AppError::InvalidInput(format!(
+            "Invalid DeepSeek Harness profile name: {name}"
+        )));
+    }
+    Ok(name.to_string())
+}
+
+/// Write one provider to both official Harness surfaces.
+///
+/// Unrelated YAML sections and extra credentials survive, while the managed Harness section is
+/// serialized canonically because CC Switch owns that complete schema namespace.
+pub fn set_provider(
+    provider_id: &str,
+    config: &DeepSeekHarnessProviderConfig,
+) -> Result<(), AppError> {
+    let mut config = config.clone();
+    if config
+        .profile
+        .as_deref()
+        .map(str::trim)
+        .unwrap_or("")
+        .is_empty()
+    {
+        config.profile = Some(DESKTOP_PROFILE_NAME.to_string());
+    }
+    let config_value = serde_json::to_value(&config)
+        .map_err(|error| AppError::Config(format!("Serialize DeepSeek Harness config: {error}")))?;
+    let object = config_value.as_object().ok_or_else(|| {
+        AppError::Config("DeepSeek Harness configuration must be an object".to_string())
+    })?;
+
+    ensure_profile(config.profile.as_deref())?;
+
+    {
+        let mut section = YamlHash::new();
+        for (key, value) in object {
+            if key == API_KEY_FIELD {
+                continue;
+            }
+            section.insert(mapping_key(key), yaml_value(value)?);
+        }
+        section.insert(
+            mapping_key("apiKeyEnv"),
+            Yaml::String(API_KEY_REF.to_string()),
+        );
+        update_yaml_document(&get_settings_path(), |document| {
+            merge_mapping_value(document, SETTINGS_NAMESPACE, Yaml::Hash(section));
+            Ok(())
+        })?;
+    }
+
+    if let Some(api_key) = config
+        .api_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        update_yaml_document(&get_credentials_path(), |document| {
+            merge_mapping_value(document, API_KEY_REF, Yaml::String(api_key.to_string()));
+            Ok(())
+        })?;
+    }
+
+    log::debug!("DeepSeek Harness provider '{provider_id}' written to live config");
+    Ok(())
+}
+
+/// Remove a provider's CC Switch-managed settings and credential.
+///
+/// DeepSeek Harness has one official provider route, so deletion clears that route rather than
+/// attempting a dictionary removal that the official schema cannot represent.
+pub fn remove_provider() -> Result<(), AppError> {
+    let settings_path = get_settings_path();
+    if settings_path.exists() {
+        update_yaml_document(&settings_path, |document| {
+            if let Yaml::Hash(hash) = document {
+                hash.remove(&mapping_key(SETTINGS_NAMESPACE));
+            }
+            Ok(())
+        })?;
+    }
+
+    let credentials_path = get_credentials_path();
+    if credentials_path.exists() {
+        update_yaml_document(&credentials_path, |document| {
+            if let Yaml::Hash(hash) = document {
+                hash.remove(&mapping_key(API_KEY_REF));
+            }
+            Ok(())
+        })?;
+    }
+    Ok(())
+}
+
+fn ensure_profile(profile: Option<&str>) -> Result<(), AppError> {
+    let profile_dir = get_profile_dir(profile)?;
+    fs::create_dir_all(&profile_dir).map_err(|error| AppError::io(&profile_dir, error))?;
+
+    let manifest_path = profile_dir.join("package.json");
+    if !manifest_path.exists() {
+        let profile_name = normalize_profile_name(profile)?;
+        let manifest = serde_json::json!({
+            "name": format!("dsh-profile-{profile_name}"),
+            "private": true,
+            "dependencies": {},
+            "dsh": { "profile": { "bundles": [
+                "@deepseek-ai/dsh-base",
+                "@deepseek-ai/dsh-web-app",
+                "@deepseek-ai/dsh-plugin-desktop",
+            ] } }
+        });
+        crate::config::write_json_file(&manifest_path, &manifest)?;
+    }
+
+    initialize_if_missing(
+        &profile_dir.join("cordis.patch.yml"),
+        PROFILE_PATCH_TEMPLATE,
+    )?;
+    initialize_if_missing(
+        &profile_dir.join("pnpm-workspace.yaml"),
+        PROFILE_PNPM_WORKSPACE,
+    )?;
+    Ok(())
+}
+
+fn parse_yaml_document(path: &Path) -> Result<Yaml, AppError> {
+    if !path.exists() {
+        return Ok(Yaml::Hash(YamlHash::new()));
+    }
+    let contents = fs::read_to_string(path).map_err(|error| AppError::io(path, error))?;
+    let mut documents = YamlLoader::load_from_str(&contents)
+        .map_err(|error| AppError::Config(format!("Parse {}: {error}", path.display())))?;
+    match documents.len() {
+        0 => Ok(Yaml::Hash(YamlHash::new())),
+        1 => Ok(documents.remove(0)),
+        _ => Err(AppError::Config(format!(
+            "{} must contain exactly one YAML document",
+            path.display()
+        ))),
+    }
+}
+
+fn update_yaml_document(
+    path: &Path,
+    update: impl FnOnce(&mut Yaml) -> Result<(), AppError>,
+) -> Result<(), AppError> {
+    let mut document = parse_yaml_document(path)?;
+    update(&mut document)?;
+    let mut output = String::new();
+    let mut emitter = YamlEmitter::new(&mut output);
+    emitter
+        .dump(&document)
+        .map_err(|error| AppError::Config(format!("Serialize {}: {error:?}", path.display())))?;
+    output.push('\n');
+    if path.file_name().and_then(|name| name.to_str()) == Some(".credentials.yaml") {
+        atomic_write_private(path, output.as_bytes())
+    } else {
+        crate::config::write_text_file(path, &output)
+    }
+}
+
+fn mapping_key(name: &str) -> Yaml {
+    Yaml::String(name.to_string())
+}
+
+fn merge_mapping_value(document: &mut Yaml, key: &str, value: Yaml) {
+    if !matches!(document, Yaml::Hash(_)) {
+        *document = Yaml::Hash(YamlHash::new());
+    }
+    if let Yaml::Hash(hash) = document {
+        hash.insert(mapping_key(key), value);
+    }
+}
+
+fn yaml_value(value: &Value) -> Result<Yaml, AppError> {
+    Ok(match value {
+        Value::Null => Yaml::Null,
+        Value::Bool(value) => Yaml::Boolean(*value),
+        Value::Number(value) => {
+            if let Some(number) = value.as_i64() {
+                Yaml::Integer(number)
+            } else if let Some(number) = value.as_f64() {
+                Yaml::Real(number.to_string())
+            } else {
+                return Err(AppError::Config(format!("Unsupported number: {value}")));
+            }
+        }
+        Value::String(value) => Yaml::String(value.clone()),
+        Value::Array(values) => Yaml::Array(
+            values
+                .iter()
+                .map(yaml_value)
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+        Value::Object(values) => {
+            let mut hash = YamlHash::new();
+            for (name, value) in values {
+                hash.insert(mapping_key(name), yaml_value(value)?);
+            }
+            Yaml::Hash(hash)
+        }
+    })
+}
+
+fn initialize_if_missing(path: &Path, contents: &str) -> Result<(), AppError> {
+    if !path.exists() {
+        crate::config::write_text_file(path, contents)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn with_temp_home(test: impl FnOnce(&Path)) {
+        let directory = tempfile::tempdir().unwrap();
+        let previous = std::env::var_os("DSH_HOME");
+        std::env::set_var("DSH_HOME", directory.path());
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| test(directory.path())));
+        match previous {
+            Some(value) => std::env::set_var("DSH_HOME", value),
+            None => std::env::remove_var("DSH_HOME"),
+        }
+        result.unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn writes_official_settings_credentials_and_desktop_profile() {
+        with_temp_home(|home| {
+            std::fs::write(
+                home.join("settings.yaml"),
+                "# preserved\nother-plugin:\n  enabled: true\n",
+            )
+            .unwrap();
+
+            let config = DeepSeekHarnessProviderConfig {
+                api_key: Some("sk-test".to_string()),
+                base_url: Some("https://example.com".to_string()),
+                profile: None,
+                models: Some(serde_json::json!([
+                    { "id": "deepseek-v4-flash", "name": "Flash" }
+                ])),
+                ..Default::default()
+            };
+            set_provider("official", &config).unwrap();
+
+            let settings = std::fs::read_to_string(home.join("settings.yaml")).unwrap();
+            assert!(settings.contains(r#""other-plugin":"#));
+            assert!(settings.contains(r#""llm-deepseek":"#));
+            assert!(settings.contains(r#"baseURL: "https://example.com""#));
+            assert!(settings.contains("apiKeyEnv: DEEPSEEK_API_KEY"));
+            assert!(!settings.contains("sk-test"));
+
+            let credentials = std::fs::read_to_string(home.join(".credentials.yaml")).unwrap();
+            assert_eq!(credentials, "---\nDEEPSEEK_API_KEY: \"sk-test\"\n");
+            assert!(home.join("profiles/desktop/package.json").exists());
+            assert!(home.join("profiles/desktop/cordis.patch.yml").exists());
+            assert!(home.join("profiles/desktop/pnpm-workspace.yaml").exists());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn preserves_sibling_credentials_and_rejects_profile_traversal() {
+        with_temp_home(|home| {
+            std::fs::write(home.join(".credentials.yaml"), "OTHER_KEY: keep\n").unwrap();
+            set_provider(
+                "official",
+                &DeepSeekHarnessProviderConfig {
+                    api_key: Some("rotated".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            let credentials = std::fs::read_to_string(home.join(".credentials.yaml")).unwrap();
+            assert!(credentials.contains("OTHER_KEY: keep"));
+            assert!(credentials.contains("DEEPSEEK_API_KEY: rotated"));
+
+            let error = get_profile_dir(Some("../outside")).unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("Invalid DeepSeek Harness profile"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn removes_managed_configuration_only() {
+        with_temp_home(|home| {
+            std::fs::write(
+                home.join("settings.yaml"),
+                "# preserved\nllm-deepseek:\n  baseURL: https://example.com\nother-plugin: keep\n",
+            )
+            .unwrap();
+            std::fs::write(
+                home.join(".credentials.yaml"),
+                "DEEPSEEK_API_KEY: secret\nOTHER_KEY: keep\n",
+            )
+            .unwrap();
+
+            remove_provider().unwrap();
+
+            let settings = std::fs::read_to_string(home.join("settings.yaml")).unwrap();
+            assert!(!settings.contains("llm-deepseek"));
+            assert!(settings.contains(r#""other-plugin": keep"#));
+            let credentials = std::fs::read_to_string(home.join(".credentials.yaml")).unwrap();
+            assert!(!credentials.contains("DEEPSEEK_API_KEY"));
+            assert!(credentials.contains("OTHER_KEY: keep"));
+        });
+    }
+}

--- a/src-tauri/src/deepseek_harness_config.rs
+++ b/src-tauri/src/deepseek_harness_config.rs
@@ -142,14 +142,18 @@ pub fn set_provider(
         })?;
     }
 
-    if let Some(api_key) = config
-        .api_key
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        update_yaml_document(&get_credentials_path(), |document| {
+    let credentials_path = get_credentials_path();
+    let api_key = config.api_key.as_deref().map(str::trim).unwrap_or("");
+    if !api_key.is_empty() {
+        update_yaml_document(&credentials_path, |document| {
             merge_mapping_value(document, API_KEY_REF, Yaml::String(api_key.to_string()));
+            Ok(())
+        })?;
+    } else if credentials_path.exists() {
+        update_yaml_document(&credentials_path, |document| {
+            if let Yaml::Hash(hash) = document {
+                hash.remove(&mapping_key(API_KEY_REF));
+            }
             Ok(())
         })?;
     }
@@ -183,6 +187,11 @@ pub fn remove_provider() -> Result<(), AppError> {
         })?;
     }
     Ok(())
+}
+
+pub fn provider_exists_in_live_config() -> Result<bool, AppError> {
+    let document = parse_yaml_document(&get_settings_path())?;
+    Ok(matches!(document, Yaml::Hash(hash) if hash.contains_key(&mapping_key(SETTINGS_NAMESPACE))))
 }
 
 fn ensure_profile(profile: Option<&str>) -> Result<(), AppError> {
@@ -383,6 +392,32 @@ mod tests {
 
     #[test]
     #[serial]
+    fn clears_stale_credentials_when_api_key_is_removed() {
+        with_temp_home(|home| {
+            std::fs::write(
+                home.join(".credentials.yaml"),
+                "DEEPSEEK_API_KEY: secret\nOTHER_KEY: keep\n",
+            )
+            .unwrap();
+
+            set_provider(
+                "official",
+                &DeepSeekHarnessProviderConfig {
+                    api_key: None,
+                    base_url: Some("https://api.deepseek.com".to_string()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+            let credentials = std::fs::read_to_string(home.join(".credentials.yaml")).unwrap();
+            assert!(!credentials.contains("DEEPSEEK_API_KEY"));
+            assert!(credentials.contains("OTHER_KEY: keep"));
+        });
+    }
+
+    #[test]
+    #[serial]
     fn preserves_custom_providers_when_switching_managed_route() {
         with_temp_home(|home| {
             std::fs::write(
@@ -463,6 +498,24 @@ mod tests {
             let credentials = std::fs::read_to_string(home.join(".credentials.yaml")).unwrap();
             assert!(!credentials.contains("DEEPSEEK_API_KEY"));
             assert!(credentials.contains("OTHER_KEY: keep"));
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn detects_managed_live_route() {
+        with_temp_home(|home| {
+            assert!(!provider_exists_in_live_config().unwrap());
+
+            std::fs::write(
+                home.join("settings.yaml"),
+                "llm-deepseek:\n  baseURL: https://example.com\n",
+            )
+            .unwrap();
+            assert!(provider_exists_in_live_config().unwrap());
+
+            remove_provider().unwrap();
+            assert!(!provider_exists_in_live_config().unwrap());
         });
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod commands;
 mod config;
 mod database;
 mod deeplink;
+mod deepseek_harness_config;
 mod error;
 mod gemini_config;
 mod gemini_mcp;
@@ -48,6 +49,9 @@ pub use commands::*;
 pub use config::{get_claude_mcp_path, get_claude_settings_path, read_json_file};
 pub use database::{Database, Profile};
 pub use deeplink::{import_provider_from_deeplink, parse_deeplink_url, DeepLinkImportRequest};
+pub use deepseek_harness_config::{
+    get_credentials_path, get_dsh_home, get_profile_dir, get_settings_path,
+};
 pub use error::AppError;
 pub use grok_config::get_grok_config_path;
 pub use mcp::{

--- a/src-tauri/src/prompt_files.rs
+++ b/src-tauri/src/prompt_files.rs
@@ -27,6 +27,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::OpenClaw => get_openclaw_dir(),
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
         AppType::Pi => crate::pi_config::get_pi_agent_dir()?,
+        AppType::DeepSeekHarness => crate::deepseek_harness_config::get_dsh_home(),
         AppType::ClaudeDesktop => unreachable!("handled above"),
     };
 
@@ -36,7 +37,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::Gemini => "GEMINI.md",
         AppType::GrokBuild | AppType::OpenCode | AppType::OpenClaw => "AGENTS.md",
         AppType::Hermes => "SOUL.md",
-        AppType::Pi => "AGENTS.md",
+        AppType::Pi | AppType::DeepSeekHarness => "AGENTS.md",
         AppType::ClaudeDesktop => unreachable!("handled above"),
     };
 

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -212,6 +212,11 @@ impl Provider {
                 crate::pi_config::provider_base_url(settings).unwrap_or_default(),
                 str_at(settings.get("apiKey")),
             ),
+            // DeepSeek Harness keeps the official settings and credential surfaces separate.
+            AppType::DeepSeekHarness => (
+                str_at(settings.get("baseUrl")),
+                str_at(settings.get("apiKey")),
+            ),
             // OpenCode (OMO) nests credentials under `options` (the SDK options object).
             AppType::OpenCode => {
                 let options = settings.get("options");

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -214,7 +214,14 @@ impl Provider {
             ),
             // DeepSeek Harness keeps the official settings and credential surfaces separate.
             AppType::DeepSeekHarness => (
-                str_at(settings.get("baseUrl")),
+                {
+                    let base_url = str_at(settings.get("baseURL"));
+                    if base_url.is_empty() {
+                        str_at(settings.get("baseUrl"))
+                    } else {
+                        base_url
+                    }
+                },
                 str_at(settings.get("apiKey")),
             ),
             // OpenCode (OMO) nests credentials under `options` (the SDK options object).
@@ -1541,6 +1548,21 @@ mod tests {
             (
                 "https://api.deepseek.com".to_string(),
                 "sk-openclaw".to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_credentials_deepseek_harness_base_url() {
+        let p = provider_with(json!({
+            "baseURL": "https://api.deepseek.com/v1",
+            "apiKey": "sk-dsh",
+        }));
+        assert_eq!(
+            p.resolve_usage_credentials(&AppType::DeepSeekHarness),
+            (
+                "https://api.deepseek.com/v1".to_string(),
+                "sk-dsh".to_string()
             )
         );
     }

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -208,7 +208,7 @@ impl ProviderType {
             }
             AppType::GrokBuild => ProviderType::Codex,
             AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => ProviderType::Codex,
-            AppType::Pi => return None,
+            AppType::Pi | AppType::DeepSeekHarness => return None,
         };
         Some(provider_type)
     }
@@ -264,7 +264,7 @@ pub fn get_adapter(app_type: &AppType) -> Option<Box<dyn ProviderAdapter>> {
         AppType::Gemini => Box::new(GeminiAdapter::new()),
         AppType::GrokBuild => Box::new(CodexAdapter::new()),
         AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => Box::new(CodexAdapter::new()),
-        AppType::Pi => return None,
+        AppType::Pi | AppType::DeepSeekHarness => return None,
     })
 }
 

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -142,6 +142,9 @@ impl ConfigService {
                 // Pi owns its shared models/settings documents; this legacy
                 // single-provider live-sync path must not rewrite them.
             }
+            AppType::DeepSeekHarness => {
+                // DeepSeek Harness providers are synced through ProviderService.
+            }
         }
 
         Ok(())

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -145,7 +145,7 @@ impl McpService {
             AppType::Hermes => {
                 mcp::sync_single_server_to_hermes(&Default::default(), &server.id, &server.server)?;
             }
-            AppType::Pi => {}
+            AppType::Pi | AppType::DeepSeekHarness => {}
         }
         Ok(())
     }
@@ -182,7 +182,7 @@ impl McpService {
             AppType::Hermes => {
                 mcp::remove_server_from_hermes(id)?;
             }
-            AppType::Pi => {}
+            AppType::Pi | AppType::DeepSeekHarness => {}
         }
         Ok(())
     }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -531,7 +531,8 @@ fn settings_contain_common_config(app_type: &AppType, settings: &Value, snippet:
         | AppType::OpenClaw
         | AppType::Hermes
         | AppType::Pi
-        | AppType::ClaudeDesktop => false,
+        | AppType::ClaudeDesktop
+        | AppType::DeepSeekHarness => false,
     }
 }
 
@@ -606,7 +607,8 @@ pub(crate) fn remove_common_config_from_settings(
         | AppType::OpenClaw
         | AppType::Hermes
         | AppType::Pi
-        | AppType::ClaudeDesktop => Ok(settings.clone()),
+        | AppType::ClaudeDesktop
+        | AppType::DeepSeekHarness => Ok(settings.clone()),
     }
 }
 
@@ -666,7 +668,8 @@ fn apply_common_config_to_settings(
         | AppType::OpenClaw
         | AppType::Hermes
         | AppType::Pi
-        | AppType::ClaudeDesktop => Ok(settings.clone()),
+        | AppType::ClaudeDesktop
+        | AppType::DeepSeekHarness => Ok(settings.clone()),
     }
 }
 
@@ -1384,6 +1387,18 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
             crate::hermes_config::set_provider(&provider.id, provider.settings_config.clone())?;
             log::debug!("Hermes provider '{}' written to live config", provider.id);
         }
+        AppType::DeepSeekHarness => {
+            let config = serde_json::from_value::<
+                crate::deepseek_harness_config::DeepSeekHarnessProviderConfig,
+            >(provider.settings_config.clone())
+            .map_err(|error| {
+                AppError::Config(format!(
+                    "Invalid DeepSeek Harness provider '{}': {error}",
+                    provider.id
+                ))
+            })?;
+            crate::deepseek_harness_config::set_provider(&provider.id, &config)?;
+        }
         AppType::Pi => {
             return Err(AppError::InvalidInput(
                 "Pi providers use the Pi provider service".to_string(),
@@ -1665,6 +1680,10 @@ pub fn read_live_settings(app_type: AppType) -> Result<Value, AppError> {
         AppType::Pi => Err(AppError::InvalidInput(
             "Pi providers are read from Pi's native models file".to_string(),
         )),
+        AppType::DeepSeekHarness => Err(AppError::InvalidInput(
+            "DeepSeek Harness settings are read through its dedicated configuration module"
+                .to_string(),
+        )),
     }
 }
 
@@ -1774,7 +1793,11 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
             })
         }
         // OpenCode, OpenClaw and Hermes use additive mode and are handled by early return above
-        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Pi => {
+        AppType::OpenCode
+        | AppType::OpenClaw
+        | AppType::Hermes
+        | AppType::Pi
+        | AppType::DeepSeekHarness => {
             unreachable!("additive mode apps are handled by early return")
         }
     };

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -189,6 +189,9 @@ pub(crate) fn provider_exists_in_live_config(
         AppType::Hermes => crate::hermes_config::get_providers()
             .map(|providers| providers.contains_key(provider_id)),
         AppType::Pi => crate::pi_config::pi_provider_exists(provider_id),
+        AppType::DeepSeekHarness => {
+            crate::deepseek_harness_config::provider_exists_in_live_config()
+        }
         _ => Ok(false),
     }
 }
@@ -1694,7 +1697,7 @@ pub fn read_live_settings(app_type: AppType) -> Result<Value, AppError> {
 pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool, AppError> {
     // Additive mode apps (OpenCode, OpenClaw) should use their dedicated
     // import_xxx_providers_from_live functions, not this generic default config import
-    if app_type.is_additive_mode() {
+    if app_type.is_additive_mode() || matches!(app_type, AppType::DeepSeekHarness) {
         return Ok(false);
     }
 
@@ -1792,13 +1795,15 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
                 "config": config_obj
             })
         }
-        // OpenCode, OpenClaw and Hermes use additive mode and are handled by early return above
+        // OpenCode, OpenClaw and Hermes use additive mode and are handled by early return above.
+        // DeepSeek Harness uses one exclusive route, but importing live settings needs its
+        // credentials file as well as settings.yaml, so it is not handled by this generic path.
         AppType::OpenCode
         | AppType::OpenClaw
         | AppType::Hermes
         | AppType::Pi
         | AppType::DeepSeekHarness => {
-            unreachable!("additive mode apps are handled by early return")
+            unreachable!("unsupported apps are handled by early return")
         }
     };
 
@@ -1867,7 +1872,7 @@ pub fn should_import_default_config_on_startup(
     state: &AppState,
     app_type: &AppType,
 ) -> Result<bool, AppError> {
-    if app_type.is_additive_mode() {
+    if app_type.is_additive_mode() || matches!(app_type, AppType::DeepSeekHarness) {
         return Ok(false);
     }
 

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -5501,6 +5501,7 @@ impl ProviderService {
                     AppType::OpenCode => remove_opencode_provider_from_live(id)?,
                     AppType::OpenClaw => remove_openclaw_provider_from_live(id)?,
                     AppType::Hermes => remove_hermes_provider_from_live(id)?,
+                    AppType::DeepSeekHarness => crate::deepseek_harness_config::remove_provider()?,
                     _ => {}
                 }
             }
@@ -5569,6 +5570,9 @@ impl ProviderService {
             }
             AppType::Hermes => {
                 remove_hermes_provider_from_live(id)?;
+            }
+            AppType::DeepSeekHarness => {
+                crate::deepseek_harness_config::remove_provider()?;
             }
             _ => {
                 return Err(AppError::Message(format!(
@@ -5912,6 +5916,7 @@ impl ProviderService {
                     AppType::OpenCode => remove_opencode_provider_from_live(&provider.id),
                     AppType::OpenClaw => remove_openclaw_provider_from_live(&provider.id),
                     AppType::Hermes => remove_hermes_provider_from_live(&provider.id),
+                    AppType::DeepSeekHarness => crate::deepseek_harness_config::remove_provider(),
                     _ => Ok(()),
                 };
 
@@ -6199,6 +6204,7 @@ impl ProviderService {
             AppType::OpenClaw => Self::extract_openclaw_common_config(&provider.settings_config),
             AppType::Hermes => Ok(String::new()), // Hermes doesn't use common config snippets
             AppType::Pi => Ok(String::new()),
+            AppType::DeepSeekHarness => Ok(String::new()),
         }
     }
 
@@ -6217,6 +6223,7 @@ impl ProviderService {
             AppType::OpenClaw => Self::extract_openclaw_common_config(settings_config),
             AppType::Hermes => Ok(String::new()), // Hermes doesn't use common config snippets
             AppType::Pi => Ok(String::new()),
+            AppType::DeepSeekHarness => Ok(String::new()),
         }
     }
 
@@ -6982,6 +6989,18 @@ impl ProviderService {
                     ));
                 }
             }
+            AppType::DeepSeekHarness => {
+                serde_json::from_value::<
+                    crate::deepseek_harness_config::DeepSeekHarnessProviderConfig,
+                >(provider.settings_config.clone())
+                .map_err(|error| {
+                    AppError::localized(
+                        "provider.deepseek_harness.settings.invalid",
+                        format!("DeepSeek Harness 配置无效：{error}"),
+                        format!("Invalid DeepSeek Harness configuration: {error}"),
+                    )
+                })?;
+            }
             AppType::Pi => {
                 crate::pi_config::validate_provider_node(&provider.id, &provider.settings_config)?;
             }
@@ -7189,7 +7208,7 @@ impl ProviderService {
 
                 Ok((api_key, base_url))
             }
-            AppType::OpenClaw | AppType::Hermes | AppType::Pi => {
+            AppType::OpenClaw | AppType::Hermes | AppType::Pi | AppType::DeepSeekHarness => {
                 // These native formats use apiKey and baseUrl directly on the object.
                 let api_key = provider
                     .settings_config

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -2275,6 +2275,11 @@ requires_openai_auth = true
             .expect("set current provider");
         crate::settings::set_current_provider(&AppType::ClaudeDesktop, Some("p1"))
             .expect("set local current provider");
+        let mut proxy_config = db.get_proxy_config().await.expect("get proxy config");
+        proxy_config.listen_port = 0;
+        db.update_proxy_config(proxy_config)
+            .await
+            .expect("set test proxy config to an ephemeral port");
 
         // Claude Desktop keeps backup state from takeover startup; this sentinel only
         // marks takeover as active so provider updates rewrite the 3P profile.
@@ -2292,7 +2297,7 @@ requires_openai_auth = true
                 .expect("update app proxy config");
         }
 
-        state
+        let proxy_info = state
             .proxy_service
             .start()
             .await
@@ -2340,7 +2345,10 @@ requires_openai_auth = true
         let profile: Value = read_json_file(&profile_path).expect("read desktop profile");
         assert_eq!(
             profile["inferenceGatewayBaseUrl"],
-            json!("http://127.0.0.1:15721/claude-desktop"),
+            json!(format!(
+                "http://127.0.0.1:{}/claude-desktop",
+                proxy_info.port
+            )),
             "desktop profile should stay pointed at the local gateway during takeover"
         );
         assert_eq!(profile["inferenceGatewayAuthScheme"], json!("bearer"));

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -7208,7 +7208,7 @@ impl ProviderService {
 
                 Ok((api_key, base_url))
             }
-            AppType::OpenClaw | AppType::Hermes | AppType::Pi | AppType::DeepSeekHarness => {
+            AppType::OpenClaw | AppType::Hermes | AppType::Pi => {
                 // These native formats use apiKey and baseUrl directly on the object.
                 let api_key = provider
                     .settings_config
@@ -7226,6 +7226,30 @@ impl ProviderService {
                 let base_url = provider
                     .settings_config
                     .get("baseUrl")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                Ok((api_key, base_url))
+            }
+            AppType::DeepSeekHarness => {
+                let api_key = provider
+                    .settings_config
+                    .get("apiKey")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        AppError::localized(
+                            "provider.deepseek_harness.api_key.missing",
+                            "缺少 API Key",
+                            "API key is missing",
+                        )
+                    })?
+                    .to_string();
+
+                let base_url = provider
+                    .settings_config
+                    .get("baseURL")
+                    .or_else(|| provider.settings_config.get("baseUrl"))
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -605,7 +605,7 @@ impl SkillService {
                     return Ok(custom.join("skills"));
                 }
             }
-            AppType::Pi => {
+            AppType::Pi | AppType::DeepSeekHarness => {
                 return Ok(crate::pi_config::get_pi_agent_dir()?.join("skills"));
             }
         }
@@ -625,6 +625,9 @@ impl SkillService {
             AppType::OpenClaw => home.join(".openclaw").join("skills"),
             AppType::Hermes => crate::hermes_config::get_hermes_dir().join("skills"),
             AppType::Pi => crate::pi_config::get_pi_agent_dir()?.join("skills"),
+            AppType::DeepSeekHarness => {
+                crate::deepseek_harness_config::get_dsh_home().join("skills")
+            }
         })
     }
 

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -605,9 +605,10 @@ impl SkillService {
                     return Ok(custom.join("skills"));
                 }
             }
-            AppType::Pi | AppType::DeepSeekHarness => {
+            AppType::Pi => {
                 return Ok(crate::pi_config::get_pi_agent_dir()?.join("skills"));
             }
+            AppType::DeepSeekHarness => {}
         }
 
         // 默认路径：回退到用户主目录下的标准位置。
@@ -2466,7 +2467,10 @@ impl SkillService {
 
     /// Caller must hold either the Skills state read or write guard.
     fn sync_to_app_unlocked(db: &Arc<Database>, app: &AppType) -> Result<()> {
-        if matches!(app, AppType::ClaudeDesktop | AppType::Pi) {
+        if matches!(
+            app,
+            AppType::ClaudeDesktop | AppType::Pi | AppType::DeepSeekHarness
+        ) {
             return Ok(());
         }
 
@@ -5794,6 +5798,10 @@ mod tests {
             "skills dir must live under the overridden test home, got {}",
             dir.display()
         );
+
+        let dsh_dir = SkillService::get_app_skills_dir(&AppType::DeepSeekHarness)
+            .expect("resolve deepseek harness skills dir");
+        assert_eq!(dsh_dir, temp.path().join(".dsh").join("skills"));
     }
 
     #[test]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -48,6 +48,13 @@ pub struct VisibleApps {
     pub hermes: bool,
     #[serde(default = "default_true")]
     pub pi: bool,
+    #[serde(
+        rename = "deepseek-harness",
+        alias = "deepseekHarness",
+        alias = "deepseek_harness",
+        default = "default_true"
+    )]
+    pub deepseek_harness: bool,
 }
 
 impl Default for VisibleApps {
@@ -62,6 +69,7 @@ impl Default for VisibleApps {
             openclaw: true,
             hermes: false, // 默认不显示，需用户手动启用
             pi: true,
+            deepseek_harness: true,
         }
     }
 }
@@ -79,6 +87,7 @@ impl VisibleApps {
             AppType::OpenClaw => self.openclaw,
             AppType::Hermes => self.hermes,
             AppType::Pi => self.pi,
+            AppType::DeepSeekHarness => self.deepseek_harness,
         }
     }
 }
@@ -999,7 +1008,7 @@ pub fn get_current_provider(app_type: &AppType) -> Option<String> {
         AppType::OpenCode => settings.current_provider_opencode.clone(),
         AppType::OpenClaw => settings.current_provider_openclaw.clone(),
         AppType::Hermes => settings.current_provider_hermes.clone(),
-        AppType::Pi => None,
+        AppType::Pi | AppType::DeepSeekHarness => None,
     }
 }
 
@@ -1018,7 +1027,7 @@ pub fn set_current_provider(app_type: &AppType, id: Option<&str>) -> Result<(), 
         AppType::OpenCode => settings.current_provider_opencode = id_owned.clone(),
         AppType::OpenClaw => settings.current_provider_openclaw = id_owned.clone(),
         AppType::Hermes => settings.current_provider_hermes = id_owned.clone(),
-        AppType::Pi => {}
+        AppType::Pi | AppType::DeepSeekHarness => {}
     })
 }
 

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -37,6 +37,7 @@ const APP_ICON_NAME: Record<AppId, string> = {
   openclaw: "openclaw",
   hermes: "hermes",
   pi: "pi",
+  "deepseek-harness": "deepseek",
 };
 
 const APP_DISPLAY_NAME: Record<AppId, string> = {
@@ -49,6 +50,7 @@ const APP_DISPLAY_NAME: Record<AppId, string> = {
   openclaw: "OpenClaw",
   hermes: "Hermes",
   pi: "Pi",
+  "deepseek-harness": "DeepSeek Harness",
 };
 
 /** 应用图标 + 角标（Claude Code / Desktop 用角标区分终端与桌面） */

--- a/src/components/common/AppCountBar.tsx
+++ b/src/components/common/AppCountBar.tsx
@@ -1,29 +1,28 @@
-import React from "react";
 import { useTranslation } from "react-i18next";
 import { Badge, badgeVariants } from "@/components/ui/badge";
 import type { AppId } from "@/lib/api/types";
 import { APP_IDS, APP_ICON_MAP } from "@/config/appConfig";
 import { cn } from "@/lib/utils";
 
-interface AppCountBarProps {
+interface AppCountBarProps<TApp extends AppId = AppId> {
   totalLabel: string;
   counts: Partial<Record<AppId, number>>;
-  appIds?: AppId[];
+  appIds?: TApp[];
   totalCount?: number;
-  onToggleAll?: (app: AppId, enabled: boolean) => void | Promise<void>;
-  pendingApp?: AppId | null;
+  onToggleAll?: (app: TApp, enabled: boolean) => void | Promise<void>;
+  pendingApp?: TApp | null;
   disabled?: boolean;
 }
 
-export const AppCountBar: React.FC<AppCountBarProps> = ({
+export const AppCountBar = <TApp extends AppId>({
   totalLabel,
   counts,
-  appIds = APP_IDS,
+  appIds = APP_IDS as TApp[],
   totalCount,
   onToggleAll,
   pendingApp,
   disabled = false,
-}) => {
+}: AppCountBarProps<TApp>) => {
   const { t } = useTranslation();
   const bulkToggleEnabled = totalCount !== undefined && !!onToggleAll;
   const bulkTotalCount = totalCount ?? 0;

--- a/src/components/prompts/PromptFormPanel.tsx
+++ b/src/components/prompts/PromptFormPanel.tsx
@@ -35,6 +35,7 @@ const PromptFormPanel: React.FC<PromptFormPanelProps> = ({
     openclaw: "AGENTS.md",
     hermes: "SOUL.md",
     pi: "AGENTS.md",
+    "deepseek-harness": "AGENTS.md",
   };
   const filename = filenameMap[appId];
   const [name, setName] = useState("");

--- a/src/components/providers/forms/EndpointSpeedTest.tsx
+++ b/src/components/providers/forms/EndpointSpeedTest.tsx
@@ -19,6 +19,7 @@ const ENDPOINT_TIMEOUT_SECS: Record<AppId, number> = {
   openclaw: 8,
   hermes: 8,
   pi: 8,
+  "deepseek-harness": 8,
 };
 
 interface TestResult {

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -55,6 +55,11 @@ import {
   hermesProviderPresets,
   type HermesProviderPreset,
 } from "@/config/hermesProviderPresets";
+import {
+  DEEPSEEK_HARNESS_DEFAULT_CONFIG,
+  getDeepSeekHarnessPresetEntries,
+  type DeepSeekHarnessProviderPreset,
+} from "@/config/deepseekHarnessProviderPresets";
 import { OpenCodeFormFields } from "./OpenCodeFormFields";
 import { OpenClawFormFields } from "./OpenClawFormFields";
 import { HermesFormFields } from "./HermesFormFields";
@@ -139,7 +144,8 @@ type PresetEntry = {
     | GeminiProviderPreset
     | OpenCodeProviderPreset
     | OpenClawProviderPreset
-    | HermesProviderPreset;
+    | HermesProviderPreset
+    | DeepSeekHarnessProviderPreset;
 };
 
 function getPresetProviderType(
@@ -396,8 +402,19 @@ function ProviderFormFull({
   const isAnyOmoCategory = isOmoCategory || isOmoSlimCategory;
 
   useEffect(() => {
-    setSelectedPresetId(initialData ? null : "custom");
-    setActivePreset(null);
+    const initialPresetId =
+      !initialData && appId === "deepseek-harness"
+        ? "deepseek-harness-0"
+        : "custom";
+    setSelectedPresetId(initialData ? null : initialPresetId);
+    setActivePreset(
+      !initialData && appId === "deepseek-harness"
+        ? {
+            id: initialPresetId,
+            category: "official",
+          }
+        : null,
+    );
 
     if (!initialData) {
       setDraftCustomEndpoints([]);
@@ -454,7 +471,9 @@ function ProviderFormFull({
                 ? OPENCLAW_DEFAULT_CONFIG
                 : appId === "hermes"
                   ? HERMES_DEFAULT_CONFIG
-                  : CLAUDE_DEFAULT_CONFIG,
+                  : appId === "deepseek-harness"
+                    ? JSON.stringify(DEEPSEEK_HARNESS_DEFAULT_CONFIG, null, 2)
+                    : CLAUDE_DEFAULT_CONFIG,
       icon: initialData?.icon ?? "",
       iconColor: initialData?.iconColor ?? "",
     }),
@@ -779,6 +798,8 @@ function ProviderFormFull({
         id: `hermes-${index}`,
         preset,
       }));
+    } else if (appId === "deepseek-harness") {
+      return getDeepSeekHarnessPresetEntries();
     }
     return providerPresets
       .filter((p) => !p.hidden)
@@ -2106,6 +2127,18 @@ function ProviderFormFull({
         name: preset.nameKey ? t(preset.nameKey) : preset.name,
         websiteUrl: preset.websiteUrl ?? "",
         settingsConfig: JSON.stringify(config, null, 2),
+        icon: preset.icon ?? "",
+        iconColor: preset.iconColor ?? "",
+      });
+      return;
+    }
+
+    if (appId === "deepseek-harness") {
+      const preset = entry.preset as DeepSeekHarnessProviderPreset;
+      form.reset({
+        name: preset.name,
+        websiteUrl: preset.websiteUrl,
+        settingsConfig: JSON.stringify(preset.settingsConfig, null, 2),
         icon: preset.icon ?? "",
         iconColor: preset.iconColor ?? "",
       });

--- a/src/components/providers/forms/ProviderPresetSelector.tsx
+++ b/src/components/providers/forms/ProviderPresetSelector.tsx
@@ -21,6 +21,7 @@ import type { OpenCodeProviderPreset } from "@/config/opencodeProviderPresets";
 import type { OpenClawProviderPreset } from "@/config/openclawProviderPresets";
 import type { HermesProviderPreset } from "@/config/hermesProviderPresets";
 import type { PiProviderPreset } from "@/config/piProviderPresets";
+import type { DeepSeekHarnessProviderPreset } from "@/config/deepseekHarnessProviderPresets";
 import type { ProviderCategory } from "@/types";
 import {
   universalProviderPresets,
@@ -46,7 +47,8 @@ export type AnyPreset =
   | OpenCodeProviderPreset
   | OpenClawProviderPreset
   | HermesProviderPreset
-  | PiProviderPreset;
+  | PiProviderPreset
+  | DeepSeekHarnessProviderPreset;
 
 export type PresetEntry = {
   id: string;

--- a/src/components/settings/DirectorySettings.tsx
+++ b/src/components/settings/DirectorySettings.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import type { AppId } from "@/lib/api";
 import type { ResolvedDirectories } from "@/hooks/useSettings";
 
-type DirectoryAppId = Exclude<AppId, "claude-desktop">;
+type DirectoryAppId = Exclude<AppId, "claude-desktop" | "deepseek-harness">;
 
 interface DirectorySettingsProps {
   appConfigDir?: string;

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -34,7 +34,7 @@ import { cn } from "@/lib/utils";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { settingsApi, skillsApi } from "@/lib/api";
 import { toast } from "sonner";
-import { SKILLS_APP_IDS } from "@/config/appConfig";
+import { SKILLS_APP_IDS, type SkillsAppId } from "@/config/appConfig";
 import { AppCountBar } from "@/components/common/AppCountBar";
 import { AppToggleGroup } from "@/components/common/AppToggleGroup";
 import { ListItemRow } from "@/components/common/ListItemRow";
@@ -264,6 +264,10 @@ const UnifiedSkillsPanel = React.forwardRef<
     : toggleAppMutation.isPending
       ? toggleAppMutation.variables?.app
       : null;
+  const skillsPendingApp =
+    pendingApp !== null && (SKILLS_APP_IDS as string[]).includes(pendingApp)
+      ? (pendingApp as SkillsAppId)
+      : null;
 
   const handleToggleApp = async (id: string, app: AppId, enabled: boolean) => {
     if (!beginWrite()) return;
@@ -277,7 +281,7 @@ const UnifiedSkillsPanel = React.forwardRef<
     }
   };
 
-  const handleToggleAll = async (app: AppId, enabled: boolean) => {
+  const handleToggleAll = async (app: SkillsAppId, enabled: boolean) => {
     if (!skills || !beginWrite()) return;
 
     const ids = skills
@@ -629,7 +633,7 @@ const UnifiedSkillsPanel = React.forwardRef<
             appIds={visibleSkillAppIds}
             totalCount={skills?.length ?? 0}
             onToggleAll={handleToggleAll}
-            pendingApp={pendingApp}
+            pendingApp={skillsPendingApp}
             disabled={interactionBlocked}
           />
         </div>

--- a/src/config/appConfig.tsx
+++ b/src/config/appConfig.tsx
@@ -26,6 +26,7 @@ export const APP_IDS: AppId[] = [
   "openclaw",
   "hermes",
   "pi",
+  "deepseek-harness",
 ];
 
 export const DEFAULT_VISIBLE_APPS: VisibleApps = {
@@ -38,10 +39,15 @@ export const DEFAULT_VISIBLE_APPS: VisibleApps = {
   openclaw: true,
   hermes: true,
   pi: true,
+  "deepseek-harness": true,
 };
 
 /** App IDs shown in Skills panels. */
-export const SKILLS_APP_IDS: AppId[] = [
+export type SkillsAppId = Exclude<
+  AppId,
+  "claude-desktop" | "openclaw" | "deepseek-harness"
+>;
+export const SKILLS_APP_IDS: SkillsAppId[] = [
   "claude",
   "codex",
   "gemini",
@@ -70,7 +76,7 @@ export function isProxyAppId(appId: string): appId is ProxyAppId {
 
 export type AdditiveAppId = Extract<
   AppId,
-  "opencode" | "openclaw" | "hermes" | "pi"
+  "opencode" | "openclaw" | "hermes" | "pi" | "deepseek-harness"
 >;
 
 export const ADDITIVE_APP_IDS: AdditiveAppId[] = [
@@ -78,6 +84,7 @@ export const ADDITIVE_APP_IDS: AdditiveAppId[] = [
   "openclaw",
   "hermes",
   "pi",
+  "deepseek-harness",
 ];
 
 export function isAdditiveAppId(appId: string): appId is AdditiveAppId {
@@ -85,7 +92,10 @@ export function isAdditiveAppId(appId: string): appId is AdditiveAppId {
 }
 
 /** Pi has no native MCP registry; do not manufacture a disabled mirror. */
-export type McpAppId = Exclude<AppId, "claude-desktop" | "openclaw" | "pi">;
+export type McpAppId = Exclude<
+  AppId,
+  "claude-desktop" | "openclaw" | "pi" | "deepseek-harness"
+>;
 export const MCP_APP_IDS: McpAppId[] = [
   "claude",
   "codex",
@@ -192,6 +202,21 @@ export const APP_ICON_MAP: Record<AppId, AppConfig> = {
       "bg-fuchsia-500/10 ring-1 ring-fuchsia-500/20 hover:bg-fuchsia-500/20 text-fuchsia-600 dark:text-fuchsia-400",
     badgeClass:
       "bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300 hover:bg-fuchsia-500/20 border-0 gap-1.5",
+  },
+  "deepseek-harness": {
+    label: "DeepSeek Harness",
+    icon: (
+      <ProviderIcon
+        icon="deepseek"
+        name="DeepSeek Harness"
+        size={14}
+        showFallback={false}
+      />
+    ),
+    activeClass:
+      "bg-sky-500/10 ring-1 ring-sky-500/20 hover:bg-sky-500/20 text-sky-600 dark:text-sky-400",
+    badgeClass:
+      "bg-sky-500/10 text-sky-700 dark:text-sky-300 hover:bg-sky-500/20 border-0 gap-1.5",
   },
 };
 

--- a/src/config/deepseekHarnessProviderPresets.ts
+++ b/src/config/deepseekHarnessProviderPresets.ts
@@ -1,0 +1,62 @@
+import type { ProviderCategory } from "../types";
+import type { PresetTheme, TemplateValueConfig } from "./claudeProviderPresets";
+
+export interface DeepSeekHarnessModel {
+  id: string;
+  name: string;
+}
+
+export interface DeepSeekHarnessProviderConfig {
+  apiKey?: string;
+  baseURL?: string;
+  profile?: string;
+  models?: DeepSeekHarnessModel[];
+}
+
+export interface DeepSeekHarnessProviderPreset {
+  id: string;
+  name: string;
+  nameKey?: string;
+  websiteUrl: string;
+  apiKeyUrl?: string;
+  settingsConfig: DeepSeekHarnessProviderConfig;
+  isOfficial?: boolean;
+  category?: ProviderCategory;
+  isPartner?: boolean;
+  primePartner?: boolean;
+  partnerPromotionKey?: string;
+  templateValues?: Record<string, TemplateValueConfig>;
+  theme?: PresetTheme;
+  icon?: string;
+  iconColor?: string;
+}
+
+export const DEEPSEEK_HARNESS_DEFAULT_CONFIG: DeepSeekHarnessProviderConfig = {
+  apiKey: "",
+  baseURL: "https://api.deepseek.com",
+  profile: "desktop",
+  models: [
+    { id: "deepseek-v4-flash", name: "DeepSeek-V4-Flash" },
+    { id: "deepseek-v4-pro", name: "DeepSeek-V4-Pro" },
+  ],
+};
+
+export const deepseekHarnessProviderPresets: DeepSeekHarnessProviderPreset[] = [
+  {
+    id: "deepseek-official",
+    name: "DeepSeek",
+    websiteUrl: "https://platform.deepseek.com",
+    apiKeyUrl: "https://platform.deepseek.com/api_keys",
+    settingsConfig: DEEPSEEK_HARNESS_DEFAULT_CONFIG,
+    isOfficial: true,
+    category: "official",
+    icon: "deepseek",
+  },
+];
+
+export function getDeepSeekHarnessPresetEntries() {
+  return deepseekHarnessProviderPresets.map((preset, index) => ({
+    id: `deepseek-harness-${index}`,
+    preset,
+  }));
+}

--- a/src/hooks/useDirectorySettings.ts
+++ b/src/hooks/useDirectorySettings.ts
@@ -5,7 +5,10 @@ import { homeDir, join } from "@tauri-apps/api/path";
 import { settingsApi, type AppId } from "@/lib/api";
 import type { SettingsFormState } from "./useSettingsForm";
 
-export type DirectoryAppId = Exclude<AppId, "claude-desktop">;
+export type DirectoryAppId = Exclude<
+  AppId,
+  "claude-desktop" | "deepseek-harness"
+>;
 type AppDirectoryKey =
   | "claude"
   | "codex"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -910,7 +910,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "deepseek-harness": "DeepSeek Harness"
   },
   "pi": {
     "empty": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -910,7 +910,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "deepseek-harness": "DeepSeek Harness"
   },
   "pi": {
     "empty": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -911,7 +911,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "deepseek-harness": "DeepSeek Harness"
   },
   "pi": {
     "empty": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -910,7 +910,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "deepseek-harness": "DeepSeek Harness"
   },
   "pi": {
     "empty": {

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -8,4 +8,5 @@ export type AppId =
   | "opencode"
   | "openclaw"
   | "hermes"
-  | "pi";
+  | "pi"
+  | "deepseek-harness";

--- a/src/types.ts
+++ b/src/types.ts
@@ -298,6 +298,7 @@ export interface VisibleApps {
   openclaw: boolean;
   hermes: boolean;
   pi: boolean;
+  "deepseek-harness": boolean;
 }
 
 // WebDAV 同步状态

--- a/tests/components/DeepSeekHarnessProviderForm.test.tsx
+++ b/tests/components/DeepSeekHarnessProviderForm.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { DEEPSEEK_HARNESS_DEFAULT_CONFIG } from "@/config/deepseekHarnessProviderPresets";
+import {
+  ProviderForm,
+  type ProviderFormValues,
+} from "@/components/providers/forms/ProviderForm";
+import { createTestQueryClient } from "../utils/testQueryClient";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    providersApi: {
+      ...actual.providersApi,
+      getAll: vi.fn().mockResolvedValue({}),
+    },
+  };
+});
+
+vi.mock("@/lib/query", () => ({
+  useSettingsQuery: () => ({
+    data: { commonConfigConfirmed: true },
+  }),
+}));
+
+vi.mock("@/components/JsonEditor", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <textarea
+      aria-label="Config JSON"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}));
+
+function renderForm(onSubmit: (values: ProviderFormValues) => void) {
+  return render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <ProviderForm
+        appId="deepseek-harness"
+        submitLabel="save-provider"
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("DeepSeek Harness provider form", () => {
+  it("starts with the official preset and valid default config", async () => {
+    const onSubmit = vi.fn();
+    renderForm(onSubmit);
+
+    expect(screen.getByTitle("官方")).toBeInTheDocument();
+
+    expect(screen.getByLabelText("Config JSON")).toHaveValue(
+      JSON.stringify(DEEPSEEK_HARNESS_DEFAULT_CONFIG, null, 2),
+    );
+
+    const nameInput = screen.getAllByRole("textbox")[0];
+    fireEvent.change(nameInput, { target: { value: "DeepSeek" } });
+
+    fireEvent.change(screen.getByLabelText("Config JSON"), {
+      target: {
+        value: JSON.stringify({
+          apiKey: "sk-test",
+          baseURL: "https://api.deepseek.com",
+          profile: "desktop",
+          models: [{ id: "deepseek-chat", name: "DeepSeek Chat" }],
+        }),
+      },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save-provider/u }));
+    const submitted = await vi.waitFor(() => {
+      const value = onSubmit.mock.calls[0]?.[0];
+      expect(value).toBeDefined();
+      return value;
+    });
+    expect(JSON.parse(submitted.settingsConfig)).toEqual({
+      apiKey: "sk-test",
+      baseURL: "https://api.deepseek.com",
+      profile: "desktop",
+      models: [{ id: "deepseek-chat", name: "DeepSeek Chat" }],
+    });
+  });
+});

--- a/tests/config/deepseekHarnessProviderPresets.test.ts
+++ b/tests/config/deepseekHarnessProviderPresets.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getDeepSeekHarnessPresetEntries,
+  deepseekHarnessProviderPresets,
+} from "@/config/deepseekHarnessProviderPresets";
+
+describe("DeepSeek Harness provider presets", () => {
+  it("provides the official provider defaults", () => {
+    expect(deepseekHarnessProviderPresets).toHaveLength(1);
+
+    const preset = deepseekHarnessProviderPresets[0];
+    expect(preset).toMatchObject({
+      id: "deepseek-official",
+      name: "DeepSeek",
+      category: "official",
+      icon: "deepseek",
+      websiteUrl: "https://platform.deepseek.com",
+      apiKeyUrl: "https://platform.deepseek.com/api_keys",
+      settingsConfig: {
+        baseURL: "https://api.deepseek.com",
+        models: [
+          { id: "deepseek-v4-flash", name: "DeepSeek-V4-Flash" },
+          { id: "deepseek-v4-pro", name: "DeepSeek-V4-Pro" },
+        ],
+      },
+    });
+  });
+
+  it("maps presets for the provider form", () => {
+    expect(getDeepSeekHarnessPresetEntries()).toEqual([
+      {
+        id: "deepseek-harness-0",
+        preset: deepseekHarnessProviderPresets[0],
+      },
+    ]);
+  });
+});

--- a/tests/msw/state.ts
+++ b/tests/msw/state.ts
@@ -12,7 +12,7 @@ type ProvidersByApp = Record<AppId, Record<string, Provider>>;
 type CurrentProviderState = Record<AppId, string>;
 type McpConfigState = Record<AppId, Record<string, McpServer>>;
 type LiveProviderIdsByApp = Record<
-  "opencode" | "openclaw" | "hermes",
+  "opencode" | "openclaw" | "hermes" | "deepseek-harness",
   string[]
 >;
 
@@ -74,6 +74,7 @@ const createDefaultProviders = (): ProvidersByApp => ({
   openclaw: {},
   hermes: {},
   pi: {},
+  "deepseek-harness": {},
 });
 
 const createDefaultCurrent = (): CurrentProviderState => ({
@@ -86,15 +87,17 @@ const createDefaultCurrent = (): CurrentProviderState => ({
   openclaw: "",
   hermes: "",
   pi: "",
+  "deepseek-harness": "",
 });
 
 let providers = createDefaultProviders();
 let current = createDefaultCurrent();
 let liveProviderIds: LiveProviderIdsByApp = {
-  opencode: [],
-  openclaw: [],
-  hermes: [],
-};
+    opencode: [],
+    openclaw: [],
+    hermes: [],
+    "deepseek-harness": [],
+  };
 let settingsState: Settings = {
   showInTray: true,
   minimizeToTrayOnClose: true,
@@ -200,6 +203,7 @@ let mcpConfigs: McpConfigState = {
   openclaw: {},
   hermes: {},
   pi: {},
+  "deepseek-harness": {},
 };
 
 const cloneProviders = (value: ProvidersByApp) =>
@@ -212,6 +216,7 @@ export const resetProviderState = () => {
     opencode: [],
     openclaw: [],
     hermes: [],
+    "deepseek-harness": [],
   };
   sessionsState = createDefaultSessions();
   sessionMessagesState = createDefaultSessionMessages();
@@ -270,6 +275,7 @@ export const resetProviderState = () => {
     openclaw: {},
     hermes: {},
     pi: {},
+    "deepseek-harness": {},
   };
 };
 


### PR DESCRIPTION
## Summary / 概述

Add a DeepSeek Harness app type and provider writer aligned with the official Harness and DSH Desktop configuration layout.

- Resolve non-empty `DSH_HOME`, otherwise use `~/.dsh`.
- Write `llm-deepseek` provider settings to `settings.yaml`, including the official `baseURL` field.
- Store secrets only in `.credentials.yaml` as `DEEPSEEK_API_KEY`; use mode `0600` on Unix.
- Initialize the Desktop-compatible `desktop` profile with manifest, patch layer, and pnpm workspace metadata.
- Wire app visibility, provider counts, endpoint testing, i18n, and the single-route exclusive provider lifecycle.
- Add an official DeepSeek provider preset and make it the default for new providers.
- Align official defaults with upstream Harness: `https://api.deepseek.com`, `deepseek-v4-flash`, and `deepseek-v4-pro`.
- Normalize empty/blank `baseURL` to omitted so the official runtime can apply its documented fallback.

## Review follow-up / Review 跟进

The review fixes from yang227/cc-switch#1 are now merged into this branch (`f8d8464`, merge `ca331b99`):

- DeepSeek Harness is modeled as an exclusive provider rather than additive mode.
- Harness skill resolution no longer targets the Pi skills directory, and unsupported Harness skill synchronization is skipped.
- Clearing the managed API key removes the stale `DEEPSEEK_API_KEY` credential while preserving unrelated credentials.
- Provider deletion detects and removes the managed `llm-deepseek` live route.
- Usage credential resolution reads the official `baseURL` field and retains a legacy `baseUrl` fallback.

The Claude Desktop proxy regression test also uses an OS-assigned ephemeral port so it does not collide with a locally running CC Switch instance on port 15721.

## Related Issue / 关联 Issue

Fixes #6525

## Screenshots / 截图

Not applicable; this PR primarily adds configuration integration.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

`cargo clippy --all-targets -- -D warnings` still reports the same three pre-existing upstream warnings in `src/gemini_mcp.rs`, `src/proxy/providers/codex_oauth_auth.rs`, and `src/tray.rs`. No warnings are reported in the new or changed DeepSeek Harness files.

### Local verification

- `pnpm typecheck` (`tsc --noEmit`): passed
- `pnpm format:check`: passed
- `pnpm exec vitest run`: 132 files / 978 tests passed
- Focused `deepseek_harness_config` tests after the review follow-up: 8/8 passed
- `get_app_skills_dir_honors_test_home_override`: passed, including the DeepSeek Harness `~/.dsh/skills` assertion
- `resolve_credentials_deepseek_harness_base_url`: passed
- `migrate_storage_retargets_*`: 2/2 passed
- `cargo fmt --all --check`: passed
- `cargo test --lib`: 2684 passed, 5 ignored after isolating a host-specific fixed-port collision
- Full `cargo test`: passed, including integration suites
- Upstream Harness `loader-composition.spec.ts`: 3/3 passed, including real `settings.yaml` and credentials loading
- Isolated `DSH_HOME` integration check on macOS: verified official settings, separate credentials, `0600` credential mode, and Desktop profile files
