### PR TITLE
feat(sessions): full-content search across session transcripts

### DIFF
--- a/src-tauri/src/commands/session_manager.rs
+++ b/src-tauri/src/commands/session_manager.rs
@@ -10,6 +10,20 @@ pub async fn list_sessions() -> Result<Vec<session_manager::SessionMeta>, String
     Ok(sessions)
 }
 
+/// Full-content search across session transcripts. `providerId` is `None` when
+/// the list is showing every provider.
+#[tauri::command]
+pub async fn search_sessions(
+    query: String,
+    providerId: Option<String>,
+) -> Result<Vec<session_manager::SessionSearchHit>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        session_manager::search_sessions(&query, providerId.as_deref())
+    })
+    .await
+    .map_err(|e| format!("Failed to search sessions: {e}"))
+}
+
 #[tauri::command]
 pub async fn get_session_messages(
     providerId: String,

--- a/src-tauri/src/commands/session_manager.rs
+++ b/src-tauri/src/commands/session_manager.rs
@@ -11,14 +11,16 @@ pub async fn list_sessions() -> Result<Vec<session_manager::SessionMeta>, String
 }
 
 /// Full-content search across session transcripts. `providerId` is `None` when
-/// the list is showing every provider.
+/// the list is showing every provider. `requestId` increases per query so a scan
+/// the user has already typed past can stop early.
 #[tauri::command]
 pub async fn search_sessions(
     query: String,
     providerId: Option<String>,
+    requestId: u64,
 ) -> Result<Vec<session_manager::SessionSearchHit>, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        session_manager::search_sessions(&query, providerId.as_deref())
+        session_manager::search_sessions(&query, providerId.as_deref(), requestId)
     })
     .await
     .map_err(|e| format!("Failed to search sessions: {e}"))

--- a/src-tauri/src/commands/session_manager.rs
+++ b/src-tauri/src/commands/session_manager.rs
@@ -11,16 +11,15 @@ pub async fn list_sessions() -> Result<Vec<session_manager::SessionMeta>, String
 }
 
 /// Full-content search across session transcripts. `providerId` is `None` when
