### PR TITLE
feat(zhipu): 支持智谱 V3 积分套餐的积分制度查询

### DIFF
--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -633,12 +633,20 @@ async fn query_provider_usage_inner(
             });
         }
 
-        // ZenMux 的 tier 携带 USD 额度信息，需要编码为 JSON extra
+        // ZenMux 的 tier 携带 USD 额度信息，需要编码为 JSON extra；
+        // 智谱 V3 积分套餐携带 used_credits/max_credits，同样需要 JSON extra
+        // （否则 extra 只能放裸 resets_at 字符串，前端无法区分 V2 百分比与 V3 积分）。
         let has_usd = quota
             .tiers
             .first()
             .map(|t| t.used_value_usd.is_some())
             .unwrap_or(false);
+        let has_credits = quota
+            .tiers
+            .first()
+            .map(|t| t.used_credits.is_some())
+            .unwrap_or(false);
+        let structured_extra = has_usd || has_credits;
         let plan_label = quota
             .credential_message
             .as_deref()
@@ -653,7 +661,7 @@ async fn query_provider_usage_inner(
                 let total = 100.0;
                 let used = tier.utilization;
                 let remaining = total - used;
-                let extra = if has_usd {
+                let extra = if structured_extra {
                     let mut extra_json = serde_json::json!({
                         "resetsAt": tier.resets_at,
                     });
@@ -662,6 +670,14 @@ async fn query_provider_usage_inner(
                     }
                     if let Some(v) = tier.max_value_usd {
                         extra_json["maxValueUsd"] = serde_json::json!(v);
+                    }
+                    // V3 积分套餐：透传已用/总积分（前端据此切换为积分展示）。
+                    // 字段名与前端 QuotaTier 类型对齐（camelCase）。
+                    if let Some(v) = tier.used_credits {
+                        extra_json["usedCredits"] = serde_json::json!(v);
+                    }
+                    if let Some(v) = tier.max_credits {
+                        extra_json["maxCredits"] = serde_json::json!(v);
                     }
                     if first_tier {
                         if let Some(ref label) = plan_label {

--- a/src-tauri/src/services/coding_plan.rs
+++ b/src-tauri/src/services/coding_plan.rs
@@ -170,6 +170,8 @@ async fn query_kimi(api_key: &str) -> Result<SubscriptionQuota, String> {
                     resets_at,
                     used_value_usd: None,
                     max_value_usd: None,
+                    used_credits: None,
+                    max_credits: None,
                 });
             }
         }
@@ -193,6 +195,8 @@ async fn query_kimi(api_key: &str) -> Result<SubscriptionQuota, String> {
             resets_at,
             used_value_usd: None,
             max_value_usd: None,
+            used_credits: None,
+            max_credits: None,
         });
     }
 
