### PR TITLE
fix(grokbuild): clear official grok login when switching to a custom provider

### DIFF
--- a/src-tauri/src/grok_config.rs
+++ b/src-tauri/src/grok_config.rs
@@ -2,7 +2,7 @@ use serde_json::{json, Value};
 use std::fs;
 use std::path::PathBuf;
 
-use crate::config::{get_home_dir, write_text_file};
+use crate::config::{delete_file, get_home_dir, write_text_file};
 use crate::error::AppError;
 use crate::provider::Provider;
 
@@ -387,6 +387,17 @@ pub fn write_grok_provider_live(provider: &Provider) -> Result<(), AppError> {
     // 切换流程重新补写。非官方供应商必须携带完整的自定义模型配置。
     if provider.category.as_deref() != Some("official") {
         validate_config_toml(config)?;
+
+        // 非官方（自定义）供应商应通过 config.toml 的 `api_key` / `env_key`
+        // 认证，而不是 grok.com 官方登录。若 ~/.grok/auth.json 残留了官方
+        // OIDC 会话（例如用户之前 `grok login` 过官方账号，或 grok CLI 在
+        // 一次 401 后自动触发 auth recovery 登录了官方），grok CLI 会把官方
+        // token 一起发给第三方 base_url，导致 401 Invalid token。
+        // 这里在切到非官方供应商时清掉官方会话，杜绝该冲突。
+        // 删除失败只降级为 warn，不阻断切换（config.toml 写入仍是主交付物）。
+        if let Err(error) = delete_file(&get_grok_config_dir().join("auth.json")) {
+            log::warn!("failed to clear official grok login (~/.grok/auth.json) while switching to a custom provider: {error}");
+        }
     }
 
     write_grok_live_settings(&json!({ "config": config }))
@@ -679,6 +690,80 @@ context_window = 500000
                 .get("config")
                 .and_then(Value::as_str),
             Some(valid_config())
+        );
+
+        match original_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+    }
+
+    /// Seed a fake official grok login into the test grok dir, mirroring the
+    /// real `~/.grok/auth.json` shape (a scope -> entry map).
+    fn seed_official_auth(dir: &std::path::Path) {
+        let auth_path = dir.join(".grok").join("auth.json");
+        std::fs::create_dir_all(auth_path.parent().expect("parent")).expect("mkdir");
+        std::fs::write(
+            &auth_path,
+            r#"{"https://auth.x.ai::client-123":{"auth_mode":"oidc","email":"test@example.com"}}"#,
+        )
+        .expect("write auth.json");
+    }
+
+    #[test]
+    #[serial]
+    fn switching_to_custom_provider_clears_official_auth() {
+        let temp = TempDir::new().expect("temp dir");
+        let original_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+        seed_official_auth(temp.path());
+
+        let custom = Provider::with_id(
+            "custom".to_string(),
+            "Custom".to_string(),
+            json!({ "config": valid_config() }),
+            None,
+        );
+        write_grok_provider_live(&custom).expect("write custom live config");
+
+        let auth_path = temp.path().join(".grok").join("auth.json");
+        assert!(
+            !auth_path.exists(),
+            "switching to a custom provider must clear the official grok login"
+        );
+        // config.toml itself is still written (primary deliverable)
+        assert_eq!(
+            fs::read_to_string(get_grok_config_path()).expect("read config"),
+            valid_config()
+        );
+
+        match original_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn switching_to_official_provider_keeps_auth() {
+        let temp = TempDir::new().expect("temp dir");
+        let original_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+        seed_official_auth(temp.path());
+
+        let mut official = Provider::with_id(
+            "grokbuild-official".to_string(),
+            "Grok Official".to_string(),
+            json!({ "config": "" }),
+            None,
+        );
+        official.category = Some("official".to_string());
+        write_grok_provider_live(&official).expect("write official live config");
+
+        let auth_path = temp.path().join(".grok").join("auth.json");
+        assert!(
+            auth_path.exists(),
+            "switching to the official provider must NOT clear the official grok login"
         );
 
         match original_test_home {

--- a/src-tauri/src/grok_config.rs
+++ b/src-tauri/src/grok_config.rs
@@ -387,20 +387,26 @@ pub fn write_grok_provider_live(provider: &Provider) -> Result<(), AppError> {
     // 切换流程重新补写。非官方供应商必须携带完整的自定义模型配置。
     if provider.category.as_deref() != Some("official") {
         validate_config_toml(config)?;
+    }
 
-        // 非官方（自定义）供应商应通过 config.toml 的 `api_key` / `env_key`
-        // 认证，而不是 grok.com 官方登录。若 ~/.grok/auth.json 残留了官方
-        // OIDC 会话（例如用户之前 `grok login` 过官方账号，或 grok CLI 在
-        // 一次 401 后自动触发 auth recovery 登录了官方），grok CLI 会把官方
-        // token 一起发给第三方 base_url，导致 401 Invalid token。
-        // 这里在切到非官方供应商时清掉官方会话，杜绝该冲突。
-        // 删除失败只降级为 warn，不阻断切换（config.toml 写入仍是主交付物）。
+    write_grok_live_settings(&json!({ "config": config }))?;
+
+    // 非官方（自定义）供应商应通过 config.toml 的 `api_key` / `env_key`
+    // 认证，而不是 grok.com 官方登录。若 ~/.grok/auth.json 残留了官方
+    // OIDC 会话（例如用户之前 `grok login` 过官方账号，或 grok CLI 在
+    // 一次 401 后自动触发 auth recovery 登录了官方），grok CLI 会把官方
+    // token 一起发给第三方 base_url，导致 401 Invalid token。
+    // 这里在切到非官方供应商时清掉官方会话，杜绝该冲突。
+    // 删除必须放在 config.toml 成功写入之后：若配置写入失败（磁盘满、
+    // 原子重命名失败等），官方登录态得以保留，避免"切换失败却把用户登出"。
+    // 删除失败只降级为 warn，不阻断切换（config.toml 写入仍是主交付物）。
+    if provider.category.as_deref() != Some("official") {
         if let Err(error) = delete_file(&get_grok_config_dir().join("auth.json")) {
             log::warn!("failed to clear official grok login (~/.grok/auth.json) while switching to a custom provider: {error}");
         }
     }
 
-    write_grok_live_settings(&json!({ "config": config }))
+    Ok(())
 }
 
 /// Raw live-file writer, mirroring `read_grok_live_settings` (syntax-only).
@@ -735,6 +741,43 @@ context_window = 500000
         assert_eq!(
             fs::read_to_string(get_grok_config_path()).expect("read config"),
             valid_config()
+        );
+
+        match original_test_home {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn failed_config_write_keeps_official_auth() {
+        let temp = TempDir::new().expect("temp dir");
+        let original_test_home = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", temp.path());
+        seed_official_auth(temp.path());
+
+        // 让 config.toml 写入失败：预先把目标位置占成一个非空目录，
+        // 原子 rename 会失败，模拟磁盘满 / 重命名失败等写入错误。
+        let config_path = temp.path().join(".grok").join("config.toml");
+        std::fs::create_dir_all(config_path.join("occupied")).expect("mkdir occupied dir");
+
+        let custom = Provider::with_id(
+            "custom".to_string(),
+            "Custom".to_string(),
+            json!({ "config": valid_config() }),
+            None,
+        );
+        assert!(
+            write_grok_provider_live(&custom).is_err(),
+            "config write must fail so we can verify auth is preserved"
+        );
+
+        // 关键断言：切换失败时官方登录态必须保留，不得提前清除。
+        let auth_path = temp.path().join(".grok").join("auth.json");
+        assert!(
+            auth_path.exists(),
+            "failed switch must NOT clear the official grok login"
         );
 
         match original_test_home {


### PR DESCRIPTION
## 概述 / Summary

当用户把 **Grok Build** 从官方登录（grok.com OAuth）**切换到自定义/第三方供应商**（如 apibasis、PackyCode 等）时，CC Switch 只写 `~/.grok/config.toml`，不会清除 `~/.grok/auth.json` 里残留的官方 OIDC 会话。grok CLI 会把官方 token 一起发给第三方 `base_url`，导致持续 `401 Invalid token`，且因 grok 的 auth recovery 会自动重登官方账号而循环。

本 PR 在 `write_grok_provider_live` 的**非官方分支**清除 `~/.grok/auth.json`，建立不变式：只要 live 是非官方供应商，官方登录态就不存在。切回官方时保留 auth.json，用户无需重新 `grok login`。

**Fixes: #6589**

> ⚠️ **待 CI 验证 / Pending CI verification**：改动逻辑简单（在既有非官方分支加一行 `delete_file` + 注释 + 两个单元测试），但**未在本机编译验证**（本地无 Rust 工具链，Tauri 首次编译耗时过长且占用资源）。请依赖 CI 或维护者验证编译与测试。

## 改动 / Changes

- `src-tauri/src/grok_config.rs`
  - `write_grok_provider_live` 非官方分支（`provider.category != Some("official")`）增加：删除 `get_grok_config_dir().join("auth.json")`，失败降级为 `log::warn!`，不阻断 config.toml 写入。
  - 新增 2 个单元测试（用 `CC_SWITCH_TEST_HOME` 临时目录 seed 官方 auth.json）：
    1. `switching_to_custom_provider_clears_official_auth` — 切自定义 → auth.json 被删、config.toml 正常写入
    2. `switching_to_official_provider_keeps_auth` — 切官方 → auth.json 保留

## 理由 / Rationale

- `~/.grok/auth.json` **只可能存官方登录态**（grok CLI 的 OIDC/legacy 会话）；第三方 `api_key` 走 config.toml 的 `api_key`/`env_key`。因此第三方活跃期间，auth.json 里的官方 token 没有合法用途，只会污染请求。
- 删除路径用 `get_grok_config_dir().join("auth.json")` 而非硬编码 `~/.grok`，以支持目录覆盖。
- 与 Codex 侧已有惯例一致（切第三方供应商时干净覆盖 `~/.codex/auth.json`）。

## 行为变化 / Behavior Change

- 切到非官方（自定义/第三方）供应商时会**登出官方 grok 会话**（一次性 UX 影响），这是修复的必然代价。
- 切回官方时 auth.json 被保留，用户不用重新登录；若之前被清过，`grok login` 重新登录即可。
