### PR TITLE
fix(deeplink): preserve the full model catalog when importing Grok Build links

### DIFF
--- a/src-tauri/src/deeplink/mod.rs
+++ b/src-tauri/src/deeplink/mod.rs
@@ -136,4 +136,39 @@ pub struct DeepLinkImportRequest {
     /// Auto query interval in minutes (0 to disable)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage_auto_interval: Option<u64>,
+
+    // ============ Grok Build inline config fields ============
+    /// Sanitized model catalog extracted from an inline Grok Build config
+    /// (`grokbuild_models`). Deeplink-internal only: populated by config
+    /// merging, never parsed from or serialized to the URL itself.
+    #[serde(skip)]
+    pub grokbuild_models: Option<GrokDeeplinkModels>,
+}
+
+/// 从 deeplink 内联 config.toml 提取的 Grok Build 模型目录（已消毒）。
+///
+/// 只保留可安全透传的展示/容量字段。`api_key` / `env_key` / `base_url` /
+/// `api_backend` 有意不进入这里：导入结果必须统一使用 deeplink 显式端点与
+/// 密钥（或既有的合并回退），不能让不可信链接按档案夹带凭据或私有 backend。
+#[derive(Debug, Clone, PartialEq)]
+pub struct GrokDeeplinkModels {
+    /// 内联 config 原有的 `[models] default`（指向档案键）
+    pub default_profile: String,
+    /// 全部 `[model.*]` 档案
+    pub profiles: Vec<GrokDeeplinkModel>,
+}
+
+/// 单个模型档案的安全字段（`[model.<profile>]` 表）。
+#[derive(Debug, Clone, PartialEq)]
+pub struct GrokDeeplinkModel {
+    /// `[model.<profile>]` 表键，`[models] default` 指向的就是它
+    pub profile: String,
+    /// 模型 id（`model` 字段）；缺省回落到档案键
+    pub model: String,
+    /// 展示名（`name` 字段）；缺省回落到档案键
+    pub name: String,
+    /// 可选模型描述（`description` 字段）
+    pub description: Option<String>,
+    /// 上下文窗口；缺失或非法时回落到 `DEFAULT_CONTEXT_WINDOW`
+    pub context_window: i64,
 }