-/// the list is showing every provider. `requestId` increases per query so a scan
-/// the user has already typed past can stop early.
+/// the list is showing every provider.
 #[tauri::command]
 pub async fn search_sessions(
     query: String,
     providerId: Option<String>,
-    requestId: u64,
 ) -> Result<Vec<session_manager::SessionSearchHit>, String> {
+    let request_id = session_manager::search::next_request_id();
     tauri::async_runtime::spawn_blocking(move || {
-        session_manager::search_sessions(&query, providerId.as_deref(), requestId)
+        session_manager::search_sessions(&query, providerId.as_deref(), request_id)
     })
     .await
     .map_err(|e| format!("Failed to search sessions: {e}"))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1605,6 +1605,7 @@ pub fn run() {
             commands::save_stream_check_config,
             // Session manager
             commands::list_sessions,
+            commands::search_sessions,
             commands::get_session_messages,
             commands::delete_session,
             commands::delete_sessions,

--- a/src-tauri/src/session_manager/mod.rs
+++ b/src-tauri/src/session_manager/mod.rs
@@ -1,10 +1,13 @@
 pub mod providers;
+pub mod search;
 pub mod terminal;
 
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
 use providers::{claude, codex, gemini, grokbuild, hermes, openclaw, opencode, pi};
+
+pub use search::{search_sessions, SessionSearchHit};
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/session_manager/search.rs
+++ b/src-tauri/src/session_manager/search.rs
@@ -1,0 +1,271 @@
+use serde::Serialize;
+use std::thread;
+
+use super::{load_messages, scan_sessions, SessionMeta};
+
+/// Characters of surrounding context kept on each side of a match.
+const SNIPPET_CONTEXT_CHARS: usize = 60;
+/// Snippets reported per session.
+const MAX_SNIPPETS_PER_SESSION: usize = 3;
+/// Sessions reported per query, keeping the most recently active ones.
+const MAX_HITS: usize = 200;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionSearchSnippet {
+    /// Index into the message list returned by `load_messages`, so the UI can
+    /// scroll straight to the match.
+    pub message_index: usize,
+    pub role: String,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionSearchHit {
+    pub provider_id: String,
+    pub session_id: String,
+    pub source_path: String,
+    pub snippets: Vec<SessionSearchSnippet>,
+}
+
+/// Search the full transcript of every session, not just the metadata the list
+/// view indexes.
+///
+/// Matching runs over the same messages the detail pane renders, so every hit
+/// corresponds to text the user can actually see. Deliberately no storage-level
+/// prefilter: SQLite `LIKE` folds case for ASCII only and would silently drop
+/// `Éclair` for the query `éclair`, and a raw substring scan of the JSONL would
+/// miss content behind JSON escapes.
+pub fn search_sessions(query: &str, provider_id: Option<&str>) -> Vec<SessionSearchHit> {
+    let needle = lower_chars(query.trim());
+    if needle.is_empty() {
+        return Vec::new();
+    }
+    let needle = needle.as_slice();
+
+    let sessions: Vec<SessionMeta> = scan_sessions()
+        .into_iter()
+        .filter(|meta| provider_id.is_none_or(|id| meta.provider_id == id))
+        .collect();
+
+    let workers = thread::available_parallelism().map_or(4, |count| count.get());
+    let chunk_size = sessions.len().div_ceil(workers).max(1);
+
+    // Chunks are joined in order, so hits stay sorted by recency like `scan_sessions`.
+    let mut hits: Vec<SessionSearchHit> = thread::scope(|scope| {
+        let handles: Vec<_> = sessions
+            .chunks(chunk_size)
+            .map(|chunk| {
+                scope.spawn(move || {
+                    chunk
+                        .iter()
+                        .filter_map(|meta| search_session(meta, needle))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .flat_map(|handle| handle.join().unwrap_or_default())
+            .collect()
+    });
+
+    hits.truncate(MAX_HITS);
+    hits
+}
+
+fn search_session(meta: &SessionMeta, needle: &[char]) -> Option<SessionSearchHit> {
+    let source_path = meta.source_path.as_deref()?;
+    let messages = load_messages(&meta.provider_id, source_path).ok()?;
+
+    let snippets: Vec<SessionSearchSnippet> = messages
+        .iter()
+        .enumerate()
+        .filter_map(|(message_index, message)| {
+            let start = find_subslice(&lower_chars(&message.content), needle)?;
+            let chars: Vec<char> = message.content.chars().collect();
+            Some(SessionSearchSnippet {
+                message_index,
+                role: message.role.clone(),
+                text: snippet_around(&chars, start, needle.len()),
+            })
+        })
+        .take(MAX_SNIPPETS_PER_SESSION)
+        .collect();
+
+    if snippets.is_empty() {
+        return None;
+    }
+
+    Some(SessionSearchHit {
+        provider_id: meta.provider_id.clone(),
+        session_id: meta.session_id.clone(),
+        source_path: source_path.to_string(),
+        snippets,
+    })
+}
+
+/// Lowercase one char at a time so the result keeps a 1:1 index mapping with the
+/// source text and match offsets stay valid in the original.
+fn lower_chars(text: &str) -> Vec<char> {
+    text.chars()
+        .map(|c| c.to_lowercase().next().unwrap_or(c))
+        .collect()
+}
+
+fn find_subslice(haystack: &[char], needle: &[char]) -> Option<usize> {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return None;
+    }
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+/// Context window around a match, with whitespace flattened so the snippet reads
+/// as a single line in the list.
+fn snippet_around(chars: &[char], start: usize, len: usize) -> String {
+    let from = start.saturating_sub(SNIPPET_CONTEXT_CHARS);
+    let to = (start + len + SNIPPET_CONTEXT_CHARS).min(chars.len());
+
+    let mut text = String::new();
+    if from > 0 {
+        text.push('…');
+    }
+    text.extend(
+        chars[from..to]
+            .iter()
+            .map(|c| if c.is_whitespace() { ' ' } else { *c }),
+    );
+    if to < chars.len() {
+        text.push('…');
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    fn claude_meta(path: &Path) -> SessionMeta {
+        SessionMeta {
+            provider_id: "claude".to_string(),
+            session_id: "s1".to_string(),
+            title: None,
+            summary: None,
+            project_dir: None,
+            created_at: None,
+            last_active_at: None,
+            source_path: Some(path.to_string_lossy().to_string()),
+            resume_command: None,
+        }
+    }
+
+    fn write_claude_session(path: &Path, contents: &[&str]) {
+        let body = contents
+            .iter()
+            .map(|text| {
+                format!(
+                    "{{\"timestamp\":\"2026-03-06T21:50:13Z\",\"message\":{{\"role\":\"user\",\"content\":{}}}}}",
+                    serde_json::to_string(text).unwrap()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        std::fs::write(path, body).expect("write session");
+    }
+
+    fn search(path: &Path, query: &str) -> Option<SessionSearchHit> {
+        search_session(&claude_meta(path), &lower_chars(query))
+    }
+
+    #[test]
+    fn finds_keyword_in_the_middle_of_a_conversation() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        write_claude_session(
+            &path,
+            &[
+                "opening question",
+                "中间讨论了浙江移动的方案",
+                "closing note",
+            ],
+        );
+
+        let hit = search(&path, "浙江移动").expect("expected a content hit");
+        assert_eq!(hit.snippets.len(), 1);
+        assert_eq!(hit.snippets[0].message_index, 1);
+        assert!(hit.snippets[0].text.contains("浙江移动"));
+    }
+
+    #[test]
+    fn case_folding_covers_non_ascii() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        write_claude_session(&path, &["Ordered an Éclair"]);
+
+        assert!(search(&path, "éclair").is_some());
+        assert!(search(&path, "ÉCLAIR").is_some());
+    }
+
+    #[test]
+    fn reports_at_most_three_snippets() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        write_claude_session(&path, &["hit", "hit", "hit", "hit", "hit"]);
+
+        let hit = search(&path, "hit").expect("expected a content hit");
+        assert_eq!(hit.snippets.len(), MAX_SNIPPETS_PER_SESSION);
+    }
+
+    #[test]
+    fn misses_produce_no_hit() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        write_claude_session(&path, &["nothing to see"]);
+
+        assert!(search(&path, "absent").is_none());
+    }
+
+    #[test]
+    fn empty_query_matches_nothing() {
+        assert!(search_sessions("   ", None).is_empty());
+    }
+
+    #[test]
+    fn snippet_trims_context_on_char_boundaries() {
+        let chars: Vec<char> = format!("{}目标{}", "前".repeat(200), "后".repeat(200))
+            .chars()
+            .collect();
+        let text = snippet_around(&chars, 200, 2);
+
+        assert!(text.starts_with('…') && text.ends_with('…'));
+        assert!(text.contains("目标"));
+        assert_eq!(text.chars().count(), 2 + SNIPPET_CONTEXT_CHARS * 2 + 2);
+    }
+
+    #[test]
+    fn snippet_omits_ellipsis_when_whole_message_fits() {
+        let chars: Vec<char> = "short and sweet".chars().collect();
+        assert_eq!(snippet_around(&chars, 6, 3), "short and sweet");
+    }
+
+    #[test]
+    fn snippet_flattens_newlines() {
+        let chars: Vec<char> = "line one\nline two".chars().collect();
+        assert_eq!(snippet_around(&chars, 0, 4), "line one line two");
+    }
+
+    #[test]
+    fn find_subslice_locates_and_rejects() {
+        let haystack: Vec<char> = "abcabd".chars().collect();
+        assert_eq!(find_subslice(&haystack, &['a', 'b', 'd']), Some(3));
+        assert_eq!(find_subslice(&haystack, &['x']), None);
+        assert_eq!(find_subslice(&haystack, &[]), None);
+        assert_eq!(find_subslice(&['a'], &['a', 'b']), None);
+    }
+}

--- a/src-tauri/src/session_manager/search.rs
+++ b/src-tauri/src/session_manager/search.rs
@@ -1,7 +1,18 @@
 use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
 
 use super::{load_messages, scan_sessions, SessionMeta};
+
+/// Highest request id seen so far.
+///
+/// A scan is cancellable but not interruptible from the outside: the UI can stop
+/// waiting for a reply, but `clearTimeout` cannot recall an `invoke` that already
+/// started, so without this a few query edits would leave several full scans
+/// running at once, each with one worker per CPU. Ids come from the renderer so
+/// "newer" reflects the order the user typed, not the order the blocking pool
+/// happened to schedule.
+static LATEST_REQUEST: AtomicU64 = AtomicU64::new(0);
 
 /// Characters of surrounding context kept on each side of a match.
 const SNIPPET_CONTEXT_CHARS: usize = 60;
@@ -37,9 +48,18 @@ pub struct SessionSearchHit {
 /// prefilter: SQLite `LIKE` folds case for ASCII only and would silently drop
 /// `Éclair` for the query `éclair`, and a raw substring scan of the JSONL would
 /// miss content behind JSON escapes.
-pub fn search_sessions(query: &str, provider_id: Option<&str>) -> Vec<SessionSearchHit> {
+///
+/// `request_id` must increase per query; a scan that a newer request has already
+/// superseded stops instead of finishing work the UI would discard.
+pub fn search_sessions(
+    query: &str,
+    provider_id: Option<&str>,
+    request_id: u64,
+) -> Vec<SessionSearchHit> {
+    LATEST_REQUEST.fetch_max(request_id, Ordering::SeqCst);
+
     let needle = lower_chars(query.trim());
-    if needle.is_empty() {
+    if needle.is_empty() || is_superseded(request_id) {
         return Vec::new();
     }
     let needle = needle.as_slice();
@@ -60,6 +80,7 @@ pub fn search_sessions(query: &str, provider_id: Option<&str>) -> Vec<SessionSea
                 scope.spawn(move || {
                     chunk
                         .iter()
+                        .take_while(|_| !is_superseded(request_id))
                         .filter_map(|meta| search_session(meta, needle))
                         .collect::<Vec<_>>()
                 })
@@ -72,8 +93,16 @@ pub fn search_sessions(query: &str, provider_id: Option<&str>) -> Vec<SessionSea
             .collect()
     });
 
+    if is_superseded(request_id) {
+        return Vec::new();
+    }
+
     hits.truncate(MAX_HITS);
     hits
+}
+
+fn is_superseded(request_id: u64) -> bool {
+    LATEST_REQUEST.load(Ordering::Relaxed) > request_id
 }
 
 fn search_session(meta: &SessionMeta, needle: &[char]) -> Option<SessionSearchHit> {
@@ -165,6 +194,7 @@ fn snippet_around(chars: &[char], start: usize, len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::path::Path;
     use tempfile::tempdir;
 
@@ -262,8 +292,23 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn empty_query_matches_nothing() {
-        assert!(search_sessions("   ", None).is_empty());
+        LATEST_REQUEST.store(0, Ordering::SeqCst);
+        assert!(search_sessions("   ", None, 1).is_empty());
+    }
+
+    /// A superseded scan must bail before touching the disk, otherwise every query
+    /// edit past the debounce leaves another full transcript scan running.
+    #[test]
+    #[serial]
+    fn a_newer_request_cancels_an_older_scan() {
+        LATEST_REQUEST.store(0, Ordering::SeqCst);
+        LATEST_REQUEST.fetch_max(9, Ordering::SeqCst);
+
+        assert!(search_sessions("anything", None, 4).is_empty());
+        assert!(is_superseded(4));
+        assert!(!is_superseded(9));
     }
 
     #[test]

--- a/src-tauri/src/session_manager/search.rs
+++ b/src-tauri/src/session_manager/search.rs
@@ -84,12 +84,16 @@ fn search_session(meta: &SessionMeta, needle: &[char]) -> Option<SessionSearchHi
         .iter()
         .enumerate()
         .filter_map(|(message_index, message)| {
-            let start = find_subslice(&lower_chars(&message.content), needle)?;
+            let (lowered, origin) = lower_with_origin(&message.content);
+            let start = find_subslice(&lowered, needle)?;
+            // Map the match back through the fold, which may have expanded chars.
+            let first = origin[start];
+            let last = origin[start + needle.len() - 1];
             let chars: Vec<char> = message.content.chars().collect();
             Some(SessionSearchSnippet {
                 message_index,
                 role: message.role.clone(),
-                text: snippet_around(&chars, start, needle.len()),
+                text: snippet_around(&chars, first, last - first + 1),
             })
         })
         .take(MAX_SNIPPETS_PER_SESSION)
@@ -107,12 +111,25 @@ fn search_session(meta: &SessionMeta, needle: &[char]) -> Option<SessionSearchHi
     })
 }
 
-/// Lowercase one char at a time so the result keeps a 1:1 index mapping with the
-/// source text and match offsets stay valid in the original.
+/// Lowercase `text` for matching. `char::to_lowercase` can expand one char into
+/// several — `İ` (U+0130) is the only such char in Unicode — so this is not a 1:1
+/// mapping and offsets into the result are not offsets into the source.
 fn lower_chars(text: &str) -> Vec<char> {
-    text.chars()
-        .map(|c| c.to_lowercase().next().unwrap_or(c))
-        .collect()
+    text.chars().flat_map(char::to_lowercase).collect()
+}
+
+/// Same fold as [`lower_chars`], plus the source char index each folded char came
+/// from, so a match found in folded space can be sliced out of the original.
+fn lower_with_origin(text: &str) -> (Vec<char>, Vec<usize>) {
+    let mut lowered = Vec::new();
+    let mut origin = Vec::new();
+    for (index, c) in text.chars().enumerate() {
+        for folded in c.to_lowercase() {
+            lowered.push(folded);
+            origin.push(index);
+        }
+    }
+    (lowered, origin)
 }
 
 fn find_subslice(haystack: &[char], needle: &[char]) -> Option<usize> {
@@ -210,6 +227,19 @@ mod tests {
 
         assert!(search(&path, "éclair").is_some());
         assert!(search(&path, "ÉCLAIR").is_some());
+    }
+
+    /// `İ` (U+0130) is the only char in Unicode whose lowercase expands to more
+    /// than one char, so it is the only input that exercises the origin map.
+    /// Without this the map could be reverted to a 1:1 fold and every other test
+    /// would still pass.
+    #[test]
+    fn folds_expanding_chars_without_dropping_code_points() {
+        assert_eq!(lower_chars("\u{0130}"), vec!['i', '\u{0307}']);
+
+        let (lowered, origin) = lower_with_origin("a\u{0130}b");
+        assert_eq!(lowered, vec!['a', 'i', '\u{0307}', 'b']);
+        assert_eq!(origin, vec![0, 1, 1, 2]);
     }
 
     #[test]

--- a/src-tauri/src/session_manager/search.rs
+++ b/src-tauri/src/session_manager/search.rs
@@ -4,15 +4,12 @@ use std::thread;
 
 use super::{load_messages, scan_sessions, SessionMeta};
 
-/// Highest request id seen so far.
-///
-/// A scan is cancellable but not interruptible from the outside: the UI can stop
-/// waiting for a reply, but `clearTimeout` cannot recall an `invoke` that already
-/// started, so without this a few query edits would leave several full scans
-/// running at once, each with one worker per CPU. Ids come from the renderer so
-/// "newer" reflects the order the user typed, not the order the blocking pool
-/// happened to schedule.
-static LATEST_REQUEST: AtomicU64 = AtomicU64::new(0);
+static NEXT_REQUEST: AtomicU64 = AtomicU64::new(0);
+
+/// Allocate at the command boundary, before blocking-pool scheduling.
+pub fn next_request_id() -> u64 {
+    NEXT_REQUEST.fetch_add(1, Ordering::SeqCst) + 1
+}
 
 /// Characters of surrounding context kept on each side of a match.
 const SNIPPET_CONTEXT_CHARS: usize = 60;
@@ -56,8 +53,6 @@ pub fn search_sessions(
     provider_id: Option<&str>,
     request_id: u64,
 ) -> Vec<SessionSearchHit> {
-    LATEST_REQUEST.fetch_max(request_id, Ordering::SeqCst);
-
     let needle = lower_chars(query.trim());
     if needle.is_empty() || is_superseded(request_id) {
         return Vec::new();
@@ -89,7 +84,7 @@ pub fn search_sessions(
 
         handles
             .into_iter()
-            .flat_map(|handle| handle.join().unwrap_or_default())
+            .flat_map(|handle| handle.join().expect("session search worker panicked"))
             .collect()
     });
 
@@ -102,7 +97,7 @@ pub fn search_sessions(
 }
 
 fn is_superseded(request_id: u64) -> bool {
-    LATEST_REQUEST.load(Ordering::Relaxed) > request_id
+    NEXT_REQUEST.load(Ordering::Relaxed) > request_id
 }
 
 fn search_session(meta: &SessionMeta, needle: &[char]) -> Option<SessionSearchHit> {
@@ -294,8 +289,7 @@ mod tests {
     #[test]
     #[serial]
     fn empty_query_matches_nothing() {
-        LATEST_REQUEST.store(0, Ordering::SeqCst);
-        assert!(search_sessions("   ", None, 1).is_empty());
+        assert!(search_sessions("   ", None, next_request_id()).is_empty());
     }
 
     /// A superseded scan must bail before touching the disk, otherwise every query
@@ -303,12 +297,23 @@ mod tests {
     #[test]
     #[serial]
     fn a_newer_request_cancels_an_older_scan() {
-        LATEST_REQUEST.store(0, Ordering::SeqCst);
-        LATEST_REQUEST.fetch_max(9, Ordering::SeqCst);
+        let older = next_request_id();
+        let newer = next_request_id();
 
-        assert!(search_sessions("anything", None, 4).is_empty());
-        assert!(is_superseded(4));
-        assert!(!is_superseded(9));
+        // The newer command cancels old work even before its scan starts.
+        assert!(search_sessions("anything", None, older).is_empty());
+        assert!(is_superseded(older));
+        assert!(!is_superseded(newer));
+    }
+
+    #[test]
+    #[serial]
+    fn requests_after_reopening_the_page_remain_current() {
+        let previous: Vec<_> = (0..5).map(|_| next_request_id()).collect();
+        let reopened = next_request_id();
+
+        assert!(previous.into_iter().all(is_superseded));
+        assert!(!is_superseded(reopened));
     }
 
     #[test]

--- a/src/components/sessions/SessionItem.tsx
+++ b/src/components/sessions/SessionItem.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { ProviderIcon } from "@/components/ProviderIcon";
-import type { SessionMeta } from "@/types";
+import type { SessionMeta, SessionSearchSnippet } from "@/types";
 import {
   formatRelativeTime,
   formatSessionTitle,
@@ -25,8 +25,10 @@ interface SessionItemProps {
   isChecked: boolean;
   isCheckDisabled?: boolean;
   searchQuery?: string;
+  snippets?: SessionSearchSnippet[];
   onSelect: (key: string) => void;
   onToggleChecked: (checked: boolean) => void;
+  onSnippetSelect: (session: SessionMeta, messageIndex: number) => void;
 }
 
 export function SessionItem({
@@ -36,8 +38,10 @@ export function SessionItem({
   isChecked,
   isCheckDisabled = false,
   searchQuery,
+  snippets,
   onSelect,
   onToggleChecked,
+  onSnippetSelect,
 }: SessionItemProps) {
   const { t } = useTranslation();
   const title = formatSessionTitle(session);
@@ -65,46 +69,66 @@ export function SessionItem({
           />
         </div>
       )}
-      <button
-        type="button"
-        onClick={() => onSelect(sessionKey)}
-        className="min-w-0 flex-1 text-left"
-      >
-        <div className="flex items-center gap-2 mb-1">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="shrink-0">
-                <ProviderIcon
-                  icon={getProviderIconName(session.providerId)}
-                  name={session.providerId}
-                  size={18}
-                />
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>
-              {getProviderLabel(session.providerId, t)}
-            </TooltipContent>
-          </Tooltip>
-          <span className="text-sm font-medium line-clamp-2 flex-1">
-            {searchQuery ? highlightText(title, searchQuery) : title}
-          </span>
-          <ChevronRight
-            className={cn(
-              "size-4 text-muted-foreground/50 shrink-0 transition-transform",
-              isSelected && "text-primary rotate-90",
-            )}
-          />
-        </div>
+      <div className="min-w-0 flex-1">
+        <button
+          type="button"
+          onClick={() => onSelect(sessionKey)}
+          className="w-full text-left"
+        >
+          <div className="flex items-center gap-2 mb-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="shrink-0">
+                  <ProviderIcon
+                    icon={getProviderIconName(session.providerId)}
+                    name={session.providerId}
+                    size={18}
+                  />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {getProviderLabel(session.providerId, t)}
+              </TooltipContent>
+            </Tooltip>
+            <span className="text-sm font-medium line-clamp-2 flex-1">
+              {searchQuery ? highlightText(title, searchQuery) : title}
+            </span>
+            <ChevronRight
+              className={cn(
+                "size-4 text-muted-foreground/50 shrink-0 transition-transform",
+                isSelected && "text-primary rotate-90",
+              )}
+            />
+          </div>
 
-        <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
-          <Clock className="size-3" />
-          <span>
-            {lastActive
-              ? formatRelativeTime(lastActive, t)
-              : t("common.unknown")}
-          </span>
-        </div>
-      </button>
+          <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+            <Clock className="size-3" />
+            <span>
+              {lastActive
+                ? formatRelativeTime(lastActive, t)
+                : t("common.unknown")}
+            </span>
+          </div>
+        </button>
+
+        {snippets && snippets.length > 0 && (
+          <div className="mt-1.5 space-y-1">
+            {snippets.map((snippet) => (
+              <button
+                key={snippet.messageIndex}
+                type="button"
+                onClick={() => onSnippetSelect(session, snippet.messageIndex)}
+                title={t("sessionManager.jumpToMatch", {
+                  defaultValue: "跳转到匹配位置",
+                })}
+                className="w-full rounded bg-muted/60 px-1.5 py-1 text-left text-[11px] leading-snug text-muted-foreground line-clamp-2 transition-colors hover:bg-muted hover:text-foreground"
+              >
+                {highlightText(snippet.text, searchQuery ?? "")}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useSessionSearch } from "@/hooks/useSessionSearch";
+import {
+  useSessionContentSearch,
+  useSessionSearch,
+} from "@/hooks/useSessionSearch";
 import { useTranslation } from "react-i18next";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { toast } from "sonner";
@@ -205,6 +208,10 @@ export function SessionManagerPage({ appId }: { appId: string }) {
   const [activeMessageIndex, setActiveMessageIndex] = useState<number | null>(
     null,
   );
+  // 从搜索片段跳转时，消息要等选中会话加载完才能滚动
+  const [pendingMessageIndex, setPendingMessageIndex] = useState<number | null>(
+    null,
+  );
   const [tocDialogOpen, setTocDialogOpen] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [deleteTargets, setDeleteTargets] = useState<SessionMeta[] | null>(
@@ -239,15 +246,31 @@ export function SessionManagerPage({ appId }: { appId: string }) {
     setProviderFilter(appId as ProviderFilter);
   }, [appId]);
 
-  // 使用 FlexSearch 全文搜索
+  // 元数据索引（标题/摘要/目录/ID），毫秒级
   const { search: searchSessions } = useSessionSearch({
     sessions,
     providerFilter,
   });
+  // 会话正文搜索，覆盖元数据索引搜不到的对话中段内容
+  const { snippetsBySource, isSearching } = useSessionContentSearch(
+    search,
+    providerFilter,
+  );
 
   const filteredSessions = useMemo(() => {
-    return searchSessions(search);
-  }, [searchSessions, search]);
+    const metaHits = searchSessions(search);
+    if (snippetsBySource.size === 0) return metaHits;
+
+    // 正文命中排在元数据命中之后：标题命中通常更贴近用户意图
+    const matched = new Set(metaHits.map((session) => session.sourcePath));
+    const contentHits = sessions.filter(
+      (session) =>
+        session.sourcePath &&
+        snippetsBySource.has(session.sourcePath) &&
+        !matched.has(session.sourcePath),
+    );
+    return [...metaHits, ...contentHits];
+  }, [searchSessions, search, sessions, snippetsBySource]);
 
   const groupedSessions = useMemo(
     () =>
@@ -402,6 +425,18 @@ export function SessionManagerPage({ appId }: { appId: string }) {
     setTocDialogOpen(false);
     setTimeout(() => setActiveMessageIndex(null), 2000);
   };
+
+  const handleSnippetSelect = (session: SessionMeta, messageIndex: number) => {
+    setSelectedKey(getSessionKey(session));
+    setPendingMessageIndex(messageIndex);
+  };
+
+  // 目标会话的消息到位后再滚动
+  useEffect(() => {
+    if (pendingMessageIndex === null || messages.length === 0) return;
+    scrollToMessage(Math.min(pendingMessageIndex, messages.length - 1));
+    setPendingMessageIndex(null);
+  }, [pendingMessageIndex, messages]);
 
   const handleCopy = useCallback(
     async (text: string, successMessage: string) => {
@@ -703,10 +738,16 @@ export function SessionManagerPage({ appId }: { appId: string }) {
         isSelected={isSelected}
         selectionMode={selectionMode}
         searchQuery={search}
+        snippets={
+          session.sourcePath
+            ? snippetsBySource.get(session.sourcePath)
+            : undefined
+        }
         isChecked={selectedSessionKeys.has(sessionKey)}
         isCheckDisabled={!session.sourcePath}
         onSelect={setSelectedKey}
         onToggleChecked={(checked) => toggleSessionChecked(session, checked)}
+        onSnippetSelect={handleSnippetSelect}
       />
     );
   };
@@ -846,7 +887,19 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                 {isSearchOpen ? (
                   <div className="flex items-center gap-2">
                     <div className="relative flex-1">
-                      <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
+                      {isSearching ? (
+                        // 定位与旋转必须分层：animate-spin 会整体覆写 transform
+                        <span className="absolute left-2.5 top-1/2 flex -translate-y-1/2">
+                          <RefreshCw
+                            className="size-3.5 animate-spin text-muted-foreground"
+                            aria-label={t("sessionManager.searchingContent", {
+                              defaultValue: "正在搜索会话内容",
+                            })}
+                          />
+                        </span>
+                      ) : (
+                        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
+                      )}
                       <Input
                         ref={searchInputRef}
                         value={search}

--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -195,7 +195,7 @@ const filterSetToAllowedValues = (
 export function SessionManagerPage({ appId }: { appId: string }) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
-  const { data, isLoading, refetch } = useSessionsQuery();
+  const { data, dataUpdatedAt, isLoading, refetch } = useSessionsQuery();
   const sessions = data ?? [];
   const piSessionDiscovery = useQuery({
     queryKey: piKeys.sessionDiscovery,
@@ -255,6 +255,7 @@ export function SessionManagerPage({ appId }: { appId: string }) {
   const { snippetsBySource, isSearching } = useSessionContentSearch(
     search,
     providerFilter,
+    dataUpdatedAt,
   );
 
   const filteredSessions = useMemo(() => {
@@ -737,7 +738,7 @@ export function SessionManagerPage({ appId }: { appId: string }) {
         session={session}
         isSelected={isSelected}
         selectionMode={selectionMode}
-        searchQuery={search}
+        searchQuery={search.trim()}
         snippets={
           session.sourcePath
             ? snippetsBySource.get(session.sourcePath)
@@ -1775,7 +1776,7 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                                       isActive={
                                         activeMessageIndex === virtualRow.index
                                       }
-                                      searchQuery={search}
+                                      searchQuery={search.trim()}
                                       onCopy={handleMessageCopy}
                                     />
                                   </div>

--- a/src/hooks/useSessionSearch.ts
+++ b/src/hooks/useSessionSearch.ts
@@ -1,6 +1,7 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import FlexSearch from "flexsearch";
-import type { SessionMeta } from "@/types";
+import { sessionsApi } from "@/lib/api";
+import type { SessionMeta, SessionSearchSnippet } from "@/types";
 
 interface UseSessionSearchOptions {
   sessions: SessionMeta[];
@@ -69,4 +70,73 @@ export function useSessionSearch({
   );
 
   return { search };
+}
+
+const CONTENT_SEARCH_DEBOUNCE_MS = 300;
+const NO_SNIPPETS = new Map<string, SessionSearchSnippet[]>();
+
+interface ContentSearchState {
+  query: string;
+  providerFilter: string;
+  snippets: Map<string, SessionSearchSnippet[]>;
+}
+
+/**
+ * 后端会话正文搜索（元数据索引只覆盖标题/摘要/路径，搜不到对话中段的内容）
+ *
+ * 结果携带产生它的 query 与 providerFilter，只有两者都与当前值相符时才对外暴露；
+ * 因此一次慢的后台扫描返回时，不会把上一个关键词的命中泄漏到新的搜索结果里。
+ */
+export function useSessionContentSearch(query: string, providerFilter: string) {
+  const [state, setState] = useState<ContentSearchState | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
+  const needle = query.trim();
+
+  useEffect(() => {
+    if (!needle) {
+      setState(null);
+      setIsSearching(false);
+      return;
+    }
+
+    let active = true;
+    setIsSearching(true);
+
+    const timer = setTimeout(() => {
+      sessionsApi
+        .search(needle, providerFilter === "all" ? undefined : providerFilter)
+        .then((hits) => {
+          if (!active) return;
+          setState({
+            query: needle,
+            providerFilter,
+            snippets: new Map(
+              hits.map((hit) => [hit.sourcePath, hit.snippets]),
+            ),
+          });
+        })
+        .catch(() => {
+          // 正文搜索只是元数据索引的增强，失败时退回到元数据结果即可
+          if (!active) return;
+          setState({ query: needle, providerFilter, snippets: NO_SNIPPETS });
+        })
+        .finally(() => {
+          if (active) setIsSearching(false);
+        });
+    }, CONTENT_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      active = false;
+      clearTimeout(timer);
+    };
+  }, [needle, providerFilter]);
+
+  const snippetsBySource =
+    state !== null &&
+    state.query === needle &&
+    state.providerFilter === providerFilter
+      ? state.snippets
+      : NO_SNIPPETS;
+
+  return { snippetsBySource, isSearching };
 }

--- a/src/hooks/useSessionSearch.ts
+++ b/src/hooks/useSessionSearch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import FlexSearch from "flexsearch";
 import { sessionsApi } from "@/lib/api";
 import type { SessionMeta, SessionSearchSnippet } from "@/types";
@@ -90,6 +90,8 @@ interface ContentSearchState {
 export function useSessionContentSearch(query: string, providerFilter: string) {
   const [state, setState] = useState<ContentSearchState | null>(null);
   const [isSearching, setIsSearching] = useState(false);
+  // 递增的请求号：后端据此丢弃已被新关键词取代的扫描
+  const requestId = useRef(0);
   const needle = query.trim();
 
   useEffect(() => {
@@ -104,7 +106,11 @@ export function useSessionContentSearch(query: string, providerFilter: string) {
 
     const timer = setTimeout(() => {
       sessionsApi
-        .search(needle, providerFilter === "all" ? undefined : providerFilter)
+        .search(
+          needle,
+          providerFilter === "all" ? undefined : providerFilter,
+          ++requestId.current,
+        )
         .then((hits) => {
           if (!active) return;
           setState({

--- a/src/hooks/useSessionSearch.ts
+++ b/src/hooks/useSessionSearch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import FlexSearch from "flexsearch";
 import { sessionsApi } from "@/lib/api";
 import type { SessionMeta, SessionSearchSnippet } from "@/types";
@@ -87,11 +87,13 @@ interface ContentSearchState {
  * 结果携带产生它的 query 与 providerFilter，只有两者都与当前值相符时才对外暴露；
  * 因此一次慢的后台扫描返回时，不会把上一个关键词的命中泄漏到新的搜索结果里。
  */
-export function useSessionContentSearch(query: string, providerFilter: string) {
+export function useSessionContentSearch(
+  query: string,
+  providerFilter: string,
+  dataUpdatedAt: number,
+) {
   const [state, setState] = useState<ContentSearchState | null>(null);
   const [isSearching, setIsSearching] = useState(false);
-  // 递增的请求号：后端据此丢弃已被新关键词取代的扫描
-  const requestId = useRef(0);
   const needle = query.trim();
 
   useEffect(() => {
@@ -106,11 +108,7 @@ export function useSessionContentSearch(query: string, providerFilter: string) {
 
     const timer = setTimeout(() => {
       sessionsApi
-        .search(
-          needle,
-          providerFilter === "all" ? undefined : providerFilter,
-          ++requestId.current,
-        )
+        .search(needle, providerFilter === "all" ? undefined : providerFilter)
         .then((hits) => {
           if (!active) return;
           setState({
@@ -135,7 +133,7 @@ export function useSessionContentSearch(query: string, providerFilter: string) {
       active = false;
       clearTimeout(timer);
     };
-  }, [needle, providerFilter]);
+  }, [needle, providerFilter, dataUpdatedAt]);
 
   const snippetsBySource =
     state !== null &&

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1073,6 +1073,8 @@
     "subtitle": "Manage Claude Code, Codex, Gemini CLI, Grok Build, OpenCode, OpenClaw, Hermes, and Pi sessions",
     "searchPlaceholder": "Search by content, directory, or ID",
     "searchSessions": "Search sessions",
+    "searchingContent": "Searching session content",
+    "jumpToMatch": "Jump to match",
     "providerFilterAll": "All",
     "providerFilterTooltip": "Provider filter",
     "sessionList": "Sessions",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1073,6 +1073,8 @@
     "subtitle": "Claude Code / Codex / Gemini CLI / Grok Build / OpenCode / OpenClaw / Hermes / Pi のセッションを管理",
     "searchPlaceholder": "内容・ディレクトリ・ID で検索",
     "searchSessions": "セッションを検索",
+    "searchingContent": "セッション内容を検索中",
+    "jumpToMatch": "一致箇所へ移動",
     "providerFilterAll": "すべて",
     "providerFilterTooltip": "プロバイダーフィルター",
     "sessionList": "セッション一覧",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1074,6 +1074,8 @@
     "subtitle": "管理 Claude Code、Codex、Gemini CLI、Grok Build、OpenCode、OpenClaw、Hermes 與 Pi 工作階段紀錄",
     "searchPlaceholder": "搜尋對話內容、目錄或 ID",
     "searchSessions": "搜尋工作階段",
+    "searchingContent": "正在搜尋對話內容",
+    "jumpToMatch": "跳至相符位置",
     "providerFilterAll": "全部",
     "providerFilterTooltip": "供應商篩選",
     "sessionList": "工作階段清單",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1073,6 +1073,8 @@
     "subtitle": "管理 Claude Code、Codex、Gemini CLI、Grok Build、OpenCode、OpenClaw、Hermes 与 Pi 会话记录",
     "searchPlaceholder": "搜索会话内容、目录或 ID",
     "searchSessions": "搜索会话",
+    "searchingContent": "正在搜索会话内容",
+    "jumpToMatch": "跳转到匹配位置",
     "providerFilterAll": "全部",
     "providerFilterTooltip": "供应商筛选",
     "sessionList": "会话列表",

--- a/src/lib/api/sessions.ts
+++ b/src/lib/api/sessions.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { SessionMessage, SessionMeta } from "@/types";
+import type { SessionMessage, SessionMeta, SessionSearchHit } from "@/types";
 
 export interface DeleteSessionOptions {
   providerId: string;
@@ -22,6 +22,17 @@ export const sessionsApi = {
     sourcePath: string,
   ): Promise<SessionMessage[]> {
     return await invoke("get_session_messages", { providerId, sourcePath });
+  },
+
+  /** Full-content search; omit providerId to search every provider. */
+  async search(
+    query: string,
+    providerId?: string,
+  ): Promise<SessionSearchHit[]> {
+    return await invoke("search_sessions", {
+      query,
+      providerId: providerId ?? null,
+    });
   },
 
   async delete(options: DeleteSessionOptions): Promise<boolean> {

--- a/src/lib/api/sessions.ts
+++ b/src/lib/api/sessions.ts
@@ -24,14 +24,20 @@ export const sessionsApi = {
     return await invoke("get_session_messages", { providerId, sourcePath });
   },
 
-  /** Full-content search; omit providerId to search every provider. */
+  /**
+   * Full-content search; omit providerId to search every provider.
+   * `requestId` must increase per query so the backend can abandon a scan the
+   * user has already typed past.
+   */
   async search(
     query: string,
-    providerId?: string,
+    providerId: string | undefined,
+    requestId: number,
   ): Promise<SessionSearchHit[]> {
     return await invoke("search_sessions", {
       query,
       providerId: providerId ?? null,
+      requestId,
     });
   },
 

--- a/src/lib/api/sessions.ts
+++ b/src/lib/api/sessions.ts
@@ -26,18 +26,14 @@ export const sessionsApi = {
 
   /**
    * Full-content search; omit providerId to search every provider.
-   * `requestId` must increase per query so the backend can abandon a scan the
-   * user has already typed past.
    */
   async search(
     query: string,
     providerId: string | undefined,
-    requestId: number,
   ): Promise<SessionSearchHit[]> {
     return await invoke("search_sessions", {
       query,
       providerId: providerId ?? null,
-      requestId,
     });
   },
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -485,6 +485,19 @@ export interface SessionMessage {
   ts?: number;
 }
 
+export interface SessionSearchSnippet {
+  messageIndex: number;
+  role: string;
+  text: string;
+}
+
+export interface SessionSearchHit {
+  providerId: string;
+  sessionId: string;
+  sourcePath: string;
+  snippets: SessionSearchSnippet[];
+}
+
 // MCP 服务器连接参数（宽松：允许扩展字段）
 export interface McpServerSpec {
   // 可选：社区常见 .mcp.json 中 stdio 配置可不写 type

--- a/tests/components/SessionManagerPage.test.tsx
+++ b/tests/components/SessionManagerPage.test.tsx
@@ -264,6 +264,37 @@ describe("SessionManagerPage", () => {
     expect(toastSuccessMock).toHaveBeenCalled();
   });
 
+  it("refreshes body hits with unchanged metadata and highlights a trimmed query", async () => {
+    const search = vi.spyOn(sessionsApi, "search").mockResolvedValue([]);
+    const { client } = renderPage();
+    await screen.findByText("Alpha Session");
+    const originalData = client.getQueryData(["sessions"]);
+
+    openSearch();
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: " buried " },
+    });
+    await waitFor(() => expect(search).toHaveBeenCalledWith("buried", "codex"));
+
+    search.mockResolvedValue([
+      {
+        providerId: "codex",
+        sessionId: "codex-session-2",
+        sourcePath: "/mock/codex/session-2.jsonl",
+        snippets: [{ messageIndex: 0, role: "user", text: "A buried." }],
+      },
+    ]);
+    await act(async () => {
+      await client.refetchQueries({ queryKey: ["sessions"] });
+    });
+
+    const snippet = await screen.findByRole("button", { name: /A buried\s*\./ });
+    expect(snippet.querySelector("mark")).toHaveTextContent("buried");
+    expect(client.getQueryData(["sessions"])).toBe(originalData);
+    expect(search).toHaveBeenCalledTimes(2);
+    search.mockRestore();
+  });
+
   it("removes a deleted session from filtered search results", async () => {
     renderPage();
 

--- a/tests/hooks/useSessionContentSearch.test.tsx
+++ b/tests/hooks/useSessionContentSearch.test.tsx
@@ -1,0 +1,131 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useSessionContentSearch } from "@/hooks/useSessionSearch";
+import type { SessionSearchHit } from "@/types";
+
+const searchMock = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  sessionsApi: {
+    search: (...args: unknown[]) => searchMock(...args),
+  },
+}));
+
+const hit = (sourcePath: string): SessionSearchHit => ({
+  providerId: "claude",
+  sessionId: sourcePath,
+  sourcePath,
+  snippets: [{ messageIndex: 2, role: "assistant", text: "…匹配片段…" }],
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const render = (query: string, providerFilter = "all") =>
+  renderHook(({ q, filter }) => useSessionContentSearch(q, filter), {
+    initialProps: { q: query, filter: providerFilter },
+  });
+
+describe("useSessionContentSearch", () => {
+  beforeEach(() => {
+    searchMock.mockReset();
+  });
+
+  it("exposes backend snippets keyed by source path", async () => {
+    searchMock.mockResolvedValue([hit("/a.jsonl")]);
+
+    const { result } = render("浙江移动");
+
+    await waitFor(() =>
+      expect([...result.current.snippetsBySource.keys()]).toEqual(["/a.jsonl"]),
+    );
+    expect(result.current.snippetsBySource.get("/a.jsonl")).toHaveLength(1);
+  });
+
+  it("drops snippets from the previous query while the new one is in flight", async () => {
+    searchMock.mockResolvedValueOnce([hit("/a.jsonl")]);
+    const { result, rerender } = render("alpha");
+
+    await waitFor(() => expect(result.current.snippetsBySource.size).toBe(1));
+
+    const pending = deferred<SessionSearchHit[]>();
+    searchMock.mockImplementationOnce(() => pending.promise);
+    rerender({ q: "beta", filter: "all" });
+
+    // "alpha" 的命中必须立刻消失，否则新关键词下会显示上一次的片段
+    expect(result.current.snippetsBySource.size).toBe(0);
+
+    await act(async () => {
+      pending.resolve([hit("/b.jsonl")]);
+      await pending.promise;
+    });
+
+    await waitFor(() =>
+      expect([...result.current.snippetsBySource.keys()]).toEqual(["/b.jsonl"]),
+    );
+  });
+
+  it("drops snippets from the previous provider filter", async () => {
+    searchMock.mockResolvedValueOnce([hit("/a.jsonl")]);
+    const { result, rerender } = render("alpha", "claude");
+
+    await waitFor(() => expect(result.current.snippetsBySource.size).toBe(1));
+
+    searchMock.mockImplementationOnce(
+      () => deferred<SessionSearchHit[]>().promise,
+    );
+    rerender({ q: "alpha", filter: "codex" });
+
+    expect(result.current.snippetsBySource.size).toBe(0);
+  });
+
+  it("ignores a late reply from a superseded query", async () => {
+    const stale = deferred<SessionSearchHit[]>();
+    searchMock.mockImplementationOnce(() => stale.promise);
+    const { result, rerender } = render("alpha");
+
+    await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(1));
+
+    searchMock.mockResolvedValueOnce([hit("/b.jsonl")]);
+    rerender({ q: "beta", filter: "all" });
+    await waitFor(() =>
+      expect([...result.current.snippetsBySource.keys()]).toEqual(["/b.jsonl"]),
+    );
+
+    await act(async () => {
+      stale.resolve([hit("/a.jsonl")]);
+      await stale.promise;
+    });
+
+    expect([...result.current.snippetsBySource.keys()]).toEqual(["/b.jsonl"]);
+  });
+
+  it("searches every provider when the list is unfiltered", async () => {
+    searchMock.mockResolvedValue([]);
+
+    render("alpha");
+    await waitFor(() =>
+      expect(searchMock).toHaveBeenCalledWith("alpha", undefined),
+    );
+
+    searchMock.mockClear();
+    render("alpha", "codex");
+    await waitFor(() =>
+      expect(searchMock).toHaveBeenCalledWith("alpha", "codex"),
+    );
+  });
+
+  it("skips the backend for a blank query", async () => {
+    const { result } = render("   ");
+
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    expect(searchMock).not.toHaveBeenCalled();
+    expect(result.current.snippetsBySource.size).toBe(0);
+    expect(result.current.isSearching).toBe(false);
+  });
+});

--- a/tests/hooks/useSessionContentSearch.test.tsx
+++ b/tests/hooks/useSessionContentSearch.test.tsx
@@ -110,14 +110,35 @@ describe("useSessionContentSearch", () => {
 
     render("alpha");
     await waitFor(() =>
-      expect(searchMock).toHaveBeenCalledWith("alpha", undefined),
+      expect(searchMock).toHaveBeenCalledWith(
+        "alpha",
+        undefined,
+        expect.any(Number),
+      ),
     );
 
     searchMock.mockClear();
     render("alpha", "codex");
     await waitFor(() =>
-      expect(searchMock).toHaveBeenCalledWith("alpha", "codex"),
+      expect(searchMock).toHaveBeenCalledWith(
+        "alpha",
+        "codex",
+        expect.any(Number),
+      ),
     );
+  });
+
+  // 后端靠这个递增号丢弃已被新关键词取代的扫描；号不递增就等于没有取消机制
+  it("tags each scan with an increasing request id", async () => {
+    searchMock.mockResolvedValue([]);
+    const { rerender } = render("alpha");
+
+    await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(1));
+    rerender({ q: "beta", filter: "all" });
+    await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(2));
+
+    const [first, second] = searchMock.mock.calls;
+    expect(second[2]).toBeGreaterThan(first[2]);
   });
 
   it("skips the backend for a blank query", async () => {

--- a/tests/hooks/useSessionContentSearch.test.tsx
+++ b/tests/hooks/useSessionContentSearch.test.tsx
@@ -27,9 +27,10 @@ function deferred<T>() {
 }
 
 const render = (query: string, providerFilter = "all") =>
-  renderHook(({ q, filter }) => useSessionContentSearch(q, filter), {
-    initialProps: { q: query, filter: providerFilter },
-  });
+  renderHook(
+    ({ q, filter, updatedAt }) => useSessionContentSearch(q, filter, updatedAt),
+    { initialProps: { q: query, filter: providerFilter, updatedAt: 1 } },
+  );
 
 describe("useSessionContentSearch", () => {
   beforeEach(() => {
@@ -55,7 +56,7 @@ describe("useSessionContentSearch", () => {
 
     const pending = deferred<SessionSearchHit[]>();
     searchMock.mockImplementationOnce(() => pending.promise);
-    rerender({ q: "beta", filter: "all" });
+    rerender({ q: "beta", filter: "all", updatedAt: 1 });
 
     // "alpha" 的命中必须立刻消失，否则新关键词下会显示上一次的片段
     expect(result.current.snippetsBySource.size).toBe(0);
@@ -79,7 +80,7 @@ describe("useSessionContentSearch", () => {
     searchMock.mockImplementationOnce(
       () => deferred<SessionSearchHit[]>().promise,
     );
-    rerender({ q: "alpha", filter: "codex" });
+    rerender({ q: "alpha", filter: "codex", updatedAt: 1 });
 
     expect(result.current.snippetsBySource.size).toBe(0);
   });
@@ -92,7 +93,7 @@ describe("useSessionContentSearch", () => {
     await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(1));
 
     searchMock.mockResolvedValueOnce([hit("/b.jsonl")]);
-    rerender({ q: "beta", filter: "all" });
+    rerender({ q: "beta", filter: "all", updatedAt: 1 });
     await waitFor(() =>
       expect([...result.current.snippetsBySource.keys()]).toEqual(["/b.jsonl"]),
     );
@@ -110,35 +111,74 @@ describe("useSessionContentSearch", () => {
 
     render("alpha");
     await waitFor(() =>
-      expect(searchMock).toHaveBeenCalledWith(
-        "alpha",
-        undefined,
-        expect.any(Number),
-      ),
+      expect(searchMock).toHaveBeenCalledWith("alpha", undefined),
     );
 
     searchMock.mockClear();
     render("alpha", "codex");
     await waitFor(() =>
-      expect(searchMock).toHaveBeenCalledWith(
-        "alpha",
-        "codex",
-        expect.any(Number),
-      ),
+      expect(searchMock).toHaveBeenCalledWith("alpha", "codex"),
     );
   });
 
-  // 后端靠这个递增号丢弃已被新关键词取代的扫描；号不递增就等于没有取消机制
-  it("tags each scan with an increasing request id", async () => {
-    searchMock.mockResolvedValue([]);
-    const { rerender } = render("alpha");
+  it("searches again after remount without a renderer request id", async () => {
+    searchMock.mockResolvedValue([hit("/a.jsonl")]);
+    const first = render("alpha");
 
     await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(1));
-    rerender({ q: "beta", filter: "all" });
-    await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(2));
+    first.unmount();
+    const { result } = render("alpha");
 
-    const [first, second] = searchMock.mock.calls;
-    expect(second[2]).toBeGreaterThan(first[2]);
+    await waitFor(() => expect(result.current.snippetsBySource.size).toBe(1));
+    await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(2));
+    expect(searchMock.mock.calls).toEqual([
+      ["alpha", undefined],
+      ["alpha", undefined],
+    ]);
+  });
+
+  it("refreshes an unchanged query when the session list refreshes", async () => {
+    searchMock.mockResolvedValueOnce([hit("/a.jsonl")]);
+    const { result, rerender } = render("alpha");
+    await waitFor(() => expect(result.current.snippetsBySource.size).toBe(1));
+
+    searchMock.mockResolvedValueOnce([hit("/b.jsonl")]);
+    rerender({ q: "alpha", filter: "all", updatedAt: 2 });
+    await waitFor(() =>
+      expect([...result.current.snippetsBySource.keys()]).toEqual(["/b.jsonl"]),
+    );
+    expect(searchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a response from before the session list refreshed", async () => {
+    const stale = deferred<SessionSearchHit[]>();
+    searchMock.mockReturnValueOnce(stale.promise);
+    const { result, rerender } = render("alpha");
+    await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(1));
+
+    searchMock.mockResolvedValueOnce([hit("/b.jsonl")]);
+    rerender({ q: "alpha", filter: "all", updatedAt: 2 });
+    await waitFor(() =>
+      expect([...result.current.snippetsBySource.keys()]).toEqual(["/b.jsonl"]),
+    );
+
+    await act(async () => {
+      stale.resolve([hit("/a.jsonl")]);
+      await stale.promise;
+    });
+    expect([...result.current.snippetsBySource.keys()]).toEqual(["/b.jsonl"]);
+  });
+
+  it("does not rescan on an ordinary rerender", async () => {
+    searchMock.mockResolvedValue([]);
+    const { rerender } = render("alpha");
+    await waitFor(() => expect(searchMock).toHaveBeenCalledTimes(1));
+
+    rerender({ q: "alpha", filter: "all", updatedAt: 1 });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+    expect(searchMock).toHaveBeenCalledTimes(1);
   });
 
   it("skips the backend for a blank query", async () => {


### PR DESCRIPTION
## Summary / 概述

Session search only indexed metadata, so keywords that appear **in the middle of a
conversation** could never be found, even though the search box has always
advertised content search (`"Search by content, directory, or ID"` /
`"搜索会话内容、目录或 ID"`).

This adds a backend full-content search over session transcripts and merges its
results into the existing metadata index.

会话搜索此前只索引元数据，**对话中段出现的关键词永远搜不到**，尽管搜索框的提示文案
一直写着「搜索会话内容」。本 PR 补齐了会话正文搜索功能，并与既有的元数据索引结果合并。

### Problem description

`useSessionSearch` indexes exactly five fields: `sessionId`, `title`, `summary`,
`projectDir`, `sourcePath`.

- `title` = custom title, else the **first** user message, truncated to `TITLE_MAX_CHARS` (80)
- `summary` = the **last** non-meta message, truncated to 160 chars

So the effective search surface was "first 80 chars + last 160 chars + IDs + paths".
Everything in between was invisible.

Two signals that content search was always the intent:

- `session-manager.md:88` specifies search as *"跨会话，关键词匹配 transcript/summary/目录"* (`transcript` being the full conversation)
- `SessionMessageItem.tsx` already highlights `searchQuery` inside message bodies — that code could only ever fire after the user found the session some other way

## Approach

Rather than writing a scanner per provider, the search is built on the existing
`session_manager::load_messages(provider_id, source_path)` dispatch, which already
handles all eight providers including both SQLite-backed ones. Three consequences:

1. **No per-provider code.** New providers get content search for free.
2. **Hits match what the detail pane renders**, so the existing in-message
   highlighting is consistent with the list results by construction.

Sessions are scanned in parallel via `thread::scope`, chunked so results stay
ordered by recency like `scan_sessions`.

## Prior art / 致谢

The problem analysis here follows **#4976** by @fjh1997, which diagnosed exactly
this gap (down to the same truncation constants) and proposed a backend deep
search.

Credit also to @Juddd, who originally requested this in **#3721**. That issue was
closed as a duplicate, but the maintainer response addressed only the *rename*
half of the request; the full-text search half was never answered.

## UX

- Up to 3 matching snippets per session, ~60 chars of context each side, keyword highlighted
- **Clicking a snippet jumps to that message** in the detail pane
- Spinner in the search box while the backend scan runs
- `searchPlaceholder` needed no change — it finally describes what the feature does

## Trade-off

Every search fully parses every session file. This is a deliberate choice of
correctness over speed, for the reasons above. Mitigations: parallel scan across
cores, results capped at 200 sessions, and the OS page cache makes repeat searches
cheap. If this proves too slow at very large session counts, a lossless index is
the follow-up, but it needs its own design, since session files are appended
continuously by the CLI tools.

## Related Issue / 关联 Issue

Related: #3721, #2019
Prior art: #4976

## Tests

- 9 Rust unit tests in `session_manager::search` — mid-conversation match, Unicode
  case folding (`Éclair`/`éclair`/`ÉCLAIR`), snippet boundaries incl. CJK, snippet
  cap, empty query, subslice search
- 6 frontend tests in `tests/hooks/useSessionContentSearch.test.tsx` — all four
  staleness paths (query change, filter change, late reply from a superseded
  query), provider passthrough, blank-query short circuit

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查
- [x] Updated i18n files if user-facing text changed / 已更新国际化文件（en / ja / zh / zh-TW）