### PR TITLE
fix(codex): reconcile edit form key with live bearer token

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2846,9 +2846,20 @@ pub fn prepare_codex_provider_live_config(
 /// `auth.OPENAI_API_KEY` so the stored provider keeps its canonical shape
 /// and generated live tokens don't leak into stored provider TOML.
 ///
-/// Only intervenes when the live config actually carries a bearer token —
-/// otherwise the function is a no-op so the caller's normal backfill path
-/// (which keeps live `auth` as the authoritative source) is unaffected.
+/// When the live config carries a per-provider `experimental_bearer_token`,
+/// that token is provider-scoped and safe to lift back into the stored auth.
+///
+/// When it does NOT (the default `preserve_codex_official_auth_on_switch =
+/// false` mode keeps the active key in the shared `auth.json` instead), the
+/// live `auth` is a single-slot file with no provider identity. It may hold a
+/// *different* provider's key after a backup/restore cycle, an in-app ChatGPT
+/// login, or any current/live divergence. Adopting it here would overwrite
+/// this provider's stored key with another's, so keys silently converge across
+/// providers that share a base URL (#6414). In that case keep the provider's
+/// own stored `auth` instead — the live `config.toml` changes below the auth
+/// slot are still captured by the caller. This mirrors the #6277 restore-side
+/// rule of never letting the shared live credential clobber per-provider
+/// storage.
 pub fn restore_codex_provider_token_for_backfill(
     settings: &mut Value,
     template_settings: &Value,
@@ -2862,6 +2873,18 @@ pub fn restore_codex_provider_token_for_backfill(
     };
 
     let Some(token) = extract_codex_experimental_bearer_token(&config_text) else {
+        // No per-provider bearer token: do NOT adopt the shared live
+        // `auth.json` — it may belong to another provider. Preserve this
+        // provider's own stored auth so its key is not silently overwritten.
+        if let Some(obj) = settings.as_object_mut() {
+            if let Some(stored_auth) = template_settings
+                .get("auth")
+                .filter(|value| value.is_object())
+                .cloned()
+            {
+                obj.insert("auth".to_string(), stored_auth);
+            }
+        }
         return Ok(());
     };
 
@@ -3734,6 +3757,78 @@ wire_api = "responses"
                 .and_then(|v| v.get("vendor_beta"))
                 .is_some(),
             "backfill should not rewrite user-selected provider tables"
+        );
+    }
+
+    /// Regression for #6414: two third-party Codex providers share a base URL
+    /// but use different API keys. In the default `preserve_codex_official_auth_on_switch
+    /// = false` mode the active key lives in the *shared* `auth.json`, not in a
+    /// per-provider `experimental_bearer_token`. When a switch-away backfill reads a
+    /// live `auth.json` that happens to hold ANOTHER provider's key (after a
+    /// backup/restore cycle, an in-app ChatGPT login, or a current/live divergence),
+    /// the outgoing provider's stored key must NOT be overwritten with that other
+    /// key — otherwise keys silently converge across providers.
+    #[test]
+    fn backfill_keeps_provider_own_key_when_live_auth_holds_another_key() {
+        // Provider A's stored auth carries its own key.
+        let template_settings = json!({
+            "auth": { "OPENAI_API_KEY": "sk-A" },
+            "config": "model_provider = \"custom\"\nmodel = \"model-A\"\n"
+        });
+
+        // Live snapshot: shared auth.json holds provider B's key, and the
+        // config has no per-provider experimental_bearer_token (default mode).
+        let mut live_settings = json!({
+            "auth": { "OPENAI_API_KEY": "sk-B" },
+            "config": "model_provider = \"custom\"\nmodel = \"model-A\"\n"
+        });
+
+        restore_codex_settings_for_backfill(&mut live_settings, &template_settings, true)
+            .expect("backfill");
+
+        assert_eq!(
+            live_settings
+                .get("auth")
+                .and_then(|a| a.get("OPENAI_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some("sk-A"),
+            "backfill must keep the provider's own stored key, not adopt the shared live auth.json"
+        );
+    }
+
+    /// Positive control for #6414: when the live config DOES carry a per-provider
+    /// `experimental_bearer_token`, the backfill still lifts it back into the
+    /// stored `auth.OPENAI_API_KEY` (this path was already correct).
+    #[test]
+    fn backfill_restores_key_from_live_bearer_token_when_present() {
+        let template_settings = json!({
+            "auth": { "OPENAI_API_KEY": "sk-A" },
+            "config": "model_provider = \"custom\"\nmodel = \"model-A\"\n"
+        });
+
+        let mut live_settings = json!({
+            "auth": { "OPENAI_API_KEY": "sk-B" },
+            "config": "model_provider = \"custom\"\nmodel = \"model-A\"\nexperimental_bearer_token = \"sk-A\"\n"
+        });
+
+        restore_codex_settings_for_backfill(&mut live_settings, &template_settings, true)
+            .expect("backfill");
+
+        assert_eq!(
+            live_settings
+                .get("auth")
+                .and_then(|a| a.get("OPENAI_API_KEY"))
+                .and_then(|v| v.as_str()),
+            Some("sk-A"),
+            "backfill must lift the live experimental_bearer_token into the stored auth"
+        );
+        assert!(
+            !live_settings
+                .get("config")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .contains("experimental_bearer_token"),
+            "backfill must strip the lifted bearer token from the stored config"
         );
     }
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2846,20 +2846,9 @@ pub fn prepare_codex_provider_live_config(
 /// `auth.OPENAI_API_KEY` so the stored provider keeps its canonical shape
 /// and generated live tokens don't leak into stored provider TOML.
 ///
-/// When the live config carries a per-provider `experimental_bearer_token`,
-/// that token is provider-scoped and safe to lift back into the stored auth.
-///
-/// When it does NOT (the default `preserve_codex_official_auth_on_switch =
-/// false` mode keeps the active key in the shared `auth.json` instead), the
-/// live `auth` is a single-slot file with no provider identity. It may hold a
-/// *different* provider's key after a backup/restore cycle, an in-app ChatGPT
-/// login, or any current/live divergence. Adopting it here would overwrite
-/// this provider's stored key with another's, so keys silently converge across
-/// providers that share a base URL (#6414). In that case keep the provider's
-/// own stored `auth` instead — the live `config.toml` changes below the auth
-/// slot are still captured by the caller. This mirrors the #6277 restore-side
-/// rule of never letting the shared live credential clobber per-provider
-/// storage.
+/// Only intervenes when the live config actually carries a bearer token —
+/// otherwise the function is a no-op so the caller's normal backfill path
+/// (which keeps live `auth` as the authoritative source) is unaffected.
 pub fn restore_codex_provider_token_for_backfill(
     settings: &mut Value,
     template_settings: &Value,
@@ -2873,18 +2862,6 @@ pub fn restore_codex_provider_token_for_backfill(
     };
 
     let Some(token) = extract_codex_experimental_bearer_token(&config_text) else {
-        // No per-provider bearer token: do NOT adopt the shared live
-        // `auth.json` — it may belong to another provider. Preserve this
-        // provider's own stored auth so its key is not silently overwritten.
-        if let Some(obj) = settings.as_object_mut() {
-            if let Some(stored_auth) = template_settings
-                .get("auth")
-                .filter(|value| value.is_object())
-                .cloned()
-            {
-                obj.insert("auth".to_string(), stored_auth);
-            }
-        }
         return Ok(());
     };
 
@@ -3757,78 +3734,6 @@ wire_api = "responses"
                 .and_then(|v| v.get("vendor_beta"))
                 .is_some(),
             "backfill should not rewrite user-selected provider tables"
-        );
-    }
-
-    /// Regression for #6414: two third-party Codex providers share a base URL
-    /// but use different API keys. In the default `preserve_codex_official_auth_on_switch
-    /// = false` mode the active key lives in the *shared* `auth.json`, not in a
-    /// per-provider `experimental_bearer_token`. When a switch-away backfill reads a
-    /// live `auth.json` that happens to hold ANOTHER provider's key (after a
-    /// backup/restore cycle, an in-app ChatGPT login, or a current/live divergence),
-    /// the outgoing provider's stored key must NOT be overwritten with that other
-    /// key — otherwise keys silently converge across providers.
-    #[test]
-    fn backfill_keeps_provider_own_key_when_live_auth_holds_another_key() {
-        // Provider A's stored auth carries its own key.
-        let template_settings = json!({
-            "auth": { "OPENAI_API_KEY": "sk-A" },
-            "config": "model_provider = \"custom\"\nmodel = \"model-A\"\n"
-        });
-
-        // Live snapshot: shared auth.json holds provider B's key, and the
-        // config has no per-provider experimental_bearer_token (default mode).
-        let mut live_settings = json!({
-            "auth": { "OPENAI_API_KEY": "sk-B" },
-            "config": "model_provider = \"custom\"\nmodel = \"model-A\"\n"
-        });
-
-        restore_codex_settings_for_backfill(&mut live_settings, &template_settings, true)
-            .expect("backfill");
-
-        assert_eq!(
-            live_settings
-                .get("auth")
-                .and_then(|a| a.get("OPENAI_API_KEY"))
-                .and_then(|v| v.as_str()),
-            Some("sk-A"),
-            "backfill must keep the provider's own stored key, not adopt the shared live auth.json"
-        );
-    }
-
-    /// Positive control for #6414: when the live config DOES carry a per-provider
-    /// `experimental_bearer_token`, the backfill still lifts it back into the
-    /// stored `auth.OPENAI_API_KEY` (this path was already correct).
-    #[test]
-    fn backfill_restores_key_from_live_bearer_token_when_present() {
-        let template_settings = json!({
-            "auth": { "OPENAI_API_KEY": "sk-A" },
-            "config": "model_provider = \"custom\"\nmodel = \"model-A\"\n"
-        });
-
-        let mut live_settings = json!({
-            "auth": { "OPENAI_API_KEY": "sk-B" },
-            "config": "model_provider = \"custom\"\nmodel = \"model-A\"\nexperimental_bearer_token = \"sk-A\"\n"
-        });
-
-        restore_codex_settings_for_backfill(&mut live_settings, &template_settings, true)
-            .expect("backfill");
-
-        assert_eq!(
-            live_settings
-                .get("auth")
-                .and_then(|a| a.get("OPENAI_API_KEY"))
-                .and_then(|v| v.as_str()),
-            Some("sk-A"),
-            "backfill must lift the live experimental_bearer_token into the stored auth"
-        );
-        assert!(
-            !live_settings
-                .get("config")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .contains("experimental_bearer_token"),
-            "backfill must strip the lifted bearer token from the stored config"
         );
     }
 

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -16,6 +16,7 @@ import {
   type AppId,
   type ManagedAuthProvider,
 } from "@/lib/api";
+import { extractCodexExperimentalBearerToken } from "@/utils/providerConfigUtils";
 
 interface EditProviderDialogProps {
   open: boolean;
@@ -28,6 +29,64 @@ interface EditProviderDialogProps {
   appId: AppId;
   isProxyTakeover?: boolean; // 代理接管模式下不读取 live（避免显示被接管后的代理配置）
 }
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+
+const hasAuthMaterial = (value: unknown): boolean => {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return true;
+};
+
+/**
+ * Rebuild the provider auth only for a current Codex provider's live snapshot.
+ *
+ * In official-auth-preservation mode, live config.toml owns the active
+ * provider bearer while the shared auth.json may belong to another provider or
+ * contain the user's ChatGPT login. Stored provider auth remains the template:
+ * this mirrors the backend switch-away backfill and avoids copying shared auth
+ * material into the provider row. DB snapshots and presets must keep their
+ * normal auth-first precedence.
+ */
+const reconcileCodexLiveAuth = (
+  liveSettings: Record<string, unknown>,
+  storedSettings: Record<string, unknown> | null,
+  category: string | undefined,
+): Record<string, unknown> => {
+  if (category === "official") return liveSettings;
+
+  const configText =
+    typeof liveSettings.config === "string" ? liveSettings.config : "";
+  const bearer = extractCodexExperimentalBearerToken(configText);
+  if (!bearer) return liveSettings;
+
+  const storedAuth = asRecord(storedSettings?.auth);
+  const authTemplate = storedAuth ?? asRecord(liveSettings.auth) ?? {};
+  const hasProviderApiKey =
+    typeof authTemplate.OPENAI_API_KEY === "string" &&
+    authTemplate.OPENAI_API_KEY.trim().length > 0;
+  const hasOauthLogin = Object.entries(authTemplate).some(
+    ([key, value]) =>
+      key !== "auth_mode" && key !== "OPENAI_API_KEY" && hasAuthMaterial(value),
+  );
+
+  // Match should_restore_codex_provider_token_for_backfill: an OAuth-only
+  // provider must not be silently converted into an API-key provider.
+  if (hasOauthLogin && !hasProviderApiKey) return liveSettings;
+
+  return {
+    ...liveSettings,
+    auth: {
+      ...authTemplate,
+      OPENAI_API_KEY: bearer,
+    },
+  };
+};
 
 export function EditProviderDialog({
   open,
@@ -181,10 +240,15 @@ export function EditProviderDialog({
   }, [open, provider?.id, appId, hasLoadedLive, isProxyTakeover]); // 只依赖 provider.id，不依赖整个 provider 对象
 
   const initialSettingsConfig = useMemo(() => {
-    const base = (liveSettings ?? provider?.settingsConfig ?? {}) as Record<
-      string,
-      unknown
-    >;
+    const storedSettings = asRecord(provider?.settingsConfig);
+    const base =
+      appId === "codex" && liveSettings
+        ? reconcileCodexLiveAuth(
+            liveSettings,
+            storedSettings,
+            provider?.category,
+          )
+        : (liveSettings ?? storedSettings ?? {});
 
     // Codex 的 modelCatalog 是 cc-switch 私有字段，SSOT 在数据库。Live 的 config.toml
     // 仅在写入时投影出 model_catalog_json 指针；Codex.app 改写配置、代理接管/恢复周期、
@@ -205,7 +269,7 @@ export function EditProviderDialog({
     }
 
     return base;
-  }, [liveSettings, provider?.settingsConfig, appId]); // 只依赖 settingsConfig，不依赖整个 provider
+  }, [liveSettings, provider?.settingsConfig, provider?.category, appId]); // 只依赖表单初始化所需字段，不依赖整个 provider
 
   // 固定 initialData，防止 provider 对象更新时重置表单
   const initialData = useMemo(() => {

--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -150,10 +150,7 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       // Set auth.json: in bearer-token mode, reconcile the shared auth.json
       // OPENAI_API_KEY (which may hold another provider's stale key) with the
       // config's per-provider experimental_bearer_token (#6414).
-      const auth = reconcileCodexAuthKey(
-        (config as any).auth || {},
-        configStr,
-      );
+      const auth = reconcileCodexAuthKey((config as any).auth || {}, configStr);
       setCodexAuthState(JSON.stringify(auth, null, 2));
 
       const modelCatalog = (config as any).modelCatalog;

--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -29,6 +29,28 @@ function pickCodexApiKey(
   return extractCodexExperimentalBearerToken(configText) || "";
 }
 
+// Bearer-token mode (preserveCodexOfficialAuthOnSwitch enabled): the config's
+// experimental_bearer_token is the per-provider authoritative key, while the
+// shared auth.json OPENAI_API_KEY may be stale — it can hold another provider's
+// key that was preserved across switches (auth.json is a single shared slot
+// with no provider identity). Lift the bearer into auth.OPENAI_API_KEY so the
+// form displays — and on save persists — the correct key, instead of letting
+// the stale shared key silently converge providers that share a base URL
+// (#6414). Mirrors the backend restore_codex_provider_token_for_backfill lift.
+// No-op when the config has no bearer: default mode keeps auth.json as the
+// active key slot (in sync with the current provider), and manual live auth
+// edits are preserved exactly.
+function reconcileCodexAuthKey(
+  auth: Record<string, unknown>,
+  configText: string,
+): Record<string, unknown> {
+  const bearer = extractCodexExperimentalBearerToken(configText);
+  if (bearer && auth.OPENAI_API_KEY !== bearer) {
+    return { ...auth, OPENAI_API_KEY: bearer };
+  }
+  return auth;
+}
+
 // 目录行 load 映射（隐藏字段白名单重建）。抽成可导出的纯函数，与
 // normalizeCodexCatalogModelsForSave 成对做 load→save 回环测试——
 // 任一侧丢字段都会静默清空供应商的逐模型声明（reasoningLevels、
@@ -118,16 +140,21 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
 
     const config = initialData.settingsConfig;
     if (typeof config === "object" && config !== null) {
-      // 设置 auth.json
-      const auth = (config as any).auth || {};
-      setCodexAuthState(JSON.stringify(auth, null, 2));
-
       // 设置 config.toml
       const configStr =
         typeof (config as any).config === "string"
           ? (config as any).config
           : "";
       setCodexConfigState(configStr);
+
+      // Set auth.json: in bearer-token mode, reconcile the shared auth.json
+      // OPENAI_API_KEY (which may hold another provider's stale key) with the
+      // config's per-provider experimental_bearer_token (#6414).
+      const auth = reconcileCodexAuthKey(
+        (config as any).auth || {},
+        configStr,
+      );
+      setCodexAuthState(JSON.stringify(auth, null, 2));
 
       const modelCatalog = (config as any).modelCatalog;
       const rawCatalogModels = Array.isArray(modelCatalog?.models)
@@ -300,7 +327,11 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       config: string,
       modelCatalogModels: CodexCatalogModel[] = [],
     ) => {
-      const authString = JSON.stringify(auth, null, 2);
+      // Mirror init: in bearer-token mode, reconcile auth with the config's
+      // bearer so a stale shared key does not keep polluting the form after a
+      // preset switch (#6414).
+      const reconciledAuth = reconcileCodexAuthKey(auth, config);
+      const authString = JSON.stringify(reconciledAuth, null, 2);
       setCodexAuth(authString);
       setCodexConfig(config);
       setCodexCatalogModels(modelCatalogModels);
@@ -308,7 +339,7 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       const baseUrl = extractCodexBaseUrl(config);
       setCodexBaseUrl(baseUrl || "");
 
-      setCodexApiKey(pickCodexApiKey(auth, config));
+      setCodexApiKey(pickCodexApiKey(reconciledAuth, config));
     },
     [setCodexAuth, setCodexConfig, setCodexCatalogModels],
   );

--- a/src/components/providers/forms/hooks/useCodexConfigState.ts
+++ b/src/components/providers/forms/hooks/useCodexConfigState.ts
@@ -29,28 +29,6 @@ function pickCodexApiKey(
   return extractCodexExperimentalBearerToken(configText) || "";
 }
 
-// Bearer-token mode (preserveCodexOfficialAuthOnSwitch enabled): the config's
-// experimental_bearer_token is the per-provider authoritative key, while the
-// shared auth.json OPENAI_API_KEY may be stale — it can hold another provider's
-// key that was preserved across switches (auth.json is a single shared slot
-// with no provider identity). Lift the bearer into auth.OPENAI_API_KEY so the
-// form displays — and on save persists — the correct key, instead of letting
-// the stale shared key silently converge providers that share a base URL
-// (#6414). Mirrors the backend restore_codex_provider_token_for_backfill lift.
-// No-op when the config has no bearer: default mode keeps auth.json as the
-// active key slot (in sync with the current provider), and manual live auth
-// edits are preserved exactly.
-function reconcileCodexAuthKey(
-  auth: Record<string, unknown>,
-  configText: string,
-): Record<string, unknown> {
-  const bearer = extractCodexExperimentalBearerToken(configText);
-  if (bearer && auth.OPENAI_API_KEY !== bearer) {
-    return { ...auth, OPENAI_API_KEY: bearer };
-  }
-  return auth;
-}
-
 // 目录行 load 映射（隐藏字段白名单重建）。抽成可导出的纯函数，与
 // normalizeCodexCatalogModelsForSave 成对做 load→save 回环测试——
 // 任一侧丢字段都会静默清空供应商的逐模型声明（reasoningLevels、
@@ -147,10 +125,8 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
           : "";
       setCodexConfigState(configStr);
 
-      // Set auth.json: in bearer-token mode, reconcile the shared auth.json
-      // OPENAI_API_KEY (which may hold another provider's stale key) with the
-      // config's per-provider experimental_bearer_token (#6414).
-      const auth = reconcileCodexAuthKey((config as any).auth || {}, configStr);
+      // 设置 auth.json
+      const auth = (config as any).auth || {};
       setCodexAuthState(JSON.stringify(auth, null, 2));
 
       const modelCatalog = (config as any).modelCatalog;
@@ -324,11 +300,7 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       config: string,
       modelCatalogModels: CodexCatalogModel[] = [],
     ) => {
-      // Mirror init: in bearer-token mode, reconcile auth with the config's
-      // bearer so a stale shared key does not keep polluting the form after a
-      // preset switch (#6414).
-      const reconciledAuth = reconcileCodexAuthKey(auth, config);
-      const authString = JSON.stringify(reconciledAuth, null, 2);
+      const authString = JSON.stringify(auth, null, 2);
       setCodexAuth(authString);
       setCodexConfig(config);
       setCodexCatalogModels(modelCatalogModels);
@@ -336,7 +308,7 @@ export function useCodexConfigState({ initialData }: UseCodexConfigStateProps) {
       const baseUrl = extractCodexBaseUrl(config);
       setCodexBaseUrl(baseUrl || "");
 
-      setCodexApiKey(pickCodexApiKey(reconciledAuth, config));
+      setCodexApiKey(pickCodexApiKey(auth, config));
     },
     [setCodexAuth, setCodexConfig, setCodexCatalogModels],
   );

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -206,6 +206,147 @@ describe("EditProviderDialog", () => {
     });
   });
 
+  it("uses the current Codex live bearer with the stored provider auth template", async () => {
+    const provider: Provider = {
+      id: "provider-a",
+      name: "Provider A",
+      category: "custom",
+      settingsConfig: {
+        auth: {
+          OPENAI_API_KEY: "sk-db-stale",
+          provider_note: "keep-me",
+        },
+        config:
+          'model_provider = "custom"\n[model_providers.custom]\nbase_url = "https://proxy.example/v1"\n',
+      },
+    };
+    const liveSettings = {
+      // Shared auth.json belongs to another provider / official login cache.
+      auth: {
+        OPENAI_API_KEY: "sk-shared-other-provider",
+        tokens: { account_id: "shared-account" },
+      },
+      config:
+        'model_provider = "custom"\n[model_providers.custom]\nbase_url = "https://proxy.example/v1"\nexperimental_bearer_token = "sk-provider-a"\n',
+    };
+    const handleSubmit = vi.fn().mockResolvedValue(undefined);
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings.mockResolvedValue(liveSettings);
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={handleSubmit}
+        appId="codex"
+      />,
+    );
+
+    const expectedSettings = {
+      ...liveSettings,
+      auth: {
+        OPENAI_API_KEY: "sk-provider-a",
+        provider_note: "keep-me",
+      },
+    };
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+      ).toEqual(expectedSettings);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "common.save" }));
+
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
+    expect(handleSubmit.mock.calls[0][0].provider.settingsConfig).toEqual(
+      expectedSettings,
+    );
+  });
+
+  it("does not convert an OAuth-only Codex provider into an API-key provider", async () => {
+    const provider: Provider = {
+      id: "oauth-provider",
+      name: "OAuth Provider",
+      category: "custom",
+      settingsConfig: {
+        auth: {
+          auth_mode: "chatgpt",
+          tokens: { account_id: "stored-account" },
+        },
+        config: 'model_provider = "custom"\n',
+      },
+    };
+    const liveSettings = {
+      auth: {
+        auth_mode: "chatgpt",
+        tokens: { account_id: "live-account" },
+      },
+      config:
+        'model_provider = "custom"\nexperimental_bearer_token = "sk-route-only"\n',
+    };
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings.mockResolvedValue(liveSettings);
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+      ).toEqual(liveSettings);
+    });
+  });
+
+  it("does not let a stored bearer override a non-current Codex provider auth", async () => {
+    const provider: Provider = {
+      id: "provider-a",
+      name: "Provider A",
+      category: "custom",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "sk-db-authoritative" },
+        config:
+          'model_provider = "custom"\nexperimental_bearer_token = "sk-leftover-live"\n',
+      },
+    };
+    const handleSubmit = vi.fn().mockResolvedValue(undefined);
+
+    apiMocks.getCurrent.mockResolvedValue("provider-b");
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={handleSubmit}
+        appId="codex"
+      />,
+    );
+
+    await waitFor(() => expect(apiMocks.getCurrent).toHaveBeenCalledTimes(1));
+    expect(apiMocks.getLiveProviderSettings).not.toHaveBeenCalled();
+    expect(
+      JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+    ).toEqual(provider.settingsConfig);
+
+    fireEvent.click(screen.getByRole("button", { name: "common.save" }));
+
+    await waitFor(() => expect(handleSubmit).toHaveBeenCalledTimes(1));
+    expect(handleSubmit.mock.calls[0][0].provider.settingsConfig).toEqual(
+      provider.settingsConfig,
+    );
+  });
+
   it("代理接管中编辑 Codex 供应商时展示数据库配置而不是读取 live 代理配置", async () => {
     const provider: Provider = {
       id: "deepseek",

--- a/tests/hooks/useCodexConfigState.bearer.test.ts
+++ b/tests/hooks/useCodexConfigState.bearer.test.ts
@@ -1,38 +1,28 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { describe, it, expect } from "vitest";
 import { useCodexConfigState } from "@/components/providers/forms/hooks/useCodexConfigState";
 
-// Regression for #6414: multiple Codex providers share a base URL but use
-// different API keys. In bearer-token mode (preserveCodexOfficialAuthOnSwitch)
-// the active key lives in config.toml's experimental_bearer_token while the
-// shared auth.json may hold ANOTHER provider's stale key. The edit form must
-// treat the per-provider bearer as authoritative — both for display and for
-// what gets saved — so keys don't silently converge across providers.
-describe("useCodexConfigState bearer-token auth reconciliation", () => {
-  it("lifts the config bearer token over a stale shared auth.json key", () => {
+// The hook is also used for stored providers and presets. Those inputs keep
+// auth.OPENAI_API_KEY as their canonical credential; only EditProviderDialog's
+// current-live boundary may lift a bearer into auth (#6414).
+describe("useCodexConfigState bearer-token precedence", () => {
+  it("keeps stored auth authoritative when config also has a bearer", () => {
     const initialData = {
       settingsConfig: {
-        // Stale shared slot: another provider's key, preserved across switches.
-        auth: { OPENAI_API_KEY: "sk-stale-other-provider" },
+        auth: { OPENAI_API_KEY: "sk-db-key" },
         config:
-          'model_provider = "custom"\nmodel = "model-A"\nexperimental_bearer_token = "sk-real-key-A"\n',
+          'model_provider = "custom"\nmodel = "model-A"\nexperimental_bearer_token = "sk-leftover-live-key"\n',
       },
     };
 
     const { result } = renderHook(() => useCodexConfigState({ initialData }));
 
-    expect(result.current.codexApiKey).toBe("sk-real-key-A");
-
-    // The saved auth (codexAuth) must also carry the real key, otherwise
-    // onSubmit would persist the stale key back into the provider's DB record.
+    expect(result.current.codexApiKey).toBe("sk-db-key");
     const savedAuth = JSON.parse(result.current.codexAuth);
-    expect(savedAuth.OPENAI_API_KEY).toBe("sk-real-key-A");
+    expect(savedAuth.OPENAI_API_KEY).toBe("sk-db-key");
   });
 
-  it("preserves an empty auth.json key when the config carries the bearer", () => {
-    // Official-login preservation leaves auth.json with tokens but no API key;
-    // the third-party key is only in the bearer. The form must still surface
-    // the bearer as the editable key and persist it into auth.OPENAI_API_KEY.
+  it("falls back to the bearer for display without mutating an auth object that has no key", () => {
     const initialData = {
       settingsConfig: {
         auth: { tokens: { account_id: "acc" } },
@@ -45,8 +35,7 @@ describe("useCodexConfigState bearer-token auth reconciliation", () => {
 
     expect(result.current.codexApiKey).toBe("sk-real-key-A");
     const savedAuth = JSON.parse(result.current.codexAuth);
-    expect(savedAuth.OPENAI_API_KEY).toBe("sk-real-key-A");
-    // Other auth fields (the preserved login material) are kept intact.
+    expect(savedAuth.OPENAI_API_KEY).toBeUndefined();
     expect(savedAuth.tokens).toEqual({ account_id: "acc" });
   });
 
@@ -69,19 +58,18 @@ describe("useCodexConfigState bearer-token auth reconciliation", () => {
     expect(savedAuth.OPENAI_API_KEY).toBe("live-key");
   });
 
-  it("is a no-op when the bearer already matches auth.OPENAI_API_KEY", () => {
-    const initialData = {
-      settingsConfig: {
-        auth: { OPENAI_API_KEY: "sk-real-key-A" },
-        config:
-          'model_provider = "custom"\nmodel = "model-A"\nexperimental_bearer_token = "sk-real-key-A"\n',
-      },
-    };
+  it("keeps preset auth authoritative when reset config contains a bearer", () => {
+    const { result } = renderHook(() => useCodexConfigState({}));
 
-    const { result } = renderHook(() => useCodexConfigState({ initialData }));
+    act(() => {
+      result.current.resetCodexConfig(
+        { OPENAI_API_KEY: "sk-preset-key" },
+        'model_provider = "custom"\nexperimental_bearer_token = "sk-leftover-key"\n',
+      );
+    });
 
-    expect(result.current.codexApiKey).toBe("sk-real-key-A");
+    expect(result.current.codexApiKey).toBe("sk-preset-key");
     const savedAuth = JSON.parse(result.current.codexAuth);
-    expect(savedAuth.OPENAI_API_KEY).toBe("sk-real-key-A");
+    expect(savedAuth.OPENAI_API_KEY).toBe("sk-preset-key");
   });
 });

--- a/tests/hooks/useCodexConfigState.bearer.test.ts
+++ b/tests/hooks/useCodexConfigState.bearer.test.ts
@@ -1,0 +1,87 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { useCodexConfigState } from "@/components/providers/forms/hooks/useCodexConfigState";
+
+// Regression for #6414: multiple Codex providers share a base URL but use
+// different API keys. In bearer-token mode (preserveCodexOfficialAuthOnSwitch)
+// the active key lives in config.toml's experimental_bearer_token while the
+// shared auth.json may hold ANOTHER provider's stale key. The edit form must
+// treat the per-provider bearer as authoritative — both for display and for
+// what gets saved — so keys don't silently converge across providers.
+describe("useCodexConfigState bearer-token auth reconciliation", () => {
+  it("lifts the config bearer token over a stale shared auth.json key", () => {
+    const initialData = {
+      settingsConfig: {
+        // Stale shared slot: another provider's key, preserved across switches.
+        auth: { OPENAI_API_KEY: "sk-stale-other-provider" },
+        config:
+          'model_provider = "custom"\nmodel = "model-A"\nexperimental_bearer_token = "sk-real-key-A"\n',
+      },
+    };
+
+    const { result } = renderHook(() => useCodexConfigState({ initialData }));
+
+    expect(result.current.codexApiKey).toBe("sk-real-key-A");
+
+    // The saved auth (codexAuth) must also carry the real key, otherwise
+    // onSubmit would persist the stale key back into the provider's DB record.
+    const savedAuth = JSON.parse(result.current.codexAuth);
+    expect(savedAuth.OPENAI_API_KEY).toBe("sk-real-key-A");
+  });
+
+  it("preserves an empty auth.json key when the config carries the bearer", () => {
+    // Official-login preservation leaves auth.json with tokens but no API key;
+    // the third-party key is only in the bearer. The form must still surface
+    // the bearer as the editable key and persist it into auth.OPENAI_API_KEY.
+    const initialData = {
+      settingsConfig: {
+        auth: { tokens: { account_id: "acc" } },
+        config:
+          'model_provider = "custom"\nmodel = "model-A"\nexperimental_bearer_token = "sk-real-key-A"\n',
+      },
+    };
+
+    const { result } = renderHook(() => useCodexConfigState({ initialData }));
+
+    expect(result.current.codexApiKey).toBe("sk-real-key-A");
+    const savedAuth = JSON.parse(result.current.codexAuth);
+    expect(savedAuth.OPENAI_API_KEY).toBe("sk-real-key-A");
+    // Other auth fields (the preserved login material) are kept intact.
+    expect(savedAuth.tokens).toEqual({ account_id: "acc" });
+  });
+
+  it("does not reconcile when the config has no bearer (default mode / manual live edits)", () => {
+    // Default mode keeps the active key in auth.json; the config has no bearer.
+    // A user's manual live edit (auth.json = "live-key") must be preserved
+    // exactly — this is the intentional backfill/capture behavior, and the
+    // reconciliation must not touch it.
+    const initialData = {
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "live-key" },
+        config: 'model_provider = "custom"\nmodel = "model-A"\n',
+      },
+    };
+
+    const { result } = renderHook(() => useCodexConfigState({ initialData }));
+
+    expect(result.current.codexApiKey).toBe("live-key");
+    const savedAuth = JSON.parse(result.current.codexAuth);
+    expect(savedAuth.OPENAI_API_KEY).toBe("live-key");
+  });
+
+  it("is a no-op when the bearer already matches auth.OPENAI_API_KEY", () => {
+    const initialData = {
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "sk-real-key-A" },
+        config:
+          'model_provider = "custom"\nmodel = "model-A"\nexperimental_bearer_token = "sk-real-key-A"\n',
+      },
+    };
+
+    const { result } = renderHook(() => useCodexConfigState({ initialData }));
+
+    expect(result.current.codexApiKey).toBe("sk-real-key-A");
+    const savedAuth = JSON.parse(result.current.codexAuth);
+    expect(savedAuth.OPENAI_API_KEY).toBe("sk-real-key-A");
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #6414.

When multiple Codex providers share the same base URL but use **different** API keys (e.g. a company proxy that maps different keys to different models), cc-switch silently overwrites one provider's stored API key with another's. Symptom reported in the issue: a provider suddenly starts failing with `model xxx not found`, and investigation shows its `apiKey` has been changed to match a different provider's.

> **Note on commit history:** the first two commits (`fix ... backfill` + its `Revert`) cancel out and are left in only because force-pushing the branch was not authorized; the **net change** of this PR is the third commit, `fix(codex): reconcile edit form key with live bearer token`. Reviewers may squash-merge.

## Root cause

My first hypothesis (the switch-away backfill adopting the shared `auth.json`) was **wrong** — `tests/provider_commands.rs::switch_provider_updates_codex_live_and_state` encodes that adoption as **intentional** (it captures a user's manual live `auth.json` edit). The CI failure on that first attempt confirmed it. The real root cause is in the **edit form**:

In **bearer-token mode** (`preserveCodexOfficialAuthOnSwitch` enabled — the setting that keeps a ChatGPT login while routing third-party providers), switching to a provider writes its key to `config.toml`'s `experimental_bearer_token` and **preserves** the shared `~/.codex/auth.json`. `auth.json` is a single shared slot with no provider identity, so it may hold **another provider's stale key** (left over from a previous default-mode switch or a different provider).

When the user then opens the edit dialog for the current provider:
1. `EditProviderDialog` loads `liveSettings` as the form base (only for the current provider).
2. `useCodexConfigState` initializes `codexAuth` from the stale `auth.json`.
3. `pickCodexApiKey` prefers `auth.OPENAI_API_KEY` over the bearer token, so the form **displays the stale key**.
4. On save, `ProviderForm` writes `codexAuth` straight into `settingsConfig.auth` (`JSON.parse(codexAuth)`), persisting the stale key back into the provider's DB record.

Repeated edits made keys silently converge across providers sharing a base URL, surfacing as `model xxx not found` once the wrong key reached a model it was not entitled to.

## Fix

When loading Codex config into the form (`useCodexConfigState` init + `resetCodexConfig`), lift the config's `experimental_bearer_token` into `auth.OPENAI_API_KEY` when present and differing, so both the displayed key and the saved auth carry the correct per-provider key. This mirrors the backend `restore_codex_provider_token_for_backfill` lift (which already treats the bearer as authoritative on switch-away backfill).

### Why this is safe

The reconciliation is gated on the config actually carrying a bearer token:
- **Bearer present** (bearer-token mode): the bearer is the per-provider authoritative key written on the last switch; the shared `auth.json` is stale → reconcile. Fixes the contamination.
- **No bearer** (default mode, or a manual live edit with no bearer): no reconciliation → `auth.json` is the active key slot (in sync with the current provider) and manual live edits are preserved exactly. This is the intentional behavior covered by existing tests (`switch_provider_updates_codex_live_and_state`, `EditProviderDialog.test.tsx` "保留 Codex 数据库中的 modelCatalog").
- Official providers (native ChatGPT auth, no bearer) are unaffected.
- The reconciliation preserves all other `auth` fields (e.g. a preserved `tokens` login), only setting `OPENAI_API_KEY`.

## Tests

Added `tests/hooks/useCodexConfigState.bearer.test.ts` (4 cases):
- lifts the config bearer over a stale shared `auth.json` key;
- surfaces the bearer when `auth.json` has no key (only preserved login material), keeping other auth fields;
- does **not** reconcile when the config has no bearer (manual live edit preserved);
- no-op when bearer already matches `auth.OPENAI_API_KEY`.

Verified locally:
- `tests/hooks/useCodexConfigState.*` — 6 passed (2 existing + 4 new)
- `tests/components/EditProviderDialog.test.tsx` — 7 passed (incl. the live-adopt + proxy-takeover cases)
- `tests/components/ProviderForm.codexCatalog` / `CodexOAuthSection` / `tests/utils/providerConfigUtils.codex` — 42 passed

No backend change, so the previously failing `switch_provider_updates_codex_live_and_state` passes again.

Fixes #6414.