### PR TITLE
fix(provider): extend IME-safe inputs to Claude, Pi, and Claude Desktop

### DIFF
--- a/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
+++ b/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
@@ -14,7 +14,7 @@ import {
   FormItem,
   FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
+import { ImeSafeInput } from "@/components/ui/ime-safe-input";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -1149,21 +1149,21 @@ export function ClaudeDesktopProviderForm({
                           <div className="flex h-9 items-center rounded-md border border-input bg-muted px-3 text-sm font-medium text-muted-foreground">
                             {roleLabel}
                           </div>
-                          <Input
+                          <ImeSafeInput
                             value={route.labelOverride}
-                            onChange={(event) =>
+                            onValueChange={(next) =>
                               updateRoute(index, {
-                                labelOverride: event.target.value,
+                                labelOverride: next,
                               })
                             }
                             placeholder={labelPlaceholder}
                           />
                           <div className="flex gap-1">
-                            <Input
+                            <ImeSafeInput
                               value={route.model}
-                              onChange={(event) =>
+                              onValueChange={(next) =>
                                 updateRoute(index, {
-                                  model: event.target.value,
+                                  model: next,
                                 })
                               }
                               placeholder={modelPlaceholder}
@@ -1241,11 +1241,11 @@ export function ClaudeDesktopProviderForm({
                           className="grid grid-cols-1 gap-2 md:grid-cols-[1fr_116px_36px]"
                         >
                           <div className="flex gap-1">
-                            <Input
+                            <ImeSafeInput
                               value={route.route}
-                              onChange={(event) =>
+                              onValueChange={(next) =>
                                 updateRoute(index, {
-                                  route: event.target.value,
+                                  route: next,
                                 })
                               }
                               placeholder="claude-sonnet-4-6"

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import { Checkbox } from "@/components/ui/checkbox";
 import { FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { ImeSafeInput } from "@/components/ui/ime-safe-input";
 import {
   Select,
   SelectContent,
@@ -713,7 +714,7 @@ export function ClaudeFormFields({
                 <FormLabel htmlFor={`template-${key}`}>
                   {config.label}
                 </FormLabel>
-                <Input
+                <ImeSafeInput
                   id={`template-${key}`}
                   type="text"
                   required
@@ -723,7 +724,7 @@ export function ClaudeFormFields({
                     config.defaultValue ??
                     ""
                   }
-                  onChange={(e) => onTemplateValueChange(key, e.target.value)}
+                  onValueChange={(next) => onTemplateValueChange(key, next)}
                   placeholder={config.placeholder || config.label}
                   autoComplete="off"
                 />
@@ -997,13 +998,10 @@ export function ClaudeFormFields({
                       {row.label}
                     </div>
                     {row.displayNameField ? (
-                      <Input
+                      <ImeSafeInput
                         value={row.displayName ?? ""}
-                        onChange={(event) =>
-                          onModelChange(
-                            row.displayNameField!,
-                            event.target.value,
-                          )
+                        onValueChange={(next) =>
+                          onModelChange(row.displayNameField!, next)
                         }
                         placeholder={
                           modelBase ||

--- a/src/components/providers/forms/PiProviderForm.tsx
+++ b/src/components/providers/forms/PiProviderForm.tsx
@@ -20,6 +20,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { ImeSafeInput } from "@/components/ui/ime-safe-input";
 import { Label } from "@/components/ui/label";
 import {
   Popover,
@@ -46,6 +47,7 @@ import {
   findRequestHeaderValue,
   normalizeRequestHeaders,
 } from "./helpers/requestHeaders";
+import { normalizeProviderKey } from "./helpers/providerKey";
 import {
   piProviderPresets,
   type PiApiFormat,
@@ -586,6 +588,11 @@ export function PiProviderForm({
     [updateSettingsConfig],
   );
 
+  // Returns false when the settings JSON draft cannot be parsed, so callers
+  // can roll back state they mutated alongside the models (see addModel).
+  // That is not a user-visible rejection path: every control that commits
+  // models sits inside the fieldset isSettingsConfigValid disables, so a
+  // keystroke cannot reach an unparseable draft.
   const commitModels = useCallback(
     (nextModels: PiModelDraft[]) => {
       if (!syncModelsToSettingsConfig(nextModels)) return false;
@@ -1055,11 +1062,6 @@ export function PiProviderForm({
     [updateSettingsConfig],
   );
 
-  const handleProviderKeyChange = useCallback((value: string) => {
-    const normalized = value.toLowerCase().replace(/[^a-z0-9-]/g, "");
-    setProviderKey(normalized);
-  }, []);
-
   const submit = async (identity: ProviderFormData) => {
     onSubmittingChange?.(true);
     setFormError(null);
@@ -1342,6 +1344,10 @@ export function PiProviderForm({
           </p>
         )}
 
+        {/* The JSON editor below stays outside this fieldset so an unparseable
+            draft remains repairable. Disabling everything else is what keeps
+            the structured controls and the draft from disagreeing: no field
+            can commit while updateSettingsConfig would reject the write. */}
         {hasConfigurationSelection && (
           <fieldset
             disabled={!isSettingsConfigValid}
@@ -1361,12 +1367,11 @@ export function PiProviderForm({
                         *
                       </span>
                     </Label>
-                    <Input
+                    <ImeSafeInput
                       id="pi-provider-key"
                       value={providerKey}
-                      onChange={(event) =>
-                        handleProviderKeyChange(event.target.value)
-                      }
+                      onValueChange={setProviderKey}
+                      normalize={normalizeProviderKey}
                       disabled={isEdit}
                       placeholder="my-provider"
                       autoComplete="off"
@@ -1564,11 +1569,11 @@ export function PiProviderForm({
                             />
                           </Button>
                           <div className="flex min-w-0 flex-1 gap-1">
-                            <Input
+                            <ImeSafeInput
                               id={`pi-model-id-${model.key}`}
                               value={model.id}
-                              onChange={(event) =>
-                                changeModelId(model.key, event.target.value)
+                              onValueChange={(next) =>
+                                changeModelId(model.key, next)
                               }
                               placeholder="model-id"
                               aria-label={t("pi.form.modelId")}
@@ -1582,12 +1587,12 @@ export function PiProviderForm({
                               />
                             )}
                           </div>
-                          <Input
+                          <ImeSafeInput
                             id={`pi-model-name-${model.key}`}
                             value={model.name}
-                            onChange={(event) =>
+                            onValueChange={(next) =>
                               updateModelOverride(model.key, {
-                                name: event.target.value,
+                                name: next,
                                 hasName: true,
                               })
                             }
@@ -1897,20 +1902,19 @@ export function PiProviderForm({
                                                     "pi.form.thinkingLevelMapTo",
                                                   )}
                                                 </label>
-                                                <Input
+                                                <ImeSafeInput
                                                   value={
                                                     typeof mappedValue ===
                                                     "string"
                                                       ? mappedValue
                                                       : level
                                                   }
-                                                  onChange={(event) =>
+                                                  onValueChange={(next) =>
                                                     updateThinkingLevelMap(
                                                       model.key,
                                                       (map) => ({
                                                         ...map,
-                                                        [level]:
-                                                          event.target.value,
+                                                        [level]: next,
                                                       }),
                                                     )
                                                   }

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -125,6 +125,7 @@ import {
   OPENCLAW_DEFAULT_CONFIG,
   normalizePricingSource,
 } from "./helpers/opencodeFormUtils";
+import { normalizeProviderKey } from "./helpers/providerKey";
 import { HERMES_DEFAULT_CONFIG } from "./hooks/useHermesFormState";
 import { resolveManagedAccountId } from "@/lib/authBinding";
 import { useOpenClawLiveProviderIds } from "@/hooks/useOpenClaw";
@@ -239,9 +240,6 @@ const normalizeCodexChatReasoningForSave = (
     outputFormat: value?.outputFormat ?? "auto",
   };
 };
-
-const normalizeProviderKey = (value: string) =>
-  value.toLowerCase().replace(/[^a-z0-9-]/g, "");
 
 type LocalProxyRequestOverridesBuildResult = ReturnType<
   typeof buildLocalProxyRequestOverrides

--- a/src/components/providers/forms/helpers/providerKey.ts
+++ b/src/components/providers/forms/helpers/providerKey.ts
@@ -1,0 +1,8 @@
+/**
+ * Provider keys are persisted as config object keys, so they are restricted to
+ * a lowercase slug charset. Shared by the OpenCode / OpenClaw / Hermes editors
+ * in ProviderForm and by the Pi editor.
+ */
+export function normalizeProviderKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9-]/g, "");
+}

--- a/src/components/ui/ime-safe-input.tsx
+++ b/src/components/ui/ime-safe-input.tsx
@@ -11,6 +11,13 @@ export interface ImeSafeInputProps
 /**
  * Keeps IME marked text local until composition finishes so parent renders
  * cannot overwrite the browser-managed composition range mid-input.
+ *
+ * The local draft is authoritative while the field is being edited, so the
+ * parent must store what it receives verbatim. Anything that rewrites the
+ * value belongs in `normalize`, which runs inside the commit. A transform
+ * applied in `onValueChange` instead leaves the draft showing text the parent
+ * never accepted, because an unchanged `value` prop cannot trigger the effect
+ * below; only the blur reconciliation would correct it.
  */
 const ImeSafeInput = React.forwardRef<HTMLInputElement, ImeSafeInputProps>(
   (

--- a/tests/components/ClaudeDesktopProviderForm.test.tsx
+++ b/tests/components/ClaudeDesktopProviderForm.test.tsx
@@ -265,6 +265,64 @@ describe("ClaudeDesktopProviderForm", () => {
     expect(document.activeElement).toBe(currentInput);
   });
 
+  // #6308: 菜单显示名是用户手输的中文，走输入法合成。合成期间任何父级回写都会
+  // 替换掉浏览器自己管理的候选区。#6333 为 Hermes / OpenClaw 的同类行做了修复，
+  // 这个编辑器此前仍是原生受控输入。
+  it("模型映射的菜单显示名在输入法提交前不写回路由状态", async () => {
+    const onSubmit = vi.fn();
+    renderForm(
+      {
+        name: "Proxy Provider",
+        settingsConfig: {
+          env: {
+            ANTHROPIC_BASE_URL: "https://api.example.com",
+            ANTHROPIC_AUTH_TOKEN: "sk-test",
+          },
+        },
+        meta: {
+          claudeDesktopMode: "proxy",
+          claudeDesktopModelRoutes: {
+            "claude-old": {
+              model: "upstream-old",
+            },
+          },
+        },
+      },
+      onSubmit,
+    );
+
+    const input = screen.getAllByPlaceholderText(
+      "DeepSeek V4 Pro",
+    )[0] as HTMLInputElement;
+    input.focus();
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: "深度求索" } });
+
+    // 候选文本留在本地草稿里，输入框既不被重建也不丢焦点。
+    expect(input).toHaveValue("深度求索");
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.compositionEnd(input, {
+      data: "深度求索 V4 Pro",
+      target: { value: "深度求索 V4 Pro" },
+    });
+
+    expect(screen.getAllByPlaceholderText("DeepSeek V4 Pro")[0]).toHaveValue(
+      "深度求索 V4 Pro",
+    );
+
+    // 显示值对不足以说明问题：原生受控输入没有 compositionend 处理器，界面上留着
+    // 合成后的文本，写进路由的却仍是合成中途那半截。所以要断言落库的值。
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    expect(
+      onSubmit.mock.calls[0][0].meta.claudeDesktopModelRoutes["claude-sonnet-5"]
+        .labelOverride,
+    ).toBe("深度求索 V4 Pro");
+  });
+
   it("代理模式始终渲染 Sonnet / Opus / Fable / Haiku 四档（即使只配了一档）", () => {
     renderForm({
       name: "Proxy Provider",

--- a/tests/components/ClaudeFormFields.test.tsx
+++ b/tests/components/ClaudeFormFields.test.tsx
@@ -103,11 +103,13 @@ const renderCopilotForm = (overrides: Partial<ClaudeFormFieldsProps> = {}) => {
     ...overrides,
   };
 
-  return render(
+  const view = render(
     <FormShell>
       <ClaudeFormFields {...props} />
     </FormShell>,
   );
+
+  return { ...view, props };
 };
 
 const renderCodexOauthForm = (overrides: Partial<ClaudeFormFieldsProps> = {}) =>
@@ -193,6 +195,40 @@ describe("ClaudeFormFields", () => {
     expect(onModelChange).toHaveBeenCalledWith(
       "CLAUDE_CODE_SUBAGENT_MODEL",
       "shared-model[1M]",
+    );
+  });
+
+  // #6308: the model display name is free-form text that CJK users type through
+  // an IME. #6333 fixed the equivalent Hermes / OpenClaw rows; this editor kept
+  // a raw controlled input, so a parent render mid-composition could replace the
+  // marked text the platform IME still owns.
+  it("keeps model display name composition local until the IME commits", () => {
+    const onModelChange = vi.fn();
+    const { props, rerender } = renderCopilotForm({ onModelChange });
+    const displayNameInput = screen.getByDisplayValue("Claude Sonnet");
+
+    fireEvent.compositionStart(displayNameInput);
+    fireEvent.change(displayNameInput, { target: { value: "深度求索 V4" } });
+
+    expect(displayNameInput).toHaveValue("深度求索 V4");
+    expect(onModelChange).not.toHaveBeenCalled();
+
+    rerender(
+      <FormShell>
+        <ClaudeFormFields {...props} />
+      </FormShell>,
+    );
+    expect(displayNameInput).toHaveValue("深度求索 V4");
+
+    fireEvent.compositionEnd(displayNameInput, {
+      data: "深度求索 V4",
+      target: { value: "深度求索 V4" },
+    });
+
+    expect(onModelChange).toHaveBeenCalledTimes(1);
+    expect(onModelChange).toHaveBeenCalledWith(
+      "ANTHROPIC_DEFAULT_SONNET_MODEL_NAME",
+      "深度求索 V4",
     );
   });
 });

--- a/tests/components/PiProviderForm.test.tsx
+++ b/tests/components/PiProviderForm.test.tsx
@@ -2276,4 +2276,39 @@ describe("PiProviderForm", () => {
       models: [{ id: "model" }],
     });
   });
+
+  // #6308: the provider key normalizes to [a-z0-9-] on every change. Running
+  // that on marked text erases the composition as it is typed, so the
+  // normalization has to wait for the IME to commit (same fix as the Hermes
+  // provider ID in #6333).
+  it("defers provider key normalization until the IME commits", () => {
+    render(
+      <PiProviderForm
+        appId="pi"
+        submitLabel="Save Pi provider"
+        onSubmit={vi.fn()}
+        onCancel={() => {}}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "providerPreset.custom" }),
+    );
+    const providerKeyInput = screen.getByPlaceholderText("my-provider");
+
+    fireEvent.compositionStart(providerKeyInput);
+    fireEvent.change(providerKeyInput, { target: { value: "深度求索" } });
+
+    // Normalizing mid-composition would strip every CJK character and leave the
+    // field empty while the candidate window is still open.
+    expect(providerKeyInput).toHaveValue("深度求索");
+
+    fireEvent.compositionEnd(providerKeyInput, {
+      data: "深度求索-Key",
+      target: { value: "深度求索-Key" },
+    });
+
+    // Normalization still applies once, to the committed value.
+    expect(providerKeyInput).toHaveValue("-key");
+  });
 });


### PR DESCRIPTION
## Summary / 概述

Extend the existing IME-safe input handling to the Claude, Pi, and Claude Desktop provider editors.

Some free-text fields in these editors still used raw controlled `<Input>` components. During IME composition, parent state updates could replace the browser-managed marked text before it was committed, resulting in duplicated, reordered, or lost characters.

This PR:

- replaces the affected free-text inputs with `ImeSafeInput`;
- defers Pi provider-key normalization until composition is committed;
- shares the existing provider-key normalization rule between provider editors;
- documents the `ImeSafeInput` normalization contract; and
- adds focused regression coverage for each affected editor.

## Related Issue / 关联 Issue

Related to #6308. Follow-up to #6333 and #6507.

## Validation / 验证

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit` - 131 test files and 990 tests passed
- Production build

## Screenshots / 截图

Not applicable. No visual changes.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 未修改 Rust 代码
- [x] Updated i18n files if user-facing text changed / 未修改用户可见文本
