### PR TITLE
fix(codex): keep resumed thread provider state consistent

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -15,10 +15,10 @@ use std::process::{Command, Stdio};
 use toml_edit::DocumentMut;
 
 pub const CC_SWITCH_CODEX_MODEL_PROVIDER_ID: &str = "custom";
+pub const OPENAI_CODEX_MODEL_PROVIDER_ID: &str = "openai";
 /// Temporary model-provider id used while the built-in `codex-official`
-/// provider is routed through CC Switch.  A dedicated id is an ownership
-/// marker: unlike a generic localhost `base_url`, it can be detected and
-/// cleaned up without mistaking a user's own local provider for takeover.
+/// provider is routed through CC Switch. The id is retained as an ownership
+/// marker and as a compatibility alias for threads created by older versions.
 pub const CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID: &str = "cc-switch-official";
 pub const CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME: &str = "cc-switch-model-catalog.json";
 const CODEX_PROXY_AUTH_PLACEHOLDER: &str = "PROXY_MANAGED";
@@ -2505,12 +2505,53 @@ fn remove_codex_proxy_placeholders_from_providers(providers: &mut toml_edit::Tab
     }
 }
 
+fn insert_codex_official_proxy_aliases(providers: &mut toml_edit::Table, proxy_base_url: &str) {
+    let table = codex_official_provider_table(Some(proxy_base_url), false);
+    providers.insert(
+        OPENAI_CODEX_MODEL_PROVIDER_ID,
+        toml_edit::Item::Table(table.clone()),
+    );
+    providers.insert(
+        CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
+        toml_edit::Item::Table(table),
+    );
+}
+
+/// Add local-route aliases for native and legacy official Codex threads while
+/// preserving the currently selected provider. This is also used when a
+/// third-party provider is active, because resuming an older official thread
+/// must still enter the local proxy instead of bypassing it.
+pub fn apply_codex_official_proxy_aliases(
+    config_text: &str,
+    proxy_base_url: &str,
+) -> Result<String, AppError> {
+    let mut doc = config_text
+        .parse::<DocumentMut>()
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+    let mut providers = match doc.as_table_mut().remove("model_providers") {
+        Some(item) => item.into_table().map_err(|_| {
+            AppError::Message(
+                "Invalid Codex config.toml: model_providers must be a table".to_string(),
+            )
+        })?,
+        None => {
+            let mut table = toml_edit::Table::new();
+            table.set_implicit(true);
+            table
+        }
+    };
+    insert_codex_official_proxy_aliases(&mut providers, proxy_base_url);
+    doc["model_providers"] = toml_edit::Item::Table(providers);
+    Ok(doc.to_string())
+}
+
 /// Project a Codex official account card through the local proxy while keeping
 /// authentication owned by Codex itself.
 ///
