### PR TITLE
fix(proxy): always close the Anthropic SSE envelope at stream end

### DIFF
--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -663,6 +663,35 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
         // 流自然结束但未收到 [DONE] 时，确保发送缓存的 message_delta 和 message_stop。
         // 若上游已显式报错，则只保留 error 事件，避免把失败伪装成成功完成。
         if !stream_ended_with_error {
+            // 终端事件前先关掉仍打开的 content block（顺序与上面 finish_reason
+            // 路径一致：先文本/思考块，再按 index 升序的工具块）。否则流终止时
+            // 块仍处于未闭合状态，严格解析器同样会丢弃整轮——兜底就白做了。
+            if has_sent_message_start && !has_sent_message_stop {
+                if let Some(index) = current_non_tool_block_index.take() {
+                    let event = json!({
+                        "type": "content_block_stop",
+                        "index": index
+                    });
+                    let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
+                        serde_json::to_string(&event).unwrap_or_default());
+                    yield Ok(Bytes::from(sse_data));
+                }
+                if !open_tool_block_indices.is_empty() {
+                    let mut tool_indices: Vec<u32> =
+                        open_tool_block_indices.iter().copied().collect();
+                    tool_indices.sort_unstable();
+                    for index in tool_indices {
+                        let event = json!({
+                            "type": "content_block_stop",
+                            "index": index
+                        });
+                        let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
+                            serde_json::to_string(&event).unwrap_or_default());
+                        yield Ok(Bytes::from(sse_data));
+                    }
+                    open_tool_block_indices.clear();
+                }
+            }
             if let Some((stop_reason, usage_json)) = pending_message_delta.take() {
                 let event = build_message_delta_event(stop_reason, usage_json);
                 let sse_data = format!("event: message_delta\ndata: {}\n\n",
@@ -1244,6 +1273,24 @@ mod tests {
             Some("max_tokens")
         );
 
+        // EOF 时文本块（index 0）仍打开：必须先发 content_block_stop 再发终端事件，
+        // 否则严格解析器会因块未闭合丢弃整轮。
+        let block_stop_pos = events
+            .iter()
+            .position(|event| {
+                event_type(event) == Some("content_block_stop")
+                    && event.get("index").and_then(|v| v.as_u64()) == Some(0)
+            })
+            .expect("EOF fallback must close the still-open text block");
+        let delta_pos = events
+            .iter()
+            .position(|event| event_type(event) == Some("message_delta"))
+            .expect("terminal message_delta must exist");
+        assert!(
+            block_stop_pos < delta_pos,
+            "content_block_stop must precede the terminal message_delta"
+        );
+
         assert_eq!(
             events
                 .iter()
@@ -1252,6 +1299,59 @@ mod tests {
             1
         );
         assert!(!events.iter().any(|e| event_type(e) == Some("error")));
+    }
+
+    #[tokio::test]
+    async fn test_stream_end_without_finish_reason_closes_open_tool_blocks() {
+        // 同一兜底路径下的工具块：EOF 时已 started 的 tool_use 块也必须收到
+        // content_block_stop（按 index 排序），随后才是 message_delta/message_stop。
+        let input = "data: {\"id\":\"chatcmpl_tool_eof\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_eof\",\"type\":\"function\",\"function\":{\"name\":\"Bash\",\"arguments\":\"{\\\"command\\\":\\\"pwd\\\"}\"}}]}}]}\n\n";
+
+        let events = collect_anthropic_events(input).await;
+
+        let tool_block_index = events
+            .iter()
+            .find_map(|event| {
+                if event_type(event) == Some("content_block_start")
+                    && event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
+                        == Some("tool_use")
+                {
+                    return event.get("index").and_then(|v| v.as_u64());
+                }
+                None
+            })
+            .expect("tool block must have been started before EOF");
+
+        let block_stop_pos = events
+            .iter()
+            .position(|event| {
+                event_type(event) == Some("content_block_stop")
+                    && event.get("index").and_then(|v| v.as_u64()) == Some(tool_block_index)
+            })
+            .expect("EOF fallback must close the still-open tool block");
+        let delta_pos = events
+            .iter()
+            .position(|event| event_type(event) == Some("message_delta"))
+            .expect("terminal message_delta must exist");
+        assert!(
+            block_stop_pos < delta_pos,
+            "content_block_stop must precede the terminal message_delta"
+        );
+
+        assert_eq!(
+            events.last().and_then(|event| event_type(event)),
+            Some("message_stop")
+        );
+        assert_eq!(
+            events
+                .iter()
+                .find(|event| event_type(event) == Some("message_delta"))
+                .and_then(|event| event.pointer("/delta/stop_reason"))
+                .and_then(|v| v.as_str()),
+            Some("max_tokens")
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -171,6 +171,15 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
         let mut tool_blocks_by_index: HashMap<usize, ToolBlockState> = HashMap::new();
         let mut open_tool_block_indices: HashSet<u32> = HashSet::new();
 
+        // 上游流结束后追加一个只含空行分隔符的哨兵块：带缓冲的反向代理可能在交付
+        // 最后一帧时省略尾部空行并直接关闭连接，这帧会一直残留在 buffer 里。
+        // 哨兵让这样的最后一帧（finish_reason / [DONE]）也走统一的块处理循环，
+        // 而不是在 EOF 时被静默丢弃（与 streaming_codex_anthropic.rs 的 EOF 尾块
+        // 处理同源）。buffer 为空或只剩空白时它只会产生一个被跳过的空块。
+        let stream = stream.chain(futures::stream::iter([Ok::<Bytes, E>(
+            Bytes::from_static(b"\n\n"),
+        )]));
+
         tokio::pin!(stream);
 
         while let Some(chunk) = stream.next().await {
@@ -514,7 +523,14 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                         // 注意：OpenRouter 某些 provider 会发送多个带 finish_reason 的 chunk
                                         // （第一个 usage 为 null，后续才补全）。此处只做缓存，不立即发送，
                                         // 等到 [DONE] 或流末尾再统一发出，确保 usage 完整且只发一次。
-                                        if let Some(finish_reason) = &choice.finish_reason {
+                                        // 部分兼容网关会在每个 chunk 上发空字符串 finish_reason（#5087）：
+                                        // 空串等同缺失，不是终止信号，否则会提前关块并占掉唯一的
+                                        // message_delta 名额。
+                                        let finish_reason = choice
+                                            .finish_reason
+                                            .as_deref()
+                                            .filter(|reason| !reason.is_empty());
+                                        if let Some(finish_reason) = finish_reason {
                                             let stop_reason = map_stop_reason(Some(finish_reason));
                                             let usage_json =
                                                 chunk_usage_json.clone().or_else(|| latest_usage.clone());
@@ -647,20 +663,28 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
         // 流自然结束但未收到 [DONE] 时，确保发送缓存的 message_delta 和 message_stop。
         // 若上游已显式报错，则只保留 error 事件，避免把失败伪装成成功完成。
         if !stream_ended_with_error {
-            let emitted_pending_message_delta = if let Some((stop_reason, usage_json)) =
-                pending_message_delta.take()
-            {
+            if let Some((stop_reason, usage_json)) = pending_message_delta.take() {
                 let event = build_message_delta_event(stop_reason, usage_json);
                 let sse_data = format!("event: message_delta\ndata: {}\n\n",
                     serde_json::to_string(&event).unwrap_or_default());
                 log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_delta (at stream end)");
                 yield Ok(Bytes::from(sse_data));
-                true
-            } else {
-                false
-            };
+            } else if has_sent_message_start && !has_sent_message_stop {
+                // 上游没发过任何 finish_reason 就结束了（无 [DONE] 的干净 EOF，常见于
+                // 中间层直接断开）。按 Anthropic 语义用 max_tokens 标记截断，不把残缺
+                // 输出伪装成正常完成；严格客户端（omp/pi-ai 等）缺 message_stop 会
+                // 整轮丢弃。
+                let event = build_message_delta_event(
+                    Some("max_tokens".to_string()),
+                    latest_usage.clone(),
+                );
+                let sse_data = format!("event: message_delta\ndata: {}\n\n",
+                    serde_json::to_string(&event).unwrap_or_default());
+                log::debug!("[Claude/OpenRouter] >>> Anthropic SSE: message_delta (truncation fallback)");
+                yield Ok(Bytes::from(sse_data));
+            }
 
-            if emitted_pending_message_delta && !has_sent_message_stop {
+            if has_sent_message_start && !has_sent_message_stop {
                 let event = json!({"type": "message_stop"});
                 let sse_data = format!("event: message_stop\ndata: {}\n\n",
                     serde_json::to_string(&event).unwrap_or_default());
@@ -1199,17 +1223,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_stream_end_without_finish_reason_does_not_emit_success_terminal_events() {
+    async fn test_stream_end_without_finish_reason_finalizes_as_truncated() {
+        // #6462: a clean EOF without any finish_reason must still complete the
+        // Anthropic envelope — strict clients (omp's pi-ai parser) discard the
+        // whole turn when message_stop is missing. Truncation is reported via
+        // stop_reason=max_tokens (not a success end_turn), mirroring how
+        // streaming_codex_anthropic.rs finalizes vanished upstreams.
         let input = "data: {\"id\":\"chatcmpl_truncated\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n";
 
         let events = collect_anthropic_events(input).await;
 
-        assert!(!events
+        let message_delta = events
             .iter()
-            .any(|event| event_type(event) == Some("message_delta")));
-        assert!(!events
-            .iter()
-            .any(|event| event_type(event) == Some("message_stop")));
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("truncated stream must emit a terminal message_delta");
+        assert_eq!(
+            message_delta
+                .pointer("/delta/stop_reason")
+                .and_then(|v| v.as_str()),
+            Some("max_tokens")
+        );
+
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event_type(event) == Some("message_stop"))
+                .count(),
+            1
+        );
+        assert!(!events.iter().any(|e| event_type(e) == Some("error")));
     }
 
     #[tokio::test]
@@ -1244,5 +1286,87 @@ mod tests {
         assert!(!events
             .iter()
             .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
+    }
+
+    #[tokio::test]
+    async fn test_trailing_frame_without_final_blank_line_is_flushed_at_eof() {
+        // A buffering reverse proxy may deliver the terminal frame without its
+        // trailing blank line and close the connection; that frame must not be
+        // silently dropped (#6462).
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_tail\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_tail\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":1}}"
+        );
+
+        let events = collect_anthropic_events(input).await;
+
+        let message_delta = events
+            .iter()
+            .find(|event| event_type(event) == Some("message_delta"))
+            .expect("trailing finish_reason frame must be parsed at EOF");
+        assert_eq!(
+            message_delta
+                .pointer("/delta/stop_reason")
+                .and_then(|v| v.as_str()),
+            Some("end_turn")
+        );
+        assert_eq!(
+            message_delta
+                .pointer("/usage/input_tokens")
+                .and_then(|v| v.as_u64()),
+            Some(3)
+        );
+
+        let message_stops = events
+            .iter()
+            .filter(|event| event_type(event) == Some("message_stop"))
+            .count();
+        assert_eq!(message_stops, 1);
+    }
+
+    #[tokio::test]
+    async fn test_empty_finish_reason_is_treated_as_absent() {
+        // Some compatible gateways put `finish_reason: ""` on every chunk
+        // (#5087). An empty reason must not act as a terminal signal: it must
+        // not fragment content blocks nor consume the single message_delta.
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_empty\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"you\"},\"finish_reason\":\"\"}]}\n\n",
+            "data: {\"id\":\"chatcmpl_empty\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\" & me\"},\"finish_reason\":\"\"}]}\n\n",
+            "data: {\"id\":\"chatcmpl_empty\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+
+        let text_block_starts = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_start"))
+            .filter(|event| {
+                event
+                    .pointer("/content_block/type")
+                    .and_then(|v| v.as_str())
+                    == Some("text")
+            })
+            .count();
+        assert_eq!(
+            text_block_starts, 1,
+            "empty finish_reason must not fragment the text block"
+        );
+
+        let text_deltas: Vec<&str> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_delta"))
+            .filter_map(|event| event.pointer("/delta/text").and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(text_deltas, vec!["you", " & me"]);
+
+        let message_deltas = events
+            .iter()
+            .filter(|event| event_type(event) == Some("message_delta"))
+            .count();
+        assert_eq!(
+            message_deltas, 1,
+            "empty finish_reason must not consume the terminal message_delta slot"
+        );
     }
 }


### PR DESCRIPTION
Hi! Another one from the pile I mentioned in #6482, this time for the OpenAI → Anthropic streaming converter. 🙂

## Summary / 概述

`create_anthropic_sse_stream` could end a converted stream without `event: message_stop`, so strict Anthropic clients reject the whole turn — omp's bundled pi-ai parser throws `stream ended before message_stop` and discards the output (#6462). Three gaps, as diagnosed in the issue (building on #5087):

- **Empty `finish_reason: ""` was treated as terminal.** Some gateways send it on every chunk; it would prematurely close content blocks and consume the one-shot `message_delta` slot (#5087).
- **The trailing buffer was never flushed.** `take_sse_block` only yields `\n\n`-delimited blocks, so a final frame delivered without its trailing blank line (common with buffering reverse proxies) was silently dropped — including its `finish_reason`.
- **The EOF fallback was gated on a parsed `finish_reason`.** `message_stop` was only emitted when `pending_message_delta` existed, so a clean EOF with no terminal chunk produced neither `message_delta` nor `message_stop`.

The fix:

- filter an empty-string `finish_reason` down to absent (non-terminal);
- chain an EOF sentinel block (`"\n\n"`) after the upstream so an unterminated trailing frame goes through the same block-processing loop — same intent as the EOF tail handling in `streaming_codex_anthropic.rs`, without duplicating the ~400-line block body;
- at a clean EOF where no `finish_reason` was ever seen, finalize with `stop_reason=max_tokens` + `message_stop` — reporting truncation instead of silently dropping the envelope, mirroring how `streaming_codex_anthropic.rs` finalizes vanished upstreams.

Error paths are unchanged: an explicit `error` event still suppresses the success terminals.

One existing test encoded the old contract (`test_stream_end_without_finish_reason_does_not_emit_success_terminal_events`); it is updated to the new one (`..._finalizes_as_truncated`) since #6462 shows the old behavior breaks strict clients. Happy to split or drop that semantic change if you'd rather keep the envelope open on truncation.

## Related Issue / 关联 Issue

Fixes #6462

## Screenshots / 截图

Not applicable — SSE conversion behavior, covered by unit tests.

## Test Plan / 测试

- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::providers::streaming`: 160 passed
- full `cargo test --manifest-path src-tauri/Cargo.toml`: green across all targets (2,678 lib tests)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `pnpm typecheck` / `pnpm format:check` / `pnpm test:unit` (975 passed) — frontend untouched, ran as baseline

New regression tests: truncated-stream finalization, trailing-frame flush at EOF, empty-`finish_reason` non-terminality.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
