### PR TITLE
feat(proxy): bridge Codex hosted web_search to Kimi builtin $web_search

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1458,6 +1458,9 @@ impl RequestForwarder {
         let mut codex_anthropic_one_m = false;
 
         // 转换请求体（如果需要）
+        // Kimi/Moonshot Chat 上游：把 Codex 的托管 web_search 工具桥接为服务端
+        // 内置 `$web_search`（详见 proxy::providers::kimi_web_search 模块文档）。
+        let mut kimi_web_search_bridged = false;
         let mut request_body = if codex_responses_to_chat {
             let mut mapped_body = mapped_body;
             let explicit_prompt_cache_key = mapped_body
@@ -1476,10 +1479,22 @@ impl RequestForwarder {
             super::providers::apply_codex_chat_upstream_model(provider, &mut mapped_body);
             let reasoning_config =
                 super::providers::resolve_codex_chat_reasoning_config(provider, &mapped_body);
+            let wants_web_search =
+                super::providers::kimi_web_search::request_has_web_search_tool(&mapped_body);
             let mut chat_body = super::providers::transform_codex_chat::responses_to_chat_completions_with_reasoning(
                 mapped_body,
                 reasoning_config.as_ref(),
             )?;
+            if wants_web_search
+                && super::providers::kimi_web_search::provider_supports_builtin_web_search(provider)
+            {
+                super::providers::kimi_web_search::inject_builtin_web_search(&mut chat_body);
+                kimi_web_search_bridged = true;
+                log::debug!(
+                    "[Codex] Bridging hosted web_search to Kimi builtin $web_search (provider={})",
+                    provider.id
+                );
+            }
             super::providers::inject_codex_chat_prompt_cache_key(
                 provider,
                 &mut chat_body,
@@ -2255,6 +2270,9 @@ impl RequestForwarder {
         );
 
         // 发送请求
+        // The hyper raw-write branch below moves `ordered_headers`; keep a copy
+        // for the Kimi builtin web_search echo rounds that run after the send.
+        let kimi_web_search_echo_headers = kimi_web_search_bridged.then(|| ordered_headers.clone());
         let response = if is_socks_proxy || !preserve_exact_header_case {
             // OpenAI / Copilot / Codex 类后端不依赖原始 header 大小写；走 reqwest
             // 连接池，避免 raw TCP/TLS path 每次请求都重新握手。SOCKS5 也只能走 reqwest。
@@ -2343,6 +2361,14 @@ impl RequestForwarder {
                     response = self.validate_responses_stream_start(response).await?;
                 }
             }
+            if kimi_web_search_bridged {
+                let echo_headers = kimi_web_search_echo_headers
+                    .as_ref()
+                    .expect("echo headers are captured when the bridge is armed");
+                response = self
+                    .bridge_kimi_builtin_web_search(response, &url, echo_headers, &filtered_body)
+                    .await?;
+            }
             Ok((response, resolved_claude_api_format, outbound_model))
         } else {
             let status_code = status.as_u16();
@@ -2409,6 +2435,105 @@ impl RequestForwarder {
     /// Some Anthropic-compatible gateways return an Anthropic error envelope with
     /// HTTP 2xx. Validate it inside the retry loop so the request can fail over to
     /// the next provider; the response transformer runs too late for that.
+    /// Kimi/Moonshot builtin `$web_search` bridge: the upstream executes the
+    /// search server-side and answers with a `builtin_function` tool_call whose
+    /// arguments carry the search results; per Kimi's contract the client echoes
+    /// that tool_call back as `role: "tool"` messages to get the final answer.
+    /// Run those echo rounds here so the loop stays transparent to the Codex
+    /// client, then mark the buffered final Chat completion with
+    /// BRIDGED_HEADER so the response handler converts (and optionally streams)
+    /// it like any other Chat → Responses result.
+    async fn bridge_kimi_builtin_web_search(
+        &self,
+        response: ProxyResponse,
+        url: &str,
+        request_headers: &http::HeaderMap,
+        request_body: &Value,
+    ) -> Result<ProxyResponse, ProxyError> {
+        let status = response.status();
+        let headers = response.headers().clone();
+        let body = response.bytes_with_limit(MAX_RESPONSE_BODY_BYTES).await?;
+
+        let Ok(mut chat_json) = serde_json::from_slice::<Value>(&body) else {
+            // Defensive: we forced stream=false upstream, but pass whatever came
+            // back through untouched rather than failing the request.
+            return Ok(ProxyResponse::buffered(status, headers, body));
+        };
+
+        let mut request_body = request_body.clone();
+        // api.kimi.com's k3 chat template cannot tokenize the builtin echo
+        // conversation; run the echo rounds under the kimi-for-coding alias.
+        super::providers::kimi_web_search::apply_echo_model_override(url, &mut request_body);
+        let mut rounds = 0usize;
+        while super::providers::kimi_web_search::has_builtin_tool_calls(&chat_json) {
+            if rounds >= super::providers::kimi_web_search::MAX_ECHO_ROUNDS
+                || !super::providers::kimi_web_search::append_echo_messages(
+                    &mut request_body,
+                    &chat_json,
+                )
+            {
+                break;
+            }
+            rounds += 1;
+            log::debug!("[Codex] Kimi builtin web_search echo round {rounds}");
+
+            let echo_body = serde_json::to_vec(&request_body).map_err(|e| {
+                ProxyError::Internal(format!("Failed to serialize web_search echo body: {e}"))
+            })?;
+            let timeout = if self.non_streaming_timeout.is_zero() {
+                std::time::Duration::from_secs(600)
+            } else {
+                self.non_streaming_timeout
+            };
+            let client = super::http_client::get();
+            let mut request = client.post(url).timeout(timeout).body(echo_body);
+            for (key, value) in request_headers {
+                request = request.header(key, value);
+            }
+            let echo_response = request.send().await.map_err(map_reqwest_send_error)?;
+            let echo_status = echo_response.status();
+            let echo_headers = echo_response.headers().clone();
+            let echo_bytes = echo_response
+                .bytes()
+                .await
+                .map_err(map_reqwest_send_error)?;
+            if !echo_status.is_success() {
+                // Surface the upstream failure as-is so the handler's error
+                // conversion can shape it for the Codex client.
+                return Ok(ProxyResponse::buffered(
+                    echo_status,
+                    echo_headers,
+                    echo_bytes,
+                ));
+            }
+            chat_json = serde_json::from_slice(&echo_bytes).map_err(|e| {
+                ProxyError::TransformError(format!(
+                    "Failed to parse Kimi web_search echo response: {e}"
+                ))
+            })?;
+        }
+
+        let mut out_headers = headers;
+        out_headers.remove(http::header::CONTENT_ENCODING);
+        out_headers.remove(http::header::CONTENT_LENGTH);
+        out_headers.insert(
+            http::header::CONTENT_TYPE,
+            http::HeaderValue::from_static("application/json"),
+        );
+        out_headers.insert(
+            super::providers::kimi_web_search::BRIDGED_HEADER,
+            http::HeaderValue::from_static("1"),
+        );
+        let out_body = serde_json::to_vec(&chat_json).map_err(|e| {
+            ProxyError::Internal(format!("Failed to serialize bridged chat response: {e}"))
+        })?;
+        Ok(ProxyResponse::buffered(
+            status,
+            out_headers,
+            Bytes::from(out_body),
+        ))
+    }
+
     async fn validate_codex_anthropic_success_response(
         &self,
         response: ProxyResponse,

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -2460,6 +2460,13 @@ impl RequestForwarder {
             return Ok(ProxyResponse::buffered(status, headers, body));
         };
 
+        // The bridge issues one billable upstream request per round; aggregate
+        // usage across all rounds so downstream logging reflects the real cost.
+        let mut total_usage = serde_json::json!({});
+        if let Some(usage) = chat_json.get("usage") {
+            super::providers::kimi_web_search::accumulate_chat_usage(&mut total_usage, usage);
+        }
+
         let mut request_body = request_body.clone();
         // api.kimi.com's k3 chat template cannot tokenize the builtin echo
         // conversation; run the echo rounds under the kimi-for-coding alias.
@@ -2492,25 +2499,33 @@ impl RequestForwarder {
             }
             let echo_response = request.send().await.map_err(map_reqwest_send_error)?;
             let echo_status = echo_response.status();
-            let echo_headers = echo_response.headers().clone();
-            let echo_bytes = echo_response
-                .bytes()
-                .await
-                .map_err(map_reqwest_send_error)?;
+            // Bounded collection, same 128 MiB cap as every other non-streaming
+            // path, instead of reqwest's unbounded `bytes()`.
+            let echo_bytes = ProxyResponse::Reqwest(echo_response)
+                .bytes_with_limit(MAX_RESPONSE_BODY_BYTES)
+                .await?;
             if !echo_status.is_success() {
-                // Surface the upstream failure as-is so the handler's error
-                // conversion can shape it for the Codex client.
-                return Ok(ProxyResponse::buffered(
-                    echo_status,
-                    echo_headers,
-                    echo_bytes,
-                ));
+                // Return an error (not an Ok response) so the retry/failover
+                // wrapper applies its normal status categorization and can try
+                // the next provider instead of recording this as a success.
+                let body_text = String::from_utf8(echo_bytes.to_vec()).ok();
+                return Err(ProxyError::UpstreamError {
+                    status: echo_status.as_u16(),
+                    body: body_text,
+                });
             }
             chat_json = serde_json::from_slice(&echo_bytes).map_err(|e| {
                 ProxyError::TransformError(format!(
                     "Failed to parse Kimi web_search echo response: {e}"
                 ))
             })?;
+            if let Some(usage) = chat_json.get("usage") {
+                super::providers::kimi_web_search::accumulate_chat_usage(&mut total_usage, usage);
+            }
+        }
+
+        if rounds > 0 {
+            chat_json["usage"] = total_usage;
         }
 
         let mut out_headers = headers;

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -1312,6 +1312,13 @@ async fn handle_codex_chat_to_responses_transform(
 ) -> Result<axum::response::Response, ProxyError> {
     let status = response.status();
 
+    // The forwarder ran the Kimi builtin `$web_search` echo rounds and buffered
+    // a final Chat completion; serve it via the non-stream conversion path even
+    // when the client asked for a stream (SSE is synthesized after conversion).
+    let web_search_bridged = response
+        .headers()
+        .contains_key(super::providers::kimi_web_search::BRIDGED_HEADER);
+
     if !status.is_success() {
         // 上游 Chat 错误体形状与 Responses 不一致（如 MiniMax 的 base_resp、自定义 detail 字段）；
         // 直接透传会让 Codex 客户端无法识别错误码。这里统一转换为 Responses 风格
@@ -1319,7 +1326,7 @@ async fn handle_codex_chat_to_responses_transform(
         return handle_codex_chat_error_response(response, ctx, status).await;
     }
 
-    if is_stream || response.is_sse() {
+    if (is_stream || response.is_sse()) && !web_search_bridged {
         let stream = response.bytes_stream();
         let sse_stream = create_responses_sse_stream_from_chat_with_context(stream, tool_context);
         let sse_stream = record_responses_sse_stream(sse_stream, state.codex_chat_history.clone());
@@ -1508,8 +1515,38 @@ async fn handle_codex_chat_to_responses_transform(
 
     strip_entity_headers_for_rebuilt_body(&mut response_headers);
     strip_hop_by_hop_response_headers(&mut response_headers);
+    response_headers.remove(super::providers::kimi_web_search::BRIDGED_HEADER);
     // Builder::header 是 append 语义；不先 remove 会和上游 Content-Type 双发。
     response_headers.remove(axum::http::header::CONTENT_TYPE);
+
+    // Kimi builtin web_search bridge: the upstream call was forced non-streaming
+    // for the echo rounds, but a streaming Codex client still expects SSE — replay
+    // the converted response as a Responses event stream.
+    if web_search_bridged && is_stream {
+        let events =
+            super::providers::kimi_web_search::responses_value_to_sse_bytes(&responses_response);
+        let mut sse_body = Vec::new();
+        for event in events {
+            sse_body.extend_from_slice(&event);
+        }
+        let mut builder = axum::response::Response::builder().status(status);
+        for (key, value) in response_headers.iter() {
+            builder = builder.header(key, value);
+        }
+        builder = builder
+            .header(
+                axum::http::header::CONTENT_TYPE,
+                axum::http::HeaderValue::from_static("text/event-stream"),
+            )
+            .header(
+                axum::http::header::CACHE_CONTROL,
+                axum::http::HeaderValue::from_static("no-cache"),
+            );
+        return builder.body(axum::body::Body::from(sse_body)).map_err(|e| {
+            log::error!("[Codex] 构建 web_search 桥接 SSE 响应失败: {e}");
+            ProxyError::Internal(format!("Failed to build bridged SSE response: {e}"))
+        });
+    }
 
     let mut builder = axum::response::Response::builder().status(status);
     for (key, value) in response_headers.iter() {

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -684,7 +684,7 @@ fn extract_codex_model_from_toml(config_text: &str) -> Option<String> {
         .map(ToString::to_string)
 }
 
-fn extract_codex_base_url_from_toml(config_text: &str) -> Option<String> {
+pub(crate) fn extract_codex_base_url_from_toml(config_text: &str) -> Option<String> {
     // Canonical parser lives in codex_config; keep this thin alias so the
     // proxy hot path and the usage-credential resolver share one implementation.
     crate::codex_config::extract_codex_base_url(config_text)

--- a/src-tauri/src/proxy/providers/kimi_web_search.rs
+++ b/src-tauri/src/proxy/providers/kimi_web_search.rs
@@ -89,8 +89,70 @@ pub(crate) fn provider_supports_builtin_web_search(provider: &Provider) -> bool 
     let Some(base_url) = provider_base_url(provider) else {
         return false;
     };
-    let base_url = base_url.to_ascii_lowercase();
-    base_url.contains("kimi.com") || base_url.contains("moonshot.")
+    base_url_supports_builtin_web_search(&base_url)
+}
+
+/// URL-level check, kept separate from the provider plumbing so it can be
+/// unit-tested without constructing a full `Provider`.
+fn base_url_supports_builtin_web_search(base_url: &str) -> bool {
+    // Match against the parsed hostname (exact or subdomain), not the raw URL
+    // string: a substring match would also fire for URLs that merely mention
+    // the domains in a path/query or for lookalike hosts such as
+    // `api.kimi.com.example`, injecting a nonstandard builtin tool into
+    // upstreams that do not support it.
+    let Ok(url) = url::Url::parse(base_url) else {
+        return false;
+    };
+    let Some(host) = url.host_str().map(str::to_ascii_lowercase) else {
+        return false;
+    };
+    ["kimi.com", "moonshot.cn", "moonshot.ai"]
+        .iter()
+        .any(|domain| host == *domain || host.ends_with(&format!(".{domain}")))
+}
+
+/// Accumulate Chat Completions `usage` objects across bridge rounds. The
+/// bridge issues one upstream request per round (initial search + each echo),
+/// each separately billable, so the final response must carry the sum,
+/// otherwise downstream conversion/usage logging only accounts for the last
+/// echo round.
+pub(crate) fn accumulate_chat_usage(total: &mut Value, usage: &Value) {
+    const NUMERIC_FIELDS: &[&str] = &["prompt_tokens", "completion_tokens", "total_tokens"];
+    let Some(total_obj) = total.as_object_mut() else {
+        return;
+    };
+    for field in NUMERIC_FIELDS {
+        let delta = usage.get(*field).and_then(|v| v.as_u64()).unwrap_or(0);
+        let current = total_obj.get(*field).and_then(|v| v.as_u64()).unwrap_or(0);
+        total_obj.insert((*field).to_string(), json!(current + delta));
+    }
+    // Preserve nested details (cached/reasoning tokens) by summing them too
+    // when both sides carry the same sub-object shape.
+    for (details_field, sub_keys) in [
+        ("prompt_tokens_details", ["cached_tokens"].as_slice()),
+        ("completion_tokens_details", ["reasoning_tokens"].as_slice()),
+    ] {
+        let Some(usage_details) = usage.get(details_field).and_then(|v| v.as_object()) else {
+            continue;
+        };
+        let total_details = total_obj
+            .entry(details_field.to_string())
+            .or_insert_with(|| json!({}));
+        let Some(total_details) = total_details.as_object_mut() else {
+            continue;
+        };
+        for sub_key in sub_keys {
+            let delta = usage_details
+                .get(*sub_key)
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let current = total_details
+                .get(*sub_key)
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            total_details.insert(sub_key.to_string(), json!(current + delta));
+        }
+    }
 }
 
 /// Whether the original Codex Responses request declares the hosted
@@ -313,7 +375,12 @@ pub(crate) fn responses_value_to_sse_bytes(responses: &Value) -> Vec<Bytes> {
     }
 
     let mut completed = responses.clone();
-    completed["status"] = json!("completed");
+    // Preserve the converted terminal status: a truncated answer
+    // (finish_reason "length") converts to "incomplete" and must stay so;
+    // only default to "completed" when the value carries no status.
+    if completed.get("status").and_then(|s| s.as_str()).is_none() {
+        completed["status"] = json!("completed");
+    }
     events.push(sse::response_completed(&completed));
 
     events
@@ -336,6 +403,63 @@ mod tests {
         let mut body = json!({"model": "k3"});
         apply_echo_model_override("not a url", &mut body);
         assert_eq!(body["model"], json!("k3"));
+    }
+
+    #[test]
+    fn support_check_matches_parsed_hostname_only() {
+        assert!(base_url_supports_builtin_web_search(
+            "https://api.kimi.com/coding/v1"
+        ));
+        assert!(base_url_supports_builtin_web_search(
+            "https://api.moonshot.cn/v1"
+        ));
+        assert!(base_url_supports_builtin_web_search(
+            "https://api.moonshot.ai/v1"
+        ));
+        // Lookalike hosts and mere mentions in path/query must NOT match.
+        assert!(!base_url_supports_builtin_web_search(
+            "https://api.kimi.com.example.com/v1"
+        ));
+        assert!(!base_url_supports_builtin_web_search(
+            "https://relay.example.com/kimi.com/v1"
+        ));
+        assert!(!base_url_supports_builtin_web_search(
+            "https://api.openai.com/v1?q=moonshot.cn"
+        ));
+        assert!(!base_url_supports_builtin_web_search("not a url"));
+    }
+
+    #[test]
+    fn usage_accumulates_across_rounds() {
+        let mut total = json!({});
+        accumulate_chat_usage(
+            &mut total,
+            &json!({
+                "prompt_tokens": 100,
+                "completion_tokens": 10,
+                "total_tokens": 110,
+                "prompt_tokens_details": {"cached_tokens": 40},
+                "completion_tokens_details": {"reasoning_tokens": 5}
+            }),
+        );
+        accumulate_chat_usage(
+            &mut total,
+            &json!({
+                "prompt_tokens": 50,
+                "completion_tokens": 20,
+                "total_tokens": 70,
+                "prompt_tokens_details": {"cached_tokens": 10},
+                "completion_tokens_details": {"reasoning_tokens": 7}
+            }),
+        );
+        assert_eq!(total["prompt_tokens"], json!(150));
+        assert_eq!(total["completion_tokens"], json!(30));
+        assert_eq!(total["total_tokens"], json!(180));
+        assert_eq!(total["prompt_tokens_details"]["cached_tokens"], json!(50));
+        assert_eq!(
+            total["completion_tokens_details"]["reasoning_tokens"],
+            json!(12)
+        );
     }
 
     #[test]
@@ -446,5 +570,36 @@ mod tests {
         assert!(text.contains("event: response.completed"));
         assert!(text.contains("\"hello\""));
         assert!(text.contains("\"function_call\""));
+    }
+
+    #[test]
+    fn synthesized_sse_preserves_incomplete_status() {
+        let responses = json!({
+            "id": "resp_1",
+            "object": "response",
+            "created_at": 1,
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"},
+            "model": "k3",
+            "output": [{
+                "id": "msg_1",
+                "type": "message",
+                "status": "incomplete",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "truncated…", "annotations": []}]
+            }]
+        });
+        let bytes = responses_value_to_sse_bytes(&responses);
+        let text = bytes
+            .iter()
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+            .collect::<Vec<_>>()
+            .join("");
+        let completed = text
+            .split("\n\n")
+            .find(|chunk| chunk.starts_with("event: response.completed"))
+            .expect("completed event present");
+        assert!(completed.contains("\"status\":\"incomplete\""));
+        assert!(!completed.contains("\"status\":\"completed\""));
     }
 }

--- a/src-tauri/src/proxy/providers/kimi_web_search.rs
+++ b/src-tauri/src/proxy/providers/kimi_web_search.rs
@@ -1,0 +1,450 @@
+//! Bridge Codex's hosted `web_search` tool to Kimi/Moonshot's server-side
+//! builtin `$web_search` on the Responses → Chat Completions conversion path.
+//!
+//! Codex sends `{"type": "web_search"}` in Responses requests. Chat
+//! Completions upstreams have no equivalent, so the converter used to drop it
+//! silently and the model answered "I cannot search the web". Kimi's Chat
+//! Completions endpoints (api.kimi.com / api.moonshot.cn / api.moonshot.ai)
+//! do have a server-side equivalent: the builtin function `$web_search`.
+//! When declared, the upstream executes the search itself and returns a
+//! `builtin_function` tool_call whose `function.arguments` already contain
+//! the search results; the client only has to echo that tool_call back as a
+//! `role: "tool"` message to get the final answer.
+//!
+//! This module implements that contract so it stays transparent to Codex:
+//! the request side injects the builtin declaration (and forces a
+//! non-streaming upstream request so the echo rounds can run inside the
+//! proxy), and the response side loops the echo rounds until the model
+//! produces a final answer. The marker header [`BRIDGED_HEADER`] tells the
+//! response handler the body is a *final* Chat completion that still needs
+//! the normal Chat → Responses conversion (and possibly SSE synthesis for
+//! streaming clients).
+
+use bytes::Bytes;
+use serde_json::{json, Value};
+
+use super::codex_responses_sse as sse;
+use crate::provider::Provider;
+
+/// Hop-local marker header: set on the buffered upstream response after the
+/// builtin web-search echo rounds completed inside the forwarder. Consumed
+/// (and stripped) by the Codex chat→responses handler; never forwarded to
+/// the client.
+pub(crate) const BRIDGED_HEADER: &str = "x-cc-switch-web-search-bridged";
+
+/// Maximum number of builtin echo rounds per client request (the model may
+/// chain several searches before answering).
+pub(crate) const MAX_ECHO_ROUNDS: usize = 4;
+
+/// Model alias override for the echo rounds on api.kimi.com.
+///
+/// Verified 2026-08-18 against the live endpoint: the `k3` alias on
+/// api.kimi.com/coding accepts the builtin `$web_search` declaration and
+/// returns the server-executed search tool_call, but its chat template fails
+/// to tokenize the *echoed* conversation (assistant `builtin_function`
+/// tool_call + `role: "tool"` message) with HTTP 400 "tokenization failed",
+/// while the `kimi-for-coding` alias handles the identical echo correctly.
+/// Rewriting the tool_call shape (e.g. `type: "function"`) avoids the crash
+/// but then the search results are no longer resolved server-side, so the
+/// only working contract on this endpoint is: run the echo rounds under the
+/// `kimi-for-coding` alias. The first (search) round keeps the client's
+/// model; only the echo rounds switch.
+const KIMI_CODING_ECHO_MODEL: &str = "kimi-for-coding";
+
+/// Apply the echo-round model override when the upstream is api.kimi.com
+/// (see [`KIMI_CODING_ECHO_MODEL`]). Other Moonshot hosts keep the client's
+/// model, whose chat template handles the builtin echo natively.
+pub(crate) fn apply_echo_model_override(url: &str, request_body: &mut Value) {
+    let is_kimi_coding = url::Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(str::to_string))
+        .map(|host| host.eq_ignore_ascii_case("api.kimi.com"))
+        .unwrap_or(false);
+    if is_kimi_coding {
+        request_body["model"] = json!(KIMI_CODING_ECHO_MODEL);
+    }
+}
+
+/// Extract the provider's upstream base_url (mirrors the extraction chain
+/// used elsewhere on the Codex path: explicit field, then config.toml).
+fn provider_base_url(provider: &Provider) -> Option<String> {
+    provider
+        .settings_config
+        .get("base_url")
+        .or_else(|| provider.settings_config.get("baseURL"))
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string)
+        .or_else(|| {
+            provider
+                .settings_config
+                .get("config")
+                .and_then(|value| value.as_str())
+                .and_then(super::codex::extract_codex_base_url_from_toml)
+        })
+}
+
+/// Whether the provider's upstream is a Kimi/Moonshot Chat Completions
+/// endpoint known to support the builtin `$web_search` tool.
+pub(crate) fn provider_supports_builtin_web_search(provider: &Provider) -> bool {
+    let Some(base_url) = provider_base_url(provider) else {
+        return false;
+    };
+    let base_url = base_url.to_ascii_lowercase();
+    base_url.contains("kimi.com") || base_url.contains("moonshot.")
+}
+
+/// Whether the original Codex Responses request declares the hosted
+/// `web_search` tool (which the chat converter would otherwise drop).
+pub(crate) fn request_has_web_search_tool(body: &Value) -> bool {
+    body.get("tools")
+        .and_then(|tools| tools.as_array())
+        .map(|tools| {
+            tools.iter().any(|tool| {
+                matches!(
+                    tool.get("type").and_then(|t| t.as_str()),
+                    Some("web_search") | Some("web_search_preview")
+                )
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Inject the `$web_search` builtin declaration into the converted Chat
+/// Completions request and force a non-streaming upstream call so the echo
+/// rounds can run inside the proxy before anything reaches the client.
+pub(crate) fn inject_builtin_web_search(chat_body: &mut Value) {
+    let Some(obj) = chat_body.as_object_mut() else {
+        return;
+    };
+    let tools = obj.entry("tools".to_string()).or_insert_with(|| json!([]));
+    if let Some(tools) = tools.as_array_mut() {
+        let already = tools.iter().any(|tool| {
+            tool.get("type").and_then(|t| t.as_str()) == Some("builtin_function")
+                && tool
+                    .get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|n| n.as_str())
+                    == Some("$web_search")
+        });
+        if !already {
+            tools.push(json!({
+                "type": "builtin_function",
+                "function": { "name": "$web_search" }
+            }));
+        }
+    }
+    obj.insert("stream".to_string(), json!(false));
+    obj.remove("stream_options");
+}
+
+/// Builtin tool calls from an upstream Chat completion (Kimi marks them
+/// `type: "builtin_function"`; also accept a `$`-prefixed function name as a
+/// fallback signal).
+fn builtin_tool_calls(chat_response: &Value) -> Vec<Value> {
+    chat_response
+        .get("choices")
+        .and_then(|choices| choices.as_array())
+        .and_then(|choices| choices.first())
+        .and_then(|choice| choice.get("message"))
+        .and_then(|message| message.get("tool_calls"))
+        .and_then(|tool_calls| tool_calls.as_array())
+        .map(|tool_calls| {
+            tool_calls
+                .iter()
+                .filter(|call| {
+                    call.get("type").and_then(|t| t.as_str()) == Some("builtin_function")
+                        || call
+                            .get("function")
+                            .and_then(|f| f.get("name"))
+                            .and_then(|n| n.as_str())
+                            .map(|name| name.starts_with('$'))
+                            .unwrap_or(false)
+                })
+                .cloned()
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Whether this upstream response still expects builtin echo rounds.
+pub(crate) fn has_builtin_tool_calls(chat_response: &Value) -> bool {
+    !builtin_tool_calls(chat_response).is_empty()
+}
+
+/// Append the assistant message (with its builtin tool_calls) and the
+/// `role: "tool"` echoes to the request messages, per Kimi's builtin-tool
+/// contract. Returns false when the request/response shape was unexpected
+/// (caller should then stop looping and pass the response through).
+pub(crate) fn append_echo_messages(request_body: &mut Value, chat_response: &Value) -> bool {
+    let calls = builtin_tool_calls(chat_response);
+    if calls.is_empty() {
+        return false;
+    }
+    let Some(message) = chat_response
+        .get("choices")
+        .and_then(|choices| choices.as_array())
+        .and_then(|choices| choices.first())
+        .and_then(|choice| choice.get("message"))
+    else {
+        return false;
+    };
+    let Some(messages) = request_body
+        .get_mut("messages")
+        .and_then(|messages| messages.as_array_mut())
+    else {
+        return false;
+    };
+
+    let mut assistant = json!({ "role": "assistant" });
+    if let Some(content) = message.get("content") {
+        assistant["content"] = content.clone();
+    }
+    if let Some(tool_calls) = message.get("tool_calls") {
+        assistant["tool_calls"] = tool_calls.clone();
+    }
+    messages.push(assistant);
+
+    for call in calls {
+        let Some(id) = call.get("id").and_then(|id| id.as_str()) else {
+            continue;
+        };
+        let name = call
+            .get("function")
+            .and_then(|f| f.get("name"))
+            .and_then(|n| n.as_str())
+            .unwrap_or("$web_search");
+        let arguments = call
+            .get("function")
+            .and_then(|f| f.get("arguments"))
+            .and_then(|a| a.as_str())
+            .unwrap_or("");
+        messages.push(json!({
+            "role": "tool",
+            "tool_call_id": id,
+            "name": name,
+            "content": arguments,
+        }));
+    }
+    true
+}
+
+/// Synthesize a complete Responses SSE stream from a finished Responses JSON
+/// value, reusing the shared event builders so the wire format matches the
+/// streaming converters exactly. Used when the builtin web-search echo
+/// rounds forced the upstream call to be non-streaming while the Codex
+/// client still expects an SSE stream.
+pub(crate) fn responses_value_to_sse_bytes(responses: &Value) -> Vec<Bytes> {
+    let mut events = Vec::new();
+
+    let mut started = responses.clone();
+    started["status"] = json!("in_progress");
+    started["output"] = json!([]);
+    if let Some(obj) = started.as_object_mut() {
+        obj.remove("usage");
+    }
+    events.push(sse::response_created(&started));
+    events.push(sse::response_in_progress(&started));
+
+    let output = responses
+        .get("output")
+        .and_then(|output| output.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    for (index, item) in output.iter().enumerate() {
+        let index = index as u32;
+        let fallback_id = format!("item_{index}");
+        let item_id = item
+            .get("id")
+            .and_then(|id| id.as_str())
+            .unwrap_or(&fallback_id)
+            .to_string();
+        match item.get("type").and_then(|t| t.as_str()) {
+            Some("message") => {
+                events.push(sse::message_item_added(index, &item_id));
+                let text = item
+                    .get("content")
+                    .and_then(|content| content.as_array())
+                    .map(|parts| {
+                        parts
+                            .iter()
+                            .filter(|part| {
+                                part.get("type").and_then(|t| t.as_str()) == Some("output_text")
+                            })
+                            .filter_map(|part| part.get("text").and_then(|text| text.as_str()))
+                            .collect::<Vec<_>>()
+                            .join("")
+                    })
+                    .unwrap_or_default();
+                events.push(sse::message_content_part_added(index, &item_id));
+                if !text.is_empty() {
+                    events.push(sse::output_text_delta(index, &item_id, &text));
+                }
+                let (close_events, _item) = sse::message_close(index, &item_id, &text);
+                events.extend(close_events);
+            }
+            Some("reasoning") => {
+                events.push(sse::reasoning_item_added(index, &item_id));
+                let text = item
+                    .get("summary")
+                    .and_then(|summary| summary.as_array())
+                    .map(|parts| {
+                        parts
+                            .iter()
+                            .filter_map(|part| part.get("text").and_then(|text| text.as_str()))
+                            .collect::<Vec<_>>()
+                            .join("")
+                    })
+                    .unwrap_or_default();
+                events.push(sse::reasoning_summary_part_added(index, &item_id));
+                if !text.is_empty() {
+                    events.push(sse::reasoning_summary_text_delta(index, &item_id, &text));
+                }
+                let (close_events, _item) = sse::reasoning_close(index, &item_id, &text);
+                events.extend(close_events);
+            }
+            _ => {
+                // function_call / custom_tool_call / …: emit the finished item
+                // directly; the client consumes it from output_item.done.
+                events.push(sse::output_item_added(index, item));
+                events.push(sse::output_item_done(index, item));
+            }
+        }
+    }
+
+    let mut completed = responses.clone();
+    completed["status"] = json!("completed");
+    events.push(sse::response_completed(&completed));
+
+    events
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn echo_model_override_only_on_kimi_coding_host() {
+        let mut body = json!({"model": "k3"});
+        apply_echo_model_override("https://api.kimi.com/coding/v1/chat/completions", &mut body);
+        assert_eq!(body["model"], json!("kimi-for-coding"));
+
+        let mut body = json!({"model": "kimi-k3"});
+        apply_echo_model_override("https://api.moonshot.cn/v1/chat/completions", &mut body);
+        assert_eq!(body["model"], json!("kimi-k3"));
+
+        let mut body = json!({"model": "k3"});
+        apply_echo_model_override("not a url", &mut body);
+        assert_eq!(body["model"], json!("k3"));
+    }
+
+    #[test]
+    fn detects_web_search_tool_in_request() {
+        assert!(request_has_web_search_tool(&json!({
+            "tools": [{"type": "web_search"}]
+        })));
+        assert!(request_has_web_search_tool(&json!({
+            "tools": [{"type": "function", "function": {"name": "x"}}, {"type": "web_search_preview"}]
+        })));
+        assert!(!request_has_web_search_tool(&json!({
+            "tools": [{"type": "function", "function": {"name": "web_search"}}]
+        })));
+        assert!(!request_has_web_search_tool(&json!({})));
+    }
+
+    #[test]
+    fn injects_builtin_and_forces_non_stream() {
+        let mut body = json!({
+            "model": "k3",
+            "stream": true,
+            "stream_options": {"include_usage": true},
+            "tools": [{"type": "function", "function": {"name": "exec", "parameters": {}}}]
+        });
+        inject_builtin_web_search(&mut body);
+        assert_eq!(body["stream"], json!(false));
+        assert!(body.get("stream_options").is_none());
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[1]["type"], json!("builtin_function"));
+        assert_eq!(tools[1]["function"]["name"], json!("$web_search"));
+
+        // Idempotent: no duplicate builtin on re-injection.
+        inject_builtin_web_search(&mut body);
+        assert_eq!(body["tools"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn echo_round_appends_assistant_and_tool_messages() {
+        let mut request = json!({
+            "messages": [{"role": "user", "content": "news?"}]
+        });
+        let response = json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "t-1",
+                        "type": "builtin_function",
+                        "function": {"name": "$web_search", "arguments": "{\"search_result\":{}}"}
+                    }]
+                }
+            }]
+        });
+        assert!(has_builtin_tool_calls(&response));
+        assert!(append_echo_messages(&mut request, &response));
+        let messages = request["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1]["role"], json!("assistant"));
+        assert_eq!(messages[2]["role"], json!("tool"));
+        assert_eq!(messages[2]["tool_call_id"], json!("t-1"));
+        assert_eq!(messages[2]["name"], json!("$web_search"));
+
+        let final_response = json!({
+            "choices": [{"message": {"role": "assistant", "content": "done"}}]
+        });
+        assert!(!has_builtin_tool_calls(&final_response));
+        assert!(!append_echo_messages(&mut request, &final_response));
+    }
+
+    #[test]
+    fn synthesizes_sse_for_message_and_function_call() {
+        let responses = json!({
+            "id": "resp_1",
+            "object": "response",
+            "created_at": 1,
+            "status": "completed",
+            "model": "k3",
+            "output": [
+                {
+                    "id": "msg_1",
+                    "type": "message",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "hello", "annotations": []}]
+                },
+                {
+                    "id": "fc_1",
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "exec",
+                    "arguments": "{}",
+                    "status": "completed"
+                }
+            ],
+            "usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+        });
+        let bytes = responses_value_to_sse_bytes(&responses);
+        let text = bytes
+            .iter()
+            .map(|b| String::from_utf8_lossy(b).into_owned())
+            .collect::<Vec<_>>()
+            .join("");
+        assert!(text.contains("event: response.created"));
+        assert!(text.contains("event: response.output_item.added"));
+        assert!(text.contains("event: response.output_text.delta"));
+        assert!(text.contains("event: response.output_item.done"));
+        assert!(text.contains("event: response.completed"));
+        assert!(text.contains("\"hello\""));
+        assert!(text.contains("\"function_call\""));
+    }
+}

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -24,6 +24,7 @@ pub mod copilot_model_map;
 mod gemini;
 pub(crate) mod gemini_schema;
 pub mod gemini_shadow;
+pub(crate) mod kimi_web_search;
 pub mod models;
 pub(crate) mod reasoning_bridge;
 pub mod streaming;


### PR DESCRIPTION
## 问题

通过本地路由把 Codex 接到 Kimi（Kimi For Coding / Moonshot）时，Codex 内置的 `web_search` 工具会在 Responses → Chat Completions 转换中被静默丢弃（`CodexToolContext::add_response_tool` 对未知工具类型 `_ => {}`），模型完全感知不到联网能力，只会回答"我没有联网搜索功能"。

关联 issue：#6508（本人所提，含复现与方案）、同类问题 #5233。

## 方案

Kimi 的 Chat Completions 端点支持服务端内置工具 `$web_search`（`{"type":"builtin_function","function":{"name":"$web_search"}}`）：上游自己执行搜索并返回 `builtin_function` tool_call，客户端把该 tool_call 以 `role: "tool"` 消息回显后即可得到最终答案。本 PR 在代理内实现这个契约，对 Codex 完全透明：

- **请求侧**（`forwarder.rs` + 新模块 `kimi_web_search.rs`）：Responses 请求含 `web_search` 工具且上游是 Kimi/Moonshot（`kimi.com` / `moonshot.` host）时，在转换后的 Chat 请求中注入 `$web_search` builtin 声明，并强制上游非流式（echo 轮次需要在代理内完成）。
- **响应侧**（`forwarder.rs::bridge_kimi_builtin_web_search`）：检测到 `builtin_function` tool_call 时，在代理内部循环执行 echo 轮次（上限 4 轮），拿到最终 Chat completion 后打上内部标记头。
- **出口侧**（`handlers.rs`）：带标记的响应走常规 Chat → Responses 转换（用量统计、history 记录不变）；客户端要求流式时，用 `codex_responses_sse` 的共享事件构造器把完整响应合成为 Responses SSE。

## 关键实测发现（已验证，写在代码注释里）

api.kimi.com 的 `k3` 模型别名能接受 `$web_search` 声明并返回搜索结果，但其 chat template **无法 tokenize 回显会话**（assistant 的 `builtin_function` tool_call + tool 消息），报 HTTP 400 "tokenization failed"；改写 tool_call 形状（如 `type: "function"`）虽不报错但服务端不再解析搜索结果。该端点上唯一可行的契约是 echo 轮次改用 `kimi-for-coding` 别名（首轮仍用客户端模型），本 PR 的 `apply_echo_model_override` 即处理此 case；Moonshot 平台端点（api.moonshot.cn/.ai）无此问题，保持原模型。

## 验证

- 新增 5 个单元测试（`kimi_web_search.rs`），`cargo test --lib` 通过；`cargo fmt --check` / `cargo clippy --lib` 无告警。
- 实机验证（macOS，Kimi For Coding 供应商，模型 k3 / kimi-for-coding）：
  - `POST /v1/responses` 带 `{"type":"web_search"}` → 返回真实搜索结果（北京实时气温，含 timeanddate / Wunderground 等来源引用），usage 正常记账；
  - Codex CLI 端到端：开启 `web_search = "live"` 后模型可联网检索并正确回答时效性问题；
  - 修复前同一请求模型只会回答"我没有联网搜索能力"。

## 影响面

- 仅当请求显式携带 `web_search` 工具且上游为 Kimi/Moonshot host 时触发；其他供应商、其他请求路径行为完全不变。
- 上游不支持 builtin 的 Kimi 系网关（理论上）会按原样透传并返回上游错误，不影响正常对话请求。
