### PR TITLE
fix(i18n): align Grok Build and Codex routing copy

### DIFF
--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -902,7 +902,7 @@ export function CodexFormFields({
                   })
                 : t("codexConfig.advancedSectionHint", {
                     defaultValue:
-                      "包含上游格式、模型映射、思考能力与自定义 User-Agent。使用 Chat Completions 协议的供应商需开启路由接管才能使用。",
+                      "包含上游格式、模型映射、思考能力与自定义 User-Agent。使用 Chat Completions / Anthropic Messages 协议的供应商需开启路由接管才能使用。",
                   })}
             </p>
           )}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1056,10 +1056,8 @@
     "more": "More apps"
   },
   "grokBuild": {
-    "apiBackend": "API backend",
     "contextWindow": "Context window",
     "contextWindowInvalid": "Context window must be a positive integer",
-    "profile": "Client model profile",
     "rawConfig": "config.toml",
     "invalidToml": "Invalid config.toml: {{error}}",
     "defaultModelPlaceholder": "e.g. grok-4.5",
@@ -1575,7 +1573,7 @@
     "reasoningEffortHint": "Enable when the upstream supports thinking-depth control such as low/high/max. Enabling this also turns on thinking mode and converts Codex's reasoning.effort into the upstream Chat parameter.",
     "reasoningGroupTitle": "Reasoning Capability",
     "reasoningSectionHint": "Preset providers are configured automatically; custom providers are inferred from name/URL. Override manually only when auto-detection is wrong.",
-    "advancedSectionHint": "Includes upstream format, model mapping, reasoning overrides and custom User-Agent. Providers using the Chat Completions protocol require routing takeover to be enabled.",
+    "advancedSectionHint": "Includes upstream format, model mapping, reasoning overrides and custom User-Agent. Providers using the Chat Completions or Anthropic Messages protocol require routing takeover to be enabled.",
     "noCommonConfigToApply": "The common config snippet is empty or contains nothing to write"
   },
   "geminiConfig": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1056,10 +1056,8 @@
     "more": "その他のアプリ"
   },
   "grokBuild": {
-    "apiBackend": "API Backend",
     "contextWindow": "コンテキストウィンドウ",
     "contextWindowInvalid": "コンテキストウィンドウは正の整数で指定してください",
-    "profile": "クライアントモデルプロファイル",
     "rawConfig": "config.toml",
     "invalidToml": "config.toml の形式が不正です: {{error}}",
     "defaultModelPlaceholder": "例: grok-4.5",
@@ -1575,7 +1573,7 @@
     "reasoningEffortHint": "上流が low/high/max などの思考の深さの制御に対応している場合に有効化します。有効にすると思考モードも自動的にオンになり、Codex の reasoning.effort を上流の Chat パラメータに変換します。",
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "プリセットの供給元は自動的に設定され、カスタム供給元は名前/URL から自動推論されます。自動識別が正しくない場合のみ手動で上書きしてください。",
-    "advancedSectionHint": "上流フォーマット、モデルマッピング、思考能力、カスタム User-Agent の設定を含みます。Chat Completions プロトコルを使用するプロバイダーはルーティング引き継ぎの有効化が必要です。",
+    "advancedSectionHint": "上流フォーマット、モデルマッピング、思考能力、カスタム User-Agent の設定を含みます。Chat Completions / Anthropic Messages プロトコルを使用するプロバイダーはルーティング引き継ぎの有効化が必要です。",
     "noCommonConfigToApply": "共通設定スニペットが空か、書き込む内容がありません"
   },
   "geminiConfig": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1057,10 +1057,8 @@
     "more": "更多應用程式"
   },
   "grokBuild": {
-    "apiBackend": "API Backend",
     "contextWindow": "上下文視窗",
     "contextWindowInvalid": "上下文視窗必須是正整數",
-    "profile": "用戶端模型檔位",
     "rawConfig": "config.toml",
     "invalidToml": "config.toml 格式錯誤：{{error}}",
     "defaultModelPlaceholder": "例如: grok-4.5",
@@ -1576,7 +1574,7 @@
     "reasoningEffortHint": "上游支援 low/high/max 等思考深度控制時啟用。啟用後會自動啟用思考模式，並把 Codex 的 reasoning.effort 轉成上游 Chat 參數。",
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "預設供應商已自動設定；自訂供應商會按名稱/位址自動推斷。僅當自動識別不準時才需手動覆寫。",
-    "advancedSectionHint": "包含上游格式、模型映射、思考能力與自訂 User-Agent。使用 Chat Completions 協定的供應商需開啟路由接管才能使用。",
+    "advancedSectionHint": "包含上游格式、模型映射、思考能力與自訂 User-Agent。使用 Chat Completions / Anthropic Messages 協定的供應商需開啟路由接管才能使用。",
     "noCommonConfigToApply": "通用設定片段為空或沒有可寫入的內容"
   },
   "geminiConfig": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1056,10 +1056,8 @@
     "more": "更多应用"
   },
   "grokBuild": {
-    "apiBackend": "API Backend",
     "contextWindow": "上下文窗口",
     "contextWindowInvalid": "上下文窗口必须是正整数",
-    "profile": "客户端模型档位",
     "rawConfig": "config.toml",
     "invalidToml": "config.toml 格式错误：{{error}}",
     "defaultModelPlaceholder": "例如: grok-4.5",
@@ -1575,7 +1573,7 @@
     "reasoningEffortHint": "上游支持 low/high/max 等思考深度控制时启用。启用后会自动启用思考模式，并把 Codex 的 reasoning.effort 转成上游 Chat 参数。",
     "reasoningGroupTitle": "思考能力",
     "reasoningSectionHint": "预设供应商已自动配置；自定义供应商会按名称/地址自动推断。仅当自动识别不准时才需手动覆盖。",
-    "advancedSectionHint": "包含上游格式、模型映射、思考能力与自定义 User-Agent。使用 Chat Completions 协议的供应商需开启路由接管才能使用。",
+    "advancedSectionHint": "包含上游格式、模型映射、思考能力与自定义 User-Agent。使用 Chat Completions / Anthropic Messages 协议的供应商需开启路由接管才能使用。",
     "noCommonConfigToApply": "通用配置片段为空或没有可写入的内容"
   },
   "geminiConfig": {

--- a/tests/config/localeCoverage.test.ts
+++ b/tests/config/localeCoverage.test.ts
@@ -51,6 +51,7 @@ const locales = [
   ["ja", ja],
   ["zh-TW", zhTW],
 ] as const;
+const supportedLocales = [["en", en], ...locales] as const;
 
 describe("locale coverage", () => {
   it.each(locales)("covers every Pi translation key in %s", (_name, tree) => {
@@ -89,6 +90,18 @@ describe("locale coverage", () => {
       });
 
       expect(missingMentions).toEqual([]);
+    },
+  );
+});
+
+describe("Codex routing hint coverage", () => {
+  it.each(supportedLocales)(
+    "mentions every routed upstream protocol in %s",
+    (_name, tree) => {
+      const hint = tree.codexConfig.advancedSectionHint;
+
+      expect(hint).toContain("Chat Completions");
+      expect(hint).toContain("Anthropic Messages");
     },
   );
 });


### PR DESCRIPTION
## Summary

- remove the orphaned `grokBuild.apiBackend` and `grokBuild.profile` locale keys from all four supported locales
- update the Codex advanced-section hint and fallback copy to state that both Chat Completions and Anthropic Messages upstreams require routing takeover
- add locale coverage so every supported translation keeps both routed protocols in the hint

## Background

This follows up on the two optional cleanup suggestions from #6511.

The Grok Build API-backend and profile controls were removed previously, but their translation keys remained unused. The Codex hint also mentioned only Chat Completions even though Anthropic Messages is bridged through the local routing layer as well.

This PR changes only bundled copy and dead locale entries; it does not change routing or protocol-conversion behavior.

## Validation

- `pnpm test:unit -- tests/config/localeCoverage.test.ts tests/components/GrokBuildProviderForm.test.tsx` (21 tests passed)
- `pnpm exec prettier --check ...`
- `pnpm typecheck`
- Codex Security diff review: complete coverage, no findings
