### PR TITLE
fix(db): make recovery quit button work

### DIFF
--- a/src/components/DatabaseUpgrade.tsx
+++ b/src/components/DatabaseUpgrade.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { exit } from "@tauri-apps/plugin-process";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   Database,
   Download,
@@ -289,7 +289,7 @@ export function DatabaseUpgrade({ payload }: DatabaseUpgradeProps) {
           <Button
             variant="ghost"
             className="ml-auto text-muted-foreground"
-            onClick={() => void exit(0)}
+            onClick={() => void getCurrentWindow().close()}
             disabled={phase === "updating"}
           >
             {t("dbUpgrade.quit", "退出")}


### PR DESCRIPTION
## Summary

- replace the recovery screens unauthorized process exit call with the already-authorized window close API
- reuse the existing database-recovery CloseRequested path, which exits instead of minimizing to tray
- avoid expanding process plugin permissions

## Context

The exact missing-permission bug was identified in the original review for PR #4575 but was not addressed before merge: https://github.com/farion1231/cc-switch/pull/4575#discussion_r3463860584

Related reports #2484 and #4515 cover the broader too-new-database recovery experience, but neither reports this Quit-button ACL failure, so this PR does not close them.

## Validation

- pnpm typecheck
- Prettier and git diff checks
- pnpm test:unit: 131 files, 987 tests passed
- two independent blind reviews found no in-scope P0/P1/P2 issues
- macOS real-machine test with CC_SWITCH_TEST_HOME and an isolated SQLite database at user_version 18: the recovery screen appeared, one click on Quit immediately closed the process, normal exit cleanup completed, no ACL or unhandled-rejection error was logged, and the real CC Switch database hash remained unchanged

The macOS app bundle was built and exercised. Updater signing was not performed because no release private key is available locally.