-/// The resulting custom provider explicitly opts into OpenAI authentication,
-/// so Codex forwards its existing ChatGPT login to the local `/responses`
-/// endpoint.  No API key or bearer placeholder is written to `auth.json`.
+/// Both the native `openai` bucket and CC Switch's legacy official bucket are
+/// pointed at the same local endpoint. New threads stay in `openai`, so route
+/// changes never need to rewrite Codex rollout JSONL or state SQLite files.
+/// No API key or bearer placeholder is written to `auth.json`.
 pub fn apply_codex_official_proxy_route(
     config_text: &str,
     proxy_base_url: &str,
@@ -2522,7 +2563,7 @@ pub fn apply_codex_official_proxy_route(
     // A third-party takeover may have left the proxy placeholder in config.toml.
     // The official route must use Codex's native OpenAI login instead.
     doc.as_table_mut().remove("experimental_bearer_token");
-    doc["model_provider"] = toml_edit::value(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID);
+    doc["model_provider"] = toml_edit::value(OPENAI_CODEX_MODEL_PROVIDER_ID);
 
     let mut providers = match doc.as_table_mut().remove("model_providers") {
         Some(item) => item.into_table().map_err(|_| {
@@ -2542,12 +2583,7 @@ pub fn apply_codex_official_proxy_route(
     remove_codex_proxy_placeholders_from_providers(&mut providers);
 
     // The local proxy currently exposes HTTP/SSE, not Codex websocket routes.
-    let table = codex_official_provider_table(Some(proxy_base_url), false);
-
-    providers.insert(
-        CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
-        toml_edit::Item::Table(table),
-    );
+    insert_codex_official_proxy_aliases(&mut providers, proxy_base_url);
     doc["model_providers"] = toml_edit::Item::Table(providers);
     Ok(doc.to_string())
 }
@@ -2557,16 +2593,106 @@ pub fn codex_config_has_official_proxy_route(config_text: &str) -> bool {
     if !config_text.contains(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID) {
         return false;
     }
-    config_text
+    let Ok(doc) = config_text.parse::<DocumentMut>() else {
+        return false;
+    };
+    let active_provider = doc.get("model_provider").and_then(|item| item.as_str());
+    if !matches!(
+        active_provider,
+        Some(OPENAI_CODEX_MODEL_PROVIDER_ID | CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID)
+    ) {
+        return false;
+    }
+    doc.get("model_providers")
+        .and_then(|item| item.as_table())
+        .and_then(|providers| providers.get(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID))
+        .and_then(|item| item.as_table())
+        .is_some_and(table_matches_codex_managed_local_official_provider)
+}
+
+/// Whether the official route uses the current non-migrating layout. Older
+/// builds selected `cc-switch-official` directly and exposed only that table;
+/// those configs are still recognized as managed for cleanup, but must be
+/// rebuilt before an idempotent takeover can be reused.
+pub fn codex_config_has_current_official_proxy_route(config_text: &str) -> bool {
+    let Ok(doc) = config_text.parse::<DocumentMut>() else {
+        return false;
+    };
+    if doc.get("model_provider").and_then(|item| item.as_str())
+        != Some(OPENAI_CODEX_MODEL_PROVIDER_ID)
+    {
+        return false;
+    }
+    let Some(providers) = doc.get("model_providers").and_then(|item| item.as_table()) else {
+        return false;
+    };
+    let local_base_url = |provider_id: &str| {
+        providers
+            .get(provider_id)
+            .and_then(|item| item.as_table())
+            .filter(|table| table_matches_codex_managed_local_official_provider(table))
+            .and_then(|table| table.get("base_url"))
+            .and_then(|item| item.as_str())
+            .map(|url| url.trim().trim_end_matches('/').to_string())
+    };
+    matches!(
+        (
+            local_base_url(OPENAI_CODEX_MODEL_PROVIDER_ID),
+            local_base_url(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID),
+        ),
+        (Some(openai), Some(legacy)) if openai == legacy
+    )
+}
+
+fn table_matches_codex_managed_local_official_provider(table: &toml_edit::Table) -> bool {
+    table.get("name").and_then(|item| item.as_str()) == Some("OpenAI")
+        && table
+            .get("requires_openai_auth")
+            .and_then(|item| item.as_bool())
+            == Some(true)
+        && table
+            .get("supports_websockets")
+            .and_then(|item| item.as_bool())
+            == Some(false)
+        && table.get("wire_api").and_then(|item| item.as_str()) == Some("responses")
+        && table
+            .get("base_url")
+            .and_then(|item| item.as_str())
+            .is_some_and(|url| {
+                let url = url.trim().to_ascii_lowercase();
+                url.starts_with("http://127.0.0.1:")
+                    || url.starts_with("http://localhost:")
+                    || url.starts_with("http://[::1]:")
+            })
+}
+
+/// Keep threads created by older CC Switch releases resumable after local
+/// routing is disabled. The compatibility provider uses Codex's native OpenAI
+/// authentication and endpoint; it does not route through CC Switch.
+pub fn ensure_codex_official_proxy_compatibility_provider(
+    config_text: &str,
+) -> Result<String, AppError> {
+    let mut doc = config_text
         .parse::<DocumentMut>()
-        .ok()
-        .and_then(|doc| {
-            doc.get("model_provider")
-                .and_then(|item| item.as_str())
-                .map(str::to_string)
-        })
-        .as_deref()
-        == Some(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID)
+        .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
+    let mut providers = match doc.as_table_mut().remove("model_providers") {
+        Some(item) => item.into_table().map_err(|_| {
+            AppError::Message(
+                "Invalid Codex config.toml: model_providers must be a table".to_string(),
+            )
+        })?,
+        None => {
+            let mut table = toml_edit::Table::new();
+            table.set_implicit(true);
+            table
+        }
+    };
+    providers.insert(
+        CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
+        toml_edit::Item::Table(codex_unified_official_provider_table()),
+    );
+    doc["model_providers"] = toml_edit::Item::Table(providers);
+    Ok(doc.to_string())
 }
 
 /// Remove only the official takeover route owned by CC Switch. This is a
@@ -2575,20 +2701,39 @@ pub fn remove_codex_official_proxy_route(config_text: &str) -> Result<String, Ap
     let mut doc = config_text
         .parse::<DocumentMut>()
         .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
-    if doc.get("model_provider").and_then(|item| item.as_str())
-        != Some(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID)
-    {
+    let has_managed_route = doc
+        .get("model_providers")
+        .and_then(|item| item.as_table())
+        .and_then(|providers| providers.get(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID))
+        .and_then(|item| item.as_table())
+        .is_some_and(table_matches_codex_managed_local_official_provider);
+    if !has_managed_route {
         return Ok(config_text.to_string());
     }
 
-    doc.as_table_mut().remove("model_provider");
+    if matches!(
+        doc.get("model_provider").and_then(|item| item.as_str()),
+        Some(OPENAI_CODEX_MODEL_PROVIDER_ID | CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID)
+    ) {
+        doc.as_table_mut().remove("model_provider");
+    }
     if let Some(item) = doc.as_table_mut().remove("model_providers") {
         let mut providers = item.into_table().map_err(|_| {
             AppError::Message(
                 "Invalid Codex config.toml: model_providers must be a table".to_string(),
             )
         })?;
-        providers.remove(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID);
+        let openai_is_managed = providers
+            .get(OPENAI_CODEX_MODEL_PROVIDER_ID)
+            .and_then(|item| item.as_table())
+            .is_some_and(table_matches_codex_managed_local_official_provider);
+        if openai_is_managed {
+            providers.remove(OPENAI_CODEX_MODEL_PROVIDER_ID);
+        }
+        providers.insert(
+            CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
+            toml_edit::Item::Table(codex_unified_official_provider_table()),
+        );
         remove_codex_proxy_placeholders_from_providers(&mut providers);
         if !providers.is_empty() {
             doc["model_providers"] = toml_edit::Item::Table(providers);
@@ -3220,7 +3365,7 @@ command = "example"
 
         assert_eq!(
             doc.get("model_provider").and_then(toml::Value::as_str),
-            Some(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID)
+            Some(OPENAI_CODEX_MODEL_PROVIDER_ID)
         );
         assert!(doc.get("experimental_bearer_token").is_none());
         assert!(
@@ -3228,24 +3373,45 @@ command = "example"
             "unrelated config survives"
         );
 
-        let provider = &doc["model_providers"][CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID];
-        assert_eq!(
-            provider.get("base_url").and_then(toml::Value::as_str),
-            Some("http://127.0.0.1:15721/v1")
-        );
-        assert_eq!(
-            provider
-                .get("requires_openai_auth")
-                .and_then(toml::Value::as_bool),
-            Some(true)
-        );
-        assert_eq!(
-            provider
-                .get("supports_websockets")
-                .and_then(toml::Value::as_bool),
-            Some(false)
-        );
+        for provider_id in [
+            OPENAI_CODEX_MODEL_PROVIDER_ID,
+            CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
+        ] {
+            let provider = &doc["model_providers"][provider_id];
+            assert_eq!(
+                provider.get("base_url").and_then(toml::Value::as_str),
+                Some("http://127.0.0.1:15721/v1")
+            );
+            assert_eq!(
+                provider
+                    .get("requires_openai_auth")
+                    .and_then(toml::Value::as_bool),
+                Some(true)
+            );
+            assert_eq!(
+                provider
+                    .get("supports_websockets")
+                    .and_then(toml::Value::as_bool),
+                Some(false)
+            );
+        }
         assert!(codex_config_has_official_proxy_route(&output));
+        assert!(codex_config_has_current_official_proxy_route(&output));
+    }
+
+    #[test]
+    fn legacy_official_proxy_route_is_managed_but_requires_rebuild() {
+        let legacy = r#"model_provider = "cc-switch-official"
+
+[model_providers.cc-switch-official]
+name = "OpenAI"
+base_url = "http://127.0.0.1:15721/v1"
+requires_openai_auth = true
+supports_websockets = false
+wire_api = "responses"
+"#;
+        assert!(codex_config_has_official_proxy_route(legacy));
+        assert!(!codex_config_has_current_official_proxy_route(legacy));
     }
 
     #[test]
@@ -3256,7 +3422,17 @@ command = "example"
         let cleaned = remove_codex_official_proxy_route(&projected).expect("clean");
         let doc: toml::Value = toml::from_str(&cleaned).expect("parse cleaned");
         assert!(doc.get("model_provider").is_none());
-        assert!(doc.get("model_providers").is_none());
+        assert!(
+            doc["model_providers"][CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID]
+                .get("base_url")
+                .is_none()
+        );
+        assert_eq!(
+            doc["model_providers"][CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID]
+                .get("supports_websockets")
+                .and_then(toml::Value::as_bool),
+            Some(true)
+        );
         assert_eq!(
             doc.get("model").and_then(toml::Value::as_str),
             Some("gpt-5.4")
@@ -3293,9 +3469,77 @@ model_providers = { rightcode = { name = "RightCode", experimental_bearer_token 
         let cleaned_doc: toml::Value = toml::from_str(&cleaned).expect("parse cleaned");
         assert!(cleaned_doc.get("model_provider").is_none());
         assert!(cleaned_doc["model_providers"].get("rightcode").is_some());
+        assert!(
+            cleaned_doc["model_providers"][CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID]
+                .get("base_url")
+                .is_none()
+        );
         assert!(cleaned_doc["model_providers"]
-            .get(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID)
+            .get(OPENAI_CODEX_MODEL_PROVIDER_ID)
             .is_none());
+    }
+
+    #[test]
+    fn official_proxy_compatibility_provider_is_native_and_idempotent() {
+        let once = ensure_codex_official_proxy_compatibility_provider("model = \"gpt-5.4\"\n")
+            .expect("add compatibility provider");
+        let twice = ensure_codex_official_proxy_compatibility_provider(&once)
+            .expect("add compatibility provider again");
+        assert_eq!(twice, once);
+
+        let doc: toml::Value = toml::from_str(&once).expect("parse compatibility config");
+        let provider = &doc["model_providers"][CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID];
+        assert!(provider.get("base_url").is_none());
+        assert_eq!(
+            provider
+                .get("requires_openai_auth")
+                .and_then(toml::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            provider
+                .get("supports_websockets")
+                .and_then(toml::Value::as_bool),
+            Some(true)
+        );
+        assert!(!codex_config_has_official_proxy_route(&once));
+    }
+
+    #[test]
+    fn official_proxy_aliases_preserve_active_third_party_route() {
+        let input = r#"model_provider = "rightcode"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "http://127.0.0.1:15721/v1"
+wire_api = "responses"
+experimental_bearer_token = "PROXY_MANAGED"
+"#;
+        let output = apply_codex_official_proxy_aliases(input, "http://127.0.0.1:15721/v1")
+            .expect("add official aliases");
+        let doc: toml::Value = toml::from_str(&output).expect("parse aliased config");
+        assert_eq!(
+            doc.get("model_provider").and_then(toml::Value::as_str),
+            Some("rightcode")
+        );
+        assert_eq!(
+            doc["model_providers"]["rightcode"]
+                .get("experimental_bearer_token")
+                .and_then(toml::Value::as_str),
+            Some("PROXY_MANAGED")
+        );
+        for provider_id in [
+            OPENAI_CODEX_MODEL_PROVIDER_ID,
+            CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
+        ] {
+            assert_eq!(
+                doc["model_providers"][provider_id]
+                    .get("base_url")
+                    .and_then(toml::Value::as_str),
+                Some("http://127.0.0.1:15721/v1")
+            );
+        }
+        assert!(!codex_config_has_official_proxy_route(&output));
     }
 
     #[test]

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2618,7 +2618,8 @@ pub fn codex_config_has_official_proxy_route(config_text: &str) -> bool {
 /// builds selected `cc-switch-official` directly or redefined Codex's reserved
 /// `openai` provider. Those configs remain recognizable for cleanup but must
 /// be rebuilt before an idempotent takeover can be reused.
-pub fn codex_config_has_current_official_proxy_route(config_text: &str) -> bool {
+#[cfg(test)]
+fn codex_config_has_current_official_proxy_route(config_text: &str) -> bool {
     let Ok(doc) = config_text.parse::<DocumentMut>() else {
         return false;
     };
@@ -2627,27 +2628,49 @@ pub fn codex_config_has_current_official_proxy_route(config_text: &str) -> bool 
     {
         return false;
     }
-    let Some(providers) = doc.get("model_providers").and_then(|item| item.as_table()) else {
+    matches!(
+        current_codex_official_proxy_alias_urls(&doc),
+        Some((openai, legacy)) if openai == legacy
+    )
+}
+
+/// Whether both official-thread compatibility aliases point at the active
+/// local proxy. This applies to official and third-party takeovers alike:
+/// third-party configs keep their selected `model_provider`, but resumed
+/// built-in/legacy official threads still require these two aliases.
+pub fn codex_config_has_current_official_proxy_aliases(
+    config_text: &str,
+    proxy_base_url: &str,
+) -> bool {
+    let Ok(doc) = config_text.parse::<DocumentMut>() else {
         return false;
     };
+    let expected = proxy_base_url.trim().trim_end_matches('/');
+    matches!(
+        current_codex_official_proxy_alias_urls(&doc),
+        Some((openai, legacy)) if openai == expected && legacy == expected
+    )
+}
+
+fn current_codex_official_proxy_alias_urls(doc: &DocumentMut) -> Option<(&str, &str)> {
+    let providers = doc.get("model_providers")?.as_table()?;
     if providers.contains_key(OPENAI_CODEX_MODEL_PROVIDER_ID) {
-        return false;
+        return None;
     }
     let openai_base_url = doc
-        .get("openai_base_url")
-        .and_then(|item| item.as_str())
-        .map(|url| url.trim().trim_end_matches('/').to_string());
+        .get("openai_base_url")?
+        .as_str()?
+        .trim()
+        .trim_end_matches('/');
     let compatibility_base_url = providers
         .get(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID)
         .and_then(|item| item.as_table())
-        .filter(|table| table_matches_codex_managed_local_official_provider(table))
-        .and_then(|table| table.get("base_url"))
-        .and_then(|item| item.as_str())
-        .map(|url| url.trim().trim_end_matches('/').to_string());
-    matches!(
-        (openai_base_url, compatibility_base_url),
-        (Some(openai), Some(legacy)) if openai == legacy
-    )
+        .filter(|table| table_matches_codex_managed_local_official_provider(table))?
+        .get("base_url")?
+        .as_str()?
+        .trim()
+        .trim_end_matches('/');
+    Some((openai_base_url, compatibility_base_url))
 }
 
 fn table_matches_codex_managed_local_official_provider(table: &toml_edit::Table) -> bool {
@@ -3616,6 +3639,18 @@ experimental_bearer_token = "PROXY_MANAGED"
             Some("http://127.0.0.1:15721/v1")
         );
         assert!(!codex_config_has_official_proxy_route(&output));
+        assert!(codex_config_has_current_official_proxy_aliases(
+            &output,
+            "http://127.0.0.1:15721/v1/"
+        ));
+        assert!(
+            !codex_config_has_current_official_proxy_aliases(input, "http://127.0.0.1:15721/v1"),
+            "legacy third-party takeovers without aliases require rebuilding"
+        );
+        assert!(
+            !codex_config_has_current_official_proxy_aliases(&output, "http://127.0.0.1:15722/v1"),
+            "aliases for an old proxy port require rebuilding"
+        );
     }
 
     #[test]

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2505,22 +2505,25 @@ fn remove_codex_proxy_placeholders_from_providers(providers: &mut toml_edit::Tab
     }
 }
 
-fn insert_codex_official_proxy_aliases(providers: &mut toml_edit::Table, proxy_base_url: &str) {
+fn configure_codex_official_proxy_routes(
+    doc: &mut DocumentMut,
+    providers: &mut toml_edit::Table,
+    proxy_base_url: &str,
+) {
     let table = codex_official_provider_table(Some(proxy_base_url), false);
-    providers.insert(
-        OPENAI_CODEX_MODEL_PROVIDER_ID,
-        toml_edit::Item::Table(table.clone()),
-    );
+    doc["openai_base_url"] = toml_edit::value(proxy_base_url.trim_end_matches('/'));
+    providers.remove(OPENAI_CODEX_MODEL_PROVIDER_ID);
     providers.insert(
         CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
         toml_edit::Item::Table(table),
     );
 }
 
-/// Add local-route aliases for native and legacy official Codex threads while
-/// preserving the currently selected provider. This is also used when a
-/// third-party provider is active, because resuming an older official thread
-/// must still enter the local proxy instead of bypassing it.
+/// Add local routes for native and legacy official Codex threads while
+/// preserving the currently selected provider. Native `openai` threads use
+/// Codex's supported top-level `openai_base_url`; legacy CC Switch threads use
+/// a non-reserved compatibility provider. This is also used when a third-party
+/// provider is active so resuming an official thread cannot bypass the proxy.
 pub fn apply_codex_official_proxy_aliases(
     config_text: &str,
     proxy_base_url: &str,
@@ -2540,7 +2543,7 @@ pub fn apply_codex_official_proxy_aliases(
             table
         }
     };
-    insert_codex_official_proxy_aliases(&mut providers, proxy_base_url);
+    configure_codex_official_proxy_routes(&mut doc, &mut providers, proxy_base_url);
     doc["model_providers"] = toml_edit::Item::Table(providers);
     Ok(doc.to_string())
 }
@@ -2548,10 +2551,11 @@ pub fn apply_codex_official_proxy_aliases(
 /// Project a Codex official account card through the local proxy while keeping
 /// authentication owned by Codex itself.
 ///
-/// Both the native `openai` bucket and CC Switch's legacy official bucket are
-/// pointed at the same local endpoint. New threads stay in `openai`, so route
-/// changes never need to rewrite Codex rollout JSONL or state SQLite files.
-/// No API key or bearer placeholder is written to `auth.json`.
+/// The built-in `openai` bucket is redirected with `openai_base_url`, while CC
+/// Switch's legacy official bucket uses a legal custom provider alias pointed
+/// at the same endpoint. New threads stay in `openai`, so route changes never
+/// need to rewrite Codex rollout JSONL or state SQLite files. No API key or
+/// bearer placeholder is written to `auth.json`.
 pub fn apply_codex_official_proxy_route(
     config_text: &str,
     proxy_base_url: &str,
@@ -2583,7 +2587,7 @@ pub fn apply_codex_official_proxy_route(
     remove_codex_proxy_placeholders_from_providers(&mut providers);
 
     // The local proxy currently exposes HTTP/SSE, not Codex websocket routes.
-    insert_codex_official_proxy_aliases(&mut providers, proxy_base_url);
+    configure_codex_official_proxy_routes(&mut doc, &mut providers, proxy_base_url);
     doc["model_providers"] = toml_edit::Item::Table(providers);
     Ok(doc.to_string())
 }
@@ -2611,9 +2615,9 @@ pub fn codex_config_has_official_proxy_route(config_text: &str) -> bool {
 }
 
 /// Whether the official route uses the current non-migrating layout. Older
-/// builds selected `cc-switch-official` directly and exposed only that table;
-/// those configs are still recognized as managed for cleanup, but must be
-/// rebuilt before an idempotent takeover can be reused.
+/// builds selected `cc-switch-official` directly or redefined Codex's reserved
+/// `openai` provider. Those configs remain recognizable for cleanup but must
+/// be rebuilt before an idempotent takeover can be reused.
 pub fn codex_config_has_current_official_proxy_route(config_text: &str) -> bool {
     let Ok(doc) = config_text.parse::<DocumentMut>() else {
         return false;
@@ -2626,20 +2630,22 @@ pub fn codex_config_has_current_official_proxy_route(config_text: &str) -> bool 
     let Some(providers) = doc.get("model_providers").and_then(|item| item.as_table()) else {
         return false;
     };
-    let local_base_url = |provider_id: &str| {
-        providers
-            .get(provider_id)
-            .and_then(|item| item.as_table())
-            .filter(|table| table_matches_codex_managed_local_official_provider(table))
-            .and_then(|table| table.get("base_url"))
-            .and_then(|item| item.as_str())
-            .map(|url| url.trim().trim_end_matches('/').to_string())
-    };
+    if providers.contains_key(OPENAI_CODEX_MODEL_PROVIDER_ID) {
+        return false;
+    }
+    let openai_base_url = doc
+        .get("openai_base_url")
+        .and_then(|item| item.as_str())
+        .map(|url| url.trim().trim_end_matches('/').to_string());
+    let compatibility_base_url = providers
+        .get(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID)
+        .and_then(|item| item.as_table())
+        .filter(|table| table_matches_codex_managed_local_official_provider(table))
+        .and_then(|table| table.get("base_url"))
+        .and_then(|item| item.as_str())
+        .map(|url| url.trim().trim_end_matches('/').to_string());
     matches!(
-        (
-            local_base_url(OPENAI_CODEX_MODEL_PROVIDER_ID),
-            local_base_url(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID),
-        ),
+        (openai_base_url, compatibility_base_url),
         (Some(openai), Some(legacy)) if openai == legacy
     )
 }
@@ -2701,21 +2707,31 @@ pub fn remove_codex_official_proxy_route(config_text: &str) -> Result<String, Ap
     let mut doc = config_text
         .parse::<DocumentMut>()
         .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
-    let has_managed_route = doc
+    let managed_route_base_url = doc
         .get("model_providers")
         .and_then(|item| item.as_table())
         .and_then(|providers| providers.get(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID))
         .and_then(|item| item.as_table())
-        .is_some_and(table_matches_codex_managed_local_official_provider);
-    if !has_managed_route {
+        .filter(|table| table_matches_codex_managed_local_official_provider(table))
+        .and_then(|table| table.get("base_url"))
+        .and_then(|item| item.as_str())
+        .map(|url| url.trim().trim_end_matches('/').to_string());
+    let Some(managed_route_base_url) = managed_route_base_url else {
         return Ok(config_text.to_string());
-    }
+    };
 
     if matches!(
         doc.get("model_provider").and_then(|item| item.as_str()),
         Some(OPENAI_CODEX_MODEL_PROVIDER_ID | CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID)
     ) {
         doc.as_table_mut().remove("model_provider");
+    }
+    let openai_base_url_is_managed = doc
+        .get("openai_base_url")
+        .and_then(|item| item.as_str())
+        .is_some_and(|url| url.trim().trim_end_matches('/') == managed_route_base_url.as_str());
+    if openai_base_url_is_managed {
+        doc.as_table_mut().remove("openai_base_url");
     }
     if let Some(item) = doc.as_table_mut().remove("model_providers") {
         let mut providers = item.into_table().map_err(|_| {
@@ -3373,30 +3389,87 @@ command = "example"
             "unrelated config survives"
         );
 
-        for provider_id in [
-            OPENAI_CODEX_MODEL_PROVIDER_ID,
-            CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
-        ] {
-            let provider = &doc["model_providers"][provider_id];
-            assert_eq!(
-                provider.get("base_url").and_then(toml::Value::as_str),
-                Some("http://127.0.0.1:15721/v1")
-            );
-            assert_eq!(
-                provider
-                    .get("requires_openai_auth")
-                    .and_then(toml::Value::as_bool),
-                Some(true)
-            );
-            assert_eq!(
-                provider
-                    .get("supports_websockets")
-                    .and_then(toml::Value::as_bool),
-                Some(false)
-            );
-        }
+        assert_eq!(
+            doc.get("openai_base_url").and_then(toml::Value::as_str),
+            Some("http://127.0.0.1:15721/v1")
+        );
+        assert!(doc["model_providers"]
+            .get(OPENAI_CODEX_MODEL_PROVIDER_ID)
+            .is_none());
+        let provider = &doc["model_providers"][CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID];
+        assert_eq!(
+            provider.get("base_url").and_then(toml::Value::as_str),
+            Some("http://127.0.0.1:15721/v1")
+        );
+        assert_eq!(
+            provider
+                .get("requires_openai_auth")
+                .and_then(toml::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            provider
+                .get("supports_websockets")
+                .and_then(toml::Value::as_bool),
+            Some(false)
+        );
         assert!(codex_config_has_official_proxy_route(&output));
         assert!(codex_config_has_current_official_proxy_route(&output));
+    }
+
+    #[test]
+    fn official_proxy_route_never_overrides_reserved_openai_provider() {
+        let proxy_base_url = "http://127.0.0.1:15721/v1";
+        let output = apply_codex_official_proxy_route("model = \"gpt-5.4\"\n", proxy_base_url)
+            .expect("apply official proxy route");
+        let doc: toml::Value = toml::from_str(&output).expect("parse output");
+
+        assert_eq!(
+            doc.get("openai_base_url").and_then(toml::Value::as_str),
+            Some(proxy_base_url)
+        );
+        assert!(
+            doc.get("model_providers")
+                .and_then(toml::Value::as_table)
+                .is_none_or(|providers| !providers.contains_key(OPENAI_CODEX_MODEL_PROVIDER_ID)),
+            "Codex reserves the built-in `openai` provider id"
+        );
+    }
+
+    #[test]
+    fn official_proxy_route_upgrades_legacy_reserved_openai_override() {
+        let legacy_invalid = r#"model_provider = "openai"
+
+[model_providers.openai]
+name = "OpenAI"
+base_url = "http://127.0.0.1:15721/v1"
+requires_openai_auth = true
+supports_websockets = false
+wire_api = "responses"
+
+[model_providers.cc-switch-official]
+name = "OpenAI"
+base_url = "http://127.0.0.1:15721/v1"
+requires_openai_auth = true
+supports_websockets = false
+wire_api = "responses"
+"#;
+        assert!(codex_config_has_official_proxy_route(legacy_invalid));
+        assert!(!codex_config_has_current_official_proxy_route(
+            legacy_invalid
+        ));
+
+        let upgraded =
+            apply_codex_official_proxy_route(legacy_invalid, "http://127.0.0.1:15721/v1")
+                .expect("upgrade legacy invalid route");
+        let doc: toml::Value = toml::from_str(&upgraded).expect("parse upgraded route");
+
+        assert_eq!(
+            doc.get("openai_base_url").and_then(toml::Value::as_str),
+            Some("http://127.0.0.1:15721/v1")
+        );
+        assert!(doc["model_providers"].get("openai").is_none());
+        assert!(codex_config_has_current_official_proxy_route(&upgraded));
     }
 
     #[test]
@@ -3422,6 +3495,7 @@ wire_api = "responses"
         let cleaned = remove_codex_official_proxy_route(&projected).expect("clean");
         let doc: toml::Value = toml::from_str(&cleaned).expect("parse cleaned");
         assert!(doc.get("model_provider").is_none());
+        assert!(doc.get("openai_base_url").is_none());
         assert!(
             doc["model_providers"][CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID]
                 .get("base_url")
@@ -3528,17 +3602,19 @@ experimental_bearer_token = "PROXY_MANAGED"
                 .and_then(toml::Value::as_str),
             Some("PROXY_MANAGED")
         );
-        for provider_id in [
-            OPENAI_CODEX_MODEL_PROVIDER_ID,
-            CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
-        ] {
-            assert_eq!(
-                doc["model_providers"][provider_id]
-                    .get("base_url")
-                    .and_then(toml::Value::as_str),
-                Some("http://127.0.0.1:15721/v1")
-            );
-        }
+        assert_eq!(
+            doc.get("openai_base_url").and_then(toml::Value::as_str),
+            Some("http://127.0.0.1:15721/v1")
+        );
+        assert!(doc["model_providers"]
+            .get(OPENAI_CODEX_MODEL_PROVIDER_ID)
+            .is_none());
+        assert_eq!(
+            doc["model_providers"][CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID]
+                .get("base_url")
+                .and_then(toml::Value::as_str),
+            Some("http://127.0.0.1:15721/v1")
+        );
         assert!(!codex_config_has_official_proxy_route(&output));
     }
 

--- a/src-tauri/src/codex_history_migration.rs
+++ b/src-tauri/src/codex_history_migration.rs
@@ -393,9 +393,13 @@ fn restore_codex_official_history_inner(
     collect_jsonl_files(&codex_dir.join("archived_sessions"), &mut files, 0, 4);
     let mut restored_jsonl_files = 0;
     for file_path in files {
-        if rewrite_codex_session_file_lines(&file_path, codex_dir, restore_backup_root, |line| {
-            rewrite_codex_session_meta_line_for_restore(line, &official_session_ids)
-        })? {
+        if rewrite_codex_session_file_lines(
+            &file_path,
+            codex_dir,
+            restore_backup_root,
+            |content| codex_session_file_is_in_official_ledger(content, &official_session_ids),
+            rewrite_codex_session_provider_line_for_restore,
+        )? {
             restored_jsonl_files += 1;
         }
     }
@@ -564,30 +568,32 @@ fn collect_files_with_extension(
     }
 }
 
-fn rewrite_codex_session_meta_line_for_restore(
-    line: &str,
+fn codex_session_file_is_in_official_ledger(
+    content: &str,
     official_session_ids: &HashSet<String>,
-) -> Option<String> {
-    if !line.contains("\"session_meta\"") || !line.contains("\"model_provider\"") {
-        return None;
-    }
-    let mut value: Value = serde_json::from_str(line).ok()?;
-    if value.get("type").and_then(Value::as_str) != Some("session_meta") {
-        return None;
-    }
-    let payload = value.get_mut("payload")?.as_object_mut()?;
-    if payload.get("model_provider")?.as_str()? != CC_SWITCH_CODEX_MODEL_PROVIDER_ID {
-        return None;
-    }
-    let session_id = payload.get("id")?.as_str()?;
-    if !official_session_ids.contains(session_id) {
-        return None;
-    }
-    payload.insert(
-        "model_provider".to_string(),
-        Value::String(OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID.to_string()),
-    );
-    serde_json::to_string(&value).ok()
+) -> bool {
+    content.lines().any(|line| {
+        if !line.contains("\"session_meta\"") {
+            return false;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            return false;
+        };
+        value.get("type").and_then(Value::as_str) == Some("session_meta")
+            && value
+                .get("payload")
+                .and_then(|payload| payload.get("id"))
+                .and_then(Value::as_str)
+                .is_some_and(|session_id| official_session_ids.contains(session_id))
+    })
+}
+
+fn rewrite_codex_session_provider_line_for_restore(line: &str) -> Option<String> {
+    rewrite_codex_session_provider_line_if(
+        line,
+        |provider_id| provider_id == CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+        OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID,
+    )
 }
 
 fn restore_codex_state_db_official_threads(
@@ -963,6 +969,20 @@ fn migrate_codex_jsonl_files(
     source_provider_ids: &BTreeSet<String>,
     backup_root: &Path,
 ) -> Result<usize, AppError> {
+    migrate_codex_jsonl_files_to_provider(
+        codex_dir,
+        source_provider_ids,
+        CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+        backup_root,
+    )
+}
+
+fn migrate_codex_jsonl_files_to_provider(
+    codex_dir: &Path,
+    source_provider_ids: &BTreeSet<String>,
+    target_provider_id: &str,
+    backup_root: &Path,
+) -> Result<usize, AppError> {
     let mut files = Vec::new();
     collect_jsonl_files(&codex_dir.join("sessions"), &mut files, 0, 8);
     collect_jsonl_files(&codex_dir.join("archived_sessions"), &mut files, 0, 4);
@@ -974,6 +994,7 @@ fn migrate_codex_jsonl_files(
             &file_path,
             codex_dir,
             &source_provider_ids,
+            target_provider_id,
             backup_root,
         )? {
             migrated += 1;
@@ -1012,23 +1033,32 @@ fn rewrite_codex_session_file_for_provider_bucket(
     path: &Path,
     codex_dir: &Path,
     source_provider_ids: &HashSet<String>,
+    target_provider_id: &str,
     backup_root: &Path,
 ) -> Result<bool, AppError> {
-    rewrite_codex_session_file_lines(path, codex_dir, backup_root, |line| {
-        rewrite_codex_session_meta_line(line, source_provider_ids)
-    })
+    rewrite_codex_session_file_lines(
+        path,
+        codex_dir,
+        backup_root,
+        |_| true,
+        |line| rewrite_codex_session_provider_line(line, source_provider_ids, target_provider_id),
+    )
 }
 
 fn rewrite_codex_session_file_lines(
     path: &Path,
     codex_dir: &Path,
     backup_root: &Path,
+    should_rewrite_file: impl FnOnce(&str) -> bool,
     rewrite_line: impl Fn(&str) -> Option<String>,
 ) -> Result<bool, AppError> {
     let metadata_before = fs::metadata(path).map_err(|e| AppError::io(path, e))?;
     let modified_before = metadata_before.modified().ok();
     let len_before = metadata_before.len();
     let content = fs::read_to_string(path).map_err(|e| AppError::io(path, e))?;
+    if !should_rewrite_file(&content) {
+        return Ok(false);
+    }
 
     let mut rewritten = String::with_capacity(content.len());
     let mut changed = false;
@@ -1054,6 +1084,13 @@ fn rewrite_codex_session_file_lines(
     backup_codex_jsonl_file(path, codex_dir, backup_root)?;
     ensure_codex_session_file_unchanged(path, modified_before, len_before)?;
     atomic_write(path, rewritten.as_bytes())?;
+    if let Some(modified_before) = modified_before {
+        fs::File::options()
+            .write(true)
+            .open(path)
+            .and_then(|file| file.set_modified(modified_before))
+            .map_err(|e| AppError::io(path, e))?;
+    }
     Ok(true)
 }
 
@@ -1072,29 +1109,53 @@ fn ensure_codex_session_file_unchanged(
     Ok(())
 }
 
-fn rewrite_codex_session_meta_line(
+fn rewrite_codex_session_provider_line(
     line: &str,
     source_provider_ids: &HashSet<String>,
+    target_provider_id: &str,
 ) -> Option<String> {
-    if !line.contains("\"session_meta\"") || !line.contains("\"model_provider\"") {
+    rewrite_codex_session_provider_line_if(
+        line,
+        |provider_id| source_provider_ids.contains(provider_id),
+        target_provider_id,
+    )
+}
+
+fn rewrite_codex_session_provider_line_if(
+    line: &str,
+    is_source_provider: impl FnOnce(&str) -> bool,
+    target_provider_id: &str,
+) -> Option<String> {
+    if !line.contains("\"model_provider") {
         return None;
     }
 
     let mut value: Value = serde_json::from_str(line).ok()?;
-    if value.get("type").and_then(Value::as_str) != Some("session_meta") {
-        return None;
-    }
+    let is_session_meta = value.get("type").and_then(Value::as_str) == Some("session_meta");
+    let is_thread_settings_applied = value.get("type").and_then(Value::as_str) == Some("event_msg")
+        && value
+            .get("payload")
+            .and_then(|payload| payload.get("type"))
+            .and_then(Value::as_str)
+            == Some("thread_settings_applied");
 
     let payload = value.get_mut("payload")?.as_object_mut()?;
-    let current_provider = payload.get("model_provider")?.as_str()?;
-    if !source_provider_ids.contains(current_provider) {
+    let provider = if is_session_meta {
+        payload.get_mut("model_provider")?
+    } else if is_thread_settings_applied {
+        payload
+            .get_mut("thread_settings")?
+            .as_object_mut()?
+            .get_mut("model_provider_id")?
+    } else {
+        return None;
+    };
+    let current_provider = provider.as_str()?;
+    if !is_source_provider(current_provider) {
         return None;
     }
 
-    payload.insert(
-        "model_provider".to_string(),
-        Value::String(CC_SWITCH_CODEX_MODEL_PROVIDER_ID.to_string()),
-    );
+    *provider = Value::String(target_provider_id.to_string());
     serde_json::to_string(&value).ok()
 }
 
@@ -1104,22 +1165,56 @@ fn migrate_codex_state_dbs(
     backup_root: &Path,
 ) -> Result<usize, AppError> {
     let config_text = read_codex_config_text().unwrap_or_default();
+    migrate_codex_state_dbs_to_provider(
+        codex_dir,
+        &config_text,
+        source_provider_ids,
+        CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+        backup_root,
+    )
+}
+
+fn migrate_codex_state_dbs_to_provider(
+    codex_dir: &Path,
+    config_text: &str,
+    source_provider_ids: &BTreeSet<String>,
+    target_provider_id: &str,
+    backup_root: &Path,
+) -> Result<usize, AppError> {
     let mut migrated = 0;
-    for db_path in codex_state_db_paths(codex_dir, &config_text) {
-        migrated += migrate_codex_state_db_provider_bucket(
+    for db_path in codex_state_db_paths(codex_dir, config_text) {
+        migrated += migrate_codex_state_db_provider_bucket_to_provider(
             &db_path,
             codex_dir,
             source_provider_ids,
+            target_provider_id,
             backup_root,
         )?;
     }
     Ok(migrated)
 }
 
+#[cfg(test)]
 fn migrate_codex_state_db_provider_bucket(
     db_path: &Path,
     codex_dir: &Path,
     source_provider_ids: &BTreeSet<String>,
+    backup_root: &Path,
+) -> Result<usize, AppError> {
+    migrate_codex_state_db_provider_bucket_to_provider(
+        db_path,
+        codex_dir,
+        source_provider_ids,
+        CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+        backup_root,
+    )
+}
+
+fn migrate_codex_state_db_provider_bucket_to_provider(
+    db_path: &Path,
+    codex_dir: &Path,
+    source_provider_ids: &BTreeSet<String>,
+    target_provider_id: &str,
     backup_root: &Path,
 ) -> Result<usize, AppError> {
     if !db_path.exists() || source_provider_ids.is_empty() {
@@ -1156,7 +1251,7 @@ fn migrate_codex_state_db_provider_bucket(
     let update_sql =
         format!("UPDATE threads SET model_provider = ? WHERE model_provider IN ({placeholders})");
     let mut values = Vec::with_capacity(source_provider_ids.len() + 1);
-    values.push(CC_SWITCH_CODEX_MODEL_PROVIDER_ID.to_string());
+    values.push(target_provider_id.to_string());
     values.extend(source_provider_ids.iter().cloned());
     let tx = conn
         .transaction()
@@ -1739,7 +1834,10 @@ base_url = "https://proxy.example/v1"
         let official_path = session_dir.join("official.jsonl");
         fs::write(
             &official_path,
-            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s1\",\"model_provider\":\"custom\"}}\n",
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s1\",\"model_provider\":\"custom\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_settings_applied\",\"thread_settings\":{\"model_provider_id\":\"custom\"}}}\n",
+            ),
         )
         .expect("write official session");
         let on_period_dir = codex_dir.join("sessions/2026/06/12");
@@ -1749,6 +1847,7 @@ base_url = "https://proxy.example/v1"
             &on_period_path,
             concat!(
                 "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s2\",\"model_provider\":\"custom\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_settings_applied\",\"thread_settings\":{\"model_provider_id\":\"custom\"}}}\n",
                 "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s3\",\"model_provider\":\"my-private-relay\"}}\n",
             ),
         )
@@ -1789,8 +1888,10 @@ base_url = "https://proxy.example/v1"
 
         let official_text = fs::read_to_string(&official_path).expect("read official");
         assert!(official_text.contains("\"model_provider\":\"openai\""));
+        assert!(official_text.contains("\"model_provider_id\":\"openai\""));
         let on_period_text = fs::read_to_string(&on_period_path).expect("read on-period");
         assert!(on_period_text.contains("\"id\":\"s2\",\"model_provider\":\"custom\""));
+        assert!(on_period_text.contains("\"model_provider_id\":\"custom\""));
         assert!(on_period_text.contains("\"model_provider\":\"my-private-relay\""));
 
         let conn = Connection::open(&state_db_path).expect("reopen state db");
@@ -1946,7 +2047,7 @@ base_url = "https://proxy.example/v1"
     }
 
     #[test]
-    fn rewrites_only_codex_session_meta_provider_ids() {
+    fn rewrites_codex_session_provider_ids_and_creates_backup() {
         let dir = tempdir().expect("tempdir");
         let codex_dir = dir.path().join(".codex");
         let backup_root = dir.path().join("backup");
@@ -1966,6 +2067,7 @@ base_url = "https://proxy.example/v1"
             &path,
             &codex_dir,
             &HashSet::from(["rightcode".to_string()]),
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
             &backup_root,
         )
         .expect("rewrite");
@@ -1976,6 +2078,44 @@ base_url = "https://proxy.example/v1"
         assert!(backup_root
             .join("jsonl/sessions/2026/05/20/rollout-test.jsonl")
             .exists());
+    }
+
+    #[test]
+    fn migrates_persisted_runtime_provider_with_session_bucket() {
+        let dir = tempdir().expect("tempdir");
+        let codex_dir = dir.path().join(".codex");
+        let backup_root = dir.path().join("backup");
+        let session_dir = codex_dir.join("sessions/2026/08/19");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        let path = session_dir.join("rollout-runtime-provider.jsonl");
+        fs::write(
+            &path,
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s1\",\"model_provider\":\"openai\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_settings_applied\",\"thread_settings\":{\"model\":\"gpt-5.4\",\"model_provider_id\":\"openai\"}}}\n",
+                "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"user\",\"content\":\"hi\"}}\n"
+            ),
+        )
+        .expect("write session");
+
+        let migrated =
+            migrate_codex_jsonl_files(&codex_dir, &source_ids(&["openai"]), &backup_root)
+                .expect("migrate jsonl");
+
+        assert_eq!(migrated, 1);
+        let lines: Vec<Value> = fs::read_to_string(&path)
+            .expect("read rewritten session")
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("parse rollout line"))
+            .collect();
+        assert_eq!(
+            lines[0]["payload"]["model_provider"].as_str(),
+            Some(CC_SWITCH_CODEX_MODEL_PROVIDER_ID)
+        );
+        assert_eq!(
+            lines[1]["payload"]["thread_settings"]["model_provider_id"].as_str(),
+            Some(CC_SWITCH_CODEX_MODEL_PROVIDER_ID)
+        );
     }
 
     #[test]

--- a/src-tauri/src/codex_history_migration.rs
+++ b/src-tauri/src/codex_history_migration.rs
@@ -393,12 +393,19 @@ fn restore_codex_official_history_inner(
     collect_jsonl_files(&codex_dir.join("archived_sessions"), &mut files, 0, 4);
     let mut restored_jsonl_files = 0;
     for file_path in files {
+        let mut restore_current_segment = false;
         if rewrite_codex_session_file_lines(
             &file_path,
             codex_dir,
             restore_backup_root,
-            |content| codex_session_file_is_in_official_ledger(content, &official_session_ids),
-            rewrite_codex_session_provider_line_for_restore,
+            |_| true,
+            |line| {
+                rewrite_codex_session_provider_line_for_ledger_restore(
+                    line,
+                    &official_session_ids,
+                    &mut restore_current_segment,
+                )
+            },
         )? {
             restored_jsonl_files += 1;
         }
@@ -568,24 +575,30 @@ fn collect_files_with_extension(
     }
 }
 
-fn codex_session_file_is_in_official_ledger(
-    content: &str,
+fn rewrite_codex_session_provider_line_for_ledger_restore(
+    line: &str,
     official_session_ids: &HashSet<String>,
-) -> bool {
-    content.lines().any(|line| {
-        if !line.contains("\"session_meta\"") {
-            return false;
-        }
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
-            return false;
-        };
-        value.get("type").and_then(Value::as_str) == Some("session_meta")
-            && value
+    restore_current_segment: &mut bool,
+) -> Option<String> {
+    if line.contains("\"session_meta\"") {
+        // A rollout may contain copied/replayed segments for multiple sessions.
+        // Reset before parsing so a malformed boundary cannot inherit the
+        // previous segment's restoration scope.
+        *restore_current_segment = false;
+        let value = serde_json::from_str::<Value>(line).ok()?;
+        if value.get("type").and_then(Value::as_str) == Some("session_meta") {
+            *restore_current_segment = value
                 .get("payload")
                 .and_then(|payload| payload.get("id"))
                 .and_then(Value::as_str)
-                .is_some_and(|session_id| official_session_ids.contains(session_id))
-    })
+                .is_some_and(|session_id| official_session_ids.contains(session_id));
+        }
+    }
+
+    if !*restore_current_segment {
+        return None;
+    }
+    rewrite_codex_session_provider_line_for_restore(line)
 }
 
 fn rewrite_codex_session_provider_line_for_restore(line: &str) -> Option<String> {
@@ -1050,7 +1063,7 @@ fn rewrite_codex_session_file_lines(
     codex_dir: &Path,
     backup_root: &Path,
     should_rewrite_file: impl FnOnce(&str) -> bool,
-    rewrite_line: impl Fn(&str) -> Option<String>,
+    mut rewrite_line: impl FnMut(&str) -> Option<String>,
 ) -> Result<bool, AppError> {
     let metadata_before = fs::metadata(path).map_err(|e| AppError::io(path, e))?;
     let modified_before = metadata_before.modified().ok();
@@ -1928,6 +1941,71 @@ base_url = "https://proxy.example/v1"
         assert_eq!(rerun.restored_jsonl_files, 0);
         assert_eq!(rerun.restored_state_rows, 0);
         assert_eq!(rerun.skipped_reason.as_deref(), Some("nothing_to_restore"));
+    }
+
+    #[test]
+    fn restore_scopes_mixed_rollout_segments_to_ledger_session() {
+        let dir = tempdir().expect("tempdir");
+        let codex_dir = dir.path().join(".codex");
+        let ledger_parent = dir.path().join("ledger");
+        let restore_backup_root = dir.path().join("restore-backup");
+
+        let generation = ledger_parent.join("20260612_010101");
+        let backup_session_dir = generation.join("jsonl/sessions/2026/06/01");
+        fs::create_dir_all(&backup_session_dir).expect("create backup session dir");
+        fs::create_dir_all(&codex_dir).expect("create codex dir");
+        fs::write(
+            backup_session_dir.join("official.jsonl"),
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s1\",\"model_provider\":\"openai\"}}\n",
+        )
+        .expect("write backup session");
+        fs::write(
+            generation.join("meta.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "codexConfigDir": canonical_dir_string(&codex_dir)
+            }))
+            .expect("serialize meta"),
+        )
+        .expect("write meta");
+
+        let session_dir = codex_dir.join("sessions/2026/06/12");
+        fs::create_dir_all(&session_dir).expect("create session dir");
+        let mixed_path = session_dir.join("mixed.jsonl");
+        fs::write(
+            &mixed_path,
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s1\",\"model_provider\":\"custom\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_settings_applied\",\"segment\":\"s1\",\"thread_settings\":{\"model_provider_id\":\"custom\"}}}\n",
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"s2\",\"model_provider\":\"custom\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_settings_applied\",\"segment\":\"s2\",\"thread_settings\":{\"model_provider_id\":\"custom\"}}}\n",
+            ),
+        )
+        .expect("write mixed session");
+
+        let outcome = restore_codex_official_history_inner(
+            &codex_dir,
+            &ledger_parent,
+            &restore_backup_root,
+            "",
+        )
+        .expect("restore");
+        assert_eq!(outcome.restored_jsonl_files, 1);
+
+        let lines = fs::read_to_string(&mixed_path)
+            .expect("read mixed session")
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).expect("valid jsonl"))
+            .collect::<Vec<_>>();
+        assert_eq!(lines[0]["payload"]["model_provider"], "openai");
+        assert_eq!(
+            lines[1]["payload"]["thread_settings"]["model_provider_id"],
+            "openai"
+        );
+        assert_eq!(lines[2]["payload"]["model_provider"], "custom");
+        assert_eq!(
+            lines[3]["payload"]["thread_settings"]["model_provider_id"], "custom",
+            "an unrelated session segment in the same file must remain untouched"
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -59,6 +59,13 @@ pub struct ProxyServer {
     server_handle: Arc<RwLock<Option<JoinHandle<()>>>>,
 }
 
+async fn responses_websocket_fallback() -> axum::http::StatusCode {
+    // Codex's built-in OpenAI provider prefers a WebSocket handshake even
+    // when its base URL points at CC Switch. A 426 response is Codex's signal
+    // to skip WebSocket retries and immediately use the HTTP streaming route.
+    axum::http::StatusCode::UPGRADE_REQUIRED
+}
+
 impl ProxyServer {
     pub fn new(
         config: ProxyConfig,
@@ -323,10 +330,22 @@ impl ProxyServer {
             .route("/models", get(handlers::handle_models))
             .route("/v1/models", get(handlers::handle_models))
             // OpenAI Responses API (Codex CLI，支持带前缀和不带前缀)
-            .route("/responses", post(handlers::handle_responses))
-            .route("/v1/responses", post(handlers::handle_responses))
-            .route("/v1/v1/responses", post(handlers::handle_responses))
-            .route("/codex/v1/responses", post(handlers::handle_responses))
+            .route(
+                "/responses",
+                get(responses_websocket_fallback).post(handlers::handle_responses),
+            )
+            .route(
+                "/v1/responses",
+                get(responses_websocket_fallback).post(handlers::handle_responses),
+            )
+            .route(
+                "/v1/v1/responses",
+                get(responses_websocket_fallback).post(handlers::handle_responses),
+            )
+            .route(
+                "/codex/v1/responses",
+                get(responses_websocket_fallback).post(handlers::handle_responses),
+            )
             // Grok Build uses the Responses protocol but has an independent
             // provider namespace and failover queue.
             .route(
@@ -426,6 +445,48 @@ mod tests {
         path_and_query: String,
         authorization: Option<String>,
         body: Value,
+    }
+
+    #[tokio::test]
+    async fn responses_websocket_handshakes_request_http_fallback() {
+        let db = Arc::new(Database::memory().expect("memory database"));
+        let proxy = ProxyServer::new(
+            ProxyConfig {
+                listen_port: 0,
+                enable_logging: false,
+                ..ProxyConfig::default()
+            },
+            db,
+            None,
+        );
+        let proxy_info = proxy.start().await.expect("start test proxy");
+        let client = reqwest::Client::new();
+        let aliases = [
+            "/responses",
+            "/v1/responses",
+            "/v1/v1/responses",
+            "/codex/v1/responses",
+        ];
+
+        for path in aliases {
+            let response = client
+                .get(format!("http://127.0.0.1:{}{}", proxy_info.port, path))
+                .header(header::CONNECTION, "Upgrade")
+                .header(header::UPGRADE, "websocket")
+                .header("sec-websocket-version", "13")
+                .header("sec-websocket-key", "dGhlIHNhbXBsZSBub25jZQ==")
+                .send()
+                .await
+                .expect("send websocket handshake");
+
+            assert_eq!(
+                response.status(),
+                StatusCode::UPGRADE_REQUIRED,
+                "alias {path} must tell Codex to fall back to HTTP streaming"
+            );
+        }
+
+        proxy.stop().await.expect("stop test proxy");
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2535,15 +2535,15 @@ impl ProxyService {
                         Self::proxy_urls_match(url, &proxy_codex_base_url)
                     })
                 });
-                let managed_official_route_is_current = config_text.is_none_or(|config_text| {
-                    !crate::codex_config::codex_config_has_official_proxy_route(config_text)
-                        || crate::codex_config::codex_config_has_current_official_proxy_route(
-                            config_text,
-                        )
+                let official_aliases_are_current = config_text.is_some_and(|config_text| {
+                    crate::codex_config::codex_config_has_current_official_proxy_aliases(
+                        config_text,
+                        &proxy_codex_base_url,
+                    )
                 });
                 Ok(Self::is_codex_live_taken_over(&config)
                     && base_url_matches
-                    && managed_official_route_is_current)
+                    && official_aliases_are_current)
             }
             AppType::Gemini => {
                 let config = self.read_gemini_live()?;
@@ -6437,6 +6437,136 @@ wire_api = "responses"
             .expect("disable Codex takeover");
         crate::settings::update_settings(crate::settings::AppSettings::default())
             .expect("reset settings");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_set_takeover_upgrades_legacy_third_party_route_with_missing_aliases() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        crate::settings::update_settings(crate::settings::AppSettings::default())
+            .expect("reset settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        use_ephemeral_proxy_port(&db).await;
+        let service = ProxyService::new(db.clone());
+        service.start().await.expect("start proxy server");
+        let proxy_base_url = running_codex_base_url(&service).await;
+
+        let oauth_auth = json!({
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "id_token": "oauth-id",
+                "access_token": "oauth-access"
+            }
+        });
+        let original_config = r#"model_provider = "rightcode"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "https://rightcode.example/v1"
+wire_api = "responses"
+experimental_bearer_token = "rightcode-key"
+"#;
+        let legacy_takeover_config = format!(
+            r#"model_provider = "rightcode"
+
+[model_providers.rightcode]
+name = "RightCode"
+base_url = "{proxy_base_url}"
+wire_api = "responses"
+experimental_bearer_token = "PROXY_MANAGED"
+"#
+        );
+        crate::codex_config::write_codex_live_atomic(&oauth_auth, Some(&legacy_takeover_config))
+            .expect("seed legacy third-party takeover");
+
+        let mut provider = Provider::with_id(
+            "rightcode".to_string(),
+            "RightCode".to_string(),
+            json!({
+                "auth": { "OPENAI_API_KEY": "rightcode-key" },
+                "config": original_config
+            }),
+            None,
+        );
+        provider.category = Some("custom".to_string());
+        db.save_provider("codex", &provider)
+            .expect("save third-party provider");
+        db.set_current_provider("codex", &provider.id)
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Codex, Some(&provider.id))
+            .expect("set local current provider");
+        db.save_live_backup(
+            "codex",
+            &serde_json::to_string(&json!({
+                "auth": oauth_auth,
+                "config": original_config
+            }))
+            .expect("serialize original backup"),
+        )
+        .await
+        .expect("seed original live backup");
+        let mut proxy_config = db
+            .get_proxy_config_for_app("codex")
+            .await
+            .expect("get Codex proxy config");
+        proxy_config.enabled = true;
+        db.update_proxy_config_for_app(proxy_config)
+            .await
+            .expect("mark Codex takeover enabled");
+
+        assert!(
+            !service
+                .live_takeover_matches_current_proxy(&AppType::Codex)
+                .await
+                .expect("classify legacy takeover"),
+            "a legacy takeover without official aliases must be rebuilt"
+        );
+
+        service
+            .set_takeover_for_app("codex", true)
+            .await
+            .expect("upgrade legacy takeover");
+
+        let upgraded = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
+            .expect("read upgraded live config");
+        let doc: toml::Value = toml::from_str(&upgraded).expect("parse upgraded live config");
+        assert_eq!(
+            doc.get("model_provider").and_then(toml::Value::as_str),
+            Some("rightcode")
+        );
+        assert_eq!(
+            doc.get("openai_base_url").and_then(toml::Value::as_str),
+            Some(proxy_base_url.as_str())
+        );
+        assert_eq!(
+            doc["model_providers"]["cc-switch-official"]
+                .get("base_url")
+                .and_then(toml::Value::as_str),
+            Some(proxy_base_url.as_str())
+        );
+        assert!(service
+            .live_takeover_matches_current_proxy(&AppType::Codex)
+            .await
+            .expect("classify upgraded takeover"));
+
+        let backup = db
+            .get_live_backup("codex")
+            .await
+            .expect("read backup")
+            .expect("backup remains");
+        assert!(
+            backup
+                .original_config
+                .contains("https://rightcode.example/v1"),
+            "upgrade must preserve the original restorable backup"
+        );
+
+        service
+            .set_takeover_for_app("codex", false)
+            .await
+            .expect("disable upgraded takeover");
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2503,9 +2503,11 @@ impl ProxyService {
             }
         }
 
-        doc.get("base_url")
-            .and_then(|value| value.as_str())
-            .is_some_and(predicate)
+        ["openai_base_url", "base_url"].into_iter().any(|key| {
+            doc.get(key)
+                .and_then(|value| value.as_str())
+                .is_some_and(&predicate)
+        })
     }
 
     async fn live_takeover_matches_current_proxy(
@@ -4082,6 +4084,25 @@ mod tests {
                 None => env::remove_var("CC_SWITCH_TEST_HOME"),
             }
         }
+    }
+
+    #[test]
+    fn codex_base_url_matcher_recognizes_builtin_openai_override() {
+        let config = r#"model_provider = "openai"
+openai_base_url = "http://127.0.0.1:15721/v1"
+
+[model_providers.cc-switch-official]
+name = "OpenAI"
+base_url = "http://127.0.0.1:15721/v1"
+requires_openai_auth = true
+supports_websockets = false
+wire_api = "responses"
+"#;
+
+        assert!(ProxyService::codex_config_has_base_url_matching(
+            config,
+            |url| ProxyService::proxy_urls_match(url, "http://127.0.0.1:15721/v1")
+        ));
     }
 
     fn assert_env_str(env: &Map<String, Value>, key: &str, expected: Option<&str>) {
@@ -5847,15 +5868,27 @@ wire_api = "responses"
             Some("openai"),
             "new official threads must stay in the native openai bucket"
         );
-        for provider_id in ["openai", "cc-switch-official"] {
-            assert_eq!(
-                live_doc["model_providers"][provider_id]
-                    .get("base_url")
-                    .and_then(toml::Value::as_str),
-                Some(expected_proxy_base_url.as_str()),
-                "both current and legacy official thread buckets must use the local route"
-            );
-        }
+        assert_eq!(
+            live_doc
+                .get("openai_base_url")
+                .and_then(toml::Value::as_str),
+            Some(expected_proxy_base_url.as_str()),
+            "native OpenAI threads must use Codex's supported built-in base URL override"
+        );
+        assert!(
+            live_doc
+                .get("model_providers")
+                .and_then(|providers| providers.get("openai"))
+                .is_none(),
+            "the reserved built-in OpenAI provider must never be redefined"
+        );
+        assert_eq!(
+            live_doc["model_providers"]["cc-switch-official"]
+                .get("base_url")
+                .and_then(toml::Value::as_str),
+            Some(expected_proxy_base_url.as_str()),
+            "legacy CC Switch thread buckets must keep their legal local provider alias"
+        );
         let state_conn = rusqlite::Connection::open(&state_db_path).expect("reopen state db");
         for (thread_id, expected_provider) in
             [("existing", "openai"), ("legacy", "cc-switch-official")]
@@ -6733,11 +6766,11 @@ wire_api = "chat"
         .expect("apply official proxy config");
         let parsed: toml::Value = toml::from_str(&output).expect("valid official route");
         assert_eq!(parsed["model_provider"].as_str(), Some("openai"));
-        for route_id in ["openai", "cc-switch-official"] {
-            let route = &parsed["model_providers"][route_id];
-            assert_eq!(route["base_url"].as_str(), Some(proxy_url));
-            assert_eq!(route["requires_openai_auth"].as_bool(), Some(true));
-        }
+        assert_eq!(parsed["openai_base_url"].as_str(), Some(proxy_url));
+        assert!(parsed["model_providers"].get("openai").is_none());
+        let legacy_route = &parsed["model_providers"]["cc-switch-official"];
+        assert_eq!(legacy_route["base_url"].as_str(), Some(proxy_url));
+        assert_eq!(legacy_route["requires_openai_auth"].as_bool(), Some(true));
         assert!(parsed.get("experimental_bearer_token").is_none());
     }
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -2311,6 +2311,7 @@ impl ProxyService {
                 );
             } else {
                 self.write_live_config_for_app(app_type, &config)?;
+                self.ensure_codex_official_proxy_compatibility_after_restore(app_type)?;
                 log::info!("{app_type_str} Live 配置已从备份恢复");
                 return Ok(());
             }
@@ -2324,6 +2325,7 @@ impl ProxyService {
         // 2.1) 优先从 SSOT（当前供应商）重建 Live（比"清理字段"更可用）
         match self.restore_live_from_ssot_for_app(app_type) {
             Ok(true) => {
+                self.ensure_codex_official_proxy_compatibility_after_restore(app_type)?;
                 log::info!("{app_type_str} Live 配置已从 SSOT 恢复（无备份兜底）");
                 return Ok(());
             }
@@ -2341,7 +2343,30 @@ impl ProxyService {
 
         // 2.2) 最后兜底：尽力清理占位符与本地代理地址，避免长期卡在代理占位符状态
         self.cleanup_takeover_placeholders_in_live_for_app(app_type)?;
+        self.ensure_codex_official_proxy_compatibility_after_restore(app_type)?;
         log::info!("{app_type_str} Live 接管占位符已清理（无备份兜底）");
+        Ok(())
+    }
+
+    fn ensure_codex_official_proxy_compatibility_after_restore(
+        &self,
+        app_type: &AppType,
+    ) -> Result<(), String> {
+        if !matches!(app_type, AppType::Codex) {
+            return Ok(());
+        }
+        let current = crate::codex_config::read_codex_config_text()
+            .map_err(|e| format!("读取 Codex 恢复配置失败: {e}"))?;
+        let compatible =
+            crate::codex_config::ensure_codex_official_proxy_compatibility_provider(&current)
+                .map_err(|e| format!("写入 Codex 旧会话兼容路由失败: {e}"))?;
+        if compatible != current {
+            crate::config::write_text_file(
+                &crate::codex_config::get_codex_config_path(),
+                &compatible,
+            )
+            .map_err(|e| format!("写入 Codex 旧会话兼容路由失败: {e}"))?;
+        }
         Ok(())
     }
 
@@ -2502,15 +2527,21 @@ impl ProxyService {
             }
             AppType::Codex => {
                 let config = self.read_codex_live()?;
-                let base_url_matches = config
-                    .get("config")
-                    .and_then(|value| value.as_str())
-                    .is_some_and(|config_text| {
-                        Self::codex_config_has_base_url_matching(config_text, |url| {
-                            Self::proxy_urls_match(url, &proxy_codex_base_url)
-                        })
-                    });
-                Ok(Self::is_codex_live_taken_over(&config) && base_url_matches)
+                let config_text = config.get("config").and_then(|value| value.as_str());
+                let base_url_matches = config_text.is_some_and(|config_text| {
+                    Self::codex_config_has_base_url_matching(config_text, |url| {
+                        Self::proxy_urls_match(url, &proxy_codex_base_url)
+                    })
+                });
+                let managed_official_route_is_current = config_text.is_none_or(|config_text| {
+                    !crate::codex_config::codex_config_has_official_proxy_route(config_text)
+                        || crate::codex_config::codex_config_has_current_official_proxy_route(
+                            config_text,
+                        )
+                });
+                Ok(Self::is_codex_live_taken_over(&config)
+                    && base_url_matches
+                    && managed_official_route_is_current)
             }
             AppType::Gemini => {
                 let config = self.read_gemini_live()?;
@@ -2580,14 +2611,14 @@ impl ProxyService {
         }
 
         if let Some(cfg_str) = config.get("config").and_then(|v| v.as_str()) {
-            let updated = Self::remove_local_toml_base_url(cfg_str);
+            let updated = crate::codex_config::remove_codex_official_proxy_route(cfg_str)
+                .map_err(|e| format!("清理 Codex 官方接管路由失败: {e}"))?;
+            let updated = Self::remove_local_toml_base_url(&updated);
             let updated =
                 crate::codex_config::remove_codex_experimental_bearer_token_if(&updated, |token| {
                     token == PROXY_TOKEN_PLACEHOLDER
                 })
                 .map_err(|e| format!("清理 Codex 接管占位符失败: {e}"))?;
-            let updated = crate::codex_config::remove_codex_official_proxy_route(&updated)
-                .map_err(|e| format!("清理 Codex 官方接管路由失败: {e}"))?;
             config["config"] = json!(updated);
         }
 
@@ -3443,7 +3474,8 @@ impl ProxyService {
                     .map_err(|e| format!("更新 Codex 上游模型失败: {e}"))?;
         }
 
-        Ok(updated)
+        crate::codex_config::apply_codex_official_proxy_aliases(&updated, proxy_url)
+            .map_err(|e| format!("生成 Codex 旧会话兼容路由失败: {e}"))
     }
 
     fn apply_codex_takeover_auth_placeholder(settings: &mut Value, provider: Option<&Provider>) {
@@ -5696,6 +5728,216 @@ wire_api = "responses"
 
     #[tokio::test]
     #[serial]
+    async fn codex_official_takeover_routes_existing_threads_without_rewriting_history() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        crate::settings::update_settings(crate::settings::AppSettings::default())
+            .expect("reset settings");
+
+        let db = Arc::new(Database::memory().expect("init db"));
+        use_ephemeral_proxy_port(&db).await;
+        let service = ProxyService::new(db.clone());
+        crate::codex_config::write_codex_live_atomic(
+            &json!({
+                "auth_mode": "chatgpt",
+                "tokens": { "access_token": "oauth-access" }
+            }),
+            Some("model = \"gpt-5.4\"\n"),
+        )
+        .expect("seed official live config");
+
+        let mut official = Provider::with_id(
+            crate::database::CODEX_OFFICIAL_PROVIDER_ID.to_string(),
+            "OpenAI Official".to_string(),
+            json!({ "auth": {}, "config": "model = \"gpt-5.4\"\n" }),
+            None,
+        );
+        official.category = Some("official".to_string());
+        db.save_provider("codex", &official)
+            .expect("save official provider");
+        db.set_current_provider("codex", crate::database::CODEX_OFFICIAL_PROVIDER_ID)
+            .expect("set current provider");
+        crate::settings::set_current_provider(
+            &AppType::Codex,
+            Some(crate::database::CODEX_OFFICIAL_PROVIDER_ID),
+        )
+        .expect("set local current provider");
+
+        let codex_dir = crate::codex_config::get_codex_config_dir();
+        let session_dir = codex_dir.join("sessions/2026/08/19");
+        std::fs::create_dir_all(&session_dir).expect("create session dir");
+        let session_path = session_dir.join("existing-thread.jsonl");
+        std::fs::write(
+            &session_path,
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{\"id\":\"existing\",\"model_provider\":\"openai\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_settings_applied\",\"thread_settings\":{\"model_provider_id\":\"openai\"}}}\n",
+            ),
+        )
+        .expect("seed existing session");
+        let legacy_session_path = session_dir.join("legacy-routed-thread.jsonl");
+        let legacy_session = concat!(
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"legacy\",\"model_provider\":\"cc-switch-official\"}}\n",
+            "{\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_settings_applied\",\"thread_settings\":{\"model_provider_id\":\"cc-switch-official\"}}}\n",
+        );
+        std::fs::write(&legacy_session_path, legacy_session).expect("seed legacy routed session");
+        let mut active_rollout = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&session_path)
+            .expect("keep active rollout handle open");
+        let state_db_path = codex_dir.join(crate::codex_state_db::CODEX_STATE_DB_FILENAME);
+        let state_conn = rusqlite::Connection::open(&state_db_path).expect("open Codex state db");
+        state_conn
+            .execute_batch(
+                "CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT NOT NULL);
+                 INSERT INTO threads (id, model_provider) VALUES ('existing', 'openai');
+                 INSERT INTO threads (id, model_provider) VALUES ('legacy', 'cc-switch-official');",
+            )
+            .expect("seed Codex state db");
+        drop(state_conn);
+
+        service
+            .set_takeover_for_app("codex", true)
+            .await
+            .expect("enable official takeover");
+        let expected_proxy_base_url = running_codex_base_url(&service).await;
+        let legacy_route = format!(
+            r#"model_provider = "cc-switch-official"
+
+[model_providers.cc-switch-official]
+name = "OpenAI"
+base_url = "{expected_proxy_base_url}"
+requires_openai_auth = true
+supports_websockets = false
+wire_api = "responses"
+"#
+        );
+        crate::config::write_text_file(
+            &crate::codex_config::get_codex_config_path(),
+            &legacy_route,
+        )
+        .expect("simulate legacy managed route");
+        service
+            .set_takeover_for_app("codex", true)
+            .await
+            .expect("upgrade legacy official route without touching history");
+        use std::io::Write;
+        active_rollout
+            .write_all(b"{\"type\":\"response_item\",\"payload\":{\"role\":\"assistant\",\"content\":\"late-active-write\"}}\n")
+            .expect("append through active rollout handle");
+        active_rollout.flush().expect("flush active rollout");
+        let enabled_text = std::fs::read_to_string(&session_path).expect("read enabled session");
+        assert!(enabled_text.contains("\"model_provider\":\"openai\""));
+        assert!(enabled_text.contains("\"model_provider_id\":\"openai\""));
+        assert!(
+            enabled_text.contains("late-active-write"),
+            "takeover must not replace an active rollout file"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&legacy_session_path).expect("read legacy session"),
+            legacy_session,
+            "takeover must not rewrite legacy rollout metadata"
+        );
+
+        let live_config =
+            crate::codex_config::read_codex_config_text().expect("read routed Codex config");
+        let live_doc: toml::Value = toml::from_str(&live_config).expect("parse routed config");
+        assert_eq!(
+            live_doc.get("model_provider").and_then(toml::Value::as_str),
+            Some("openai"),
+            "new official threads must stay in the native openai bucket"
+        );
+        for provider_id in ["openai", "cc-switch-official"] {
+            assert_eq!(
+                live_doc["model_providers"][provider_id]
+                    .get("base_url")
+                    .and_then(toml::Value::as_str),
+                Some(expected_proxy_base_url.as_str()),
+                "both current and legacy official thread buckets must use the local route"
+            );
+        }
+        let state_conn = rusqlite::Connection::open(&state_db_path).expect("reopen state db");
+        for (thread_id, expected_provider) in
+            [("existing", "openai"), ("legacy", "cc-switch-official")]
+        {
+            let provider: String = state_conn
+                .query_row(
+                    "SELECT model_provider FROM threads WHERE id = ?1",
+                    [thread_id],
+                    |row| row.get(0),
+                )
+                .expect("read enabled provider");
+            assert_eq!(
+                provider, expected_provider,
+                "takeover must not mutate Codex state DB"
+            );
+        }
+        drop(state_conn);
+
+        service
+            .set_takeover_for_app("codex", false)
+            .await
+            .expect("disable official takeover");
+        let disabled_text = std::fs::read_to_string(&session_path).expect("read disabled session");
+        assert!(disabled_text.contains("\"model_provider\":\"openai\""));
+        assert!(disabled_text.contains("\"model_provider_id\":\"openai\""));
+        assert!(disabled_text.contains("late-active-write"));
+        assert_eq!(
+            std::fs::read_to_string(&legacy_session_path).expect("read disabled legacy session"),
+            legacy_session
+        );
+
+        let restored_config =
+            crate::codex_config::read_codex_config_text().expect("read restored Codex config");
+        let restored_doc: toml::Value =
+            toml::from_str(&restored_config).expect("parse restored Codex config");
+        let legacy_compat = &restored_doc["model_providers"]["cc-switch-official"];
+        assert!(legacy_compat.get("base_url").is_none());
+        assert_eq!(
+            legacy_compat
+                .get("requires_openai_auth")
+                .and_then(toml::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            legacy_compat
+                .get("supports_websockets")
+                .and_then(toml::Value::as_bool),
+            Some(true)
+        );
+        assert!(!crate::codex_config::codex_config_has_official_proxy_route(
+            &restored_config
+        ));
+
+        let state_conn = rusqlite::Connection::open(&state_db_path).expect("reopen restored DB");
+        let legacy_provider: String = state_conn
+            .query_row(
+                "SELECT model_provider FROM threads WHERE id = 'legacy'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read restored legacy provider");
+        assert_eq!(legacy_provider, "cc-switch-official");
+        drop(state_conn);
+
+        service
+            .restore_live_config_for_app_with_fallback_inner(&AppType::Codex)
+            .await
+            .expect("repeat startup-style restore idempotently");
+        assert_eq!(
+            crate::codex_config::read_codex_config_text()
+                .expect("read config after repeated restore"),
+            restored_config
+        );
+        assert_eq!(
+            std::fs::read_to_string(&legacy_session_path)
+                .expect("read legacy session after repeated restore"),
+            legacy_session
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn codex_takeover_enabled_commit_failure_restores_native_live_bundle() {
         let _home = TempHome::new();
         crate::settings::reload_settings().expect("reload settings");
@@ -6490,12 +6732,12 @@ wire_api = "chat"
         )
         .expect("apply official proxy config");
         let parsed: toml::Value = toml::from_str(&output).expect("valid official route");
-        let route_id = crate::codex_config::CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID;
-        let route = &parsed["model_providers"][route_id];
-
-        assert_eq!(parsed["model_provider"].as_str(), Some(route_id));
-        assert_eq!(route["base_url"].as_str(), Some(proxy_url));
-        assert_eq!(route["requires_openai_auth"].as_bool(), Some(true));
+        assert_eq!(parsed["model_provider"].as_str(), Some("openai"));
+        for route_id in ["openai", "cc-switch-official"] {
+            let route = &parsed["model_providers"][route_id];
+            assert_eq!(route["base_url"].as_str(), Some(proxy_url));
+            assert_eq!(route["requires_openai_auth"].as_bool(), Some(true));
+        }
         assert!(parsed.get("experimental_bearer_token").is_none());
     }
 
@@ -7594,9 +7836,23 @@ wire_api = "responses"
 
         let restored = service.read_codex_live().expect("read restored Codex live");
         assert_eq!(restored.get("auth"), Some(&rotated_live_auth));
+        let restored_config = restored
+            .get("config")
+            .and_then(Value::as_str)
+            .expect("restored config");
+        let restored_doc: toml::Value =
+            toml::from_str(restored_config).expect("parse restored config");
         assert_eq!(
-            restored.get("config").and_then(Value::as_str),
-            Some("model = \"gpt-5.4\"\n")
+            restored_doc.get("model").and_then(toml::Value::as_str),
+            Some("gpt-5.4")
+        );
+        let compatibility = &restored_doc["model_providers"]["cc-switch-official"];
+        assert!(compatibility.get("base_url").is_none());
+        assert_eq!(
+            compatibility
+                .get("supports_websockets")
+                .and_then(toml::Value::as_bool),
+            Some(true)
         );
     }
 


### PR DESCRIPTION
## Summary / 概述

This PR fixes stale Codex runtime provider state on resumed threads.

It covers two closely related paths:

1. Provider history migration updates both the session bucket and the persisted runtime thread_settings_applied.model_provider_id, together with the corresponding SQLite thread row.
2. OpenAI Official local-route takeover keeps existing and newly created threads routable through CC Switch without rewriting active rollout history.

The migration remains backed up and reversible, preserves rollout mtimes, and keeps JSONL and SQLite provider state consistent.

## Related Issue / 关联 Issue

Refs #5922

I originally reproduced this through OpenAI Official local-route takeover, while #5922 describes the same stale runtime-provider invariant during explicit provider migration.

Maintainer guidance is welcome on whether the local-route regression should remain in this PR or be separated into a follow-up PR.

## Root Cause

Codex restores the provider for a resumed thread from persisted runtime state, including thread_settings_applied.thread_settings.model_provider_id.

Updating only session_meta.payload.model_provider or the SQLite threads.model_provider row is insufficient. On resume, the stale runtime setting can restore the old provider and overwrite the migrated database state.

For local-route takeover, rewriting an active rollout is also unsafe because Codex may still have the file open. The route therefore redirects native OpenAI threads through the supported top-level openai_base_url setting and retains a non-reserved cc-switch-official compatibility provider for older threads.

Current Codex versions reserve the built-in openai provider ID. The takeover must not create a model_providers.openai table; doing so makes config.toml invalid and prevents Codex Desktop from resuming any thread.

## Changes

- Migrate persisted thread_settings_applied provider state.
- Keep JSONL and SQLite provider values consistent.
- Preserve rollout modification times during migration.
- Restore both session metadata and runtime provider state from backups.
- Route native OpenAI threads with openai_base_url without redefining a reserved provider.
- Keep legacy cc-switch-official threads routable through a legal compatibility alias.
- Upgrade the invalid reserved-provider layout emitted by the earlier revision of this PR.
- Preserve direct compatibility when local routing is disabled.
- Add regression coverage for migration, restoration, active rollouts, repeated startup, and current Codex config parsing.

## Testing

- cargo fmt --check --manifest-path src-tauri/Cargo.toml
- cargo clippy --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings
- Targeted official-route, takeover, restore, hot-switch, and stale-layout regression tests pass.
- cargo test --manifest-path src-tauri/Cargo.toml --lib, excluding two Windows tests that require symlink privileges: 2668 passed, 0 failed, 6 ignored.
- A complete projected config was parsed successfully by the installed Codex CLI 0.148.0-alpha.15.

The two excluded tests fail before exercising project logic with Windows error 1314 (the process lacks symlink creation privilege); they are unrelated to this change.

## Screenshots / 截图

Not applicable. This is a backend routing and persisted-runtime-state fix.

## Checklist / 检查清单

- [x] pnpm typecheck — Not applicable; no frontend files changed
- [x] pnpm format:check — Not applicable; no frontend files changed
- [x] cargo clippy passes
- [x] No user-facing text was changed, so no i18n update is required
