### PR TITLE
fix(codex): replace stale single-model mapping

### DIFF
--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -68,6 +68,23 @@ interface EndpointCandidate {
   url: string;
 }
 
+export function replaceSingleCodexCatalogModel<T extends CodexCatalogModel>(
+  models: T[],
+  nextModel: string,
+): T[] {
+  const model = nextModel.trim();
+  if (!model || models.length !== 1) return models;
+
+  const [current] = models;
+  const replacement = {
+    ...current,
+    model,
+    displayName: model,
+  };
+  delete replacement.baseInstructions;
+  return [replacement];
+}
+
 interface CodexFormFieldsProps {
   appId?: AppId;
   providerId?: string;
@@ -687,6 +704,13 @@ export function CodexFormFields({
     ]);
   }, [onCatalogModelsChange, trimmedDefaultModel]);
 
+  const handleReplaceDefaultModelInCatalog = useCallback(() => {
+    if (!onCatalogModelsChange || !trimmedDefaultModel) return;
+    setCatalogRows((current) =>
+      replaceSingleCodexCatalogModel(current, trimmedDefaultModel),
+    );
+  }, [onCatalogModelsChange, trimmedDefaultModel]);
+
   const renderCatalogActionButtons = (onAdd: () => void, addLabel: string) => (
     <div className="flex gap-1">
       <Button
@@ -858,11 +882,19 @@ export function CodexFormFields({
                 variant="link"
                 size="sm"
                 className="h-auto p-0 text-xs"
-                onClick={handleAddDefaultModelToCatalog}
+                onClick={
+                  catalogRows.length === 1
+                    ? handleReplaceDefaultModelInCatalog
+                    : handleAddDefaultModelToCatalog
+                }
               >
-                {t("codexConfig.addToModelMapping", {
-                  defaultValue: "加入映射",
-                })}
+                {catalogRows.length === 1
+                  ? t("codexConfig.replaceModelMapping", {
+                      defaultValue: "替换映射",
+                    })
+                  : t("codexConfig.addToModelMapping", {
+                      defaultValue: "加入映射",
+                    })}
               </Button>
             </p>
           )}

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -68,6 +68,26 @@ interface EndpointCandidate {
   url: string;
 }
 
+export function replaceSingleCodexCatalogModel<T extends CodexCatalogModel>(
+  models: T[],
+  nextModel: string,
+): T[] {
+  const model = nextModel.trim();
+  if (!model || models.length !== 1) return models;
+
+  const [current] = models;
+  const previousModel = current.model.trim();
+  return [
+    {
+      ...current,
+      model,
+      ...(current.displayName?.trim() === previousModel
+        ? { displayName: model }
+        : {}),
+    },
+  ];
+}
+
 interface CodexFormFieldsProps {
   appId?: AppId;
   providerId?: string;
@@ -687,6 +707,13 @@ export function CodexFormFields({
     ]);
   }, [onCatalogModelsChange, trimmedDefaultModel]);
 
