### PR TITLE
fix(proxy): inline $ref siblings in tool $defs for strict providers

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1282,7 +1282,62 @@ fn normalize_function_parameters(params: Option<&Value>) -> Value {
             }
         }
     }
-    params
+    inline_ref_siblings(&params)
+}
+
+/// Recursively inline `$ref` objects that carry sibling keywords.
+///
+/// Codex dynamic tools emit JSON Schema 2020-12 style parameters where a
+/// schema inside `$defs` combines `$ref` with siblings, e.g.
+/// `{"$ref": "#/$defs/x", "type": "string", "format": "uuid"}`. Strict
+/// providers (Moonshot/Kimi) reject siblings next to `$ref` with HTTP 400,
+/// so deep-merge the referenced definition with the siblings instead.
+fn inline_ref_siblings(node: &Value) -> Value {
+    fn inner(
+        node: &Value,
+        defs: &serde_json::Map<String, Value>,
+        resolving: &mut Vec<String>,
+    ) -> Value {
+        match node {
+            Value::Array(items) => {
+                Value::Array(items.iter().map(|v| inner(v, defs, resolving)).collect())
+            }
+            Value::Object(obj) => {
+                let ref_path = obj.get("$ref").and_then(|v| v.as_str());
+                let has_siblings = obj.keys().any(|k| k != "$ref");
+                if let (Some(ref_path), true) = (ref_path, has_siblings) {
+                    if let Some(name) = ref_path.strip_prefix("#/$defs/") {
+                        if !resolving.iter().any(|n| n == name) {
+                            if let Some(target @ Value::Object(_)) = defs.get(name) {
+                                resolving.push(name.to_string());
+                                let resolved = inner(target, defs, resolving);
+                                resolving.pop();
+                                if let Value::Object(mut merged) = resolved {
+                                    for (k, v) in obj.iter().filter(|(k, _)| *k != "$ref") {
+                                        merged.insert(k.clone(), inner(v, defs, resolving));
+                                    }
+                                    return Value::Object(merged);
+                                }
+                            }
+                        }
+                    }
+                }
+                Value::Object(
+                    obj.iter()
+                        .map(|(k, v)| (k.clone(), inner(v, defs, resolving)))
+                        .collect(),
+                )
+            }
+            other => other.clone(),
+        }
+    }
+
+    let empty = serde_json::Map::new();
+    let defs = node
+        .get("$defs")
+        .and_then(|v| v.as_object())
+        .unwrap_or(&empty);
+    inner(node, defs, &mut Vec::new())
 }
 
 fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option<Value> {
@@ -2400,6 +2455,50 @@ mod tests {
         assert_eq!(parameters["type"], "object");
         assert_eq!(parameters["properties"]["query"]["type"], "string");
         assert_eq!(parameters["required"], json!(["query"]));
+    }
+
+    #[test]
+    fn responses_request_to_chat_inlines_ref_siblings_in_tool_defs() {
+        // Codex dynamic tools emit JSON Schema 2020-12 style `$defs` where a
+        // `$ref` carries sibling keywords. Strict providers (Moonshot/Kimi)
+        // reject siblings next to `$ref` with HTTP 400, so they must be
+        // deep-merged into the referenced definition.
+        let input = json!({
+            "model": "kimi-k3",
+            "tools": [{
+                "type": "function",
+                "name": "request_user_input",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "targetThreadId": {"$ref": "#/$defs/__schema20"}
+                    },
+                    "$defs": {
+                        "__schema7": {"type": "string"},
+                        "__schema20": {
+                            "$ref": "#/$defs/__schema7",
+                            "type": "string",
+                            "format": "uuid",
+                            "minLength": 1
+                        }
+                    }
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let def20 = &result["tools"][0]["function"]["parameters"]["$defs"]["__schema20"];
+
+        assert!(def20.get("$ref").is_none(), "$ref should be inlined");
+        assert_eq!(def20["type"], "string");
+        assert_eq!(def20["format"], "uuid");
+        assert_eq!(def20["minLength"], 1);
+        // A bare `$ref` without siblings stays untouched.
+        assert_eq!(
+            result["tools"][0]["function"]["parameters"]["properties"]["targetThreadId"],
+            json!({"$ref": "#/$defs/__schema20"})
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1308,10 +1308,37 @@ fn inline_ref_siblings(node: &Value) -> Value {
                 if let (Some(ref_path), true) = (ref_path, has_siblings) {
                     if let Some(name) = ref_path.strip_prefix("#/$defs/") {
                         if !resolving.iter().any(|n| n == name) {
-                            if let Some(target @ Value::Object(_)) = defs.get(name) {
-                                resolving.push(name.to_string());
+                            // Follow bare-ref alias chain: if the target is
+                            // itself a bare $ref (no siblings), follow it so
+                            // siblings merge into the ultimate definition,
+                            // not another $ref-with-siblings.
+                            let mut chain = vec![name.to_string()];
+                            let mut target = defs.get(name);
+                            while let Some(Value::Object(t_obj)) = target {
+                                let t_ref = t_obj.get("$ref").and_then(|v| v.as_str());
+                                let t_has_siblings = t_obj.keys().any(|k| k != "$ref");
+                                if let (Some(t_ref), false) = (t_ref, t_has_siblings) {
+                                    if let Some(next_name) = t_ref.strip_prefix("#/$defs/") {
+                                        if chain.iter().any(|n| n == next_name)
+                                            || resolving.iter().any(|n| n == next_name)
+                                        {
+                                            break; // cycle
+                                        }
+                                        chain.push(next_name.to_string());
+                                        target = defs.get(next_name);
+                                        continue;
+                                    }
+                                }
+                                break;
+                            }
+                            if let Some(target @ Value::Object(_)) = target {
+                                for n in &chain {
+                                    resolving.push(n.clone());
+                                }
                                 let resolved = inner(target, defs, resolving);
-                                resolving.pop();
+                                for _ in &chain {
+                                    resolving.pop();
+                                }
                                 if let Value::Object(mut merged) = resolved {
                                     for (k, v) in obj.iter().filter(|(k, _)| *k != "$ref") {
                                         merged.insert(k.clone(), inner(v, defs, resolving));
@@ -2499,6 +2526,43 @@ mod tests {
             result["tools"][0]["function"]["parameters"]["properties"]["targetThreadId"],
             json!({"$ref": "#/$defs/__schema20"})
         );
+    }
+
+    #[test]
+    fn responses_request_to_chat_follows_bare_ref_aliases_before_inlining_siblings() {
+        // When a sibling-bearing $ref points to a definition that is itself a
+        // bare $ref (an alias), the siblings must merge into the ultimate
+        // target — not into the alias, which would leave a $ref-with-siblings
+        // shape that strict providers reject.
+        let input = json!({
+            "model": "kimi-k3",
+            "tools": [{
+                "type": "function",
+                "name": "set_tag",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {"$ref": "#/$defs/__alias", "minLength": 1}
+                    },
+                    "$defs": {
+                        "__concrete": {"type": "string", "format": "uuid"},
+                        "__alias": {"$ref": "#/$defs/__concrete"}
+                    }
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let tag = &result["tools"][0]["function"]["parameters"]["properties"]["tag"];
+
+        assert!(
+            tag.get("$ref").is_none(),
+            "bare-ref alias should be followed so no $ref remains, got: {tag}"
+        );
+        assert_eq!(tag["type"], "string");
+        assert_eq!(tag["format"], "uuid");
+        assert_eq!(tag["minLength"], 1);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #6614

## Root cause

Codex dynamic tools (e.g. Plan mode's `request_user_input`) emit JSON Schema 2020-12 style parameters where a `$defs` entry combines `$ref` with sibling keywords:

```json
{"$ref": "#/$defs/__schema7", "type": "string", "format": "uuid", "minLength": 1}
```

OpenAI accepts 2020-12 `$ref` sibling semantics, but Moonshot/Kimi enforce draft-07 rules and reject the request with HTTP 400 (`tools.function.parameters is not a valid moonshot flavored json schema`). `normalize_function_parameters()` only ensured the top-level `type` was `"object"` and passed `$defs` through unchanged, so every subsequent turn of the session failed.

## Change

`normalize_function_parameters()` now runs `inline_ref_siblings()`, which recursively deep-merges a `#/$defs/...`-referenced definition with the sibling keywords (siblings win on key conflicts), guarded against reference cycles. Bare `$ref` without siblings is left untouched, and non-`#/$defs/` references pass through as before.

## Validation

- Added `responses_request_to_chat_inlines_ref_siblings_in_tool_defs`: the exact `request_user_input` shape from the issue.
- RED on current `main` (`$ref` passed through); GREEN after the fix.
- `cargo test --lib proxy::providers::transform_codex_chat`: 90 passed, 0 failed.
- `cargo fmt --check` and `cargo clippy --lib --no-deps` clean.