@@ -242,10 +246,20 @@ fn classify_zhipu_window(item: &serde_json::Value) -> Option<ZhipuWindow> {
 ///    five_hour（5 小时桶在 0% 等状态下可能没有 reset），其余按 reset 升序
 ///    依次填入仍空缺的槽位。
 ///
-/// 老套餐（2026-02-12 前订阅）只回 1 条
-/// `TOKENS_LIMIT`，自然降级为仅展示 `five_hour`；新套餐回 2 条。
+/// 套餐代次（按智谱官网前端常量区分）：
+/// - V1（老套餐，2026-02-12 前）：仅 1 条 `TOKENS_LIMIT`（unit=3，5 小时）。
+/// - V2（新套餐）：2 条 `TOKENS_LIMIT`（unit=3 五小时 + unit=6 每周），按 Token
+///   计费，前端展示百分比。
+/// - V3（积分套餐）：2 条 `CREDIT_LIMIT`（unit=3 五小时 + unit=6 每周），按积分
+///   计费。除 `percentage` 外还携带 `currentValue`（已用积分）与 `usage`（总
+///   积分），官网以 "currentValue / usage 积分" 形式展示；本函数将其填入
+///   `used_credits` / `max_credits`，前端据此切换为积分绝对值展示。
+///
+/// `TOKENS_LIMIT` 与 `CREDIT_LIMIT` 不会在同一响应中混出现，故两代次共用同一对
+/// 槽位（five_hour / weekly）。
 fn parse_zhipu_token_tiers(data: &serde_json::Value) -> Vec<QuotaTier> {
-    type Entry = (Option<i64>, f64, Option<String>);
+    // (reset_ms, percentage, reset_iso, used_credits, max_credits)
+    type Entry = (Option<i64>, f64, Option<String>, Option<f64>, Option<f64>);
     let mut five_hour: Option<Entry> = None;
     let mut weekly: Option<Entry> = None;
     let mut unclassified: Vec<Entry> = Vec::new();
@@ -268,7 +282,12 @@ fn parse_zhipu_token_tiers(data: &serde_json::Value) -> Vec<QuotaTier> {
                 .unwrap_or(0.0);
             let reset_ms = limit_item.get("nextResetTime").and_then(|v| v.as_i64());
             let reset_iso = reset_ms.and_then(millis_to_iso8601);
-            let entry = (reset_ms, percentage, reset_iso);
+            // V3 积分套餐特有：currentValue（已用积分）/ usage（总积分）。
+            // 仅 CREDIT_LIMIT 条目携带，TOKENS_LIMIT 条目这两个字段缺失 → None。
+            // 字段名与上游 JSON 一致（驼峰）。
+            let used_credits = limit_item.get("currentValue").and_then(|v| v.as_f64());
+            let max_credits = limit_item.get("usage").and_then(|v| v.as_f64());
+            let entry = (reset_ms, percentage, reset_iso, used_credits, max_credits);
             match classify_zhipu_window(limit_item) {
                 Some(ZhipuWindow::FiveHour) if five_hour.is_none() => five_hour = Some(entry),
                 Some(ZhipuWindow::Weekly) if weekly.is_none() => weekly = Some(entry),
@@ -277,25 +296,27 @@ fn parse_zhipu_token_tiers(data: &serde_json::Value) -> Vec<QuotaTier> {
         }
     }
 
-    unclassified.sort_by_key(|(reset, _, _)| (reset.is_some(), reset.unwrap_or(i64::MIN)));
+    unclassified.sort_by_key(|(reset, _, _, _, _)| (reset.is_some(), reset.unwrap_or(i64::MIN)));
     for entry in unclassified {
         if five_hour.is_none() {
             five_hour = Some(entry);
         } else if weekly.is_none() {
             weekly = Some(entry);
         }
-        // 智谱当前最多两条 TOKENS_LIMIT，多余的忽略
+        // 智谱当前最多两条 TOKENS_LIMIT/CREDIT_LIMIT，多余的忽略
     }
 
     let mut tiers = Vec::new();
     for (name, slot) in [(TIER_FIVE_HOUR, five_hour), (TIER_WEEKLY_LIMIT, weekly)] {
-        if let Some((_, percentage, resets_at)) = slot {
+        if let Some((_, percentage, resets_at, used_credits, max_credits)) = slot {
             tiers.push(QuotaTier {
                 name: name.to_string(),
                 utilization: percentage,
                 resets_at,
                 used_value_usd: None,
                 max_value_usd: None,
+                used_credits,
+                max_credits,
             });
         }
     }
@@ -577,6 +598,8 @@ async fn query_zenmux(base_url: &str, api_key: &str) -> Result<SubscriptionQuota
             resets_at,
             used_value_usd: used_usd,
             max_value_usd: max_usd,
+            used_credits: None,
+            max_credits: None,
         });
     }
 
@@ -598,6 +621,8 @@ async fn query_zenmux(base_url: &str, api_key: &str) -> Result<SubscriptionQuota
             resets_at,
             used_value_usd: used_usd,
             max_value_usd: max_usd,
+            used_credits: None,
+            max_credits: None,
         });
     }
 
@@ -673,6 +698,8 @@ fn parse_minimax_tiers(body: &serde_json::Value) -> Vec<QuotaTier> {
             resets_at,
             used_value_usd: None,
             max_value_usd: None,
+            used_credits: None,
+            max_credits: None,
         });
     }
 
@@ -692,6 +719,8 @@ fn parse_minimax_tiers(body: &serde_json::Value) -> Vec<QuotaTier> {
                 resets_at,
                 used_value_usd: None,
                 max_value_usd: None,
+                used_credits: None,
+                max_credits: None,
             });
         }
     }
