### PR TITLE
feat(provider): add OrcaRouter provider presets

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -1258,6 +1258,22 @@ export const providerPresets: ProviderPreset[] = [
     iconColor: "#6566F1",
   },
   {
+    name: "OrcaRouter",
+    websiteUrl: "https://www.orcarouter.ai",
+    apiKeyUrl: "https://www.orcarouter.ai",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.orcarouter.ai",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_MODEL: "anthropic/claude-sonnet-5",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "anthropic/claude-haiku-4.5",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "anthropic/claude-sonnet-5",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "anthropic/claude-opus-5",
+      },
+    },
+    category: "aggregator",
+  },
+  {
     name: "TheRouter",
     websiteUrl: "https://therouter.ai",
     apiKeyUrl: "https://dashboard.therouter.ai",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -1992,6 +1992,18 @@ base_url = "https://cc-api.pipellm.ai/v1"`,
     iconColor: "#6566F1",
   },
   {
+    name: "OrcaRouter",
+    websiteUrl: "https://www.orcarouter.ai",
+    apiKeyUrl: "https://www.orcarouter.ai",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "orcarouter",
+      "https://api.orcarouter.ai/v1",
+      "anthropic/claude-sonnet-5",
+    ),
+    category: "aggregator",
+  },
+  {
     name: "TheRouter",
     websiteUrl: "https://therouter.ai",
     apiKeyUrl: "https://dashboard.therouter.ai",

--- a/src/config/orcarouterProviderPresets.test.ts
+++ b/src/config/orcarouterProviderPresets.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { providerPresets } from "./claudeProviderPresets";
+import { codexProviderPresets } from "./codexProviderPresets";
+
+describe("OrcaRouter presets", () => {
+  it("registers exactly one Claude Code preset", () => {
+    const orca = providerPresets.filter((p) => p.name === "OrcaRouter");
+    expect(orca).toHaveLength(1);
+    expect(orca[0].settingsConfig).toEqual({
+      env: {
+        ANTHROPIC_BASE_URL: "https://api.orcarouter.ai",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_MODEL: "anthropic/claude-sonnet-5",
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: "anthropic/claude-haiku-4.5",
+        ANTHROPIC_DEFAULT_SONNET_MODEL: "anthropic/claude-sonnet-5",
+        ANTHROPIC_DEFAULT_OPUS_MODEL: "anthropic/claude-opus-5",
+      },
+    });
+  });
+
+  it("registers exactly one Codex preset", () => {
+    const orca = codexProviderPresets.filter((p) => p.name === "OrcaRouter");
+    expect(orca).toHaveLength(1);
+    expect(orca[0].config).toContain(
+      'base_url = "https://api.orcarouter.ai/v1"',
+    );
+    expect(orca[0].config).toContain('model = "anthropic/claude-sonnet-5"');
+    expect(orca[0].auth).toEqual({ OPENAI_API_KEY: "" });
+  });
+});


### PR DESCRIPTION
## Summary / 概述

Add **[OrcaRouter](https://www.orcarouter.ai)** as a named provider preset in the Claude Code and Codex provider lists, mirroring the existing OpenRouter / TheRouter entries. OrcaRouter is an AI gateway that serves Anthropic- (`/v1/messages`), OpenAI- (`/v1/chat/completions`) and Responses-compatible (`/v1/responses`) endpoints from one base URL with namespaced model ids (`anthropic/claude-sonnet-5`, …). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- **`src/config/claudeProviderPresets.ts`** — add an `OrcaRouter` preset for Claude Code: `ANTHROPIC_BASE_URL = https://api.orcarouter.ai`, namespaced `anthropic/*` defaults (sonnet-5 / haiku-4.5 / opus-5), key entered via `ANTHROPIC_AUTH_TOKEN` (Bearer).
- **`src/config/codexProviderPresets.ts`** — add an `OrcaRouter` preset for Codex: `base_url = https://api.orcarouter.ai/v1`, `wire_api = "responses"`, default model `anthropic/claude-sonnet-5`, `OPENAI_API_KEY` auth.
- **`src/config/orcarouterProviderPresets.test.ts`** — focused unit coverage for both presets, following the existing `ppioProviderPresets.test.ts` pattern.

### Verification

- `pnpm typecheck` — passes
- `pnpm format:check` — passes
- `pnpm test:unit` — 131 files / 977 tests pass (including the 2 new OrcaRouter cases)
- Live checks against `https://api.orcarouter.ai`: `POST /v1/messages` (Bearer and `x-api-key`) → `ORCA-OK`; `POST /v1/chat/completions` → `ORCA-CHAT-OK`; `POST /v1/responses` (with `tools` + object `tool_choice`) → correct `function_call` output.

### Screenshots / 截图

Not applicable — this change adds provider preset data without changing the selector layout.

### Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）— N/A, no Rust change
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — N/A, provider name has no i18n key (same as OpenRouter/TheRouter)

I'm an engineer on the OrcaRouter team.
