### PR TITLE
fix(codex): allow multiple follow-login providers

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -764,16 +764,6 @@ pub fn run() {
                 Err(e) => log::warn!("✗ Failed to seed official providers: {e}"),
             }
 
-            match crate::services::provider::ProviderService::migrate_legacy_codex_official_managed_binding(
-                &app_state,
-            ) {
-                Ok(Some(provider_id)) => log::info!(
-                    "✓ Migrated legacy Codex Official account binding to {provider_id}"
-                ),
-                Ok(None) => {}
-                Err(e) => log::warn!("✗ Failed to migrate legacy Codex Official binding: {e}"),
-            }
-
             {
                 let db_for_codex_history_migration = app_state.db.clone();
                 tauri::async_runtime::spawn_blocking(move || {

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -219,20 +219,91 @@ pub fn provider_needs_responses_namespace_flatten(provider: &Provider) -> bool {
     provider.is_xai_oauth()
 }
 
-/// A native-login or managed-account Codex Official card receives
-/// authentication from the calling Codex client (`requires_openai_auth =
-/// true`). Legacy unbound Official rows keep their previous stored-key behavior.
+fn has_explicit_codex_third_party_upstream(provider: &Provider) -> bool {
+    let non_empty_setting = |key: &str| {
+        provider
+            .settings_config
+            .get(key)
+            .and_then(JsonValue::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    let config = provider
+        .settings_config
+        .get("config")
+        .and_then(JsonValue::as_str)
+        .map(|text| {
+            crate::codex_config::strip_codex_unified_session_bucket(text)
+                .unwrap_or_else(|_| text.to_string())
+        });
+    let config = config.as_deref();
+
+    ["baseUrl", "baseURL", "base_url"]
+        .into_iter()
+        .any(non_empty_setting)
+        || config
+            .and_then(crate::codex_config::extract_codex_experimental_bearer_token)
+            .is_some()
+        || config
+            .and_then(crate::codex_config::extract_codex_base_url)
+            .is_some()
+        || config
+            .and_then(|text| text.parse::<TomlValue>().ok())
+            .and_then(|doc| {
+                doc.get("model_provider")
+                    .and_then(TomlValue::as_str)
+                    .map(str::trim)
+                    .filter(|provider_id| !provider_id.is_empty())
+                    .map(str::to_string)
+            })
+            .is_some_and(|provider_id| !provider_id.eq_ignore_ascii_case("openai"))
+}
+
+/// Codex Official ChatGPT cards receive authentication from the calling Codex
+/// client (`requires_openai_auth = true`). Unbound cards with a stored API key
+/// stay on the direct OpenAI API path instead of being sent to the ChatGPT
+/// backend. The fixed legacy card keeps its existing behavior.
 pub fn is_codex_official_provider(provider: &Provider) -> bool {
-    if provider.category.as_deref() != Some("official") {
+    let is_fixed_official_id = provider.id == crate::database::CODEX_OFFICIAL_PROVIDER_ID;
+    if is_fixed_official_id && provider.category.as_deref() == Some("official") {
+        return true;
+    }
+
+    let has_auth_object = provider
+        .settings_config
+        .get("auth")
+        .is_some_and(JsonValue::is_object);
+    let has_valid_config_shape = provider
+        .settings_config
+        .get("config")
+        .is_none_or(|config| config.is_null() || config.is_string());
+    if !has_auth_object || !has_valid_config_shape {
         return false;
     }
 
-    provider.id == crate::database::CODEX_OFFICIAL_PROVIDER_ID
-        || provider
-            .meta
-            .as_ref()
-            .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
-            .is_some_and(|account_id| !account_id.trim().is_empty())
+    if has_explicit_codex_third_party_upstream(provider) {
+        return false;
+    }
+
+    let has_managed_account = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
+        .is_some_and(|account_id| !account_id.trim().is_empty());
+    if has_managed_account {
+        return true;
+    }
+
+    let has_stored_api_key = provider
+        .settings_config
+        .get("auth")
+        .and_then(|auth| auth.get("OPENAI_API_KEY"))
+        .and_then(JsonValue::as_str)
+        .is_some_and(|key| !key.trim().is_empty());
+    if has_stored_api_key {
+        return false;
+    }
+
+    is_fixed_official_id || provider.category.as_deref() == Some("official")
 }
 
 /// Resolve the model-catalog tool profile for a Codex provider using the SAME
@@ -977,17 +1048,26 @@ context_window = 500000
     }
 
     #[test]
-    fn official_account_card_uses_fixed_chatgpt_backend_without_stored_key() {
-        let mut provider = create_provider(json!({ "auth": {}, "config": "" }));
-        provider.id = "managed-official-account".to_string();
+    fn explicit_codex_official_cards_use_chatgpt_backend() {
+        let mut provider = create_provider(json!({
+            "auth": {
+                "auth_mode": "chatgpt",
+                "OPENAI_API_KEY": null,
+                "tokens": { "refresh_token": "legacy-live-only-token" }
+            },
+            "config": ""
+        }));
+        provider.id = "unbound-official-account".to_string();
         provider.category = Some("official".to_string());
-        assert!(!is_codex_official_provider(&provider));
+        assert!(is_codex_official_provider(&provider));
 
         let mut native = provider.clone();
         native.id = crate::database::CODEX_OFFICIAL_PROVIDER_ID.to_string();
         assert!(is_codex_official_provider(&native));
 
+        provider.id = "managed-official-account".to_string();
         provider.meta = Some(crate::provider::ProviderMeta {
+            provider_type: Some("codex_oauth".to_string()),
             auth_binding: Some(crate::provider::AuthBinding {
                 source: crate::provider::AuthBindingSource::ManagedAccount,
                 auth_provider: Some("codex_oauth".to_string()),
@@ -1012,6 +1092,69 @@ context_window = 500000
             ),
             "https://chatgpt.com/backend-api/codex/responses/compact"
         );
+
+        let mut official_api_key = create_provider(json!({
+            "auth": { "OPENAI_API_KEY": "sk-official" },
+            "config": ""
+        }));
+        official_api_key.category = Some("official".to_string());
+        assert!(!is_codex_official_provider(&official_api_key));
+
+        let mut stored_bearer = create_provider(json!({
+            "auth": {},
+            "config": "experimental_bearer_token = \"sk-legacy\""
+        }));
+        stored_bearer.category = Some("official".to_string());
+        assert!(!is_codex_official_provider(&stored_bearer));
+
+        let mut unmarked_custom = create_provider(json!({
+            "auth": {},
+            "config": "model_provider = \"custom\"\n[model_providers.custom]\nbase_url = \"https://example.com/v1\""
+        }));
+        unmarked_custom.category = Some("official".to_string());
+        assert!(!is_codex_official_provider(&unmarked_custom));
+
+        let mut category_less_fixed_custom = unmarked_custom.clone();
+        category_less_fixed_custom.id = crate::database::CODEX_OFFICIAL_PROVIDER_ID.to_string();
+        category_less_fixed_custom.category = None;
+        assert!(!is_codex_official_provider(&category_less_fixed_custom));
+
+        let mut category_less_fixed_api_key = official_api_key.clone();
+        category_less_fixed_api_key.id = crate::database::CODEX_OFFICIAL_PROVIDER_ID.to_string();
+        category_less_fixed_api_key.category = None;
+        assert!(!is_codex_official_provider(&category_less_fixed_api_key));
+
+        let mut explicit_openai = create_provider(json!({
+            "auth": { "OPENAI_API_KEY": "sk-official" },
+            "config": "model_provider = \"openai\""
+        }));
+        explicit_openai.category = Some("official".to_string());
+        assert!(!is_codex_official_provider(&explicit_openai));
+
+        let mut managed_with_null_config = provider.clone();
+        managed_with_null_config.category = None;
+        managed_with_null_config.settings_config["config"] = JsonValue::Null;
+        assert!(is_codex_official_provider(&managed_with_null_config));
+
+        let mut unified_session = create_provider(json!({
+            "auth": {},
+            "config": crate::codex_config::inject_codex_unified_session_bucket("")
+                .expect("inject unified session route")
+        }));
+        unified_session.category = Some("official".to_string());
+        assert!(is_codex_official_provider(&unified_session));
+
+        let mut implicit_custom = create_provider(json!({
+            "auth": {},
+            "config": "model_provider = \"ollama\""
+        }));
+        implicit_custom.category = Some("official".to_string());
+        assert!(!is_codex_official_provider(&implicit_custom));
+
+        let mut grok_official = create_provider(json!({ "config": "" }));
+        grok_official.id = crate::database::GROKBUILD_OFFICIAL_PROVIDER_ID.to_string();
+        grok_official.category = Some("official".to_string());
+        assert!(!is_codex_official_provider(&grok_official));
     }
 
     #[test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -749,18 +749,25 @@ pub(crate) fn build_effective_provider_for_live_with_codex_oauth_manager(
     let mut effective_provider = provider.clone();
     effective_provider.settings_config =
         build_effective_settings_with_common_config(db, app_type, provider)?;
-    apply_codex_managed_oauth_auth(app_type, &mut effective_provider, Some(codex_oauth_manager))?;
+    apply_codex_official_auth(app_type, &mut effective_provider, Some(codex_oauth_manager))?;
     Ok(effective_provider)
 }
 
-fn apply_codex_managed_oauth_auth(
+fn apply_codex_official_auth(
     app_type: &AppType,
     provider: &mut Provider,
     codex_oauth_manager: Option<&Arc<CodexOAuthManager>>,
 ) -> Result<(), AppError> {
-    if !matches!(app_type, AppType::Codex) || provider.category.as_deref() != Some("official") {
+    if !matches!(app_type, AppType::Codex)
+        || !crate::proxy::providers::is_codex_official_provider(provider)
+    {
         return Ok(());
     }
+
+    // Early OAuth builds could bind the fixed card before its category was
+    // persisted. Normalize only the in-memory live snapshot; the DB row and ID
+    // remain untouched.
+    provider.category = Some("official".to_string());
 
     let Some(account_id) = provider
         .meta
@@ -769,6 +776,9 @@ fn apply_codex_managed_oauth_auth(
         .map(|id| id.trim().to_string())
         .filter(|id| !id.is_empty())
     else {
+        // Preserve the historical unbound Official behavior: an empty stored
+        // auth follows Codex's current login, while a backfilled login snapshot
+        // is restored when switching back to this card.
         return Ok(());
     };
 
@@ -1055,7 +1065,9 @@ fn restore_live_settings_for_provider_backfill(
 
     // 统一会话开关注入的共享 `custom` 路由只属于 live 配置；切换回填时
     // 必须剥掉，否则官方供应商的存储配置被污染，关闭开关后无法还原。
-    if provider.category.as_deref() == Some("official") {
+    if provider.category.as_deref() == Some("official")
+        || crate::proxy::providers::is_codex_official_provider(provider)
+    {
         if let Err(err) =
             crate::codex_config::strip_codex_unified_session_bucket_from_settings(&mut settings)
         {
@@ -2698,7 +2710,7 @@ base_url = "https://a.example/v1"
     }
 
     #[test]
-    fn codex_official_managed_oauth_binding_replaces_auth_with_selected_account_token() {
+    fn category_less_managed_codex_binding_with_null_config_uses_selected_account_token() {
         let temp = tempfile::tempdir().expect("tempdir");
         let manager = Arc::new(CodexOAuthManager::new(temp.path().to_path_buf()));
         tauri::async_runtime::block_on(async {
@@ -2713,17 +2725,16 @@ base_url = "https://a.example/v1"
         });
 
         let mut provider = Provider::with_id(
-            "openai-official".to_string(),
+            "managed-official".to_string(),
             "OpenAI Official".to_string(),
             json!({
                 "auth": {
                     "OPENAI_API_KEY": "stale-key"
                 },
-                "config": ""
+                "config": null
             }),
             None,
         );
-        provider.category = Some("official".to_string());
         provider.meta = Some(ProviderMeta {
             auth_binding: Some(AuthBinding {
                 source: AuthBindingSource::ManagedAccount,
@@ -2733,8 +2744,10 @@ base_url = "https://a.example/v1"
             ..Default::default()
         });
 
-        apply_codex_managed_oauth_auth(&AppType::Codex, &mut provider, Some(&manager))
+        apply_codex_official_auth(&AppType::Codex, &mut provider, Some(&manager))
             .expect("apply managed OAuth auth");
+
+        assert_eq!(provider.category.as_deref(), Some("official"));
 
         // last_refresh 是写入时刻的时间戳（非确定），因此逐字段断言而非整体等值。
         let auth = provider.settings_config.get("auth").expect("auth written");
@@ -2773,7 +2786,7 @@ base_url = "https://a.example/v1"
     }
 
     #[test]
-    fn codex_official_without_binding_does_not_fall_back_to_managed_default_account() {
+    fn codex_follow_login_without_binding_keeps_stored_auth() {
         let temp = tempfile::tempdir().expect("tempdir");
         let manager = Arc::new(CodexOAuthManager::new(temp.path().to_path_buf()));
         tauri::async_runtime::block_on(async {
@@ -2802,14 +2815,70 @@ base_url = "https://a.example/v1"
         );
         provider.category = Some("official".to_string());
 
-        apply_codex_managed_oauth_auth(&AppType::Codex, &mut provider, Some(&manager))
-            .expect("no binding should be a no-op");
+        apply_codex_official_auth(&AppType::Codex, &mut provider, Some(&manager))
+            .expect("apply follow-login auth policy");
 
         assert_eq!(
             provider.settings_config.get("auth"),
             Some(&original_auth),
-            "unbound official providers must keep native Codex auth instead of using the managed default account"
+            "follow-login providers must preserve their historical auth snapshot instead of using the managed default"
         );
+    }
+
+    #[test]
+    fn follow_login_backfill_preserves_latest_live_tokens() {
+        let mut provider = Provider::with_id(
+            "follow-login".to_string(),
+            "OpenAI Official".to_string(),
+            json!({ "auth": {}, "config": "" }),
+            None,
+        );
+        provider.category = Some("official".to_string());
+        let mut live_settings = json!({
+            "auth": {
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": "live-access-secret",
+                    "refresh_token": "live-refresh-secret"
+                }
+            },
+            "config": ""
+        });
+
+        strip_codex_managed_oauth_auth_for_backfill(&provider, &mut live_settings);
+
+        assert_eq!(
+            live_settings["auth"]["tokens"]["refresh_token"],
+            json!("live-refresh-secret")
+        );
+    }
+
+    #[test]
+    fn category_less_fixed_follow_login_backfill_preserves_auth_and_strips_live_only_config() {
+        let provider = Provider::with_id(
+            crate::database::CODEX_OFFICIAL_PROVIDER_ID.to_string(),
+            "OpenAI Official".to_string(),
+            json!({ "auth": {}, "config": "" }),
+            None,
+        );
+        let injected_config = crate::codex_config::inject_codex_unified_session_bucket("")
+            .expect("inject unified session bucket");
+        let live_settings = json!({
+            "auth": {
+                "auth_mode": "chatgpt",
+                "tokens": { "refresh_token": "live-refresh-secret" }
+            },
+            "config": injected_config
+        });
+
+        let backfilled =
+            restore_live_settings_for_provider_backfill(&AppType::Codex, &provider, live_settings);
+
+        assert_eq!(
+            backfilled["auth"]["tokens"]["refresh_token"],
+            json!("live-refresh-secret")
+        );
+        assert_eq!(backfilled["config"], json!(""));
     }
 
     #[test]

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -71,7 +71,9 @@ pub fn reapply_current_codex_official_live(state: &AppState) -> Result<bool, App
     let Some(provider) = providers.get(&current_id) else {
         return Ok(false);
     };
-    if provider.category.as_deref() != Some("official") {
+    if provider.category.as_deref() != Some("official")
+        && !crate::proxy::providers::is_codex_official_provider(provider)
+    {
         return Ok(false);
     }
 
@@ -732,173 +734,46 @@ mod tests {
     }
 
     #[test]
-    fn codex_official_card_identity_keeps_one_native_login_card() {
-        let fixed_managed =
-            managed_codex_provider(crate::database::CODEX_OFFICIAL_PROVIDER_ID, "acct-managed");
-        assert!(ProviderService::validate_codex_official_card_identity(
-            &AppType::Codex,
-            &fixed_managed,
-            None,
-        )
-        .is_err());
-        let mut fixed_with_legacy_category = fixed_managed.clone();
-        fixed_with_legacy_category.category = None;
-        assert!(ProviderService::validate_codex_official_card_identity(
-            &AppType::Codex,
-            &fixed_with_legacy_category,
-            None,
-        )
-        .is_err());
-
-        let managed = managed_codex_provider("managed-official", "acct-managed");
-        ProviderService::validate_codex_official_card_identity(&AppType::Codex, &managed, None)
-            .expect("a managed account may use its own Official card");
-
-        let mut second_unbound = Provider::with_id(
-            "second-unbound".to_string(),
-            "Second Unbound".to_string(),
-            json!({ "auth": {}, "config": "" }),
-            None,
-        );
-        second_unbound.category = Some("official".to_string());
-        assert!(ProviderService::validate_codex_official_card_identity(
-            &AppType::Codex,
-            &second_unbound,
-            None,
-        )
-        .is_err());
-        ProviderService::validate_codex_official_card_identity(
-            &AppType::Codex,
-            &second_unbound,
-            Some(&second_unbound),
-        )
-        .expect("legacy unbound rows remain editable without forced migration");
-
-        let mut unbound_update = second_unbound.clone();
-        unbound_update.id = managed.id.clone();
-        assert!(ProviderService::validate_codex_official_card_identity(
-            &AppType::Codex,
-            &unbound_update,
-            Some(&managed),
-        )
-        .is_err());
-    }
-
-    #[test]
     #[serial]
-    fn update_promotes_one_legacy_unbound_codex_card_to_native_login() {
+    fn add_accepts_multiple_unbound_codex_official_cards() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
-            let legacy_id = "legacy-openai-official";
+            state
+                .db
+                .init_default_official_providers()
+                .expect("seed official providers");
             let fixed_id = crate::database::CODEX_OFFICIAL_PROVIDER_ID;
-            let mut legacy = Provider::with_id(
-                legacy_id.to_string(),
-                "Legacy OpenAI Official".to_string(),
-                json!({ "auth": {}, "config": "" }),
-                None,
-            );
-            legacy.category = Some("official".to_string());
             state
                 .db
-                .save_provider(AppType::Codex.as_str(), &legacy)
-                .expect("save legacy card");
-            state
-                .db
-                .set_current_provider(AppType::Codex.as_str(), legacy_id)
+                .set_current_provider(AppType::Codex.as_str(), fixed_id)
                 .expect("set database current");
-            crate::settings::set_current_provider(&AppType::Codex, Some(legacy_id))
+            crate::settings::set_current_provider(&AppType::Codex, Some(fixed_id))
                 .expect("set local current");
 
-            let mut promoted = legacy.clone();
-            promoted.id = fixed_id.to_string();
-            let live_before = crate::codex_config::CodexLiveStateSnapshot::capture()
-                .expect("capture live before failed promotion");
-            {
-                let conn = state.db.conn.lock().expect("lock database");
-                conn.execute_batch(
-                    "CREATE TRIGGER reject_legacy_promotion
-                     BEFORE INSERT ON providers
-                     WHEN NEW.app_type = 'codex' AND NEW.id = 'codex-official'
-                     BEGIN
-                       SELECT RAISE(ABORT, 'forced legacy promotion failure');
-                     END;",
-                )
-                .expect("install promotion failure trigger");
-            }
-            ProviderService::update(state, AppType::Codex, Some(legacy_id), promoted.clone())
-                .expect_err("failed promotion should roll back");
-            assert_eq!(
-                crate::codex_config::CodexLiveStateSnapshot::capture()
-                    .expect("capture live after rollback"),
-                live_before
-            );
-            assert!(state
-                .db
-                .get_provider_by_id(legacy_id, AppType::Codex.as_str())
-                .expect("query legacy card after rollback")
-                .is_some());
-            assert_eq!(
-                crate::settings::get_current_provider(&AppType::Codex).as_deref(),
-                Some(legacy_id)
-            );
-            {
-                let conn = state.db.conn.lock().expect("lock database");
-                conn.execute_batch("DROP TRIGGER reject_legacy_promotion;")
-                    .expect("remove promotion failure trigger");
+            for id in ["follow-login-a", "follow-login-b"] {
+                let mut provider = Provider::with_id(
+                    id.to_string(),
+                    id.to_string(),
+                    json!({ "auth": {}, "config": "" }),
+                    None,
+                );
+                provider.category = Some("official".to_string());
+                ProviderService::add(state, AppType::Codex, provider, false)
+                    .expect("add unbound Official card");
             }
 
-            ProviderService::update(state, AppType::Codex, Some(legacy_id), promoted)
-                .expect("promote legacy card");
-
-            assert!(state
+            let providers = state
                 .db
-                .get_provider_by_id(legacy_id, AppType::Codex.as_str())
-                .expect("query legacy card")
-                .is_none());
-            assert!(state
-                .db
-                .get_provider_by_id(fixed_id, AppType::Codex.as_str())
-                .expect("query native card")
-                .is_some());
-            assert_eq!(
-                state
-                    .db
-                    .get_current_provider(AppType::Codex.as_str())
-                    .expect("read database current")
-                    .as_deref(),
-                Some(fixed_id)
-            );
-            assert_eq!(
-                crate::settings::get_current_provider(&AppType::Codex).as_deref(),
-                Some(fixed_id)
-            );
-
-            let mut second_legacy = legacy;
-            second_legacy.id = "second-legacy-official".to_string();
-            state
-                .db
-                .save_provider(AppType::Codex.as_str(), &second_legacy)
-                .expect("save second legacy card");
-            let mut conflicting_promotion = second_legacy.clone();
-            conflicting_promotion.id = fixed_id.to_string();
-            assert!(ProviderService::update(
-                state,
-                AppType::Codex,
-                Some(&second_legacy.id),
-                conflicting_promotion,
-            )
-            .is_err());
-            assert!(state
-                .db
-                .get_provider_by_id(&second_legacy.id, AppType::Codex.as_str())
-                .expect("query second legacy card")
-                .is_some());
+                .get_all_providers(AppType::Codex.as_str())
+                .expect("read providers");
+            assert!(providers.contains_key("follow-login-a"));
+            assert!(providers.contains_key("follow-login-b"));
         });
     }
 
     #[test]
     #[serial]
-    fn update_switches_one_official_card_between_native_and_managed_login() {
+    fn update_keeps_official_provider_id_when_binding_and_unbinding() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
             tauri::async_runtime::block_on(async {
@@ -913,326 +788,77 @@ mod tests {
                     .expect("seed managed account");
             });
 
-            let fixed_id = crate::database::CODEX_OFFICIAL_PROVIDER_ID;
-            let managed_id = "managed-official-transition";
-            let mut native = Provider::with_id(
-                fixed_id.to_string(),
+            let provider_id = crate::database::CODEX_OFFICIAL_PROVIDER_ID;
+            let mut unbound = Provider::with_id(
+                provider_id.to_string(),
                 "OpenAI Official".to_string(),
                 json!({ "auth": {}, "config": "" }),
                 None,
             );
-            native.category = Some("official".to_string());
+            unbound.category = Some("official".to_string());
             state
                 .db
-                .save_provider(AppType::Codex.as_str(), &native)
-                .expect("save native card");
+                .save_provider(AppType::Codex.as_str(), &unbound)
+                .expect("save unbound card");
             state
                 .db
-                .add_to_failover_queue(AppType::Codex.as_str(), fixed_id)
-                .expect("seed failover state");
-            state
-                .db
-                .add_custom_endpoint(
-                    AppType::Codex.as_str(),
-                    fixed_id,
-                    "https://endpoint.example/v1",
-                )
-                .expect("seed endpoint");
-            tauri::async_runtime::block_on(state.db.update_provider_health_with_threshold(
-                fixed_id,
-                AppType::Codex.as_str(),
-                false,
-                Some("seed failure".to_string()),
-                1,
-            ))
-            .expect("seed health");
-            state
-                .db
-                .set_current_provider(AppType::Codex.as_str(), fixed_id)
+                .set_current_provider(AppType::Codex.as_str(), provider_id)
                 .expect("set database current");
-            crate::settings::set_current_provider(&AppType::Codex, Some(fixed_id))
+            crate::settings::set_current_provider(&AppType::Codex, Some(provider_id))
                 .expect("set local current");
 
-            let mut managed = managed_codex_provider(managed_id, "acct-managed");
-            managed.name = native.name.clone();
-            ProviderService::update(state, AppType::Codex, Some(fixed_id), managed.clone())
-                .expect("switch native card to managed account");
+            let mut bound = managed_codex_provider(provider_id, "acct-managed");
+            bound.name = unbound.name.clone();
+            ProviderService::update(state, AppType::Codex, Some(provider_id), bound)
+                .expect("bind managed account");
 
-            assert!(state
+            let saved_bound = state
                 .db
-                .get_provider_by_id(fixed_id, AppType::Codex.as_str())
-                .expect("query native card")
-                .is_none());
-            let saved_managed = state
-                .db
-                .get_provider_by_id(managed_id, AppType::Codex.as_str())
-                .expect("query managed card")
-                .expect("managed card should exist");
+                .get_provider_by_id(provider_id, AppType::Codex.as_str())
+                .expect("query bound card")
+                .expect("bound card should keep its ID");
             assert_eq!(
-                ProviderService::managed_codex_oauth_account_id(&saved_managed).as_deref(),
+                ProviderService::managed_codex_oauth_account_id(&saved_bound).as_deref(),
                 Some("acct-managed")
             );
-            assert!(saved_managed.in_failover_queue);
-            let listed_managed = state
-                .db
-                .get_all_providers(AppType::Codex.as_str())
-                .expect("list managed card")
-                .swap_remove(managed_id)
-                .expect("managed card should be listed");
-            assert!(listed_managed.meta.as_ref().is_some_and(|meta| meta
-                .custom_endpoints
-                .contains_key("https://endpoint.example/v1")));
-            assert!(
-                !tauri::async_runtime::block_on(
-                    state
-                        .db
-                        .get_provider_health(managed_id, AppType::Codex.as_str())
-                )
-                .expect("read migrated health")
-                .is_healthy
-            );
             assert_eq!(
                 state
                     .db
                     .get_current_provider(AppType::Codex.as_str())
                     .expect("read database current")
                     .as_deref(),
-                Some(managed_id)
+                Some(provider_id)
             );
             assert_eq!(
                 crate::settings::get_current_provider(&AppType::Codex).as_deref(),
-                Some(managed_id)
+                Some(provider_id)
             );
 
-            let mut native_again = native;
-            native_again.id = fixed_id.to_string();
-            ProviderService::update(state, AppType::Codex, Some(managed_id), native_again)
-                .expect("switch managed card back to native login");
-
-            assert!(state
-                .db
-                .get_provider_by_id(managed_id, AppType::Codex.as_str())
-                .expect("query old managed card")
-                .is_none());
-            let saved_native = state
-                .db
-                .get_provider_by_id(fixed_id, AppType::Codex.as_str())
-                .expect("query restored native card")
-                .expect("native card should exist");
-            assert!(ProviderService::managed_codex_oauth_account_id(&saved_native).is_none());
-            assert!(saved_native.in_failover_queue);
-            let listed_native = state
-                .db
-                .get_all_providers(AppType::Codex.as_str())
-                .expect("list restored native card")
-                .swap_remove(fixed_id)
-                .expect("native card should be listed");
-            assert!(listed_native.meta.as_ref().is_some_and(|meta| meta
-                .custom_endpoints
-                .contains_key("https://endpoint.example/v1")));
-            assert!(
-                !tauri::async_runtime::block_on(
-                    state
-                        .db
-                        .get_provider_health(fixed_id, AppType::Codex.as_str())
-                )
-                .expect("read restored health")
-                .is_healthy
+            unbound.settings_config["config"] = Value::String(
+                crate::codex_config::inject_codex_unified_session_bucket("")
+                    .expect("inject live-only unified session route"),
             );
-            assert_eq!(
-                state
-                    .db
-                    .get_current_provider(AppType::Codex.as_str())
-                    .expect("read restored database current")
-                    .as_deref(),
-                Some(fixed_id)
-            );
-            assert_eq!(
-                crate::settings::get_current_provider(&AppType::Codex).as_deref(),
-                Some(fixed_id)
-            );
+            ProviderService::update(state, AppType::Codex, Some(provider_id), unbound)
+                .expect("unbind managed account");
 
-            let conflicting_managed_id = "second-managed-official";
-            state
+            let saved_unbound = state
                 .db
-                .save_provider(
-                    AppType::Codex.as_str(),
-                    &managed_codex_provider(conflicting_managed_id, "acct-managed"),
-                )
-                .expect("save second managed card");
-            assert!(ProviderService::update(
-                state,
-                AppType::Codex,
-                Some(conflicting_managed_id),
-                saved_native,
-            )
-            .is_err());
-            assert!(state
-                .db
-                .get_provider_by_id(conflicting_managed_id, AppType::Codex.as_str())
-                .expect("query rejected source card")
-                .is_some());
-        });
-    }
-
-    #[test]
-    #[serial]
-    fn legacy_fixed_codex_account_binding_migrates_without_changing_selection() {
-        with_test_home(|state, _| {
-            crate::settings::reload_settings().expect("reload settings");
-            state
-                .db
-                .init_default_official_providers()
-                .expect("seed official providers");
-            let fixed_id = crate::database::CODEX_OFFICIAL_PROVIDER_ID;
-            let mut fixed = state
-                .db
-                .get_provider_by_id(fixed_id, AppType::Codex.as_str())
-                .expect("read fixed provider")
-                .expect("fixed provider exists");
-            fixed.settings_config["auth"] = json!({ "OPENAI_API_KEY": "legacy-live-token" });
-            fixed.meta = Some(ProviderMeta {
-                provider_type: Some("codex_oauth".to_string()),
-                auth_binding: Some(AuthBinding {
-                    source: AuthBindingSource::ManagedAccount,
-                    auth_provider: Some("codex_oauth".to_string()),
-                    account_id: Some("account-a".to_string()),
-                }),
-                ..Default::default()
-            });
-            state
-                .db
-                .save_provider(AppType::Codex.as_str(), &fixed)
-                .expect("save legacy binding");
-            state
-                .db
-                .set_current_provider(AppType::Codex.as_str(), fixed_id)
-                .expect("set database current");
-            state
-                .db
-                .add_to_failover_queue(AppType::Codex.as_str(), fixed_id)
-                .expect("seed stale failover membership");
-            crate::settings::set_current_provider(&AppType::Codex, Some(fixed_id))
-                .expect("set local current");
-
-            let managed_id = ProviderService::migrate_legacy_codex_official_managed_binding(state)
-                .expect("migrate legacy binding")
-                .expect("migration occurred");
-
-            let native = state
-                .db
-                .get_provider_by_id(fixed_id, AppType::Codex.as_str())
-                .expect("read native card")
-                .expect("native card remains");
-            assert!(ProviderService::managed_codex_oauth_account_id(&native).is_none());
-            assert_eq!(native.settings_config["auth"], json!({}));
-            assert!(!native.in_failover_queue);
-
-            let managed = state
-                .db
-                .get_provider_by_id(&managed_id, AppType::Codex.as_str())
-                .expect("read managed card")
-                .expect("managed card exists");
-            assert_eq!(
-                ProviderService::managed_codex_oauth_account_id(&managed).as_deref(),
-                Some("account-a")
-            );
-            assert_eq!(
-                managed.settings_config["auth"]["OPENAI_API_KEY"],
-                json!("legacy-live-token")
-            );
-            assert!(!managed.in_failover_queue);
+                .get_provider_by_id(provider_id, AppType::Codex.as_str())
+                .expect("query unbound card")
+                .expect("unbound card should keep its ID");
+            assert!(ProviderService::managed_codex_oauth_account_id(&saved_unbound).is_none());
+            assert_eq!(saved_unbound.settings_config["config"], json!(""));
             assert_eq!(
                 state
                     .db
                     .get_current_provider(AppType::Codex.as_str())
                     .expect("read database current")
                     .as_deref(),
-                Some(managed_id.as_str())
+                Some(provider_id)
             );
             assert_eq!(
                 crate::settings::get_current_provider(&AppType::Codex).as_deref(),
-                Some(managed_id.as_str())
-            );
-        });
-    }
-
-    #[test]
-    #[serial]
-    fn legacy_fixed_codex_migration_resumes_only_its_exact_clone() {
-        with_test_home(|state, _| {
-            crate::settings::reload_settings().expect("reload settings");
-            let fixed_id = crate::database::CODEX_OFFICIAL_PROVIDER_ID;
-            let mut fixed = managed_codex_provider(fixed_id, "account-a");
-            fixed.name = "Legacy OpenAI Official".to_string();
-            fixed.category = None;
-            fixed.settings_config["config"] = json!("model = \"gpt-5.4\"\n");
-            fixed.created_at = Some(10);
-            fixed.sort_index = Some(1);
-            fixed.in_failover_queue = true;
-            state
-                .db
-                .save_provider(AppType::Codex.as_str(), &fixed)
-                .expect("save legacy binding");
-
-            let mut stale = fixed.clone();
-            stale.id = "stale-same-account".to_string();
-            stale.name = "Different settings".to_string();
-            stale.created_at = Some(20);
-            stale.sort_index = Some(2);
-            stale.in_failover_queue = false;
-            state
-                .db
-                .save_provider(AppType::Codex.as_str(), &stale)
-                .expect("save unrelated same-account card");
-
-            let mut interrupted_clone = fixed.clone();
-            interrupted_clone.id = "interrupted-clone".to_string();
-            interrupted_clone.created_at = Some(30);
-            interrupted_clone.sort_index = Some(3);
-            interrupted_clone.category = Some("official".to_string());
-            interrupted_clone.in_failover_queue = false;
-            state
-                .db
-                .save_provider(AppType::Codex.as_str(), &interrupted_clone)
-                .expect("save interrupted migration clone");
-            state
-                .db
-                .set_current_provider(AppType::Codex.as_str(), &interrupted_clone.id)
-                .expect("simulate migrated database current");
-            crate::settings::set_current_provider(&AppType::Codex, Some(fixed_id))
-                .expect("leave local current unfinished");
-
-            let managed_id = ProviderService::migrate_legacy_codex_official_managed_binding(state)
-                .expect("resume migration")
-                .expect("migration resumed");
-
-            assert_eq!(managed_id, interrupted_clone.id);
-            assert_eq!(
-                state
-                    .db
-                    .get_all_providers(AppType::Codex.as_str())
-                    .expect("read providers")
-                    .len(),
-                3,
-                "resume must neither reuse the stale card nor create another clone"
-            );
-            let native = state
-                .db
-                .get_provider_by_id(fixed_id, AppType::Codex.as_str())
-                .expect("read native card")
-                .expect("native card remains");
-            assert_eq!(native.category.as_deref(), Some("official"));
-            assert!(ProviderService::managed_codex_oauth_account_id(&native).is_none());
-            let managed = state
-                .db
-                .get_provider_by_id(&managed_id, AppType::Codex.as_str())
-                .expect("read managed card")
-                .expect("managed card remains");
-            assert_eq!(managed.category.as_deref(), Some("official"));
-            assert_eq!(
-                crate::settings::get_current_provider(&AppType::Codex).as_deref(),
-                Some(interrupted_clone.id.as_str())
+                Some(provider_id)
             );
         });
     }
@@ -4306,181 +3932,6 @@ impl ProviderService {
             .filter(|id| !id.is_empty())
     }
 
-    fn validate_codex_official_card_identity(
-        app_type: &AppType,
-        provider: &Provider,
-        existing_provider: Option<&Provider>,
-    ) -> Result<(), AppError> {
-        if !matches!(app_type, AppType::Codex) {
-            return Ok(());
-        }
-
-        let is_native_login_card = provider.id == crate::database::CODEX_OFFICIAL_PROVIDER_ID;
-        let has_managed_account = Self::managed_codex_oauth_account_id(provider).is_some();
-
-        if is_native_login_card && has_managed_account {
-            return Err(AppError::localized(
-                "provider.codex.nativeLoginCard.cannotBind",
-                "Codex 当前登录卡片不能绑定托管账号，请新增一张 OpenAI Official 卡片",
-                "The Codex current-login card cannot bind a managed account; add another OpenAI Official card instead",
-            ));
-        }
-        if provider.category.as_deref() != Some("official") {
-            return Ok(());
-        }
-        let preserves_legacy_unbound_card = existing_provider.is_some_and(|existing| {
-            existing.id != crate::database::CODEX_OFFICIAL_PROVIDER_ID
-                && existing.category.as_deref() == Some("official")
-                && Self::managed_codex_oauth_account_id(existing).is_none()
-        });
-        if !is_native_login_card && !has_managed_account && !preserves_legacy_unbound_card {
-            return Err(AppError::localized(
-                "provider.codex.managedOfficial.accountRequired",
-                "新增的 OpenAI Official 卡片必须绑定托管账号",
-                "A new OpenAI Official card must bind a managed account",
-            ));
-        }
-
-        Ok(())
-    }
-
-    fn matches_interrupted_codex_official_migration(
-        original: &Provider,
-        candidate: &Provider,
-    ) -> bool {
-        let mut expected = original.clone();
-        expected.id = candidate.id.clone();
-        expected.category = Some("official".to_string());
-        expected.created_at = candidate.created_at;
-        expected.sort_index = candidate.sort_index;
-        expected.in_failover_queue = candidate.in_failover_queue;
-        serde_json::to_value(expected).ok() == serde_json::to_value(candidate).ok()
-    }
-
-    /// Upgrade the early PR shape where a managed account was bound directly
-    /// to the fixed `codex-official` row. The account keeps an independent row
-    /// and remains selected, while the fixed ID returns to native-login use.
-    pub(crate) fn migrate_legacy_codex_official_managed_binding(
-        state: &AppState,
-    ) -> Result<Option<String>, AppError> {
-        let app_type = AppType::Codex;
-        let app_type_str = app_type.as_str();
-        let fixed_id = crate::database::CODEX_OFFICIAL_PROVIDER_ID;
-        let Some(original) = state.db.get_provider_by_id(fixed_id, app_type_str)? else {
-            // Deleting the native-login card is supported. It is recreated only
-            // when the user explicitly adds "Use Codex current login" again.
-            return Ok(None);
-        };
-        let Some(account_id) = Self::managed_codex_oauth_account_id(&original) else {
-            return Ok(None);
-        };
-
-        let db_current = state.db.get_current_provider(app_type_str)?;
-        let local_current = crate::settings::get_current_provider(&app_type);
-        let providers = state.db.get_all_providers(app_type_str)?;
-        let existing_managed = providers.values().find(|provider| {
-            provider.id != fixed_id
-                && provider.category.as_deref() == Some("official")
-                && Self::managed_codex_oauth_account_id(provider).as_deref()
-                    == Some(account_id.as_str())
-                && Self::matches_interrupted_codex_official_migration(&original, provider)
-        });
-        let new_id = existing_managed
-            .map(|provider| provider.id.clone())
-            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-        let managed_to_create = existing_managed.is_none().then(|| {
-            let mut managed = original.clone();
-            managed.id = new_id.clone();
-            managed.created_at = Some(chrono::Utc::now().timestamp_millis());
-            managed.sort_index = Some(
-                providers
-                    .values()
-                    .filter_map(|provider| provider.sort_index)
-                    .max()
-                    .map_or(0, |index| index + 1),
-            );
-            managed.category = Some("official".to_string());
-            managed.in_failover_queue = false;
-            managed
-        });
-
-        let mut native = original.clone();
-        native.category = Some("official".to_string());
-        native.in_failover_queue = false;
-        if let Some(root) = native.settings_config.as_object_mut() {
-            root.insert("auth".to_string(), serde_json::json!({}));
-        }
-        if let Some(meta) = native.meta.as_mut() {
-            meta.auth_binding = None;
-            if meta.provider_type.as_deref() == Some("codex_oauth") {
-                meta.provider_type = None;
-            }
-        }
-
-        let migrate_result = (|| -> Result<(), AppError> {
-            if let Some(managed) = managed_to_create.as_ref() {
-                state.db.save_provider(app_type_str, managed)?;
-            }
-            if db_current.as_deref() == Some(fixed_id) {
-                state.db.set_current_provider(app_type_str, &new_id)?;
-            }
-            if local_current.as_deref() == Some(fixed_id) {
-                crate::settings::set_current_provider(&app_type, Some(&new_id))?;
-            }
-            state
-                .db
-                .remove_from_failover_queue(app_type_str, fixed_id)?;
-            // Clearing the fixed binding is the completion marker. If the
-            // process exits before this final write, the next startup can find
-            // the matching managed clone and resume the remaining steps.
-            state.db.save_provider(app_type_str, &native)?;
-            Ok(())
-        })();
-
-        if let Err(error) = migrate_result {
-            let mut rollback_failures = Vec::new();
-            if let Err(rollback_error) = state.db.save_provider(app_type_str, &original) {
-                rollback_failures.push(format!("restore fixed row: {rollback_error}"));
-            }
-            if original.in_failover_queue {
-                if let Err(rollback_error) = state.db.add_to_failover_queue(app_type_str, fixed_id)
-                {
-                    rollback_failures
-                        .push(format!("restore failover membership: {rollback_error}"));
-                }
-            }
-            if let Some(current_id) = db_current.as_deref() {
-                if let Err(rollback_error) = state.db.set_current_provider(app_type_str, current_id)
-                {
-                    rollback_failures.push(format!("restore database current: {rollback_error}"));
-                }
-            }
-            if managed_to_create.is_some() {
-                if let Err(rollback_error) = state.db.delete_provider(app_type_str, &new_id) {
-                    rollback_failures.push(format!("remove migrated row: {rollback_error}"));
-                }
-            }
-            if local_current.as_deref() == Some(fixed_id) {
-                if let Err(rollback_error) =
-                    crate::settings::set_current_provider(&app_type, Some(fixed_id))
-                {
-                    rollback_failures.push(format!("restore local current: {rollback_error}"));
-                }
-            }
-
-            return if rollback_failures.is_empty() {
-                Err(error)
-            } else {
-                Err(AppError::Message(format!(
-                    "迁移旧 Codex Official 账号卡失败: {error}; 回滚失败: {}",
-                    rollback_failures.join("; ")
-                )))
-            };
-        }
-
-        Ok(Some(new_id))
-    }
-
     /// 提交 current（settings/DB）前的预检：若目标是托管 Codex official provider，
     /// 先解析一次有效 live 配置（会联网换取并缓存 token）。同时返回这份已解析配置，
     /// 让后续落盘直接复用同一 token bundle，避免一次操作重复解析/刷新。
@@ -4833,7 +4284,6 @@ impl ProviderService {
         // Normalize Claude model keys
         Self::normalize_provider_if_claude(&app_type, &mut provider);
         Self::validate_provider_settings(&app_type, &provider)?;
-        Self::validate_codex_official_card_identity(&app_type, &provider, None)?;
         normalize_provider_common_config_for_storage(state.db.as_ref(), &app_type, &mut provider)?;
         Self::normalize_usage_script_credential_overrides(&app_type, &mut provider);
         if app_type.is_additive_mode() {
@@ -4970,85 +4420,15 @@ impl ProviderService {
         // Normalize Claude model keys
         Self::normalize_provider_if_claude(&app_type, &mut provider);
         Self::validate_provider_settings(&app_type, &provider)?;
-        Self::validate_codex_official_card_identity(
-            &app_type,
-            &provider,
-            existing_provider.as_ref(),
-        )?;
         normalize_provider_common_config_for_storage(state.db.as_ref(), &app_type, &mut provider)?;
+        if matches!(app_type, AppType::Codex) && provider.category.as_deref() == Some("official") {
+            crate::codex_config::strip_codex_unified_session_bucket_from_settings(
+                &mut provider.settings_config,
+            )?;
+        }
         Self::normalize_usage_script_credential_overrides(&app_type, &mut provider);
 
-        // A legacy unbound Official row may become the one fixed native-login
-        // row only when that fixed row is currently absent. No other Codex ID
-        // change is allowed.
-        let promotes_legacy_codex_native_login = provider_id_changed
-            && matches!(app_type, AppType::Codex)
-            && provider.id == crate::database::CODEX_OFFICIAL_PROVIDER_ID
-            && provider.category.as_deref() == Some("official")
-            && Self::managed_codex_oauth_account_id(&provider).is_none()
-            && existing_provider.as_ref().is_some_and(|existing| {
-                existing.id != crate::database::CODEX_OFFICIAL_PROVIDER_ID
-                    && existing.category.as_deref() == Some("official")
-                    && Self::managed_codex_oauth_account_id(existing).is_none()
-            });
-
-        // Switching the same Official card between native login and a managed
-        // account changes its storage identity: only the native card owns the
-        // fixed ID. Keep this exception narrower than general provider renames.
-        let switches_codex_official_auth_mode = provider_id_changed
-            && matches!(app_type, AppType::Codex)
-            && provider.category.as_deref() == Some("official")
-            && existing_provider.as_ref().is_some_and(|existing| {
-                if existing.category.as_deref() != Some("official") {
-                    return false;
-                }
-                let fixed_id = crate::database::CODEX_OFFICIAL_PROVIDER_ID;
-                let existing_is_native_id = existing.id == fixed_id;
-                let target_is_native_id = provider.id == fixed_id;
-                let existing_has_managed_account =
-                    Self::managed_codex_oauth_account_id(existing).is_some();
-                let target_has_managed_account =
-                    Self::managed_codex_oauth_account_id(&provider).is_some();
-
-                (existing_is_native_id && !target_is_native_id && target_has_managed_account)
-                    || (!existing_is_native_id
-                        && existing_has_managed_account
-                        && target_is_native_id
-                        && !target_has_managed_account)
-            });
-        let replaces_codex_official_identity =
-            promotes_legacy_codex_native_login || switches_codex_official_auth_mode;
-
-        if switches_codex_official_auth_mode
-            && state
-                .db
-                .get_provider_by_id(&provider.id, app_type.as_str())?
-                .is_some()
-        {
-            return Err(AppError::localized(
-                "provider.codex.nativeLoginCard.alreadyExists",
-                "目标登录方式已被另一张 OpenAI Official 卡片使用",
-                "The target login mode is already used by another OpenAI Official card",
-            ));
-        }
-
-        if promotes_legacy_codex_native_login
-            && state
-                .db
-                .get_provider_by_id(&provider.id, app_type.as_str())?
-                .is_some()
-        {
-            return Err(AppError::localized(
-                "provider.codex.nativeLoginCard.alreadyExists",
-                "跟随 Codex 登录卡片已存在",
-                "The Follow Codex login card already exists",
-            ));
-        }
-
-        if provider_id_changed
-            && !promotes_legacy_codex_native_login
-            && !switches_codex_official_auth_mode
-        {
+        if provider_id_changed {
             if !app_type.is_additive_mode() {
                 return Err(AppError::Message(
                     "Only additive-mode providers support changing provider key".to_string(),
@@ -5181,12 +4561,7 @@ impl ProviderService {
         // For other apps: Check if this is current provider (use effective current, not just DB)
         let effective_current =
             crate::settings::get_effective_current_provider(&state.db, &app_type)?;
-        let current_identity = if replaces_codex_official_identity {
-            original_id.as_str()
-        } else {
-            provider.id.as_str()
-        };
-        let is_current = effective_current.as_deref() == Some(current_identity);
+        let is_current = effective_current.as_deref() == Some(provider.id.as_str());
 
         let existing_managed_codex_account_id = existing_provider
             .as_ref()
@@ -5197,29 +4572,19 @@ impl ProviderService {
             existing_provider.as_ref(),
             &provider,
         );
-        let codex_identity_transaction = matches!(app_type, AppType::Codex)
+        let managed_codex_update = matches!(app_type, AppType::Codex)
             && (existing_managed_codex_account_id.is_some()
-                || target_managed_codex_account_id.is_some()
-                || promotes_legacy_codex_native_login);
+                || target_managed_codex_account_id.is_some());
 
-        if codex_identity_transaction {
-            // A non-current identity update still commits under the same lock:
-            // once the row is saved, a waiting switch must not observe the old ID
-            // or binding.
+        if managed_codex_update {
+            // A non-current managed row still commits under the same lock: once
+            // the row is saved, a waiting switch observes the new binding. If we
+            // released first, a switch could activate the old binding and leave
+            // DB current/live inconsistent with the subsequent save.
             if !is_current {
-                if replaces_codex_official_identity {
-                    state
-                        .db
-                        .replace_provider_id(app_type.as_str(), &original_id, &provider)?;
-                } else {
-                    state.db.save_provider(app_type.as_str(), &provider)?;
-                }
+                state.db.save_provider(app_type.as_str(), &provider)?;
                 return Ok(true);
             }
-
-            let previous_local_current = crate::settings::get_current_provider(&app_type);
-            let migrates_local_current = replaces_codex_official_identity
-                && previous_local_current.as_deref() == Some(original_id.as_str());
 
             let outgoing_live_refresh_token = Self::prepare_outgoing_managed_codex_live_auth(
                 state,
@@ -5257,28 +4622,15 @@ impl ProviderService {
                         outgoing_managed_codex_account_id.as_deref(),
                         outgoing_live_refresh_token.as_deref(),
                     )?;
-                    if migrates_local_current {
-                        crate::settings::set_current_provider(
-                            &app_type,
-                            Some(provider.id.as_str()),
-                        )?;
-                    }
-                    if replaces_codex_official_identity {
-                        state
-                            .db
-                            .replace_provider_id(app_type.as_str(), &original_id, &provider)?;
-                    } else {
-                        state.db.save_provider(app_type.as_str(), &provider)?;
-                    }
+                    state.db.save_provider(app_type.as_str(), &provider)?;
                     Ok::<(), AppError>(())
                 })();
                 if let Err(error) = commit_result {
                     return Err(Self::managed_codex_transaction_error(
-                        "更新 Codex provider",
+                        "更新托管 Codex provider",
                         error,
                         &snapshot,
-                        migrates_local_current
-                            .then_some((&app_type, previous_local_current.as_deref())),
+                        None,
                     ));
                 }
 
@@ -5340,16 +4692,7 @@ impl ProviderService {
 
                 // DB is the final commit. Every fallible side effect above can be
                 // restored exactly while the previous provider row is untouched.
-                if migrates_local_current {
-                    crate::settings::set_current_provider(&app_type, Some(provider.id.as_str()))?;
-                }
-                if replaces_codex_official_identity {
-                    state
-                        .db
-                        .replace_provider_id(app_type.as_str(), &original_id, &provider)?;
-                } else {
-                    state.db.save_provider(app_type.as_str(), &provider)?;
-                }
+                state.db.save_provider(app_type.as_str(), &provider)?;
                 Ok::<(), AppError>(())
             })();
             if let Err(error) = commit_result {
@@ -5359,8 +4702,7 @@ impl ProviderService {
                     error,
                     &snapshot,
                     previous_backup.as_ref(),
-                    migrates_local_current
-                        .then_some((&app_type, previous_local_current.as_deref())),
+                    None,
                 ));
             }
 
@@ -5729,7 +5071,6 @@ impl ProviderService {
             .as_deref()
             .and_then(|current_id| providers.get(current_id))
             .and_then(Self::managed_codex_oauth_account_id);
-
         let mut backfill_completed = false;
         if let Some(current_id) = current_id {
             if current_id != id {
@@ -5863,7 +5204,8 @@ impl ProviderService {
         // failing the switch here would report a switch that in fact happened.
         if matches!(app_type, AppType::Codex)
             && backfill_completed
-            && provider.category.as_deref() == Some("official")
+            && (provider.category.as_deref() == Some("official")
+                || crate::proxy::providers::is_codex_official_provider(provider))
             && target_managed_codex_account_id.is_none()
         {
             let db_auth = provider.settings_config.get("auth");

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2821,6 +2821,7 @@ impl ProxyService {
         };
 
         if matches!(app_type_enum, AppType::Codex) {
+            let is_codex_official = crate::proxy::providers::is_codex_official_provider(provider);
             let existing_backup_value = self
                 .db
                 .get_live_backup(app_type)
@@ -2859,7 +2860,7 @@ impl ProxyService {
                     Self::preserve_codex_auth_in_backup(
                         &mut effective_settings,
                         existing_value,
-                        crate::proxy::providers::is_codex_official_provider(provider),
+                        is_codex_official,
                     )?;
                 }
             }
@@ -2867,12 +2868,16 @@ impl ProxyService {
             // 统一会话开关：备份是接管释放时恢复 live 的来源，官方配置的
             // 共享 custom 路由注入必须落在备份里，否则恢复后开关失效。
             crate::codex_config::apply_codex_unified_session_bucket_to_settings(
-                provider.category.as_deref(),
+                if is_codex_official {
+                    Some("official")
+                } else {
+                    provider.category.as_deref()
+                },
                 &mut effective_settings,
             )
             .map_err(|e| format!("注入统一会话路由失败: {e}"))?;
 
-            if crate::proxy::providers::is_codex_official_provider(provider) {
+            if is_codex_official {
                 // auth.json keeps rotating independently while takeover is
                 // active. Persisting it in the DB backup would later roll a
                 // valid R1 generation back to the frozen R0 generation.
@@ -3068,21 +3073,22 @@ impl ProxyService {
             }
 
             if has_backup && !live_taken_over && matches!(app_type_enum, AppType::Codex) {
-                let effective_settings =
+                let effective_provider =
                     build_effective_provider_for_live_with_codex_oauth_manager(
                         self.db.as_ref(),
                         &AppType::Codex,
                         &provider,
                         &self.codex_oauth_manager,
                     )
-                    .map_err(|e| format!("构建 Codex 有效配置失败: {e}"))?
-                    .settings_config;
+                    .map_err(|e| format!("构建 Codex 有效配置失败: {e}"))?;
+                let effective_settings = &effective_provider.settings_config;
                 let auth = effective_settings
                     .get("auth")
                     .ok_or_else(|| "Codex 供应商缺少 auth 配置".to_string())?;
                 let config_str = effective_settings.get("config").and_then(|v| v.as_str());
-                let profile =
-                    crate::proxy::providers::resolve_codex_catalog_tool_profile(&provider);
+                let profile = crate::proxy::providers::resolve_codex_catalog_tool_profile(
+                    &effective_provider,
+                );
 
                 if let (Some(account_id), Some(expected_refresh_token)) = (
                     outgoing_managed_codex_account_id.as_deref(),
@@ -3096,8 +3102,8 @@ impl ProxyService {
                 }
 
                 crate::codex_config::write_codex_provider_live_with_catalog(
-                    &effective_settings,
-                    provider.category.as_deref(),
+                    effective_settings,
+                    effective_provider.category.as_deref(),
                     auth,
                     config_str,
                     profile,
@@ -5178,7 +5184,6 @@ wire_api = "responses"
             json!({ "auth": {}, "config": "model = \"gpt-5.4\"\n" }),
             None,
         );
-        managed.category = Some("official".to_string());
         managed.meta = Some(ProviderMeta {
             auth_binding: Some(AuthBinding {
                 source: AuthBindingSource::ManagedAccount,

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -834,8 +834,8 @@ requires_openai_auth = true
                 None,
             ),
         );
-        let mut official_provider = Provider::with_id(
-            "official-provider".to_string(),
+        let official_provider = Provider::with_id(
+            "codex-official".to_string(),
             "OpenAI Official".to_string(),
             json!({
                 "auth": {},
@@ -843,15 +843,14 @@ requires_openai_auth = true
             }),
             None,
         );
-        official_provider.category = Some("official".to_string());
         manager
             .providers
-            .insert("official-provider".to_string(), official_provider);
+            .insert("codex-official".to_string(), official_provider);
     }
 
     let state = create_test_state_with_config(&initial_config).expect("create test state");
 
-    ProviderService::switch(&state, AppType::Codex, "official-provider")
+    ProviderService::switch(&state, AppType::Codex, "codex-official")
         .expect("switch to official provider should succeed without API key");
 
     let auth_value: serde_json::Value =
@@ -1062,8 +1061,8 @@ fn reapply_codex_official_live_resyncs_mcp_servers() {
         let manager = initial_config
             .get_manager_mut(&AppType::Codex)
             .expect("codex manager");
-        let mut official = Provider::with_id(
-            "official-provider".to_string(),
+        let official = Provider::with_id(
+            "codex-official".to_string(),
             "Official".to_string(),
             json!({
                 "auth": {
@@ -1075,10 +1074,9 @@ fn reapply_codex_official_live_resyncs_mcp_servers() {
             }),
             None,
         );
-        official.category = Some("official".to_string());
         manager
             .providers
-            .insert("official-provider".to_string(), official);
+            .insert("codex-official".to_string(), official);
     }
     let servers = initial_config
         .mcp
@@ -1110,7 +1108,7 @@ fn reapply_codex_official_live_resyncs_mcp_servers() {
 
     let state = create_test_state_with_config(&initial_config).expect("create test state");
 
-    ProviderService::switch(&state, AppType::Codex, "official-provider")
+    ProviderService::switch(&state, AppType::Codex, "codex-official")
         .expect("switch to official provider");
     let live = std::fs::read_to_string(cc_switch_lib::get_codex_config_path())
         .expect("read config.toml after switch");

--- a/src/components/providers/AddProviderDialog.tsx
+++ b/src/components/providers/AddProviderDialog.tsx
@@ -35,7 +35,6 @@ interface AddProviderDialogProps {
       providerKey?: string;
       suggestedDefaults?: OpenClawSuggestedDefaults;
       ensureClaudeDesktopOfficialSeed?: boolean;
-      ensureCodexOfficialSeed?: boolean;
       ensureGrokBuildOfficialSeed?: boolean;
     },
   ) => Promise<void> | void;
@@ -165,7 +164,6 @@ export function AddProviderDialog({
         providerKey?: string;
         suggestedDefaults?: OpenClawSuggestedDefaults;
         ensureClaudeDesktopOfficialSeed?: boolean;
-        ensureCodexOfficialSeed?: boolean;
         ensureGrokBuildOfficialSeed?: boolean;
       } = {
         name: values.name.trim(),
@@ -183,14 +181,6 @@ export function AddProviderDialog({
         );
         const preset = claudeDesktopProviderPresets[presetIndex];
         providerData.ensureClaudeDesktopOfficialSeed =
-          values.presetCategory === "official" &&
-          preset?.category === "official";
-      }
-
-      if (appId === "codex" && values.presetId) {
-        const presetIndex = parseInt(values.presetId.replace("codex-", ""));
-        const preset = codexProviderPresets[presetIndex];
-        providerData.ensureCodexOfficialSeed =
           values.presetCategory === "official" &&
           preset?.category === "official";
       }

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -16,9 +16,6 @@ import {
   type AppId,
   type ManagedAuthProvider,
 } from "@/lib/api";
-import { resolveManagedAccountId } from "@/lib/authBinding";
-import { CODEX_OFFICIAL_PROVIDER_ID } from "@/utils/providerCapabilities";
-import { generateUUID } from "@/utils/uuid";
 
 interface EditProviderDialogProps {
   open: boolean;
@@ -240,21 +237,11 @@ export function EditProviderDialog({
         string,
         unknown
       >;
-      const convertsNativeCodexLoginToManagedAccount =
-        appId === "codex" &&
-        provider.id === CODEX_OFFICIAL_PROVIDER_ID &&
-        Boolean(resolveManagedAccountId(values.meta, "codex_oauth")?.trim());
       const nextProviderId =
-        appId === "codex" && values.codexNativeLoginSelected
-          ? CODEX_OFFICIAL_PROVIDER_ID
-          : convertsNativeCodexLoginToManagedAccount
-            ? generateUUID()
-            : (appId === "opencode" ||
-                  appId === "openclaw" ||
-                  appId === "pi") &&
-                values.providerKey?.trim()
-              ? values.providerKey.trim()
-              : provider.id;
+        (appId === "opencode" || appId === "openclaw" || appId === "pi") &&
+        values.providerKey?.trim()
+          ? values.providerKey.trim()
+          : provider.id;
 
       const updatedProvider: Provider = {
         ...provider,

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -32,7 +32,6 @@ import {
 } from "@/utils/providerConfigUtils";
 import { resolveManagedAccountId } from "@/lib/authBinding";
 import {
-  CODEX_OFFICIAL_PROVIDER_ID,
   resolveCodexOfficialIdentity,
   supportsOfficialProxyTakeover,
   providerNeedsRouting,
@@ -299,13 +298,8 @@ export function ProviderCard({
   const isHermesReadOnly =
     appId === "hermes" && isHermesReadOnlyProvider(provider.settingsConfig);
   const isCodexOauth =
-    provider.meta?.providerType === PROVIDER_TYPES.CODEX_OAUTH;
-  const canDuplicate = !(
-    appId === "codex" &&
-    (provider.id === CODEX_OFFICIAL_PROVIDER_ID ||
-      (provider.category === "official" &&
-        !resolveManagedAccountId(provider.meta, "codex_oauth")?.trim()))
-  );
+    provider.meta?.providerType === PROVIDER_TYPES.CODEX_OAUTH &&
+    (appId !== "codex" || codexOfficialIdentity === "managed_account");
   // xAI OAuth (SuperGrok 反代)：额度经自管 OAuth token 自动显示，与 codex_oauth 同构
   const isXaiOauth = provider.meta?.providerType === PROVIDER_TYPES.XAI_OAUTH;
   // 统一权威谓词（详见 providerNeedsRouting）：以 providerType 为准，不受
@@ -516,7 +510,7 @@ export function ProviderCard({
               )}
             </div>
 
-            {codexOfficialIdentity ? (
+            {codexOfficialIdentity && codexOfficialIdentity !== "api_key" ? (
               <div className="flex min-w-0 items-center gap-2 text-sm text-muted-foreground">
                 {codexOfficialIdentity === "native_login" ? (
                   <span className="min-w-0 truncate" title={manualNote}>
@@ -525,26 +519,6 @@ export function ProviderCard({
                         defaultValue: "账号会随 Codex CLI 当前登录变化",
                       })}
                   </span>
-                ) : codexOfficialIdentity === "unbound" ? (
-                  <>
-                    <span className="inline-flex min-w-0 items-center gap-1 text-sm text-amber-700 dark:text-amber-300">
-                      <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-                      <span className="truncate">
-                        {t("codex.accountNotSelected", {
-                          defaultValue: "尚未选择账号",
-                        })}
-                      </span>
-                    </span>
-                    <button
-                      type="button"
-                      className="shrink-0 text-sm font-medium text-primary hover:underline"
-                      onClick={() => onEdit(provider)}
-                    >
-                      {t("codex.chooseAccount", {
-                        defaultValue: "选择账号",
-                      })}
-                    </button>
-                  </>
                 ) : managedCodexAccount ? (
                   <>
                     <span
@@ -708,9 +682,7 @@ export function ProviderCard({
               isOmo={isAnyOmo}
               onSwitch={() => onSwitch(provider)}
               onEdit={() => onEdit(provider)}
-              onDuplicate={
-                canDuplicate ? () => onDuplicate(provider) : undefined
-              }
+              onDuplicate={() => onDuplicate(provider)}
               onTest={
                 // 连通检测对第三方/自定义/Copilot/Codex-OAuth 供应商开放（这些正是旧的
                 // 真实请求探测会误报、而可达性探测能正确处理的对象）。官方供应商

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -129,7 +129,7 @@ import { HERMES_DEFAULT_CONFIG } from "./hooks/useHermesFormState";
 import { resolveManagedAccountId } from "@/lib/authBinding";
 import { useOpenClawLiveProviderIds } from "@/hooks/useOpenClaw";
 import { useHermesLiveProviderIds } from "@/hooks/useHermes";
-import { CODEX_OFFICIAL_PROVIDER_ID } from "@/utils/providerCapabilities";
+import { resolveCodexOfficialIdentity } from "@/utils/providerCapabilities";
 
 type PresetEntry = {
   id: string;
@@ -306,24 +306,18 @@ function ProviderFormFull({
 
   const { t } = useTranslation();
   const isEditMode = Boolean(initialData);
-  const isCodexNativeLoginProvider =
-    appId === "codex" && providerId === CODEX_OFFICIAL_PROVIDER_ID;
-  const startsAsLegacyUnboundCodexOfficial =
-    appId === "codex" &&
-    isEditMode &&
-    providerId !== CODEX_OFFICIAL_PROVIDER_ID &&
-    initialData?.category === "official" &&
-    !resolveManagedAccountId(initialData.meta, "codex_oauth")?.trim();
-  const { data: codexNativeLoginProviderExists = true } = useQuery({
-    queryKey: ["providers", "codex", "native-login-exists"],
-    enabled: appId === "codex" && !isCodexNativeLoginProvider,
-    queryFn: async () => {
-      const providers = await providersApi.getAll("codex");
-      return Boolean(providers[CODEX_OFFICIAL_PROVIDER_ID]);
-    },
-  });
-  const canCreateCodexNativeLoginProvider =
-    appId === "codex" && !isEditMode && !codexNativeLoginProviderExists;
+  const initialCodexOfficialIdentity =
+    appId === "codex" && initialData
+      ? resolveCodexOfficialIdentity(appId, {
+          id: providerId ?? "",
+          category: initialData.category,
+          meta: initialData.meta,
+          settingsConfig: initialData.settingsConfig ?? {},
+        })
+      : null;
+  const hasExistingCodexOfficialIdentity =
+    initialCodexOfficialIdentity !== null &&
+    initialCodexOfficialIdentity !== "api_key";
   const queryClient = useQueryClient();
   const { data: settingsData } = useSettingsQuery();
   const showCommonConfigNotice =
@@ -389,7 +383,9 @@ function ProviderFormFull({
     appId,
     selectedPresetId,
     isEditMode,
-    initialCategory: initialData?.category,
+    initialCategory:
+      initialData?.category ??
+      (hasExistingCodexOfficialIdentity ? "official" : undefined),
   });
   const isOmoCategory = appId === "opencode" && category === "omo";
   const isOmoSlimCategory = appId === "opencode" && category === "omo-slim";
@@ -421,6 +417,7 @@ function ProviderFormFull({
     setSelectedCodexAccountId(
       resolveManagedAccountId(initialData?.meta, "codex_oauth"),
     );
+    setHasValidCodexOfficialSelection(true);
     setCodexFastMode(initialData?.meta?.codexFastMode ?? false);
     setCodexChatReasoning(initialData?.meta?.codexChatReasoning ?? {});
     setPromptCacheRouting(initialData?.meta?.promptCacheRouting ?? "auto");
@@ -605,10 +602,8 @@ function ProviderFormFull({
   const [selectedCodexAccountId, setSelectedCodexAccountId] = useState<
     string | null
   >(() => resolveManagedAccountId(initialData?.meta, "codex_oauth"));
-  const [
-    hasExplicitCodexOfficialSelection,
-    setHasExplicitCodexOfficialSelection,
-  ] = useState(isEditMode && !startsAsLegacyUnboundCodexOfficial);
+  const [hasValidCodexOfficialSelection, setHasValidCodexOfficialSelection] =
+    useState(true);
   const [selectedXaiAccountId, setSelectedXaiAccountId] = useState<
     string | null
   >(() => resolveManagedAccountId(initialData?.meta, "xai_oauth"));
@@ -809,23 +804,19 @@ function ProviderFormFull({
   const isXaiOauthProvider =
     (appId === "claude" || appId === "codex") &&
     (presetProviderType === "xai_oauth" || initialProviderType === "xai_oauth");
+  const wasCodexOfficialManagedOauthBound =
+    appId === "codex" &&
+    Boolean(resolveManagedAccountId(initialData?.meta, "codex_oauth"));
   const isCodexOfficialProvider =
     appId === "codex" &&
-    (category === "official" ||
+    (hasExistingCodexOfficialIdentity ||
+      wasCodexOfficialManagedOauthBound ||
       (presetProviderType === "codex_oauth" &&
         selectedPresetEntry?.preset.category === "official"));
   const isCodexOfficialManagedOauthBound =
     isCodexOfficialProvider && Boolean(selectedCodexAccountId);
-  const wasCodexOfficialManagedOauthBound =
-    appId === "codex" &&
-    initialData?.category === "official" &&
-    Boolean(resolveManagedAccountId(initialData?.meta, "codex_oauth"));
-  const canSelectCodexNativeLogin =
-    isCodexNativeLoginProvider ||
-    canCreateCodexNativeLoginProvider ||
-    (isEditMode && isCodexOfficialProvider && !codexNativeLoginProviderExists);
   const requiresExplicitCodexOfficialSelection =
-    isCodexOfficialProvider && !hasExplicitCodexOfficialSelection;
+    isCodexOfficialProvider && !hasValidCodexOfficialSelection;
   const requiresCodexOauthLogin =
     isClaudeCodexOauthProvider || isCodexOfficialManagedOauthBound;
 
@@ -1510,17 +1501,16 @@ function ProviderFormFull({
 
     if (appId === "codex") {
       try {
-        const shouldStripManagedCodexAuth =
-          category === "official" &&
-          (isCodexOfficialManagedOauthBound ||
-            wasCodexOfficialManagedOauthBound);
-        const authJson = shouldStripManagedCodexAuth
+        const shouldStripCodexOfficialAuth =
+          isCodexOfficialManagedOauthBound || wasCodexOfficialManagedOauthBound;
+        const authJson = shouldStripCodexOfficialAuth
           ? {}
           : JSON.parse(codexAuth);
+        const codexConfigForSave = codexConfig ?? "";
         let normalizedCodexConfig =
-          category !== "official" && (codexConfig ?? "").trim()
-            ? setCodexWireApi(codexConfig ?? "", "responses")
-            : (codexConfig ?? "");
+          category !== "official" && codexConfigForSave.trim()
+            ? setCodexWireApi(codexConfigForSave, "responses")
+            : codexConfigForSave;
         // 模型映射与「路由接管」解耦：对所有非官方供应商，填了就持久化
         //（Chat 生成兼容路由、原生 Responses 生成 model-catalogs.json），
         // 留空归一化为 [] 即不写。后端只看 modelCatalog.models 是否非空。
@@ -1603,10 +1593,7 @@ function ProviderFormFull({
     };
 
     if (isCodexOfficialProvider) {
-      payload.codexNativeLoginSelected =
-        !selectedCodexAccountId &&
-        hasExplicitCodexOfficialSelection &&
-        canSelectCodexNativeLogin;
+      payload.presetCategory = "official";
     }
 
     if (appId === "opencode") {
@@ -2471,10 +2458,10 @@ function ProviderFormFull({
               selectedCodexAccountId={selectedCodexAccountId}
               onCodexAccountSelect={setSelectedCodexAccountId}
               onCodexAuthSelectionConfirmed={() =>
-                setHasExplicitCodexOfficialSelection(true)
+                setHasValidCodexOfficialSelection(true)
               }
               onCodexAuthSelectionInvalidated={() =>
-                setHasExplicitCodexOfficialSelection(false)
+                setHasValidCodexOfficialSelection(false)
               }
               onManageAuthAccounts={onManageAuthAccounts}
               codexOauthSelectionLabel={t("codexOauth.signInMethod")}
@@ -2482,10 +2469,8 @@ function ProviderFormFull({
               codexOauthNoneOptionDescription={t(
                 "codex.followCodexLoginDescription",
               )}
-              codexOauthAllowUnboundSelection={canSelectCodexNativeLogin}
-              codexOauthAllowUnboundSelectionWithoutStatus={
-                canSelectCodexNativeLogin
-              }
+              codexOauthAllowUnboundSelection
+              codexOauthAllowUnboundSelectionWithoutStatus
               codexOauthRequireExplicitSelection={
                 requiresExplicitCodexOfficialSelection
               }
@@ -2886,6 +2871,4 @@ export type ProviderFormValues = ProviderFormData & {
   meta?: ProviderMeta;
   providerKey?: string; // OpenCode/OpenClaw: user-defined provider key
   suggestedDefaults?: OpenClawSuggestedDefaults; // OpenClaw: suggested default model configuration
-  /** Transient UI intent used to promote a legacy Codex Official row. */
-  codexNativeLoginSelected?: boolean;
 };

--- a/src/hooks/useProviderActions.ts
+++ b/src/hooks/useProviderActions.ts
@@ -89,7 +89,6 @@ export function useProviderActions(
         suggestedDefaults?: OpenClawSuggestedDefaults;
         addToLive?: boolean;
         ensureClaudeDesktopOfficialSeed?: boolean;
-        ensureCodexOfficialSeed?: boolean;
         ensureGrokBuildOfficialSeed?: boolean;
       },
     ) => {

--- a/src/lib/query/mutations.ts
+++ b/src/lib/query/mutations.ts
@@ -15,11 +15,7 @@ import { invalidateHermesProviderCaches } from "@/hooks/useHermes";
 import { proxyKeys } from "@/lib/query/proxy";
 import { usageKeys } from "@/lib/query/usage";
 import { invalidatePiProviderCaches } from "@/lib/query/pi";
-import { resolveManagedAccountId } from "@/lib/authBinding";
-import {
-  CODEX_OFFICIAL_PROVIDER_ID,
-  GROKBUILD_OFFICIAL_PROVIDER_ID,
-} from "@/utils/providerCapabilities";
+import { GROKBUILD_OFFICIAL_PROVIDER_ID } from "@/utils/providerCapabilities";
 
 export const useAddProviderMutation = (appId: AppId) => {
   const queryClient = useQueryClient();
@@ -31,7 +27,6 @@ export const useAddProviderMutation = (appId: AppId) => {
         providerKey?: string;
         addToLive?: boolean;
         ensureClaudeDesktopOfficialSeed?: boolean;
-        ensureCodexOfficialSeed?: boolean;
         ensureGrokBuildOfficialSeed?: boolean;
       },
     ) => {
@@ -39,7 +34,6 @@ export const useAddProviderMutation = (appId: AppId) => {
         providerKey: _providerKey,
         addToLive,
         ensureClaudeDesktopOfficialSeed,
-        ensureCodexOfficialSeed,
         ensureGrokBuildOfficialSeed,
         ...rest
       } = providerInput;
@@ -52,34 +46,6 @@ export const useAddProviderMutation = (appId: AppId) => {
           throw new Error("Claude Desktop official provider was not created");
         }
         return officialProvider;
-      }
-
-      if (appId === "codex" && ensureCodexOfficialSeed) {
-        // The fixed seed is the one native "Codex current login" card.
-        // A managed account gets its own provider row so several accounts can
-        // coexist without replacing that native-login entry.
-        const managedAccountId = resolveManagedAccountId(
-          rest.meta,
-          "codex_oauth",
-        )?.trim();
-        if (!managedAccountId) {
-          await providersApi.ensureCodexOfficialProvider();
-          const providers = await providersApi.getAll(appId);
-          const nativeLoginProvider = providers[CODEX_OFFICIAL_PROVIDER_ID];
-          if (!nativeLoginProvider) {
-            throw new Error("Codex current-login provider was not created");
-          }
-          return nativeLoginProvider;
-        }
-
-        const managedOfficialProvider: Provider = {
-          ...rest,
-          id: generateUUID(),
-          category: "official",
-          createdAt: Date.now(),
-        };
-        await providersApi.add(managedOfficialProvider, appId, addToLive);
-        return managedOfficialProvider;
       }
 
       if (appId === "grokbuild" && ensureGrokBuildOfficialSeed) {

--- a/src/utils/providerCapabilities.test.ts
+++ b/src/utils/providerCapabilities.test.ts
@@ -16,11 +16,16 @@ const codexConfig = (wireApi: "chat_completions" | "responses") =>
   `model_provider = "custom"\n\n[model_providers.custom]\nname = "X"\nbase_url = "https://x.example/v1"\nwire_api = "${wireApi}"\n`;
 
 describe("providerNeedsRouting", () => {
-  it("allows only native-login and managed Codex Official cards during takeover", () => {
-    const native = mkProvider({ id: "codex-official", category: "official" });
+  it("allows explicit Codex Official cards during takeover", () => {
+    const native = mkProvider({
+      id: "codex-official",
+      category: "official",
+      settingsConfig: { auth: {}, config: "" },
+    });
     const managed = mkProvider({
       id: "managed-account-card",
       category: "official",
+      settingsConfig: { auth: {}, config: "" },
       meta: {
         authBinding: {
           source: "managed_account",
@@ -30,20 +35,157 @@ describe("providerNeedsRouting", () => {
       },
     });
     const unbound = mkProvider({
-      id: "legacy-unbound",
+      id: "follow-login",
       category: "official",
+      settingsConfig: {
+        auth: {
+          auth_mode: "chatgpt",
+          tokens: { refresh_token: "legacy-live-only-token" },
+        },
+        config: "",
+      },
+    });
+    const fixedManaged = mkProvider({
+      id: "codex-official",
+      category: "official",
+      settingsConfig: { auth: {}, config: "" },
+      meta: {
+        providerType: "codex_oauth",
+        authBinding: {
+          source: "managed_account",
+          authProvider: "codex_oauth",
+          accountId: "acct-fixed-managed",
+        },
+      },
     });
 
     expect(resolveCodexOfficialIdentity("codex", native)).toBe("native_login");
     expect(resolveCodexOfficialIdentity("codex", managed)).toBe(
       "managed_account",
     );
-    expect(resolveCodexOfficialIdentity("codex", unbound)).toBe("unbound");
+    expect(resolveCodexOfficialIdentity("codex", unbound)).toBe("native_login");
+    expect(resolveCodexOfficialIdentity("codex", fixedManaged)).toBe(
+      "managed_account",
+    );
     expect(resolveCodexOfficialIdentity("claude", managed)).toBeNull();
 
     expect(supportsOfficialProxyTakeover("codex", native)).toBe(true);
     expect(supportsOfficialProxyTakeover("codex", managed)).toBe(true);
-    expect(supportsOfficialProxyTakeover("codex", unbound)).toBe(false);
+    expect(supportsOfficialProxyTakeover("codex", unbound)).toBe(true);
+  });
+
+  it("does not infer Codex login identity from a stale Official category", () => {
+    const storedAuthKey = mkProvider({
+      id: "legacy-api-key",
+      category: "official",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "sk-legacy" },
+        config: "",
+      },
+    });
+    const storedBearer = mkProvider({
+      id: "legacy-bearer",
+      category: "official",
+      settingsConfig: {
+        auth: {},
+        config: 'experimental_bearer_token = "sk-legacy"',
+      },
+    });
+    const explicitOpenAi = mkProvider({
+      id: "official-openai",
+      category: "official",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "sk-official" },
+        config: 'model_provider = "openai"',
+      },
+    });
+    const grokOfficial = mkProvider({
+      id: "grokbuild-official",
+      category: "official",
+      settingsConfig: { config: "" },
+    });
+    const unmarkedCustom = mkProvider({
+      id: "custom-upstream",
+      category: "official",
+      settingsConfig: {
+        auth: {},
+        config:
+          'model_provider = "custom"\n[model_providers.custom]\nbase_url = "https://example.com/v1"',
+      },
+    });
+    const implicitCustom = mkProvider({
+      id: "implicit-custom-upstream",
+      category: "official",
+      settingsConfig: {
+        auth: {},
+        config: 'model_provider = "ollama"',
+      },
+    });
+    expect(resolveCodexOfficialIdentity("codex", storedAuthKey)).toBe(
+      "api_key",
+    );
+    expect(supportsOfficialProxyTakeover("codex", storedAuthKey)).toBe(false);
+    expect(resolveCodexOfficialIdentity("codex", storedBearer)).toBeNull();
+    expect(resolveCodexOfficialIdentity("codex", explicitOpenAi)).toBe(
+      "api_key",
+    );
+    expect(resolveCodexOfficialIdentity("codex", grokOfficial)).toBeNull();
+    expect(resolveCodexOfficialIdentity("codex", unmarkedCustom)).toBeNull();
+    expect(resolveCodexOfficialIdentity("codex", implicitCustom)).toBeNull();
+
+    const unifiedSession = mkProvider({
+      id: "unified-session",
+      category: "official",
+      settingsConfig: {
+        auth: {},
+        config:
+          'model_provider = "custom"\n[model_providers.custom]\nname = "OpenAI"\nrequires_openai_auth = true\nsupports_websockets = true\nwire_api = "responses"',
+      },
+    });
+    expect(resolveCodexOfficialIdentity("codex", unifiedSession)).toBe(
+      "native_login",
+    );
+  });
+
+  it("keeps category-less fixed and managed legacy cards recognizable", () => {
+    const fixed = mkProvider({
+      id: "codex-official",
+      settingsConfig: { auth: {}, config: "" },
+    });
+    const fixedApiKey = mkProvider({
+      id: "codex-official",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "sk-legacy" },
+        config: "",
+      },
+    });
+    const fixedCustom = mkProvider({
+      id: "codex-official",
+      settingsConfig: {
+        auth: {},
+        config: 'model_provider = "custom"',
+      },
+    });
+    const managed = mkProvider({
+      id: "legacy-managed",
+      settingsConfig: { auth: {}, config: null },
+      meta: {
+        authBinding: {
+          source: "managed_account",
+          authProvider: "codex_oauth",
+          accountId: "acct-managed",
+        },
+      },
+    });
+
+    expect(resolveCodexOfficialIdentity("codex", fixed)).toBe("native_login");
+    expect(resolveCodexOfficialIdentity("codex", managed)).toBe(
+      "managed_account",
+    );
+    expect(resolveCodexOfficialIdentity("codex", fixedApiKey)).toBeNull();
+    expect(resolveCodexOfficialIdentity("codex", fixedCustom)).toBeNull();
+    expect(providerNeedsRouting("codex", fixed)).toBe(false);
+    expect(providerNeedsRouting("codex", managed)).toBe(false);
   });
 
   it("官方供应商一律不需要路由（即便 providerType 是 OAuth）", () => {

--- a/src/utils/providerCapabilities.ts
+++ b/src/utils/providerCapabilities.ts
@@ -3,7 +3,10 @@ import type { Provider } from "@/types";
 import { isOAuthProviderType } from "@/config/constants";
 import { resolveManagedAccountId } from "@/lib/authBinding";
 import {
+  extractCodexBaseUrl,
+  extractCodexExperimentalBearerToken,
   extractCodexWireApi,
+  hasExplicitNonOpenAiCodexModelProvider,
   isCodexAnthropicWireApi,
   isCodexChatWireApi,
 } from "@/utils/providerConfigUtils";
@@ -14,27 +17,87 @@ export const GROKBUILD_OFFICIAL_PROVIDER_ID = "grokbuild-official";
 export type CodexOfficialIdentity =
   | "native_login"
   | "managed_account"
-  | "unbound";
+  | "api_key";
+
+const nonEmptyString = (value: unknown): boolean =>
+  typeof value === "string" && value.trim().length > 0;
+
+function hasExplicitCodexThirdPartyUpstream(
+  settings: Record<string, unknown>,
+): boolean {
+  const config = typeof settings.config === "string" ? settings.config : "";
+
+  return (
+    nonEmptyString(settings.baseUrl) ||
+    nonEmptyString(settings.baseURL) ||
+    nonEmptyString(settings.base_url) ||
+    Boolean(extractCodexExperimentalBearerToken(config)) ||
+    Boolean(extractCodexBaseUrl(config)) ||
+    hasExplicitNonOpenAiCodexModelProvider(config)
+  );
+}
+
+function hasStoredCodexApiKey(settings: Record<string, unknown>): boolean {
+  const auth = settings.auth as Record<string, unknown> | undefined;
+  return nonEmptyString(auth?.OPENAI_API_KEY);
+}
 
 export function resolveCodexOfficialIdentity(
   appId: AppId,
-  provider: Pick<Provider, "id" | "category" | "meta">,
+  provider: Pick<Provider, "id" | "category" | "meta" | "settingsConfig">,
 ): CodexOfficialIdentity | null {
-  if (appId !== "codex" || provider.category !== "official") return null;
-  if (provider.id === CODEX_OFFICIAL_PROVIDER_ID) return "native_login";
-  if (resolveManagedAccountId(provider.meta, "codex_oauth")?.trim()) {
+  if (appId !== "codex") return null;
+
+  const managedAccountId = resolveManagedAccountId(
+    provider.meta,
+    "codex_oauth",
+  )?.trim();
+  const hasFixedOfficialId = provider.id === CODEX_OFFICIAL_PROVIDER_ID;
+  if (hasFixedOfficialId && provider.category === "official") {
+    return managedAccountId ? "managed_account" : "native_login";
+  }
+
+  const settings = provider.settingsConfig as Record<string, unknown>;
+  const auth = settings?.auth;
+  const config = settings?.config;
+  if (
+    !auth ||
+    typeof auth !== "object" ||
+    Array.isArray(auth) ||
+    (config != null && typeof config !== "string")
+  ) {
+    return null;
+  }
+
+  if (hasExplicitCodexThirdPartyUpstream(settings)) {
+    return null;
+  }
+
+  if (managedAccountId) {
     return "managed_account";
   }
-  return "unbound";
+  if (hasStoredCodexApiKey(settings)) {
+    return provider.category === "official" ? "api_key" : null;
+  }
+  return hasFixedOfficialId || provider.category === "official"
+    ? "native_login"
+    : null;
 }
 
 /** Keep the UI capability rule aligned with the Rust takeover policy. */
 export function supportsOfficialProxyTakeover(
   appId: AppId,
-  provider: Pick<Provider, "id" | "category" | "meta">,
+  provider: Pick<Provider, "id" | "category" | "meta" | "settingsConfig">,
 ): boolean {
   const identity = resolveCodexOfficialIdentity(appId, provider);
-  return identity === "native_login" || identity === "managed_account";
+  if (!identity || identity === "api_key") return false;
+  if (
+    provider.id === CODEX_OFFICIAL_PROVIDER_ID ||
+    identity === "managed_account"
+  ) {
+    return true;
+  }
+  return true;
 }
 
 /**
@@ -54,7 +117,11 @@ export function providerNeedsRouting(
   appId: AppId,
   provider: Provider,
 ): boolean {
-  if (provider.category === "official") return false;
+  if (
+    provider.category === "official" ||
+    resolveCodexOfficialIdentity(appId, provider)
+  )
+    return false;
 
   const isManagedOAuth = isOAuthProviderType(provider.meta?.providerType);
 

--- a/src/utils/providerConfigUtils.ts
+++ b/src/utils/providerConfigUtils.ts
@@ -566,6 +566,38 @@ const getCodexModelProviderName = (configText: string): string | undefined => {
   return providerName || undefined;
 };
 
+const isCodexUnifiedSessionProjection = (configText: string): boolean => {
+  try {
+    const parsed = parseToml(normalizeTomlText(configText)) as Record<
+      string,
+      any
+    >;
+    const custom = parsed.model_providers?.custom;
+    return (
+      parsed.model_provider === "custom" &&
+      isPlainObject(custom) &&
+      Object.keys(custom).length === 4 &&
+      custom.name === "OpenAI" &&
+      custom.requires_openai_auth === true &&
+      custom.supports_websockets === true &&
+      custom.wire_api === "responses"
+    );
+  } catch {
+    return false;
+  }
+};
+
+export const hasExplicitNonOpenAiCodexModelProvider = (
+  configText: string | undefined | null,
+): boolean => {
+  if (typeof configText !== "string") return false;
+  if (isCodexUnifiedSessionProjection(configText)) return false;
+  const providerName = getCodexModelProviderName(configText);
+  return Boolean(
+    providerName && providerName.trim().toLowerCase() !== "openai",
+  );
+};
+
 const getCodexProviderSectionName = (
   configText: string,
 ): string | undefined => {

--- a/tests/components/AddProviderDialog.test.tsx
+++ b/tests/components/AddProviderDialog.test.tsx
@@ -162,7 +162,7 @@ describe("AddProviderDialog", () => {
     });
   });
 
-  it("submits the managed account selected from the Codex Official preset", async () => {
+  it("submits the optional managed account from the Codex Official preset", async () => {
     const handleSubmit = vi.fn().mockResolvedValue(undefined);
     const officialPresetIndex = codexProviderPresets.findIndex(
       (preset) =>
@@ -201,7 +201,6 @@ describe("AddProviderDialog", () => {
     expect(handleSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         category: "official",
-        ensureCodexOfficialSeed: true,
         meta: expect.objectContaining({
           authBinding: {
             source: "managed_account",
@@ -210,6 +209,9 @@ describe("AddProviderDialog", () => {
           },
         }),
       }),
+    );
+    expect(handleSubmit.mock.calls[0][0]).not.toHaveProperty(
+      "ensureCodexOfficialSeed",
     );
   });
 

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -15,7 +15,6 @@ const apiMocks = vi.hoisted(() => ({
   getOpenClawLiveProvider: vi.fn(),
 }));
 let mockFormReady = true;
-let mockCodexNativeLoginSelected = false;
 let mockCodexManagedAccountSelected = false;
 let submitReadyCallbacks: Array<(isReady: boolean) => void> = [];
 
@@ -74,7 +73,6 @@ vi.mock("@/components/providers/forms/ProviderForm", () => ({
       meta?: Record<string, unknown>;
       icon?: string;
       iconColor?: string;
-      codexNativeLoginSelected?: boolean;
     }) => void;
     onSubmitReadyChange?: (isReady: boolean) => void;
     onManageAuthAccounts?: (target: "codex_oauth") => void;
@@ -110,7 +108,6 @@ vi.mock("@/components/providers/forms/ProviderForm", () => ({
               : initialData.meta,
             icon: initialData.icon,
             iconColor: initialData.iconColor,
-            codexNativeLoginSelected: mockCodexNativeLoginSelected,
           });
         }}
       >
@@ -141,7 +138,6 @@ import { EditProviderDialog } from "@/components/providers/EditProviderDialog";
 describe("EditProviderDialog", () => {
   beforeEach(() => {
     mockFormReady = true;
-    mockCodexNativeLoginSelected = false;
     mockCodexManagedAccountSelected = false;
     submitReadyCallbacks = [];
     apiMocks.getCurrent.mockReset();
@@ -283,8 +279,7 @@ describe("EditProviderDialog", () => {
     });
   });
 
-  it("promotes a legacy Codex Official row after native login is selected", async () => {
-    mockCodexNativeLoginSelected = true;
+  it("keeps an unbound Codex Official provider ID unchanged", async () => {
     apiMocks.getCurrent.mockResolvedValue(null);
     const onSubmit = vi.fn();
     const provider: Provider = {
@@ -310,12 +305,12 @@ describe("EditProviderDialog", () => {
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         originalId: "legacy-unbound-official",
-        provider: expect.objectContaining({ id: "codex-official" }),
+        provider: expect.objectContaining({ id: "legacy-unbound-official" }),
       }),
     );
   });
 
-  it("moves the fixed Codex card to a managed-account ID when its login changes", async () => {
+  it("keeps the fixed Codex provider ID when an account is bound", async () => {
     mockCodexManagedAccountSelected = true;
     apiMocks.getCurrent.mockResolvedValue(null);
     const onSubmit = vi.fn();
@@ -341,10 +336,7 @@ describe("EditProviderDialog", () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     const submitted = onSubmit.mock.calls[0][0];
     expect(submitted.originalId).toBe("codex-official");
-    expect(submitted.provider.id).not.toBe("codex-official");
-    expect(submitted.provider.id).toMatch(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
-    );
+    expect(submitted.provider.id).toBe("codex-official");
     expect(submitted.provider.meta?.authBinding).toEqual({
       source: "managed_account",
       authProvider: "codex_oauth",

--- a/tests/components/ProviderCard.codexAccount.test.tsx
+++ b/tests/components/ProviderCard.codexAccount.test.tsx
@@ -1,6 +1,5 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ProviderCard } from "@/components/providers/ProviderCard";
 import type { ManagedAuthStatus } from "@/lib/api";
@@ -8,7 +7,10 @@ import type { Provider } from "@/types";
 import { createTestQueryClient } from "../utils/testQueryClient";
 
 vi.mock("@/components/providers/ProviderActions", () => ({
-  ProviderActions: () => null,
+  ProviderActions: ({ onDuplicate }: { onDuplicate?: () => void }) =>
+    onDuplicate ? (
+      <button onClick={onDuplicate}>duplicate-provider</button>
+    ) : null,
 }));
 
 vi.mock("@/components/ProviderIcon", () => ({
@@ -21,7 +23,7 @@ vi.mock("@/components/SubscriptionQuotaFooter", () => ({
 }));
 vi.mock("@/components/CopilotQuotaFooter", () => ({ default: () => null }));
 vi.mock("@/components/CodexOauthQuotaFooter", () => ({
-  default: () => null,
+  default: () => <div>codex-oauth-quota</div>,
 }));
 vi.mock("@/components/XaiOauthQuotaFooter", () => ({ default: () => null }));
 
@@ -40,7 +42,7 @@ const managedProvider = (
   id: "managed-official",
   name,
   category: "official",
-  settingsConfig: {},
+  settingsConfig: { auth: {}, config: "" },
   meta: {
     providerType: "codex_oauth",
     authBinding: {
@@ -165,7 +167,7 @@ describe("ProviderCard Codex Official account identity", () => {
       id: "codex-official",
       name: "OpenAI Official",
       category: "official",
-      settingsConfig: {},
+      settingsConfig: { auth: {}, config: "" },
     });
 
     expect(
@@ -174,6 +176,24 @@ describe("ProviderCard Codex Official account identity", () => {
     expect(
       screen.getByText("账号会随 Codex CLI 当前登录变化"),
     ).toBeInTheDocument();
+    expect(screen.queryByText("codex-oauth-quota")).not.toBeInTheDocument();
+  });
+
+  it("shows the managed account when it is bound to the fixed card", () => {
+    const login = "fixed@example.com";
+    renderCard(
+      {
+        ...managedProvider("OpenAI Official"),
+        id: "codex-official",
+      },
+      { status: authStatus(login) },
+    );
+
+    expect(screen.getByText(login)).toBeInTheDocument();
+    expect(
+      screen.queryByText("账号会随 Codex CLI 当前登录变化"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("codex-oauth-quota")).toBeInTheDocument();
   });
 
   it("shows a manual note instead of generated account guidance", () => {
@@ -182,7 +202,7 @@ describe("ProviderCard Codex Official account identity", () => {
       name: "OpenAI Official",
       notes: "Primary work provider",
       category: "official",
-      settingsConfig: {},
+      settingsConfig: { auth: {}, config: "" },
     });
 
     expect(screen.getByText("Primary work provider")).toBeInTheDocument();
@@ -191,24 +211,41 @@ describe("ProviderCard Codex Official account identity", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("makes a legacy unbound card actionable without changing it", async () => {
-    const user = userEvent.setup();
-    const onEdit = vi.fn();
+  it("treats a legacy unbound Official card as follow-login", () => {
     const provider: Provider = {
       id: "legacy-unbound",
       name: "Legacy Official",
       category: "official",
-      settingsConfig: {},
+      settingsConfig: { auth: {}, config: "" },
+      meta: { providerType: "codex_oauth" },
     };
-    renderCard(provider, { isCurrent: true, onEdit });
+    renderCard(provider, { isCurrent: true });
 
-    expect(screen.getByText("尚未选择账号").parentElement).toHaveClass(
-      "text-sm",
-    );
-    const chooseAccount = screen.getByRole("button", { name: "选择账号" });
-    expect(chooseAccount).toHaveClass("text-sm");
-    expect(screen.queryByText("使用中")).not.toBeInTheDocument();
-    await user.click(chooseAccount);
-    expect(onEdit).toHaveBeenCalledWith(provider);
+    expect(
+      screen.getByText("账号会随 Codex CLI 当前登录变化"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "选择账号" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "duplicate-provider" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("codex-oauth-quota")).not.toBeInTheDocument();
+  });
+
+  it("does not label a stored API-key card as follow-login", () => {
+    renderCard({
+      id: "legacy-api-key",
+      name: "Legacy API Key",
+      category: "official",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "sk-stored" },
+        config: "",
+      },
+    });
+
+    expect(
+      screen.queryByText("账号会随 Codex CLI 当前登录变化"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/tests/components/ProviderForm.codexManagedAccount.test.tsx
+++ b/tests/components/ProviderForm.codexManagedAccount.test.tsx
@@ -13,9 +13,6 @@ const authState = vi.hoisted(() => ({
 const toastMocks = vi.hoisted(() => ({
   error: vi.fn(),
 }));
-const providerApiMocks = vi.hoisted(() => ({
-  getAll: vi.fn(),
-}));
 
 vi.mock("sonner", () => ({
   toast: {
@@ -24,43 +21,29 @@ vi.mock("sonner", () => ({
   },
 }));
 
-vi.mock("@/lib/api", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/api")>();
-  return {
-    ...actual,
-    providersApi: {
-      ...actual.providersApi,
-      getAll: (...args: unknown[]) => providerApiMocks.getAll(...args),
-    },
-  };
-});
-
 vi.mock("@/components/providers/forms/CodexOAuthSection", () => ({
   CodexOAuthSection: ({
     onAccountSelect,
     onSelectionConfirmed,
     onSelectionInvalidated,
     allowUnboundSelection = true,
-    nativeLoginOnly = false,
-    requireExplicitSelection = false,
+    allowUnboundSelectionWithoutStatus = false,
   }: {
     onAccountSelect?: (accountId: string | null) => void;
     onSelectionConfirmed?: () => void;
     onSelectionInvalidated?: () => void;
     allowUnboundSelection?: boolean;
-    nativeLoginOnly?: boolean;
-    requireExplicitSelection?: boolean;
+    allowUnboundSelectionWithoutStatus?: boolean;
   }) => (
     <div>
-      <output data-testid="native-login-only">
-        {nativeLoginOnly ? "true" : "false"}
+      <output data-testid="allow-unbound-selection">
+        {allowUnboundSelection ? "true" : "false"}
       </output>
-      <output data-testid="explicit-selection-required">
-        {requireExplicitSelection ? "true" : "false"}
+      <output data-testid="allow-unbound-without-status">
+        {allowUnboundSelectionWithoutStatus ? "true" : "false"}
       </output>
       <button
         type="button"
-        disabled={nativeLoginOnly}
         onClick={() => {
           onSelectionConfirmed?.();
           onAccountSelect?.("acct-managed");
@@ -211,14 +194,6 @@ describe("ProviderForm Codex Official managed account", () => {
   beforeEach(() => {
     authState.codexReauthRequired = false;
     toastMocks.error.mockReset();
-    providerApiMocks.getAll.mockReset().mockResolvedValue({
-      "codex-official": {
-        id: "codex-official",
-        name: "OpenAI Official",
-        settingsConfig: { auth: {}, config: "" },
-        category: "official",
-      },
-    });
   });
 
   it("persists the selected managed account while stripping OAuth secrets", async () => {
@@ -254,62 +229,31 @@ describe("ProviderForm Codex Official managed account", () => {
     });
   });
 
-  it("requires a managed account when adding another Official card", async () => {
+  it("defaults every new Official card to the current Codex login", async () => {
     const onSubmit = vi.fn();
     renderCodexForm(onSubmit);
 
     fireEvent.click(screen.getByRole("button", { name: /OpenAI Official/ }));
-    await screen.findByRole("button", { name: "select-managed-account" });
     expect(
-      screen.queryByRole("button", { name: "select-native-login" }),
-    ).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "save-provider" }));
-
-    await waitFor(() =>
-      expect(toastMocks.error).toHaveBeenCalledWith("请先选择登录方式"),
+      await screen.findByRole("button", { name: "select-native-login" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("allow-unbound-selection")).toHaveTextContent(
+      "true",
     );
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
-
-  it("offers the current-login option only when the fixed card is missing", async () => {
-    providerApiMocks.getAll.mockResolvedValueOnce({});
-    const onSubmit = vi.fn();
-    renderCodexForm(onSubmit);
-
-    fireEvent.click(screen.getByRole("button", { name: /OpenAI Official/ }));
-    const nativeLogin = await screen.findByRole("button", {
-      name: "select-native-login",
-    });
-    fireEvent.click(nativeLogin);
+    expect(
+      screen.getByTestId("allow-unbound-without-status"),
+    ).toHaveTextContent("true");
     fireEvent.click(screen.getByRole("button", { name: "save-provider" }));
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     const submitted = onSubmit.mock.calls[0][0] as ProviderFormValues;
     expect(submitted.presetCategory).toBe("official");
+    expect(submitted.meta?.providerType).toBeUndefined();
     expect(submitted.meta?.authBinding).toBeUndefined();
+    expect(submitted).not.toHaveProperty("codexNativeLoginSelected");
   });
 
-  it("does not silently create the current-login card before a choice", async () => {
-    providerApiMocks.getAll.mockResolvedValueOnce({});
-    const onSubmit = vi.fn();
-    renderCodexForm(onSubmit);
-
-    fireEvent.click(screen.getByRole("button", { name: /OpenAI Official/ }));
-    await waitFor(() =>
-      expect(
-        screen.getByTestId("explicit-selection-required"),
-      ).toHaveTextContent("true"),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "save-provider" }));
-
-    await waitFor(() =>
-      expect(toastMocks.error).toHaveBeenCalledWith("请先选择登录方式"),
-    );
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
-
-  it("requires a new choice after the selected account disappears", async () => {
-    providerApiMocks.getAll.mockResolvedValueOnce({});
+  it("requires confirmation before falling back when a selected account disappears", async () => {
     const onSubmit = vi.fn();
     renderCodexForm(onSubmit);
 
@@ -320,17 +264,21 @@ describe("ProviderForm Codex Official managed account", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "invalidate-selected-account" }),
     );
-    await waitFor(() =>
-      expect(
-        screen.getByTestId("explicit-selection-required"),
-      ).toHaveTextContent("true"),
-    );
     fireEvent.click(screen.getByRole("button", { name: "save-provider" }));
 
     await waitFor(() =>
       expect(toastMocks.error).toHaveBeenCalledWith("请先选择登录方式"),
     );
     expect(onSubmit).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "select-native-login" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "save-provider" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0].meta?.providerType).toBeUndefined();
+    expect(onSubmit.mock.calls[0][0].meta?.authBinding).toBeUndefined();
   });
 
   it("allows the fixed Official card to switch to a managed account", async () => {
@@ -346,14 +294,12 @@ describe("ProviderForm Codex Official managed account", () => {
           onCancel={vi.fn()}
           initialData={{
             name: "OpenAI Official",
-            category: "official",
             settingsConfig: { auth: {}, config: "" },
           }}
         />
       </QueryClientProvider>,
     );
 
-    expect(screen.getByTestId("native-login-only")).toHaveTextContent("false");
     expect(
       screen.getByRole("button", { name: "select-managed-account" }),
     ).toBeEnabled();
@@ -372,6 +318,10 @@ describe("ProviderForm Codex Official managed account", () => {
       authProvider: "codex_oauth",
       accountId: "acct-managed",
     });
+    expect(onSubmit.mock.calls[0][0].meta?.providerType).toBe("codex_oauth");
+    expect(onSubmit.mock.calls[0][0]).not.toHaveProperty(
+      "codexNativeLoginSelected",
+    );
   });
 
   it("does not silently strip a legacy binding from the fixed card", async () => {
@@ -387,7 +337,6 @@ describe("ProviderForm Codex Official managed account", () => {
           onCancel={vi.fn()}
           initialData={{
             name: "OpenAI Official",
-            category: "official",
             settingsConfig: { auth: {}, config: "" },
             meta: {
               providerType: "codex_oauth",
@@ -411,41 +360,7 @@ describe("ProviderForm Codex Official managed account", () => {
     });
   });
 
-  it("does not offer the current-login option on a managed Official card", () => {
-    const queryClient = createTestQueryClient();
-    render(
-      <QueryClientProvider client={queryClient}>
-        <ProviderForm
-          appId="codex"
-          providerId="managed-official"
-          submitLabel="save-provider"
-          onSubmit={vi.fn()}
-          onCancel={vi.fn()}
-          initialData={{
-            name: "OpenAI Official (user@example.com)",
-            category: "official",
-            settingsConfig: { auth: {}, config: "" },
-            meta: {
-              providerType: "codex_oauth",
-              authBinding: {
-                source: "managed_account",
-                authProvider: "codex_oauth",
-                accountId: "acct-managed",
-              },
-            },
-          }}
-        />
-      </QueryClientProvider>,
-    );
-
-    expect(screen.getByTestId("native-login-only")).toHaveTextContent("false");
-    expect(
-      screen.queryByRole("button", { name: "select-native-login" }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("allows a managed Official card to switch back when no native card exists", async () => {
-    providerApiMocks.getAll.mockResolvedValueOnce({});
+  it("keeps a category-less managed card Official when it is unbound", async () => {
     const queryClient = createTestQueryClient();
     const onSubmit = vi.fn();
     render(
@@ -458,7 +373,6 @@ describe("ProviderForm Codex Official managed account", () => {
           onCancel={vi.fn()}
           initialData={{
             name: "OpenAI Official (user@example.com)",
-            category: "official",
             settingsConfig: { auth: {}, config: "" },
             meta: {
               providerType: "codex_oauth",
@@ -479,17 +393,17 @@ describe("ProviderForm Codex Official managed account", () => {
     fireEvent.click(screen.getByRole("button", { name: "save-provider" }));
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
-    expect(onSubmit.mock.calls[0][0]).toEqual(
-      expect.objectContaining({
-        codexNativeLoginSelected: true,
-        meta: expect.not.objectContaining({
-          authBinding: expect.anything(),
-        }),
-      }),
+    expect(onSubmit.mock.calls[0][0].meta).not.toEqual(
+      expect.objectContaining({ authBinding: expect.anything() }),
+    );
+    expect(onSubmit.mock.calls[0][0].meta?.providerType).toBeUndefined();
+    expect(onSubmit.mock.calls[0][0].presetCategory).toBe("official");
+    expect(onSubmit.mock.calls[0][0]).not.toHaveProperty(
+      "codexNativeLoginSelected",
     );
   });
 
-  it("requires a managed account for a legacy card when native login already exists", async () => {
+  it("keeps an unmarked legacy Official row on follow-login", async () => {
     const queryClient = createTestQueryClient();
     const onSubmit = vi.fn();
     render(
@@ -503,74 +417,71 @@ describe("ProviderForm Codex Official managed account", () => {
           initialData={{
             name: "Legacy OpenAI Official",
             category: "official",
-            settingsConfig: { auth: {}, config: "" },
+            settingsConfig: {
+              auth: {
+                auth_mode: "chatgpt",
+                tokens: { refresh_token: "legacy-refresh-token" },
+              },
+              config: "",
+            },
           }}
         />
       </QueryClientProvider>,
     );
 
-    expect(screen.getByTestId("native-login-only")).toHaveTextContent("false");
+    expect(
+      screen.getByRole("button", { name: "select-native-login" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "save-provider" }));
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmit.mock.calls[0][0].meta?.providerType).toBeUndefined();
+    expect(onSubmit.mock.calls[0][0].meta?.authBinding).toBeUndefined();
+    expect(JSON.parse(onSubmit.mock.calls[0][0].settingsConfig).auth).toEqual({
+      auth_mode: "chatgpt",
+      tokens: { refresh_token: "legacy-refresh-token" },
+    });
+  });
+
+  it("does not add OAuth binding behavior to a third-party route with a stale Official category", async () => {
+    const queryClient = createTestQueryClient();
+    const onSubmit = vi.fn();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ProviderForm
+          appId="codex"
+          providerId="legacy-unbound-official"
+          submitLabel="save-provider"
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            name: "Legacy OpenAI Official",
+            category: "official",
+            settingsConfig: {
+              auth: { tokens: { refresh_token: "stale-secret" } },
+              config:
+                'model_provider = "custom"\nbase_url = "https://example.com/v1"\nexperimental_bearer_token = "stale-key"\n[model_providers.custom]\nrequires_openai_auth = true',
+            },
+          }}
+        />
+      </QueryClientProvider>,
+    );
+
     expect(
       screen.queryByRole("button", { name: "select-native-login" }),
     ).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "save-provider" }));
-    await waitFor(() =>
-      expect(toastMocks.error).toHaveBeenCalledWith("请先选择登录方式"),
-    );
-    expect(onSubmit).not.toHaveBeenCalled();
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "select-managed-account" }),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "save-provider" }));
-    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
-    expect(onSubmit.mock.calls[0][0].meta?.authBinding).toEqual({
-      source: "managed_account",
-      authProvider: "codex_oauth",
-      accountId: "acct-managed",
-    });
-  });
-
-  it("allows a legacy card to become the native-login card when none exists", async () => {
-    providerApiMocks.getAll.mockResolvedValueOnce({});
-    const queryClient = createTestQueryClient();
-    const onSubmit = vi.fn();
-    render(
-      <QueryClientProvider client={queryClient}>
-        <ProviderForm
-          appId="codex"
-          providerId="legacy-unbound-official"
-          submitLabel="save-provider"
-          onSubmit={onSubmit}
-          onCancel={vi.fn()}
-          initialData={{
-            name: "Legacy OpenAI Official",
-            category: "official",
-            settingsConfig: { auth: {}, config: "" },
-          }}
-        />
-      </QueryClientProvider>,
-    );
-
-    const nativeLogin = await screen.findByRole("button", {
-      name: "select-native-login",
-    });
-    expect(screen.getByTestId("explicit-selection-required")).toHaveTextContent(
-      "true",
-    );
-
-    fireEvent.click(nativeLogin);
     fireEvent.click(screen.getByRole("button", { name: "save-provider" }));
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
-    expect(onSubmit.mock.calls[0][0]).toEqual(
-      expect.objectContaining({
-        codexNativeLoginSelected: true,
-        meta: expect.not.objectContaining({
-          authBinding: expect.anything(),
-        }),
-      }),
+    const submitted = onSubmit.mock.calls[0][0] as ProviderFormValues;
+    expect(submitted.meta?.providerType).toBeUndefined();
+    const submittedSettings = JSON.parse(submitted.settingsConfig);
+    expect(submittedSettings.auth).toEqual({
+      tokens: { refresh_token: "stale-secret" },
+    });
+    expect(submittedSettings.config).toContain('model_provider = "custom"');
+    expect(submittedSettings.config).toContain(
+      'base_url = "https://example.com/v1"',
     );
   });
 

--- a/tests/hooks/useAddProviderMutation.test.tsx
+++ b/tests/hooks/useAddProviderMutation.test.tsx
@@ -7,9 +7,7 @@ import type { Provider } from "@/types";
 
 const apiMocks = vi.hoisted(() => ({
   add: vi.fn(),
-  update: vi.fn(),
   ensureClaudeDesktopOfficialProvider: vi.fn(),
-  ensureCodexOfficialProvider: vi.fn(),
   getAll: vi.fn(),
   updateTrayMenu: vi.fn(),
 }));
@@ -27,11 +25,8 @@ const toastMocks = vi.hoisted(() => ({
 vi.mock("@/lib/api", () => ({
   providersApi: {
     add: (...args: unknown[]) => apiMocks.add(...args),
-    update: (...args: unknown[]) => apiMocks.update(...args),
     ensureClaudeDesktopOfficialProvider: (...args: unknown[]) =>
       apiMocks.ensureClaudeDesktopOfficialProvider(...args),
-    ensureCodexOfficialProvider: (...args: unknown[]) =>
-      apiMocks.ensureCodexOfficialProvider(...args),
     getAll: (...args: unknown[]) => apiMocks.getAll(...args),
     updateTrayMenu: (...args: unknown[]) => apiMocks.updateTrayMenu(...args),
   },
@@ -64,11 +59,9 @@ function createWrapper() {
 
 beforeEach(() => {
   apiMocks.add.mockReset().mockResolvedValue(true);
-  apiMocks.update.mockReset().mockResolvedValue(true);
   apiMocks.ensureClaudeDesktopOfficialProvider
     .mockReset()
     .mockResolvedValue(true);
-  apiMocks.ensureCodexOfficialProvider.mockReset().mockResolvedValue(true);
   apiMocks.getAll.mockReset().mockResolvedValue({});
   apiMocks.updateTrayMenu.mockReset().mockResolvedValue(true);
   uuidMocks.generateUUID.mockReset().mockReturnValue("generated-uuid");
@@ -159,24 +152,23 @@ describe("useAddProviderMutation", () => {
         settingsConfig: { auth: {}, config: "" },
         category: "official",
         meta: {
+          providerType: "codex_oauth",
           authBinding: {
             source: "managed_account",
             authProvider: "codex_oauth",
             accountId: "acct-managed",
           },
         },
-        ensureCodexOfficialSeed: true,
       }),
     );
 
-    expect(apiMocks.ensureCodexOfficialProvider).not.toHaveBeenCalled();
     expect(apiMocks.getAll).not.toHaveBeenCalled();
-    expect(apiMocks.update).not.toHaveBeenCalled();
     expect(apiMocks.add).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "generated-uuid",
         category: "official",
         meta: {
+          providerType: "codex_oauth",
           authBinding: {
             source: "managed_account",
             authProvider: "codex_oauth",
@@ -199,35 +191,54 @@ describe("useAddProviderMutation", () => {
     );
   });
 
-  it("restores the single native-login card when it is added unbound", async () => {
-    const seedProvider: Provider = {
-      id: "codex-official",
-      name: "OpenAI Official",
-      settingsConfig: { auth: {}, config: "" },
-      category: "official",
-    };
-    apiMocks.getAll.mockResolvedValueOnce({
-      "codex-official": seedProvider,
-    });
+  it("adds every unbound Codex Official as an independent provider", async () => {
+    uuidMocks.generateUUID
+      .mockReset()
+      .mockReturnValueOnce("unbound-official-1")
+      .mockReturnValueOnce("unbound-official-2");
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useAddProviderMutation("codex"), {
       wrapper,
     });
 
-    const persistedProvider = await act(async () =>
+    const firstProvider = await act(async () =>
       result.current.mutateAsync({
-        name: "OpenAI Official",
+        name: "OpenAI Official 1",
         settingsConfig: { auth: {}, config: "" },
         category: "official",
-        ensureCodexOfficialSeed: true,
+        meta: { providerType: "codex_oauth" },
+      }),
+    );
+    const secondProvider = await act(async () =>
+      result.current.mutateAsync({
+        name: "OpenAI Official 2",
+        settingsConfig: { auth: {}, config: "" },
+        category: "official",
+        meta: { providerType: "codex_oauth" },
       }),
     );
 
-    expect(apiMocks.ensureCodexOfficialProvider).toHaveBeenCalledTimes(1);
-    expect(apiMocks.getAll).toHaveBeenCalledWith("codex");
-    expect(apiMocks.add).not.toHaveBeenCalled();
-    expect(apiMocks.update).not.toHaveBeenCalled();
-    expect(persistedProvider).toEqual(seedProvider);
+    expect(apiMocks.getAll).not.toHaveBeenCalled();
+    expect(apiMocks.add).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        id: "unbound-official-1",
+        meta: { providerType: "codex_oauth" },
+      }),
+      "codex",
+      undefined,
+    );
+    expect(apiMocks.add).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        id: "unbound-official-2",
+        meta: { providerType: "codex_oauth" },
+      }),
+      "codex",
+      undefined,
+    );
+    expect(firstProvider.id).toBe("unbound-official-1");
+    expect(secondProvider.id).toBe("unbound-official-2");
   });
 
   it("adds a Pi provider without a separate default-model command", async () => {

--- a/tests/hooks/useProviderActions.test.tsx
+++ b/tests/hooks/useProviderActions.test.tsx
@@ -433,6 +433,7 @@ describe("useProviderActions", () => {
     const provider = createProvider({
       id: "generated-uuid",
       category: "official",
+      settingsConfig: { auth: {}, config: "" },
       meta: {
         providerType: "codex_oauth",
         authBinding: {


### PR DESCRIPTION
Follow-up to #3879.

This keeps the previous Codex Official behavior and makes OAuth account binding optional.

- allow multiple Codex Official providers to use the current Codex login
- keep provider IDs unchanged when binding or unbinding an account
- keep existing provider data unchanged on startup
- preserve direct API-key and custom-upstream behavior

Tests:
- pnpm typecheck
- pnpm vitest run
- cargo test --manifest-path src-tauri/Cargo.toml --lib
- cargo test --manifest-path src-tauri/Cargo.toml --test provider_service
- cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings
- real Codex CLI request