@@ -1009,6 +1038,8 @@ fn parse_afp_tiers(result: &serde_json::Value) -> Vec<QuotaTier> {
             resets_at,
             used_value_usd: None,
             max_value_usd: None,
+            used_credits: None,
+            max_credits: None,
         });
     }
     tiers
@@ -1068,6 +1099,8 @@ fn parse_coding_plan_tiers(result: &serde_json::Value) -> Vec<QuotaTier> {
             resets_at,
             used_value_usd: None,
             max_value_usd: None,
+            used_credits: None,
+            max_credits: None,
         });
     }
     tiers
@@ -1565,6 +1598,81 @@ mod tests {
         assert_eq!(tiers.len(), 2);
         assert_eq!(tiers[0].name, TIER_FIVE_HOUR);
         assert_eq!(tiers[1].name, TIER_WEEKLY_LIMIT);
+    }
+
+    // ── 智谱 V3 积分套餐（CREDIT_LIMIT）──
+    // V3 用 type=CREDIT_LIMIT 区分于 V2 的 TOKENS_LIMIT，
+    // 携带 currentValue（已用积分）与 usage（总积分），前端据此切换为积分展示。
+
+    #[test]
+    fn zhipu_v3_credit_plan_extracts_credits() {
+        // V3 积分套餐：5 小时 + 每周均为 CREDIT_LIMIT，带 currentValue/usage。
+        let data = json!({
+            "limits": [
+                { "type": "CREDIT_LIMIT", "unit": 3, "percentage": 30.0, "currentValue": 300, "usage": 1000, "nextResetTime": 1_000_000_000_000_i64 },
+                { "type": "CREDIT_LIMIT", "unit": 6, "percentage": 12.0, "currentValue": 600, "usage": 5000, "nextResetTime": 2_000_000_000_000_i64 }
+            ]
+        });
+        let tiers = parse_zhipu_token_tiers(&data);
+        assert_eq!(tiers.len(), 2);
+
+        assert_eq!(tiers[0].name, TIER_FIVE_HOUR);
+        assert_eq!(tiers[0].utilization, 30.0);
+        assert_eq!(tiers[0].used_credits, Some(300.0));
+        assert_eq!(tiers[0].max_credits, Some(1000.0));
+        assert!(tiers[0].resets_at.is_some());
+
+        assert_eq!(tiers[1].name, TIER_WEEKLY_LIMIT);
+        assert_eq!(tiers[1].utilization, 12.0);
+        assert_eq!(tiers[1].used_credits, Some(600.0));
+        assert_eq!(tiers[1].max_credits, Some(5000.0));
+        assert!(tiers[1].resets_at.is_some());
+    }
+
+    #[test]
+    fn zhipu_v2_tokens_plan_has_no_credits() {
+        // V2 Token 套餐：TOKENS_LIMIT 不带 currentValue/usage，积分字段必须为 None。
+        let data = json!({
+            "limits": [
+                { "type": "TOKENS_LIMIT", "unit": 3, "percentage": 44.0, "nextResetTime": 1_000_000_000_000_i64 },
+                { "type": "TOKENS_LIMIT", "unit": 6, "percentage": 53.0, "nextResetTime": 2_000_000_000_000_i64 }
+            ]
+        });
+        let tiers = parse_zhipu_token_tiers(&data);
+        assert_eq!(tiers.len(), 2);
+        assert_eq!(tiers[0].used_credits, None);
+        assert_eq!(tiers[0].max_credits, None);
+        assert_eq!(tiers[1].used_credits, None);
+        assert_eq!(tiers[1].max_credits, None);
+    }
+
+    #[test]
+    fn zhipu_v3_credit_plan_case_insensitive() {
+        // 上游若把 CREDIT_LIMIT 改成小写，依然能识别并提取积分。
+        let data = json!({
+            "limits": [
+                { "type": "credit_limit", "unit": 3, "percentage": 5.0, "currentValue": 50, "usage": 1000 }
+            ]
+        });
+        let tiers = parse_zhipu_token_tiers(&data);
+        assert_eq!(tiers.len(), 1);
+        assert_eq!(tiers[0].name, TIER_FIVE_HOUR);
+        assert_eq!(tiers[0].used_credits, Some(50.0));
+        assert_eq!(tiers[0].max_credits, Some(1000.0));
+    }
+
+    #[test]
+    fn zhipu_v3_credit_plan_missing_values_defaults_to_none() {
+        // 积分值字段缺失时降级为 None（不 panic，前端回退到百分比展示）。
+        let data = json!({
+            "limits": [
+                { "type": "CREDIT_LIMIT", "unit": 3, "percentage": 10.0 }
+            ]
+        });
+        let tiers = parse_zhipu_token_tiers(&data);
+        assert_eq!(tiers.len(), 1);
+        assert_eq!(tiers[0].used_credits, None);
+        assert_eq!(tiers[0].max_credits, None);
     }
 
     // ── MiniMax ──

