### PR TITLE
fix(proxy): skip empty reasoning deltas to avoid reopening thinking block

### DIFF
--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -268,45 +268,47 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
 
                                         // 处理 reasoning（thinking）
                                         if let Some(reasoning) = &choice.delta.reasoning {
-                                            if current_non_tool_block_type != Some("thinking") {
-                                                if let Some(index) = current_non_tool_block_index.take() {
+                                            if !reasoning.is_empty() {
+                                                if current_non_tool_block_type != Some("thinking") {
+                                                    if let Some(index) = current_non_tool_block_index.take() {
+                                                        let event = json!({
+                                                            "type": "content_block_stop",
+                                                            "index": index
+                                                        });
+                                                        let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
+                                                            serde_json::to_string(&event).unwrap_or_default());
+                                                        yield Ok(Bytes::from(sse_data));
+                                                    }
+                                                    let index = next_content_index;
+                                                    next_content_index += 1;
                                                     let event = json!({
-                                                        "type": "content_block_stop",
-                                                        "index": index
+                                                        "type": "content_block_start",
+                                                        "index": index,
+                                                        "content_block": {
+                                                            "type": "thinking",
+                                                            "thinking": ""
+                                                        }
                                                     });
-                                                    let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
+                                                    let sse_data = format!("event: content_block_start\ndata: {}\n\n",
+                                                        serde_json::to_string(&event).unwrap_or_default());
+                                                    yield Ok(Bytes::from(sse_data));
+                                                    current_non_tool_block_type = Some("thinking");
+                                                    current_non_tool_block_index = Some(index);
+                                                }
+
+                                                if let Some(index) = current_non_tool_block_index {
+                                                    let event = json!({
+                                                        "type": "content_block_delta",
+                                                        "index": index,
+                                                        "delta": {
+                                                            "type": "thinking_delta",
+                                                            "thinking": reasoning
+                                                        }
+                                                    });
+                                                    let sse_data = format!("event: content_block_delta\ndata: {}\n\n",
                                                         serde_json::to_string(&event).unwrap_or_default());
                                                     yield Ok(Bytes::from(sse_data));
                                                 }
-                                                let index = next_content_index;
-                                                next_content_index += 1;
-                                                let event = json!({
-                                                    "type": "content_block_start",
-                                                    "index": index,
-                                                    "content_block": {
-                                                        "type": "thinking",
-                                                        "thinking": ""
-                                                    }
-                                                });
-                                                let sse_data = format!("event: content_block_start\ndata: {}\n\n",
-                                                    serde_json::to_string(&event).unwrap_or_default());
-                                                yield Ok(Bytes::from(sse_data));
-                                                current_non_tool_block_type = Some("thinking");
-                                                current_non_tool_block_index = Some(index);
-                                            }
-
-                                            if let Some(index) = current_non_tool_block_index {
-                                                let event = json!({
-                                                    "type": "content_block_delta",
-                                                    "index": index,
-                                                    "delta": {
-                                                        "type": "thinking_delta",
-                                                        "thinking": reasoning
-                                                    }
-                                                });
-                                                let sse_data = format!("event: content_block_delta\ndata: {}\n\n",
-                                                    serde_json::to_string(&event).unwrap_or_default());
-                                                yield Ok(Bytes::from(sse_data));
                                             }
                                         }
 
@@ -758,6 +760,34 @@ mod tests {
             map_stop_reason(Some("content_filter")),
             Some("end_turn".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn test_empty_reasoning_after_transition_does_not_reopen_thinking_block() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_reasoning\",\"model\":\"qwen3.7-max\",\"choices\":[{\"delta\":{\"reasoning_content\":\"思考\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl_reasoning\",\"model\":\"qwen3.7-max\",\"choices\":[{\"delta\":{\"reasoning_content\":\"\",\"content\":\"声音很轻，\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl_reasoning\",\"model\":\"qwen3.7-max\",\"choices\":[{\"delta\":{\"reasoning_content\":\"\",\"content\":\"“\"},\"finish_reason\":null}]}\n\n",
+            "data: {\"id\":\"chatcmpl_reasoning\",\"model\":\"qwen3.7-max\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+        let starts: Vec<&Value> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_start"))
+            .collect();
+        let stops: Vec<&Value> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_stop"))
+            .collect();
+
+        assert_eq!(starts.len(), 2, "expected one thinking and one text block");
+        assert_eq!(starts[0]["content_block"]["type"], "thinking");
+        assert_eq!(starts[1]["content_block"]["type"], "text");
+        assert_eq!(starts[1]["index"], 1);
+        assert_eq!(stops.len(), 2);
+        assert_eq!(stops[1]["index"], 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary / 概述

Some upstreams (e.g. qwen-style Chat completions) keep emitting **empty `reasoning_content` deltas after switching from reasoning to regular content**. The Anthropic SSE bridge treated every such delta as a block transition: each empty delta reopened a brand-new `thinking` `content_block_start`/`content_block_stop` pair, producing duplicate empty thinking blocks in the forwarded stream.

This PR skips empty reasoning deltas entirely — only non-empty reasoning content triggers thinking block start/delta emission.

部分上游（如 qwen 类 Chat completions）在从思考内容切换到正文后仍持续发送**空的 `reasoning_content` delta**。Anthropic SSE 桥接此前会把每个空 delta 都当作块切换处理，为每个空 delta 重新生成一对 `content_block_start`/`content_block_stop`，导致流中出现重复的空 thinking block。本 PR 直接跳过空的 reasoning delta，只有非空内容才会触发 thinking block 的创建与输出。

Added regression test `test_empty_reasoning_after_transition_does_not_reopen_thinking_block` covering the reasoning → text transition with trailing empty reasoning deltas (streaming module: 159 tests pass locally).

## Related Issue / 关联 Issue

None / 无

## Checklist / 检查清单

- [x] `cargo fmt --check` passes / 通过 Rust 格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] `cargo test` passes for touched module / 通过所改模块测试
- [x] No user-facing text changed, no i18n update needed / 无用户可见文本变更，无需更新国际化文件