### PR TITLE
fix(proxy): reject unsupported Responses tools during Chat conversion

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -68,6 +68,9 @@ pub(crate) struct CodexToolContext {
     seen_chat_names: HashSet<String>,
     chat_name_to_spec: HashMap<String, CodexToolSpec>,
     namespace_name_to_chat_name: HashMap<(String, String), String>,
+    /// Responses tool types that cannot be projected to Chat safely.
+    /// Keep these visible so callers fail loudly instead of silently dropping them.
+    unsupported_response_tools: Vec<String>,
 }
 
 impl CodexToolContext {
@@ -82,6 +85,10 @@ impl CodexToolContext {
     pub(crate) fn is_custom_tool_chat_name(&self, chat_name: &str) -> bool {
         self.lookup_chat_name(chat_name)
             .is_some_and(|spec| matches!(&spec.kind, CodexToolKind::Custom))
+    }
+
+    pub(crate) fn unsupported_response_tools(&self) -> &[String] {
+        &self.unsupported_response_tools
     }
 
     pub(crate) fn chat_name_for_response_function(
@@ -230,9 +237,14 @@ impl CodexToolContext {
                 Some("custom") => self.add_custom_tool(tool),
                 Some("tool_search") => self.add_tool_search_tool(),
                 Some("namespace") => self.add_namespace_tool(tool),
-                _ => {}
+                Some(tool_type) => self.unsupported_response_tools.push(tool_type.to_string()),
+                None => self
+                    .unsupported_response_tools
+                    .push("<missing type>".to_string()),
             },
-            _ => {}
+            _ => self
+                .unsupported_response_tools
+                .push("<non-object tool>".to_string()),
         }
     }
 }
@@ -267,6 +279,15 @@ pub fn responses_to_chat_completions_with_reasoning(
 ) -> Result<Value, ProxyError> {
     let mut result = json!({});
     let tool_context = build_codex_tool_context_from_request(&body);
+    if !tool_context.unsupported_response_tools().is_empty() {
+        let mut types = tool_context.unsupported_response_tools().to_vec();
+        types.sort();
+        types.dedup();
+        return Err(ProxyError::TransformError(format!(
+            "Unsupported Responses tool type(s) for Chat upstream: {}",
+            types.join(", ")
+        )));
+    }
 
     if let Some(model) = body.get("model") {
         result["model"] = model.clone();
@@ -2509,6 +2530,20 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("mcp__codex_apps__gmail"));
+    }
+
+    #[test]
+    fn unsupported_responses_tool_type_fails_loudly_instead_of_being_dropped() {
+        let error = responses_to_chat_completions(json!({
+            "model": "third-party",
+            "input": "use the hosted file index",
+            "tools": [{ "type": "file_search" }]
+        }))
+        .expect_err("unsupported Responses tools must not disappear silently");
+
+        assert!(
+            matches!(error, ProxyError::TransformError(message) if message.contains("file_search"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 摘要

### English

When CC Switch converts a Codex Responses request to an OpenAI-compatible Chat Completions request, the converter already projects supported tool types such as `function`, `custom`, `tool_search`, and `namespace`. Any other Responses tool type was previously ignored silently.

This PR makes that boundary explicit:

- record unsupported or malformed Responses tool entries in the conversion context;
- return a `ProxyError::TransformError` with the concrete tool type(s);
- deduplicate and sort the reported types for deterministic diagnostics;
- keep supported tool conversion unchanged;
- add a regression test for `file_search`.

### 中文

CC Switch 将 Codex Responses 请求转换为 OpenAI 兼容的 Chat Completions 请求时，已经支持将 `function`、`custom`、`tool_search` 和 `namespace` 等工具投影到 Chat 格式。但此前遇到其它 Responses 工具类型时会被静默丢弃。

本 PR 收紧这个协议边界：

- 在转换上下文中记录不支持或结构异常的 Responses 工具；
- 返回包含具体工具类型的 `ProxyError::TransformError`；
- 对错误中的工具类型排序并去重，保证诊断稳定；
- 不改变现有受支持工具的转换行为；
- 为 `file_search` 增加回归测试。

## Root cause / 根因

### English

Silently dropping a tool makes the outgoing Chat request look valid while removing a capability that Codex expects to call. The eventual failure then appears later as an opaque unsupported-call or missing-tool result, which is difficult to attribute to the conversion boundary.

### 中文

静默丢弃工具会让发出的 Chat 请求看起来仍然合法，但实际上已经删掉了 Codex 预期可调用的能力。最终错误往往在后续表现为不透明的 unsupported-call 或工具缺失，难以定位到协议转换边界。

## Effect / 实际效果

### English

The upstream now receives either a complete projection of supported tools or an immediate, actionable conversion error. This avoids false-success requests and makes unsupported protocol features visible to logs, callers, and maintainers.

### 中文

现在上游要么收到完整的受支持工具投影，要么立即得到可操作的转换错误。这样可以避免“请求表面成功、工具能力实际丢失”的情况，并让日志、调用方和维护者直接看到不支持的协议能力。

## Validation / 验证

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::providers::transform_codex_chat::tests --lib`
- Result: 90 passed, 0 failed
- The focused regression proves `file_search` is rejected instead of dropped.
- `git diff --check`
- Strict UTF-8/no-BOM verification performed on changed text.

This is intentionally a small, provider-agnostic conversion fix. It does not add provider-specific exceptions or claim support for a tool type that the Chat protocol cannot represent safely.