--- a/src-tauri/src/services/subscription.rs
+++ b/src-tauri/src/services/subscription.rs
@@ -38,6 +38,14 @@ pub struct QuotaTier {
     /// ZenMux: 窗口上限（USD）
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_value_usd: Option<f64>,
+    /// 智谱 V3 积分套餐：已用积分（对应上游 `currentValue`）。
+    /// 仅当 limits 条目 `type=CREDIT_LIMIT` 时填充，其他套餐保持 None。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub used_credits: Option<f64>,
+    /// 智谱 V3 积分套餐：总积分（对应上游 `usage`）。
+    /// 仅当 limits 条目 `type=CREDIT_LIMIT` 时填充。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_credits: Option<f64>,
 }
 
 /// 超额使用信息
@@ -406,6 +414,8 @@ async fn query_claude_quota(access_token: &str) -> Result<SubscriptionQuota, Str
                         resets_at: w.resets_at,
                         used_value_usd: None,
                         max_value_usd: None,
+                        used_credits: None,
+                        max_credits: None,
                     });
                 }
             }
@@ -426,6 +436,8 @@ async fn query_claude_quota(access_token: &str) -> Result<SubscriptionQuota, Str
                         resets_at: w.resets_at,
                         used_value_usd: None,
                         max_value_usd: None,
+                        used_credits: None,
+                        max_credits: None,
                     });
                 }
             }
@@ -749,6 +761,8 @@ pub(crate) async fn query_codex_quota(
                     resets_at: window.reset_at.and_then(unix_ts_to_iso),
                     used_value_usd: None,
                     max_value_usd: None,
+                    used_credits: None,
+                    max_credits: None,
                 });
             }
         }
@@ -1212,6 +1226,8 @@ async fn query_gemini_quota(access_token: &str) -> Result<SubscriptionQuota, Str
             resets_at: reset_time,
             used_value_usd: None,
             max_value_usd: None,
+            used_credits: None,
+            max_credits: None,
         })
         .collect();
 