+  const handleReplaceDefaultModelInCatalog = useCallback(() => {
+    if (!onCatalogModelsChange || !trimmedDefaultModel) return;
+    setCatalogRows((current) =>
+      replaceSingleCodexCatalogModel(current, trimmedDefaultModel),
+    );
+  }, [onCatalogModelsChange, trimmedDefaultModel]);
+
   const renderCatalogActionButtons = (onAdd: () => void, addLabel: string) => (
     <div className="flex gap-1">
       <Button
@@ -858,11 +885,19 @@ export function CodexFormFields({
                 variant="link"
                 size="sm"
                 className="h-auto p-0 text-xs"
-                onClick={handleAddDefaultModelToCatalog}
+                onClick={
+                  catalogRows.length === 1
+                    ? handleReplaceDefaultModelInCatalog
+                    : handleAddDefaultModelToCatalog
+                }
               >
-                {t("codexConfig.addToModelMapping", {
-                  defaultValue: "加入映射",
-                })}
+                {catalogRows.length === 1
+                  ? t("codexConfig.replaceModelMapping", {
+                      defaultValue: "替换映射",
+                    })
+                  : t("codexConfig.addToModelMapping", {
+                      defaultValue: "加入映射",
+                    })}
               </Button>
             </p>
           )}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1555,6 +1555,7 @@
     "defaultModelHint": "The model Codex requests by default; change it anytime without waiting for a preset update. If left empty while model mapping is configured, the first mapping row is used.",
     "defaultModelNotInCatalog": "This model is not in the model mapping, so the Codex /model menu won't list it (direct requests still work).",
     "addToModelMapping": "Add to mapping",
+    "replaceModelMapping": "Replace mapping",
     "modelMappingTitle": "Model Mapping",
     "modelMappingHint": "Generates Codex model_catalog_json so /model can show these third-party model names; entries are saved exactly as listed. Codex must be restarted to refresh the model list after changes.",
     "addCatalogModel": "Add Model",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1553,6 +1553,7 @@
     "defaultModelHint": "The model Codex requests by default; change it anytime without waiting for a preset update. If left empty while model mapping is configured, the first mapping row is used.",
     "defaultModelNotInCatalog": "This model is not in the model mapping, so the Codex /model menu won't list it (direct requests still work).",
     "addToModelMapping": "Add to mapping",
+    "replaceModelMapping": "Replace mapping",
     "modelMappingTitle": "Model Mapping",
     "modelMappingHint": "Generates Codex model_catalog_json so /model can show these third-party model names; entries are saved exactly as listed. Codex must be restarted to refresh the model list after changes.",
     "addCatalogModel": "Add Model",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1555,6 +1555,7 @@
     "defaultModelHint": "Codex がデフォルトでリクエストするモデルです。プリセットの更新を待たずにいつでも変更できます。空欄のままモデルマッピングを設定している場合は、マッピングの先頭行が使われます。",
     "defaultModelNotInCatalog": "このモデルはモデルマッピングにないため、Codex の /model メニューには表示されません（直接リクエストは有効です）。",
     "addToModelMapping": "マッピングに追加",
+    "replaceModelMapping": "マッピングを置換",
     "modelMappingTitle": "モデルマッピング",
     "modelMappingHint": "Codex model_catalog_json を生成し、/model コマンドでこれらの第三者モデル名を表示できるようにします。リストの内容はそのまま保存されます。変更後、モデルリストを更新するには Codex の再起動が必要です。",
     "addCatalogModel": "モデルを追加",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1553,6 +1553,7 @@
     "defaultModelHint": "Codex がデフォルトでリクエストするモデルです。プリセットの更新を待たずにいつでも変更できます。空欄のままモデルマッピングを設定している場合は、マッピングの先頭行が使われます。",
     "defaultModelNotInCatalog": "このモデルはモデルマッピングにないため、Codex の /model メニューには表示されません（直接リクエストは有効です）。",
     "addToModelMapping": "マッピングに追加",
+    "replaceModelMapping": "マッピングを置換",
     "modelMappingTitle": "モデルマッピング",
     "modelMappingHint": "Codex model_catalog_json を生成し、/model コマンドでこれらの第三者モデル名を表示できるようにします。リストの内容はそのまま保存されます。変更後、モデルリストを更新するには Codex の再起動が必要です。",
     "addCatalogModel": "モデルを追加",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1550,6 +1550,7 @@
     "defaultModelHint": "Codex 預設請求的模型，隨時可改，無需等待軟體更新供應商範本。留空且設定了模型映射時，預設使用映射第一行。",
     "defaultModelNotInCatalog": "該模型不在模型映射中，Codex 的 /model 選單不會列出它（直接請求仍然有效）。",
     "addToModelMapping": "加入映射",
+    "replaceModelMapping": "取代映射",
     "modelMappingTitle": "模型映射",
     "modelMappingHint": "產生 Codex model_catalog_json，讓 /model 指令顯示這些第三方模型名；表中條目按填寫內容原樣儲存。修改後需要重新啟動 Codex 才能重新整理模型清單。",
     "addCatalogModel": "新增模型",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1548,6 +1548,7 @@
     "defaultModelHint": "Codex 預設請求的模型，隨時可改，無需等待軟體更新供應商範本。留空且設定了模型映射時，預設使用映射第一行。",
     "defaultModelNotInCatalog": "該模型不在模型映射中，Codex 的 /model 選單不會列出它（直接請求仍然有效）。",
     "addToModelMapping": "加入映射",
+    "replaceModelMapping": "取代映射",
     "modelMappingTitle": "模型映射",
     "modelMappingHint": "產生 Codex model_catalog_json，讓 /model 指令顯示這些第三方模型名；表中條目按填寫內容原樣儲存。修改後需要重新啟動 Codex 才能重新整理模型清單。",
     "addCatalogModel": "新增模型",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1555,6 +1555,7 @@
     "defaultModelHint": "Codex 默认请求的模型，随时可改，无需等待预设更新。留空且配置了模型映射时，默认使用映射第一行。",
     "defaultModelNotInCatalog": "该模型不在模型映射中，Codex 的 /model 菜单不会列出它（直接请求仍然有效）。",
     "addToModelMapping": "加入映射",
+    "replaceModelMapping": "替换映射",
     "modelMappingTitle": "模型映射",
     "modelMappingHint": "生成 Codex model_catalog_json，让 /model 命令显示这些第三方模型名；表中条目按填写内容原样保存。修改后需要重启 Codex 才能刷新模型列表。",
     "addCatalogModel": "添加模型",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1553,6 +1553,7 @@
     "defaultModelHint": "Codex 默认请求的模型，随时可改，无需等待预设更新。留空且配置了模型映射时，默认使用映射第一行。",
     "defaultModelNotInCatalog": "该模型不在模型映射中，Codex 的 /model 菜单不会列出它（直接请求仍然有效）。",
     "addToModelMapping": "加入映射",
+    "replaceModelMapping": "替换映射",
     "modelMappingTitle": "模型映射",
     "modelMappingHint": "生成 Codex model_catalog_json，让 /model 命令显示这些第三方模型名；表中条目按填写内容原样保存。修改后需要重启 Codex 才能刷新模型列表。",
     "addCatalogModel": "添加模型",

--- a/tests/components/CodexFormFields.test.tsx
+++ b/tests/components/CodexFormFields.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ComponentProps, PropsWithChildren } from "react";
+import { useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import { CodexFormFields } from "@/components/providers/forms/CodexFormFields";
+import { Form } from "@/components/ui/form";
+
+type CodexFormFieldsProps = ComponentProps<typeof CodexFormFields>;
+
+const FormShell = ({ children }: PropsWithChildren) => {
+  const form = useForm();
+
+  return <Form {...form}>{children}</Form>;
+};
+
+const renderFields = (
+  catalogModels: NonNullable<CodexFormFieldsProps["catalogModels"]>,
+) => {
+  const onCatalogModelsChange = vi.fn();
+  const props: CodexFormFieldsProps = {
+    codexApiKey: "",
+    onApiKeyChange: vi.fn(),
+    category: "custom",
+    shouldShowApiKeyLink: false,
+    websiteUrl: "",
+    shouldShowSpeedTest: false,
+    codexBaseUrl: "https://api.example.com/v1",
+    onBaseUrlChange: vi.fn(),
+    isFullUrl: false,
+    onFullUrlChange: vi.fn(),
+    isEndpointModalOpen: false,
+    onEndpointModalToggle: vi.fn(),
+    autoSelect: false,
+    onAutoSelectChange: vi.fn(),
+    codexModel: "gpt-5.3-codex",
+    onModelChange: vi.fn(),
+    apiFormat: "openai_responses",
+    onApiFormatChange: vi.fn(),
+    anthropicAuthField: "ANTHROPIC_AUTH_TOKEN",
+    onAnthropicAuthFieldChange: vi.fn(),
+    impersonateClaudeCode: false,
+    onImpersonateClaudeCodeChange: vi.fn(),
+    maxOutputTokens: "",
+    onMaxOutputTokensChange: vi.fn(),
+    promptCacheRouting: "auto",
+    onPromptCacheRoutingChange: vi.fn(),
+    catalogModels,
+    onCatalogModelsChange,
+    speedTestEndpoints: [],
+    customUserAgent: "",
+    onCustomUserAgentChange: vi.fn(),
+    localProxyHeadersOverride: "",
+    onLocalProxyHeadersOverrideChange: vi.fn(),
+    localProxyBodyOverride: "",
+    onLocalProxyBodyOverrideChange: vi.fn(),
+  };
+
+  render(
+    <FormShell>
+      <CodexFormFields {...props} />
+    </FormShell>,
+  );
+  return onCatalogModelsChange;
+};
+
+describe("CodexFormFields model mapping action", () => {
+  it("replaces the only mapping after an explicit action", async () => {
+    const onCatalogModelsChange = renderFields([
+      {
+        model: "gpt-5.6-sol",
+        displayName: "gpt-5.6-sol",
+        contextWindow: 372000,
+      },
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "替换映射" }));
+
+    await waitFor(() =>
+      expect(onCatalogModelsChange).toHaveBeenLastCalledWith([
+        {
+          model: "gpt-5.3-codex",
+          displayName: "gpt-5.3-codex",
+          contextWindow: 372000,
+        },
+      ]),
+    );
+  });
+
+  it("adds the default without replacing multiple mappings", async () => {
+    const onCatalogModelsChange = renderFields([
+      { model: "gpt-5.6-sol" },
+      { model: "gpt-5.6-luna" },
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "加入映射" }));
+
+    await waitFor(() => {
+      const models = onCatalogModelsChange.mock.lastCall?.[0];
+      expect(models?.map(({ model }: { model: string }) => model)).toEqual([
+        "gpt-5.6-sol",
+        "gpt-5.6-luna",
+        "gpt-5.3-codex",
+      ]);
+    });
+  });
+});

