### PR TITLE
fix(docs): repair broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ For new features, please open an issue for discussion before submitting a PR. PR
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=farion1231/cc-switch&type=Date)](https://www.star-history.com/#farion1231/cc-switch&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=farion1231/cc-switch&type=Date)](https://star-history.dera.page/#farion1231/cc-switch&Date)
 
 ## License
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -584,7 +584,7 @@ Eröffnen Sie für neue Funktionen bitte vor dem Einreichen eines PR ein Issue z
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=farion1231/cc-switch&type=Date)](https://www.star-history.com/#farion1231/cc-switch&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=farion1231/cc-switch&type=Date)](https://star-history.dera.page/#farion1231/cc-switch&Date)
 
 ## Lizenz
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -584,7 +584,7 @@ PR を送る前に以下をご確認ください：
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=farion1231/cc-switch&type=Date)](https://www.star-history.com/#farion1231/cc-switch&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=farion1231/cc-switch&type=Date)](https://star-history.dera.page/#farion1231/cc-switch&Date)
 
 ## ライセンス
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -587,7 +587,7 @@ pnpm test:unit --coverage
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=farion1231/cc-switch&type=Date)](https://www.star-history.com/#farion1231/cc-switch&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=farion1231/cc-switch&type=Date)](https://star-history.dera.page/#farion1231/cc-switch&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README has stopped rendering because it relies on the GitHub stargazer API, which now restricts access. This swaps the chart to an alternative source that needs no API token, so it works reliably again. The badge remains untouched. Updated in README, README_ZH, README_JA, and README_DE.