--- a/src-tauri/src/services/subscription_grok.rs
+++ b/src-tauri/src/services/subscription_grok.rs
@@ -664,6 +664,8 @@ pub(crate) async fn query_grok_quota(
             .map(|dt| dt.to_rfc3339()),
         used_value_usd: None,
         max_value_usd: None,
+        used_credits: None,
+        max_credits: None,
     };
 
     Ok(SubscriptionQuota {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1310,6 +1310,8 @@ mod tests {
             resets_at: None,
             used_value_usd: None,
             max_value_usd: None,
+            used_credits: None,
+            max_credits: None,
         }
     }
 

--- a/src/components/SubscriptionQuotaFooter.tsx
+++ b/src/components/SubscriptionQuotaFooter.tsx
@@ -317,15 +317,32 @@ export const TierBadge: React.FC<{
   const countdown = countdownStr(tier.resetsAt);
 
   const hasUsd = tier.usedValueUsd != null && tier.maxValueUsd != null;
+  // 智谱 V3 积分套餐：有 usedCredits/maxCredits 时改用积分绝对值展示，
+  // 替换 V2 的百分比，对齐智谱官网 "currentValue / usage 积分" 形式。
+  const hasCredits = tier.usedCredits != null && tier.maxCredits != null;
 
   return (
     <div className="flex items-center gap-0.5">
       <span className="text-gray-500 dark:text-gray-400">{label}:</span>
-      <span
-        className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
-      >
-        {t("subscription.utilization", { value: Math.round(tier.utilization) })}
-      </span>
+      {hasCredits ? (
+        <span
+          className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
+        >
+          {t("subscription.creditUsage", {
+            used: Math.round(tier.usedCredits!),
+            total: Math.round(tier.maxCredits!),
+            unit: t("subscription.creditsUnit"),
+          })}
+        </span>
+      ) : (
+        <span
+          className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
+        >
+          {t("subscription.utilization", {
+            value: Math.round(tier.utilization),
+          })}
+        </span>
+      )}
       {hasUsd && (
         <span className="text-muted-foreground/60">
           (${tier.usedValueUsd!.toFixed(2)}/${tier.maxValueUsd!.toFixed(2)})
@@ -378,11 +395,23 @@ const TierBar: React.FC<{
         className="flex items-center gap-2 flex-shrink-0"
         style={{ width: "30%" }}
       >
-        <span
-          className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
-        >
-          {Math.round(tier.utilization)}%
-        </span>
+        {tier.usedCredits != null && tier.maxCredits != null ? (
+          <span
+            className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
+          >
+            {t("subscription.creditUsage", {
+              used: Math.round(tier.usedCredits),
+              total: Math.round(tier.maxCredits),
+              unit: t("subscription.creditsUnit"),
+            })}
+          </span>
+        ) : (
+          <span
+            className={`font-semibold tabular-nums ${utilizationColor(tier.utilization)}`}
+          >
+            {Math.round(tier.utilization)}%
+          </span>
+        )}
         {resetText && (
           <span
             className="text-[10px] text-muted-foreground/70 truncate"

--- a/src/components/UsageFooter.tsx
+++ b/src/components/UsageFooter.tsx
@@ -19,7 +19,7 @@ interface UsageFooterProps {
 }
 
 /** UsageData → QuotaTier 转换（Token Plan 使用） */
-function toQuotaTier(data: UsageData): QuotaTier {
+export function toQuotaTier(data: UsageData): QuotaTier {
   const extra = data.extra;
   if (extra && extra.startsWith("{")) {
     try {
@@ -30,6 +30,8 @@ function toQuotaTier(data: UsageData): QuotaTier {
         resetsAt: parsed.resetsAt || null,
         usedValueUsd: parsed.usedValueUsd ?? null,
         maxValueUsd: parsed.maxValueUsd ?? null,
+        usedCredits: parsed.usedCredits ?? null,
+        maxCredits: parsed.maxCredits ?? null,
         planLabel: parsed.planLabel ?? null,
       };
     } catch {

--- a/src/components/__tests__/quotaTier.test.ts
+++ b/src/components/__tests__/quotaTier.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import type { UsageData } from "@/types";
+import { toQuotaTier } from "@/components/UsageFooter";
+
+describe("toQuotaTier", () => {
+  it("V2 套餐：extra 为裸 resets_at 字符串时，积分字段缺失", () => {
+    const data: UsageData = {
+      planName: "5小时",
+      used: 30,
+      extra: "2026-08-20T00:00:00Z",
+    };
+    const tier = toQuotaTier(data);
+    expect(tier.usedCredits).toBeUndefined();
+    expect(tier.maxCredits).toBeUndefined();
+    expect(tier.utilization).toBe(30);
+    expect(tier.resetsAt).toBe("2026-08-20T00:00:00Z");
+  });
+
+  it("V3 套餐：extra 为 JSON 时解析出 usedCredits/maxCredits", () => {
+    const data: UsageData = {
+      planName: "5小时",
+      used: 30,
+      extra: JSON.stringify({
+        resetsAt: "2026-08-20T00:00:00Z",
+        usedCredits: 300,
+        maxCredits: 1000,
+      }),
+    };
+    const tier = toQuotaTier(data);
+    expect(tier.usedCredits).toBe(300);
+    expect(tier.maxCredits).toBe(1000);
+    expect(tier.resetsAt).toBe("2026-08-20T00:00:00Z");
+    expect(tier.utilization).toBe(30);
+  });
+
+  it("V3 套餐：JSON 缺少积分字段时降级为 null（前端回退到百分比）", () => {
+    const data: UsageData = {
+      planName: "5小时",
+      used: 10,
+      extra: JSON.stringify({ resetsAt: "2026-08-20T00:00:00Z" }),
+    };
+    const tier = toQuotaTier(data);
+    expect(tier.usedCredits).toBeNull();
+    expect(tier.maxCredits).toBeNull();
+  });
+
+  it("ZenMux：JSON 携带 USD 字段时积分字段仍为 null", () => {
+    const data: UsageData = {
+      planName: "Pro",
+      used: 50,
+      extra: JSON.stringify({
+        resetsAt: null,
+        usedValueUsd: 1.23,
+        maxValueUsd: 10.0,
+        planLabel: "ZenMux·PRO",
+      }),
+    };
+    const tier = toQuotaTier(data);
+    expect(tier.usedValueUsd).toBe(1.23);
+    expect(tier.maxValueUsd).toBe(10.0);
+    expect(tier.usedCredits).toBeNull();
+    expect(tier.maxCredits).toBeNull();
+    expect(tier.planLabel).toBe("ZenMux·PRO");
+  });
+
+  it("extra 为非法 JSON 但以 { 开头时回退到裸字符串", () => {
+    const data: UsageData = {
+      planName: "5小时",
+      used: 5,
+      extra: "{not valid json",
+    };
+    const tier = toQuotaTier(data);
+    expect(tier.resetsAt).toBe("{not valid json");
+    expect(tier.usedCredits).toBeUndefined();
+  });
+
+  it("extra 为空时返回空 resetsAt", () => {
+    const data: UsageData = { planName: "5小时", used: 0 };
+    const tier = toQuotaTier(data);
+    expect(tier.resetsAt).toBeNull();
+    expect(tier.utilization).toBe(0);
+  });
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3239,6 +3239,8 @@
     "credits": "Credits",
     "copilotPremium": "Premium",
     "utilization": "{{value}}%",
+    "creditsUnit": "credits",
+    "creditUsage": "{{used}}/{{total}} {{unit}}",
     "resetsIn": "Resets in {{time}}",
     "extraUsage": "Extra Usage",
     "expired": "Session expired",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3239,6 +3239,8 @@
     "credits": "クレジット",
     "copilotPremium": "プレミアム",
     "utilization": "{{value}}%",
+    "creditsUnit": "クレジット",
+    "creditUsage": "{{used}}/{{total}} {{unit}}",
     "resetsIn": "{{time}}後にリセット",
     "extraUsage": "超過使用量",
     "expired": "セッション期限切れ",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3240,6 +3240,8 @@
     "credits": "額度",
     "copilotPremium": "進階請求",
     "utilization": "{{value}}%",
+    "creditsUnit": "點數",
+    "creditUsage": "{{used}}/{{total}} {{unit}}",
     "resetsIn": "{{time}} 後重設",
     "extraUsage": "超額用量",
     "expired": "工作階段已過期",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3239,6 +3239,8 @@
     "credits": "额度",
     "copilotPremium": "高级请求",
     "utilization": "{{value}}%",
+    "creditsUnit": "积分",
+    "creditUsage": "{{used}}/{{total}} {{unit}}",
     "resetsIn": "{{time}}后重置",
     "extraUsage": "超额用量",
     "expired": "会话已过期",

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -10,6 +10,11 @@ export interface QuotaTier {
   resetsAt: string | null;
   usedValueUsd?: number | null;
   maxValueUsd?: number | null;
+  /** 智谱 V3 积分套餐：已用积分（对应上游 currentValue）。
+   * 仅当 limits 条目 type=CREDIT_LIMIT 时填充，前端据此切换为积分展示。 */
+  usedCredits?: number | null;
+  /** 智谱 V3 积分套餐：总积分（对应上游 usage）。 */
+  maxCredits?: number | null;
   planLabel?: string | null;
 }
 


### PR DESCRIPTION
## Summary / 概述

智谱最近新出了V3积分制度套餐，适配智谱V3积分套餐用量查询

## Related Issue / 关联 Issue


Fixes #

## Screenshots / 截图

<!-- If applicable, add before/after screenshots. / 如有需要，请添加修改前后的截图。 -->

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
|       
<img width="2037" height="606" alt="img_v3_0214n_686d644e-489a-4d70-8d75-470ae0b91a4g" src="https://github.com/user-attachments/assets/56ff42c9-286a-4094-a3d6-a46c67a5924a" />
          |       
<img width="1028" height="374" alt="img_v3_0214o_635491fc-ada6-438b-bc5e-61d66a00221g" src="https://github.com/user-attachments/assets/d798ccb2-e2e7-4540-a391-353b173e1a43" />
        |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