--- a/tests/components/ProviderForm.codexCatalog.test.ts
+++ b/tests/components/ProviderForm.codexCatalog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { replaceSingleCodexCatalogModel } from "@/components/providers/forms/CodexFormFields";
 import { normalizeCodexCatalogModelsForSave } from "@/components/providers/forms/ProviderForm";
 import { mapCodexCatalogModelForForm } from "@/components/providers/forms/hooks/useCodexConfigState";
 
@@ -115,5 +116,51 @@ describe("ProviderForm Codex catalog helpers", () => {
         { model: "glm-5.2", reasoningLevels: [" high ", "max"] },
       ]),
     ).toEqual([{ model: "glm-5.2", reasoningLevels: ["high", "max"] }]);
+  });
+
+  it("replaces a single catalog model only when explicitly requested", () => {
+    expect(
+      replaceSingleCodexCatalogModel(
+        [
+          {
+            model: "gpt-5.6-sol",
+            displayName: "gpt-5.6-sol",
+            contextWindow: 372000,
+            inputModalities: ["text", "image"],
+            baseInstructions: "You are gpt-5.6-sol.",
+          },
+        ],
+        "gpt-5.3-codex",
+      ),
+    ).toEqual([
+      {
+        model: "gpt-5.3-codex",
+        displayName: "gpt-5.3-codex",
+        contextWindow: 372000,
+        inputModalities: ["text", "image"],
+      },
+    ]);
+  });
+
+  it("resets stale display names and refuses multi-model replacement", () => {
+    const stalePresetDisplayName = [
+      { model: "zai-org/glm-5.1", displayName: "GLM 5.1" },
+    ];
+    expect(
+      replaceSingleCodexCatalogModel(stalePresetDisplayName, "glm-5.2"),
+    ).toEqual([{ model: "glm-5.2", displayName: "glm-5.2" }]);
+
+    const multipleModels = [
+      { model: "gpt-5.6-sol" },
+      { model: "gpt-5.6-luna" },
+    ];
+    expect(
+      replaceSingleCodexCatalogModel(multipleModels, "gpt-5.3-codex"),
+    ).toBe(multipleModels);
+  });
+
+  it("does not replace a catalog model with an empty value", () => {
+    const models = [{ model: "gpt-5.6-sol" }];
+    expect(replaceSingleCodexCatalogModel(models, "")).toBe(models);
   });
 });

