### PR TITLE
fix(linux): apply the DMABUF renderer workaround only on NVIDIA systems

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,7 +7,15 @@ fn main() {
     // 参考: https://github.com/tauri-apps/tauri/issues/9394
     #[cfg(target_os = "linux")]
     {
-        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+        // 该规避针对的是 NVIDIA 驱动这一类环境（tauri#9394）。在现代 WebKitGTK +
+        // Mesa 上（如 2.52 + Mesa 26 + AMD）强制禁用 DMABUF 反而会让回退的 EGL 路径
+        // 初始化失败，WebProcess 启动即 abort、主窗口空白（#6514），因此只在这台
+        // 机器加载了 NVIDIA 内核模块时才设置；用户预设仍然优先。
+        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err()
+            && proc_modules_indicate_nvidia(
+                &std::fs::read_to_string("/proc/modules").unwrap_or_default(),
+            )
+        {
             std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
         }
         // 禁用 WebKitGTK 合成模式，规避 resize 时 webview 崩溃以及部分 Wayland
@@ -32,4 +40,63 @@ fn main() {
     }
 
     cc_switch_lib::run();
+}
+
+/// 判断 /proc/modules 的内容是否表明加载了 NVIDIA 内核模块（闭源 `nvidia`
+/// 及其 `nvidia_*` 子模块，或开源 `nouveau`）。纯函数便于跨平台单测；读不到
+/// /proc/modules（如某些容器环境）时按未加载处理。
+#[cfg(any(target_os = "linux", test))]
+fn proc_modules_indicate_nvidia(modules: &str) -> bool {
+    modules.lines().any(|line| {
+        let module_name = line.split_whitespace().next().unwrap_or("");
+        module_name == "nvidia" || module_name == "nouveau" || module_name.starts_with("nvidia_")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::proc_modules_indicate_nvidia;
+
+    #[test]
+    fn proprietary_nvidia_module_counts() {
+        let proc_modules = concat!(
+            "nvidia 61480960 180 nvidia_modeset,nvidia_uvm,nvidia_drm, Live 0x0 (OE)\n",
+            "amdgpu 6148096 12 - Live 0x0\n",
+        );
+        assert!(proc_modules_indicate_nvidia(proc_modules));
+    }
+
+    #[test]
+    fn nvidia_submodule_alone_counts() {
+        let proc_modules = "nvidia_drm 122880 8 - Live 0x0 (E)\n";
+        assert!(proc_modules_indicate_nvidia(proc_modules));
+    }
+
+    #[test]
+    fn nouveau_counts() {
+        let proc_modules = "nouveau 2785280 16 - Live 0x0\n";
+        assert!(proc_modules_indicate_nvidia(proc_modules));
+    }
+
+    #[test]
+    fn amd_and_intel_only_do_not_count() {
+        let proc_modules = concat!(
+            "amdgpu 6148096 12 - Live 0x0\n",
+            "i915 3227648 20 - Live 0x0\n",
+            "snd_hda_intel 122880 5 - Live 0x0\n",
+        );
+        assert!(!proc_modules_indicate_nvidia(proc_modules));
+    }
+
+    #[test]
+    fn dependency_column_mentions_do_not_count() {
+        // 只看每行第一个字段（模块名）；依赖列表等其它列里出现的 nvidia 字样不算。
+        let proc_modules = "amdgpu 6148096 12 nvidia_something, Live 0x0\n";
+        assert!(!proc_modules_indicate_nvidia(proc_modules));
+    }
+
+    #[test]
+    fn empty_modules_do_not_count() {
+        assert!(!proc_modules_indicate_nvidia(""));
+    }
 }


### PR DESCRIPTION
Hi! One more small one from the pile in #6482 — this one is Linux-only. 🙂

## Summary / 概述

`main.rs` sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` unconditionally on Linux (unless the user preset it). That workaround targets the NVIDIA driver class (tauri#9394); on modern stacks it now does the opposite of its intent: with WebKitGTK 2.52 + Mesa 26 on AMD, disabling the DMABUF renderer makes the fallback EGL path abort during WebProcess startup (`Could not create default EGL display: EGL_BAD_PARAMETER`), leaving the main window blank (#6514).

This PR narrows the workaround to the hardware class it was meant for:

- only set the variable when an NVIDIA kernel module is loaded, detected from `/proc/modules` (`nvidia`, its `nvidia_*` submodules, or `nouveau`);
- AMD/Intel machines get WebKitGTK's healthy default DMABUF path back;
- user presets still win in both directions, exactly as before.

`WEBKIT_DISABLE_COMPOSITING_MODE` is deliberately left untouched: the reporter's controlled experiment shows the blank window disappears with only `WEBKIT_DISABLE_DMABUF_RENDERER=0`, while compositing mode stays disabled by the app.

The detector is a pure function over the `/proc/modules` text so it is unit-testable on any platform; the env-mutating call site stays `#[cfg(target_os = "linux")]`.

## Related Issue / 关联 Issue

Fixes #6514

## Screenshots / 截图

Not applicable — startup env gating, no UI change.

## Test Plan / 测试

- `cargo test --manifest-path src-tauri/Cargo.toml --bin cc-switch`: 6 new predicate tests pass (proprietary nvidia / submodule-only / nouveau / AMD+Intel-only / dependency-column mention / empty input)
- full `cargo test --manifest-path src-tauri/Cargo.toml`: green across all targets
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`

I don't have a Linux desktop with the affected stack at hand, so runtime behavior is validated against the issue's own bisect table: with the app no longer forcing the variable on non-NVIDIA machines, the session env matches the reporter's successful `WEBKIT_DISABLE_DMABUF_RENDERER=0` row. Would appreciate a confirmation from someone on WebKitGTK ≥ 2.52 + Mesa 26.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