--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -143,6 +143,7 @@ fn parse_provider_deeplink(
         .and_then(|v| v.parse::<u64>().ok());
 
     Ok(DeepLinkImportRequest {
+        grokbuild_models: None,
         version,
         resource,
         app: Some(app),
@@ -213,6 +214,7 @@ fn parse_prompt_deeplink(
     let enabled = params.get("enabled").and_then(|v| v.parse::<bool>().ok());
 
     Ok(DeepLinkImportRequest {
+        grokbuild_models: None,
         version,
         resource,
         app: Some(app),
@@ -285,6 +287,7 @@ fn parse_mcp_deeplink(
     let enabled = params.get("enabled").and_then(|v| v.parse::<bool>().ok());
 
     Ok(DeepLinkImportRequest {
+        grokbuild_models: None,
         version,
         resource,
         apps: Some(apps),
@@ -340,6 +343,7 @@ fn parse_skill_deeplink(
     let branch = params.get("branch").cloned();
 
     Ok(DeepLinkImportRequest {
+        grokbuild_models: None,
         version,
         resource,
         repo: Some(repo),

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -490,16 +490,16 @@ fn build_grokbuild_settings(request: &DeepLinkImportRequest) -> serde_json::Valu
         let default_profile = grokbuild_default_profile(catalog, model);
         let mut config_toml = format!(
             "[models]\ndefault = {}\n",
-            toml_edit::Value::from(default_profile).to_string()
+            toml_edit::Value::from(default_profile)
         );
         for profile in &catalog.profiles {
             config_toml.push_str(&format!(
                 "\n[model.{}]\nmodel = {}\nbase_url = {}\nname = {}\napi_key = {}\napi_backend = \"{}\"\ncontext_window = {}\n",
-                toml_edit::Value::from(profile.profile.as_str()).to_string(),
-                toml_edit::Value::from(profile.model.as_str()).to_string(),
-                toml_edit::Value::from(endpoint.as_str()).to_string(),
-                toml_edit::Value::from(profile.name.as_str()).to_string(),
-                toml_edit::Value::from(api_key).to_string(),
+                toml_edit::Value::from(profile.profile.as_str()),
+                toml_edit::Value::from(profile.model.as_str()),
+                toml_edit::Value::from(endpoint.as_str()),
+                toml_edit::Value::from(profile.name.as_str()),
+                toml_edit::Value::from(api_key),
                 crate::grok_config::DEFAULT_API_BACKEND,
                 profile.context_window,
             ));
@@ -511,7 +511,7 @@ fn build_grokbuild_settings(request: &DeepLinkImportRequest) -> serde_json::Valu
             {
                 config_toml.push_str(&format!(
                     "description = {}\n",
-                    toml_edit::Value::from(description).to_string()
+                    toml_edit::Value::from(description)
                 ));
             }
         }

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -3,7 +3,7 @@
 //! Handles importing provider configurations via ccswitch:// URLs.
 
 use super::utils::{decode_base64_param, infer_homepage_from_endpoint};
-use super::DeepLinkImportRequest;
+use super::{DeepLinkImportRequest, GrokDeeplinkModel, GrokDeeplinkModels};
 use crate::error::AppError;
 use crate::provider::{ClaudeDesktopMode, Provider, ProviderMeta, UsageScript};
 use crate::services::ProviderService;
@@ -479,6 +479,45 @@ fn build_grokbuild_settings(request: &DeepLinkImportRequest) -> serde_json::Valu
     let endpoint = get_primary_endpoint(request).trim().to_string();
     let api_key = request.api_key.as_deref().unwrap_or("").trim();
 
+    // 内联 config 带来的完整模型目录（#6457）：逐档案保留 id/name/description/
+    // context_window，端点与密钥统一用 deeplink 显式值（或既有合并回退）覆写，
+    // backend 固定为支持的 Responses——按档案夹带的凭据/端点在提取阶段就被丢弃。
+    if let Some(catalog) = request
+        .grokbuild_models
+        .as_ref()
+        .filter(|catalog| !catalog.profiles.is_empty())
+    {
+        let default_profile = grokbuild_default_profile(catalog, model);
+        let mut config_toml = format!(
+            "[models]\ndefault = {}\n",
+            toml_edit::Value::from(default_profile).to_string()
+        );
+        for profile in &catalog.profiles {
+            config_toml.push_str(&format!(
+                "\n[model.{}]\nmodel = {}\nbase_url = {}\nname = {}\napi_key = {}\napi_backend = \"{}\"\ncontext_window = {}\n",
+                toml_edit::Value::from(profile.profile.as_str()).to_string(),
+                toml_edit::Value::from(profile.model.as_str()).to_string(),
+                toml_edit::Value::from(endpoint.as_str()).to_string(),
+                toml_edit::Value::from(profile.name.as_str()).to_string(),
+                toml_edit::Value::from(api_key).to_string(),
+                crate::grok_config::DEFAULT_API_BACKEND,
+                profile.context_window,
+            ));
+            if let Some(description) = profile
+                .description
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                config_toml.push_str(&format!(
+                    "description = {}\n",
+                    toml_edit::Value::from(description).to_string()
+                ));
+            }
+        }
+        return json!({ "config": config_toml });
+    }
+
     let model_value = toml_edit::Value::from(model).to_string();
     let name_value = toml_edit::Value::from(name).to_string();
     let endpoint_value = toml_edit::Value::from(endpoint.as_str()).to_string();
@@ -491,6 +530,34 @@ fn build_grokbuild_settings(request: &DeepLinkImportRequest) -> serde_json::Valu
             crate::grok_config::DEFAULT_CONTEXT_WINDOW,
         )
     })
+}
+
+/// 选出多档案目录的 `[models] default` 指向的档案键。
+///
+/// 优先级：请求模型（URL 参数或合并回退）匹配某档案键 → 匹配某档案的
+/// `model` 字段 → 内联 config 原有的 default。保证 default 一定指向一个
+/// 实际存在的档案表。
+fn grokbuild_default_profile<'a>(
+    catalog: &'a GrokDeeplinkModels,
+    requested_model: &str,
+) -> &'a str {
+    if !requested_model.trim().is_empty() {
+        if let Some(profile) = catalog
+            .profiles
+            .iter()
+            .find(|profile| profile.profile == requested_model)
+        {
+            return &profile.profile;
+        }
+        if let Some(profile) = catalog
+            .profiles
+            .iter()
+            .find(|profile| profile.model == requested_model)
+        {
+            return &profile.profile;
+        }
+    }
+    &catalog.default_profile
 }
 
 /// Build OpenCode settings configuration
@@ -896,7 +963,60 @@ fn merge_grokbuild_config(
         }
     }
 
+    // 保留内联 config 的完整模型目录（#6457）：只提取安全字段，凭据/端点/
+    // backend 留给上面的请求级合并结果在 build 阶段统一覆写。
+    request.grokbuild_models = extract_grokbuild_model_profiles(&config_toml);
+
     Ok(())
+}
+
+/// 从内联 config.toml 提取全部 `[model.*]` 档案的**安全字段**（档案键、
+/// `model`/`name`/`description`/`context_window`）。
+///
+/// `api_key` / `env_key` / `base_url` / `api_backend` 有意丢弃：deeplink 是
+/// 不可信输入，导入结果的每个档案都必须统一使用 deeplink 显式端点与密钥
+/// （或既有合并回退）和支持的 Responses backend，不能按档案夹带。
+fn extract_grokbuild_model_profiles(config_toml: &str) -> Option<GrokDeeplinkModels> {
+    fn non_empty_string(table: &toml::value::Table, key: &str) -> Option<String> {
+        table
+            .get(key)
+            .and_then(toml::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+    }
+
+    let document = config_toml.parse::<toml::Value>().ok()?;
+    let model_entries = document.get("model")?.as_table()?;
+    let profiles: Vec<GrokDeeplinkModel> = model_entries
+        .iter()
+        .filter_map(|(profile, value)| {
+            let table = value.as_table()?;
+            Some(GrokDeeplinkModel {
+                profile: profile.clone(),
+                model: non_empty_string(table, "model").unwrap_or_else(|| profile.clone()),
+                name: non_empty_string(table, "name").unwrap_or_else(|| profile.clone()),
+                description: non_empty_string(table, "description"),
+                context_window: table
+                    .get("context_window")
+                    .and_then(toml::Value::as_integer)
+                    .filter(|value| *value > 0)
+                    .unwrap_or(crate::grok_config::DEFAULT_CONTEXT_WINDOW),
+            })
+        })
+        .collect();
+    if profiles.is_empty() {
+        return None;
+    }
+    let default_profile = document
+        .get("models")
+        .and_then(toml::Value::as_table)
+        .and_then(|models| non_empty_string(models, "default"))
+        .or_else(|| profiles.first().map(|profile| profile.profile.clone()))?;
+    Some(GrokDeeplinkModels {
+        default_profile,
+        profiles,
+    })
 }
 
 /// Merge configuration for additive mode apps (OpenClaw, OpenCode)
@@ -1022,6 +1142,107 @@ mod tests {
             Some(value) => std::env::set_var("CC_SWITCH_DEEPLINK_ENV_PROBE", value),
             None => std::env::remove_var("CC_SWITCH_DEEPLINK_ENV_PROBE"),
         }
+    }
+
+    /// 内联 config 的完整模型目录必须在导入结果里保留（#6457）：
+    /// 每档案的 id/name/description/context_window 原样带过去，端点与密钥
+    /// 统一用 deeplink 显式 URL 参数覆写，backend 固定为支持的 Responses，
+    /// 按档案夹带的凭据/端点/backend 一律丢弃。
+    #[test]
+    fn grokbuild_deeplink_preserves_multi_model_catalog_from_inline_config() {
+        let mut request = DeepLinkImportRequest {
+            resource: "provider".to_string(),
+            app: Some("grokbuild".to_string()),
+            name: Some("My Relay".to_string()),
+            endpoint: Some("https://relay.example/v1".to_string()),
+            api_key: Some("sk-from-url".to_string()),
+            model: Some("grok-4.6".to_string()),
+            ..Default::default()
+        };
+        let config = serde_json::json!({
+            "config": concat!(
+                "[models]\ndefault = \"grok-4.5\"\n\n",
+                "[model.\"grok-4.6\"]\nmodel = \"grok-4.6\"\n",
+                "base_url = \"https://evil.example/v1\"\nname = \"Grok 4.6\"\n",
+                "description = \"Fast flagship\"\napi_key = \"sk-per-model-4-6\"\n",
+                "api_backend = \"chat\"\ncontext_window = 1000000\n\n",
+                "[model.\"grok-4.5\"]\nmodel = \"grok-4.5\"\n",
+                "base_url = \"https://other.example/v1\"\nname = \"Grok 4.5\"\n",
+                "description = \"Stable\"\napi_key = \"sk-per-model-4-5\"\n",
+                "api_backend = \"chat\"\ncontext_window = 500000\n\n",
+                "[model.\"bare\"]\nmodel = \"grok-mini\"\nbase_url = \"https://bare.example\"\n",
+            )
+        });
+
+        merge_grokbuild_config(&mut request, &config).expect("merge should succeed");
+        let settings = build_grokbuild_settings(&request);
+        let rendered = settings["config"].as_str().expect("config string");
+
+        // 三个档案都在，各自的展示/容量字段保留（sparse 档案回落到档案键/默认值）
+        assert!(rendered.contains("[model.\"grok-4.6\"]"), "{rendered}");
+        assert!(rendered.contains("[model.\"grok-4.5\"]"), "{rendered}");
+        assert!(rendered.contains("[model.\"bare\"]"), "{rendered}");
+        assert!(rendered.contains("name = \"Grok 4.6\""));
+        assert!(rendered.contains("description = \"Fast flagship\""));
+        assert!(rendered.contains("context_window = 1000000"));
+        assert!(rendered.contains("model = \"grok-mini\""));
+        assert!(rendered.contains("name = \"bare\""));
+
+        // URL 参数统一覆写端点与密钥；backend 固定为 Responses
+        assert_eq!(
+            rendered
+                .matches("base_url = \"https://relay.example/v1\"")
+                .count(),
+            3
+        );
+        assert_eq!(rendered.matches("api_key = \"sk-from-url\"").count(), 3);
+        assert_eq!(rendered.matches("api_backend = \"responses\"").count(), 3);
+
+        // 按档案夹带的不可信值一个都不能漏进来
+        assert!(!rendered.contains("sk-per-model"), "{rendered}");
+        assert!(!rendered.contains("evil.example"), "{rendered}");
+        assert!(!rendered.contains("other.example"), "{rendered}");
+        assert!(!rendered.contains("bare.example"), "{rendered}");
+        assert!(!rendered.contains("env_key"), "{rendered}");
+
+        // URL 的 model 参数决定 default；生成结果必须能过 live 写入前的强校验
+        assert!(rendered.contains("[models]\ndefault = \"grok-4.6\""));
+        crate::grok_config::validate_config_toml(rendered).expect("valid config.toml");
+    }
+
+    /// URL 未带 model 时，default 跟随内联 config 原有的 `[models] default`；
+    /// 合并回退出的请求级密钥同样要覆写全部档案（其它档案的自带密钥丢弃）。
+    #[test]
+    fn grokbuild_deeplink_default_follows_config_when_url_model_absent() {
+        let mut request = DeepLinkImportRequest {
+            resource: "provider".to_string(),
+            app: Some("grokbuild".to_string()),
+            name: Some("My Relay".to_string()),
+            ..Default::default()
+        };
+        let config = serde_json::json!({
+            "config": concat!(
+                "[models]\ndefault = \"stable\"\n\n",
+                "[model.\"stable\"]\nmodel = \"grok-4.5\"\n",
+                "base_url = \"https://relay.example/v1\"\nname = \"Stable\"\n",
+                "api_key = \"sk-merged\"\napi_backend = \"responses\"\ncontext_window = 500000\n\n",
+                "[model.\"preview\"]\nmodel = \"grok-4.6\"\n",
+                "base_url = \"https://relay.example/v1\"\nname = \"Preview\"\n",
+                "api_key = \"sk-other\"\napi_backend = \"responses\"\ncontext_window = 1000000\n",
+            )
+        });
+
+        merge_grokbuild_config(&mut request, &config).expect("merge should succeed");
+        let settings = build_grokbuild_settings(&request);
+        let rendered = settings["config"].as_str().expect("config string");
+
+        assert!(
+            rendered.contains("[models]\ndefault = \"stable\""),
+            "{rendered}"
+        );
+        assert_eq!(rendered.matches("api_key = \"sk-merged\"").count(), 2);
+        assert!(!rendered.contains("sk-other"), "{rendered}");
+        crate::grok_config::validate_config_toml(rendered).expect("valid config.toml");
     }
 
     /// `env_key` 独苗的链接必须在**公开入口**上被明确拒绝。

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -205,6 +205,7 @@ fn test_build_gemini_provider_with_model() {
     use super::provider::build_provider_from_request;
 
     let request = DeepLinkImportRequest {
+        grokbuild_models: None,
         version: "v1".to_string(),
         resource: "provider".to_string(),
         app: Some("gemini".to_string()),
@@ -258,6 +259,7 @@ fn test_build_gemini_provider_without_model() {
     use super::provider::build_provider_from_request;
 
     let request = DeepLinkImportRequest {
+        grokbuild_models: None,
         version: "v1".to_string(),
         resource: "provider".to_string(),
         app: Some("gemini".to_string()),
@@ -304,6 +306,7 @@ fn test_deeplink_usage_script_does_not_copy_provider_credentials() {
     use super::provider::build_provider_from_request;
 
     let request = DeepLinkImportRequest {
+        grokbuild_models: None,
         version: "v1".to_string(),
         resource: "provider".to_string(),
         app: Some("claude".to_string()),
@@ -351,6 +354,7 @@ fn test_deeplink_usage_script_does_not_copy_provider_credentials() {
 /// 构造一个只带用量脚本字段的 provider 请求，其余保持最小。
 fn usage_script_request(code: &str, usage_enabled: Option<bool>) -> DeepLinkImportRequest {
     DeepLinkImportRequest {
+        grokbuild_models: None,
         version: "v1".to_string(),
         resource: "provider".to_string(),
         app: Some("claude".to_string()),
@@ -434,6 +438,7 @@ fn test_deeplink_usage_script_omits_explicit_credentials_that_match_provider() {
     use super::provider::build_provider_from_request;
 
     let request = DeepLinkImportRequest {
+        grokbuild_models: None,
         version: "v1".to_string(),
         resource: "provider".to_string(),
         app: Some("claude".to_string()),
@@ -482,6 +487,7 @@ fn test_deeplink_usage_script_preserves_distinct_usage_credentials() {
     use super::provider::build_provider_from_request;
 
     let request = DeepLinkImportRequest {
+        grokbuild_models: None,
         version: "v1".to_string(),
         resource: "provider".to_string(),
         app: Some("claude".to_string()),
@@ -535,6 +541,7 @@ fn test_parse_and_merge_config_claude() {
     let config_b64 = BASE64_STANDARD.encode(config_json.as_bytes());
 
     let request = DeepLinkImportRequest {
+        grokbuild_models: None,
         version: "v1".to_string(),
         resource: "provider".to_string(),
         app: Some("claude".to_string()),
@@ -658,6 +665,7 @@ fn test_parse_and_merge_config_url_override() {
     let config_b64 = BASE64_STANDARD.encode(config_json.as_bytes());
 
     let request = DeepLinkImportRequest {
+        grokbuild_models: None,
         version: "v1".to_string(),
         resource: "provider".to_string(),
         app: Some("claude".to_string()),
@@ -720,6 +728,7 @@ fn test_build_claude_provider_preserves_custom_env_fields() {
     let config_b64 = BASE64_STANDARD.encode(config_json.as_bytes());
 
     let request = DeepLinkImportRequest {
+        grokbuild_models: None,
         version: "v1".to_string(),
         resource: "provider".to_string(),
         app: Some("claude".to_string()),
@@ -776,6 +785,7 @@ fn test_build_claude_provider_without_config_unchanged() {
     use super::provider::build_provider_from_request;
 
     let request = DeepLinkImportRequest {
+        grokbuild_models: None,
         version: "v1".to_string(),
         resource: "provider".to_string(),
         app: Some("claude".to_string()),


### PR DESCRIPTION
Fixes #6457.

## Problem

Importing a `ccswitch://v1/import` grokbuild link whose inline config carries multiple `[model.*]` profiles collapses the catalog: `merge_grokbuild_config` lifts only the selected profile's fields into the flat request, and `build_grokbuild_settings` then rebuilds a single profile from those flat fields — keyed by the URL `model` param, named after the provider card, description dropped. `/model` in Grok Build ends up with one generic entry instead of the configured models.

## Fix

- The merged request now carries the sanitized model catalog (`grokbuild_models`, `#[serde(skip)]` — deeplink-internal, never parsed from or serialized to the URL): per `[model.*]` table the profile key, `model`, `name`, `description` and `context_window`, plus the original `[models] default`.
- `build_grokbuild_settings` emits every profile when the catalog is present. Each profile's `base_url` / `api_key` are overridden with the deeplink's explicit endpoint/key (or the existing merged fallback when URL params are absent), and `api_backend` is forced to the supported `responses` backend.
- Security boundary unchanged from the issue's ask: per-profile `api_key` / `env_key` / `base_url` / `api_backend` from the untrusted link are dropped at extraction time, so the existing env_key rejection and "never inline a resolved env secret" behavior is untouched.
- Default selection: URL `model` matched against profile keys, then profile `model` fields, then the config's original default — `[models] default` always points at an emitted table.
- Links without an inline config keep the previous single-profile output verbatim.

## Tests

- `grokbuild_deeplink_preserves_multi_model_catalog_from_inline_config` — three-profile catalog (one sparse): id/name/description/context_window preserved, URL endpoint+key override every profile, per-profile credentials/URLs/backends absent, output passes `validate_config_toml`.
- `grokbuild_deeplink_default_follows_config_when_url_model_absent` — default follows the config's `[models] default`; the merged fallback key overrides all profiles.
- Full `cargo test --lib`: 2681 passed, 0 failed (pre-existing env_key safety tests included). `cargo fmt` clean.

Happy to reshape the carrier (a side-channel instead of a request field) or move the override boundaries if you'd prefer different trade-offs.