--- a/tests/components/ProviderForm.codexCatalog.test.ts
+++ b/tests/components/ProviderForm.codexCatalog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { replaceSingleCodexCatalogModel } from "@/components/providers/forms/CodexFormFields";
 import { normalizeCodexCatalogModelsForSave } from "@/components/providers/forms/ProviderForm";
 import { mapCodexCatalogModelForForm } from "@/components/providers/forms/hooks/useCodexConfigState";
 
@@ -115,5 +116,50 @@ describe("ProviderForm Codex catalog helpers", () => {
         { model: "glm-5.2", reasoningLevels: [" high ", "max"] },
       ]),
     ).toEqual([{ model: "glm-5.2", reasoningLevels: ["high", "max"] }]);
+  });
+
+  it("replaces a single catalog model only when explicitly requested", () => {
+    expect(
+      replaceSingleCodexCatalogModel(
+        [
+          {
+            model: "gpt-5.6-sol",
+            displayName: "gpt-5.6-sol",
+            contextWindow: 372000,
+            inputModalities: ["text", "image"],
+          },
+        ],
+        "gpt-5.3-codex",
+      ),
+    ).toEqual([
+      {
+        model: "gpt-5.3-codex",
+        displayName: "gpt-5.3-codex",
+        contextWindow: 372000,
+        inputModalities: ["text", "image"],
+      },
+    ]);
+  });
+
+  it("preserves custom display names and refuses multi-model replacement", () => {
+    const customDisplayName = [
+      { model: "gpt-5.6-sol", displayName: "Coding Model" },
+    ];
+    expect(
+      replaceSingleCodexCatalogModel(customDisplayName, "gpt-5.3-codex"),
+    ).toEqual([{ model: "gpt-5.3-codex", displayName: "Coding Model" }]);
+
+    const multipleModels = [
+      { model: "gpt-5.6-sol" },
+      { model: "gpt-5.6-luna" },
+    ];
+    expect(
+      replaceSingleCodexCatalogModel(multipleModels, "gpt-5.3-codex"),
+    ).toBe(multipleModels);
+  });
+
+  it("does not replace a catalog model with an empty value", () => {
+    const models = [{ model: "gpt-5.6-sol" }];
+    expect(replaceSingleCodexCatalogModel(models, "")).toBe(models);
   });
 });


### PR DESCRIPTION
## Summary / 概述

- When the Codex default model is missing from a single-row model mapping, change the existing inline action from "Add to mapping" to "Replace mapping".
- Require an explicit click before replacing the row; reset model identity fields (`model`, `displayName`, and stale `baseInstructions`) while preserving capability metadata.
- Keep multi-model mappings on the existing append path.
- Add unit and component-interaction coverage for both branches, plus the new action label in all four maintained locales.

This PR does not change automatic synchronization, provider switching, proxy routing, database storage, or backend catalog generation.

## Related Issue / 关联 Issue

Fixes #6586

## Validation

- `pnpm exec vitest run tests/components/CodexFormFields.test.tsx tests/components/ProviderForm.codexCatalog.test.ts`: 10 passed
- `pnpm typecheck`
- `pnpm format:check`
- `git diff --check`
- First blind review round found stale model identity instructions; after the scoped fix, two fresh blind reviews passed with no findings.