### PR TITLE
feat(skills): show compatibility requirements

### DIFF
--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -81,6 +81,9 @@ pub struct DiscoverableSkill {
     pub name: String,
     /// 技能描述
     pub description: String,
+    /// Agent Skills 标准的环境兼容性/运行要求说明
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compatibility: Option<String>,
     /// 目录名称 (安装路径的最后一段)
     pub directory: String,
     /// GitHub README URL
@@ -331,6 +334,7 @@ const MAX_ARCHIVE_DOWNLOAD_BYTES: u64 = 128 * 1024 * 1024;
 pub struct SkillMetadata {
     pub name: Option<String>,
     pub description: Option<String>,
+    pub compatibility: Option<String>,
 }
 
 /// 导入已有 Skill 时，前端显式提交的启用应用选择
@@ -2704,6 +2708,7 @@ impl SkillService {
             key: format!("{}/{}:{}", repo.owner, repo.name, directory),
             name: meta.name.unwrap_or_else(|| directory.to_string()),
             description: meta.description.unwrap_or_default(),
+            compatibility: meta.compatibility,
             directory: directory.to_string(),
             readme_url: Self::build_skill_doc_url(&repo.owner, &repo.name, &repo.branch, doc_path),
             repo_owner: repo.owner.clone(),
@@ -2727,6 +2732,7 @@ impl SkillService {
             return Ok(SkillMetadata {
                 name: None,
                 description: None,
+                compatibility: None,
             });
         }
 
@@ -2734,6 +2740,7 @@ impl SkillService {
         let meta: SkillMetadata = serde_yaml::from_str(front_matter).unwrap_or(SkillMetadata {
             name: None,
             description: None,
+            compatibility: None,
         });
 
         Ok(meta)
@@ -4226,6 +4233,25 @@ pub fn migrate_skills_to_ssot(db: &Arc<Database>) -> Result<usize> {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    #[test]
+    fn parse_skill_metadata_preserves_standard_compatibility() {
+        let temp = tempdir().expect("tempdir");
+        let skill_md = temp.path().join("SKILL.md");
+        fs::write(
+            &skill_md,
+            "---\nname: browser-check\ndescription: Checks web pages\ncompatibility: Requires agent-browser and network access\n---\n",
+        )
+        .expect("write SKILL.md");
+
+        let metadata =
+            SkillService::parse_skill_metadata_static(&skill_md).expect("parse metadata");
+
+        assert_eq!(
+            metadata.compatibility.as_deref(),
+            Some("Requires agent-browser and network access")
+        );
+    }
 
     #[test]
     fn skill_state_lock_allows_snapshots_but_excludes_writers() {

--- a/src/components/skills/SkillCard.tsx
+++ b/src/components/skills/SkillCard.tsx
@@ -10,7 +10,13 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { ExternalLink, Download, Trash2, Loader2 } from "lucide-react";
+import {
+  CircleAlert,
+  ExternalLink,
+  Download,
+  Trash2,
+  Loader2,
+} from "lucide-react";
 import { settingsApi } from "@/lib/api";
 import type { DiscoverableSkill } from "@/lib/api/skills";
 
@@ -116,6 +122,15 @@ export function SkillCard({
         </CardContent>
       ) : (
         <div className="flex-1" />
+      )}
+      {skill.compatibility && (
+        <div className="mx-6 mb-4 flex items-start gap-2 text-xs text-amber-700 dark:text-amber-300">
+          <CircleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <p className="min-w-0 break-words leading-relaxed">
+            <span className="font-medium">{t("skills.requirements")}:</span>{" "}
+            {skill.compatibility}
+          </p>
+        </div>
       )}
       <CardFooter className="flex gap-2 pt-3 border-t border-border/50 relative z-10">
         {skill.readmeUrl && (

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2486,6 +2486,7 @@
     "uninstall": "Uninstall",
     "uninstalling": "Uninstalling...",
     "view": "View",
+    "requirements": "Requirements",
     "noDescription": "No description",
     "loadFailed": "Failed to load",
     "installSuccess": "Skill {{name}} installed",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2486,6 +2486,7 @@
     "uninstall": "アンインストール",
     "uninstalling": "アンインストール中...",
     "view": "表示",
+    "requirements": "動作要件",
     "noDescription": "説明なし",
     "loadFailed": "読み込みに失敗しました",
     "installSuccess": "スキル {{name}} をインストールしました",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2487,6 +2487,7 @@
     "uninstall": "解除安裝",
     "uninstalling": "解除安裝中...",
     "view": "檢視",
+    "requirements": "環境需求",
     "noDescription": "暫無描述",
     "loadFailed": "載入失敗",
     "installSuccess": "技能 {{name}} 已安裝",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2486,6 +2486,7 @@
     "uninstall": "卸载",
     "uninstalling": "卸载中...",
     "view": "查看",
+    "requirements": "环境要求",
     "noDescription": "暂无描述",
     "loadFailed": "加载失败",
     "installSuccess": "技能 {{name}} 已安装",

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -60,6 +60,7 @@ export interface DiscoverableSkill {
   key: string;
   name: string;
   description: string;
+  compatibility?: string;
   directory: string;
   readmeUrl?: string;
   repoOwner: string;

--- a/tests/components/SkillCard.test.tsx
+++ b/tests/components/SkillCard.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SkillCard } from "@/components/skills/SkillCard";
+
+const makeSkill = (compatibility?: string) => ({
+  key: "owner/repo:browser-check",
+  name: "browser-check",
+  description: "Checks web pages",
+  compatibility,
+  directory: "browser-check",
+  readmeUrl: "https://github.com/owner/repo/blob/main/SKILL.md",
+  repoOwner: "owner",
+  repoName: "repo",
+  repoBranch: "main",
+  installed: false,
+});
+
+describe("SkillCard", () => {
+  it("shows standard compatibility requirements before installation", () => {
+    render(
+      <SkillCard
+        skill={makeSkill("Requires agent-browser and network access")}
+        onInstall={vi.fn()}
+        onUninstall={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("skills.requirements:")).toBeInTheDocument();
+    expect(
+      screen.getByText("Requires agent-browser and network access"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render an empty requirements section", () => {
+    render(
+      <SkillCard
+        skill={makeSkill()}
+        onInstall={vi.fn()}
+        onUninstall={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("skills.requirements")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary / 概述

- Parse the optional Agent Skills `compatibility` frontmatter field.
- Expose compatibility requirements through the Rust and TypeScript discovery models.
- Show declared requirements on Skill cards with localized labels.
- Add Rust parsing coverage and React rendering coverage.

## Why / 原因

CC Switch currently drops the standard `compatibility` field while discovering
Skills. This makes Skills with external CLI, system package, product, or network
requirements appear ready to install without surfacing those requirements.

The change is intentionally metadata-only. It does not detect dependencies
heuristically or execute third-party installation commands. Skills that do not
declare `compatibility` keep their existing behavior.

## Related Issue / 关联 Issue

Fixes #6559

## Validation / 验证

- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/prettier --check ...`
- `./node_modules/.bin/vitest run tests/components/SkillCard.test.tsx` (2 tests passed)
- `cargo fmt --check`
- `cargo clippy --offline --lib --quiet`
- Rust unit test `parse_skill_metadata_preserves_standard_compatibility` (passed)
- `git diff --cached --check`

## Screenshots / 截图

Not included. The new requirements block is covered by the focused component test.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
