### PR TITLE
fix(usage): preserve Claude streaming input token count

### DIFF
--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -126,6 +126,8 @@ impl TokenUsage {
         let mut model: Option<String> = None;
         let mut message_id: Option<String> = None;
         let mut start_input_tokens = 0u32;
+        let mut input_from_delta = false;
+        let mut corrected_usage_accepted = false;
 
         for event in events {
             if let Some(event_type) = event.get("type").and_then(|v| v.as_str()) {
@@ -209,12 +211,16 @@ impl TokenUsage {
                                         _ => fresh_plus_cache_read == Some(start_input_tokens),
                                     };
 
+                                let delta_only_input = start_input_tokens == 0
+                                    && input > 0
+                                    && (!input_from_delta || input <= usage.input_tokens);
                                 let should_use_delta_input =
-                                    (start_input_tokens == 0 && input > 0) || corrected_cache_tuple;
+                                    delta_only_input || corrected_cache_tuple;
 
                                 if should_use_delta_input {
                                     usage.input_tokens = input;
                                     if start_input_tokens == 0 {
+                                        input_from_delta = true;
                                         if let Some(cache_read) = delta_cache_read {
                                             usage.cache_read_tokens = cache_read;
                                         }
@@ -222,14 +228,16 @@ impl TokenUsage {
                                             usage.cache_creation_tokens = cache_creation;
                                         }
                                     } else {
+                                        corrected_usage_accepted = true;
                                         usage.cache_read_tokens = delta_cache_read.unwrap_or(0);
                                         usage.cache_creation_tokens =
                                             delta_cache_creation.unwrap_or(0);
                                     }
                                 }
                             }
-                            let allow_cache_fallback = delta_input.is_none()
-                                || (start_input_tokens == 0 && delta_input == Some(0));
+                            let allow_cache_fallback = !corrected_usage_accepted
+                                && (delta_input.is_none()
+                                    || (start_input_tokens == 0 && delta_input == Some(0)));
                             // 从 message_delta 中处理缓存命中(cache_read_input_tokens)
                             if allow_cache_fallback && usage.cache_read_tokens == 0 {
                                 if let Some(cache_read) = delta_cache_read {
@@ -1188,6 +1196,77 @@ mod tests {
         assert_eq!(usage.cache_read_tokens, 100);
         assert_eq!(usage.cache_creation_tokens, 0);
         assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_delta_only_rejects_larger_later_input() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "qwen-max",
+                    "usage": {"input_tokens": 0}
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 80,
+                    "output_tokens": 100,
+                    "cache_read_input_tokens": 120
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 200,
+                    "output_tokens": 1_000
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 80);
+        assert_eq!(usage.output_tokens, 1_000);
+        assert_eq!(usage.cache_read_tokens, 120);
+    }
+
+    #[test]
+    fn test_claude_stream_rejects_cache_only_delta_after_correction() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "qwen-max",
+                    "usage": {
+                        "input_tokens": 200,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 80,
+                    "output_tokens": 100,
+                    "cache_read_input_tokens": 120
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "output_tokens": 1_000,
+                    "cache_creation_input_tokens": 10
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 80);
+        assert_eq!(usage.output_tokens, 1_000);
+        assert_eq!(usage.cache_read_tokens, 120);
+        assert_eq!(usage.cache_creation_tokens, 0);
     }
 
     #[test]

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -192,11 +192,12 @@ impl TokenUsage {
                             if let Some(input) = delta_input {
                                 let has_delta_cache =
                                     delta_cache_read.is_some() || delta_cache_creation.is_some();
-                                let fresh_plus_cache_read = input
-                                    .checked_add(delta_cache_read.unwrap_or(0));
-                                let fresh_plus_all_cache = fresh_plus_cache_read.and_then(|total| {
-                                    total.checked_add(delta_cache_creation.unwrap_or(0))
-                                });
+                                let fresh_plus_cache_read =
+                                    input.checked_add(delta_cache_read.unwrap_or(0));
+                                let fresh_plus_all_cache =
+                                    fresh_plus_cache_read.and_then(|total| {
+                                        total.checked_add(delta_cache_creation.unwrap_or(0))
+                                    });
                                 let corrected_cache_tuple = has_delta_cache
                                     && input < usage.input_tokens
                                     && (fresh_plus_cache_read == Some(usage.input_tokens)

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -873,14 +873,14 @@ mod tests {
     #[test]
     fn test_claude_stream_prefers_coherent_corrected_delta_usage() {
         // 部分兼容 provider 会在 start 上报总输入，再在 delta 上报 fresh input + cache。
-        // 80_000 + 120_000 恰好还原 start 的 200_000，因此接受 delta 的修正 tuple。
+        // 80_000 + 120_000 + 500 恰好还原 start 的 200_500，因此接受 delta 的修正 tuple。
         let events = vec![
             json!({
                 "type": "message_start",
                 "message": {
                     "model": "qwen-max",
                     "usage": {
-                        "input_tokens": 200_000,
+                        "input_tokens": 200_500,
                         "cache_read_input_tokens": 180_000,
                         "cache_creation_input_tokens": 2_000
                     }
@@ -946,7 +946,7 @@ mod tests {
                 "message": {
                     "model": "qwen-max",
                     "usage": {
-                        "input_tokens": 200_000,
+                        "input_tokens": 200_500,
                         "cache_read_input_tokens": 180_000,
                         "cache_creation_input_tokens": 2_000
                     }

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -211,9 +211,12 @@ impl TokenUsage {
                                         _ => fresh_plus_cache_read == Some(start_input_tokens),
                                     };
 
+                                let delta_only_has_cache = delta_cache_read.unwrap_or(0) > 0
+                                    || delta_cache_creation.unwrap_or(0) > 0;
                                 let delta_only_input = start_input_tokens == 0
-                                    && input > 0
-                                    && (!input_from_delta || input <= usage.input_tokens);
+                                    && ((input > 0
+                                        && (!input_from_delta || input <= usage.input_tokens))
+                                        || (input == 0 && delta_only_has_cache));
                                 let should_use_delta_input =
                                     delta_only_input || corrected_cache_tuple;
 
@@ -1196,6 +1199,41 @@ mod tests {
         assert_eq!(usage.cache_read_tokens, 100);
         assert_eq!(usage.cache_creation_tokens, 0);
         assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_delta_only_accepts_final_zero_input_cache_correction() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "qwen-max",
+                    "usage": {"input_tokens": 0}
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 80,
+                    "output_tokens": 100,
+                    "cache_read_input_tokens": 120
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 1_000,
+                    "cache_read_input_tokens": 200
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 0);
+        assert_eq!(usage.output_tokens, 1_000);
+        assert_eq!(usage.cache_read_tokens, 200);
+        assert_eq!(usage.cache_creation_tokens, 0);
     }
 
     #[test]

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -210,7 +210,7 @@ impl TokenUsage {
                                     };
 
                                 let should_use_delta_input =
-                                    input > 0 && (start_input_tokens == 0 || corrected_cache_tuple);
+                                    (start_input_tokens == 0 && input > 0) || corrected_cache_tuple;
 
                                 if should_use_delta_input {
                                     usage.input_tokens = input;
@@ -1005,6 +1005,38 @@ mod tests {
         assert_eq!(usage.output_tokens, 1_000);
         assert_eq!(usage.cache_read_tokens, 120_000);
         assert_eq!(usage.cache_creation_tokens, 500);
+        assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_accepts_coherent_zero_input_correction() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "qwen-max",
+                    "usage": {
+                        "input_tokens": 200_000,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_input_tokens": 200_000
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 0);
+        assert_eq!(usage.output_tokens, 0);
+        assert_eq!(usage.cache_read_tokens, 200_000);
+        assert_eq!(usage.cache_creation_tokens, 0);
         assert_eq!(usage.model, Some("qwen-max".to_string()));
     }
 

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -184,13 +184,28 @@ impl TokenUsage {
                                 .and_then(|v| v.as_u64())
                                 .map(|v| v as u32);
 
-                            // 原生 Anthropic 语义下，非零 message_start input_tokens 是该请求的
-                            // 权威输入计数，不应仅因为后续 delta 值更小就被覆盖。
-                            // 仅当 start 未提供有效输入（0/缺失）时，才回退到 delta-only provider
-                            // 的 usage；一旦进入 delta 模式，后续 delta 仍可继续更新同一组计数。
+                            // 原生 Anthropic 语义下，非零 message_start input_tokens 通常是
+                            // 权威输入计数；但部分兼容 provider 会先在 start 上报总输入，
+                            // 再在 delta 上报 fresh input + cache 的修正 tuple。仅当 delta 的
+                            // cache tuple 能与 start 总输入自洽时才接受这种修正，避免把任意
+                            // 较小 delta（例如网关的不同统计口径）误当成 fresh input。
                             if let Some(input) = delta_input {
-                                let should_use_delta_input =
-                                    input > 0 && (usage.input_tokens == 0 || input_from_delta);
+                                let has_delta_cache =
+                                    delta_cache_read.is_some() || delta_cache_creation.is_some();
+                                let fresh_plus_cache_read = input
+                                    .checked_add(delta_cache_read.unwrap_or(0));
+                                let fresh_plus_all_cache = fresh_plus_cache_read.and_then(|total| {
+                                    total.checked_add(delta_cache_creation.unwrap_or(0))
+                                });
+                                let corrected_cache_tuple = has_delta_cache
+                                    && input < usage.input_tokens
+                                    && (fresh_plus_cache_read == Some(usage.input_tokens)
+                                        || fresh_plus_all_cache == Some(usage.input_tokens));
+
+                                let should_use_delta_input = input > 0
+                                    && (usage.input_tokens == 0
+                                        || input_from_delta
+                                        || corrected_cache_tuple);
 
                                 if should_use_delta_input {
                                     usage.input_tokens = input;
@@ -852,7 +867,9 @@ mod tests {
     }
 
     #[test]
-    fn test_claude_stream_keeps_nonzero_start_when_delta_input_is_smaller() {
+    fn test_claude_stream_prefers_coherent_corrected_delta_usage() {
+        // 部分兼容 provider 会在 start 上报总输入，再在 delta 上报 fresh input + cache。
+        // 80_000 + 120_000 恰好还原 start 的 200_000，因此接受 delta 的修正 tuple。
         let events = vec![
             json!({
                 "type": "message_start",
@@ -877,10 +894,10 @@ mod tests {
         ];
 
         let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
-        assert_eq!(usage.input_tokens, 200_000);
+        assert_eq!(usage.input_tokens, 80_000);
         assert_eq!(usage.output_tokens, 1_000);
-        assert_eq!(usage.cache_read_tokens, 180_000);
-        assert_eq!(usage.cache_creation_tokens, 2_000);
+        assert_eq!(usage.cache_read_tokens, 120_000);
+        assert_eq!(usage.cache_creation_tokens, 500);
         assert_eq!(usage.model, Some("qwen-max".to_string()));
     }
 

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -218,15 +218,17 @@ impl TokenUsage {
                                     usage.cache_creation_tokens = delta_cache_creation.unwrap_or(0);
                                 }
                             }
+                            let allow_cache_fallback = delta_input.is_none()
+                                || (start_input_tokens == 0 && delta_input == Some(0));
                             // 从 message_delta 中处理缓存命中(cache_read_input_tokens)
-                            if delta_input.unwrap_or(0) == 0 && usage.cache_read_tokens == 0 {
+                            if allow_cache_fallback && usage.cache_read_tokens == 0 {
                                 if let Some(cache_read) = delta_cache_read {
                                     usage.cache_read_tokens = cache_read;
                                 }
                             }
                             // 从 message_delta 中处理缓存创建(cache_creation_input_tokens)
                             // 注: 现在 zhipu 没有返回 cache_creation_input_tokens 字段
-                            if delta_input.unwrap_or(0) == 0 && usage.cache_creation_tokens == 0 {
+                            if allow_cache_fallback && usage.cache_creation_tokens == 0 {
                                 if let Some(cache_creation) = delta_cache_creation {
                                     usage.cache_creation_tokens = cache_creation;
                                 }
@@ -1006,6 +1008,38 @@ mod tests {
         assert_eq!(usage.cache_read_tokens, 120_000);
         assert_eq!(usage.cache_creation_tokens, 500);
         assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_rejects_incoherent_zero_input_cache_tuple() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {
+                        "input_tokens": 200_000,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_input_tokens": 100_000
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 200_000);
+        assert_eq!(usage.output_tokens, 0);
+        assert_eq!(usage.cache_read_tokens, 0);
+        assert_eq!(usage.cache_creation_tokens, 0);
+        assert_eq!(usage.model, Some("claude-sonnet-4-20250514".to_string()));
     }
 
     #[test]

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -219,14 +219,14 @@ impl TokenUsage {
                                 }
                             }
                             // 从 message_delta 中处理缓存命中(cache_read_input_tokens)
-                            if usage.cache_read_tokens == 0 {
+                            if start_input_tokens == 0 && usage.cache_read_tokens == 0 {
                                 if let Some(cache_read) = delta_cache_read {
                                     usage.cache_read_tokens = cache_read;
                                 }
                             }
                             // 从 message_delta 中处理缓存创建(cache_creation_input_tokens)
                             // 注: 现在 zhipu 没有返回 cache_creation_input_tokens 字段
-                            if usage.cache_creation_tokens == 0 {
+                            if start_input_tokens == 0 && usage.cache_creation_tokens == 0 {
                                 if let Some(cache_creation) = delta_cache_creation {
                                     usage.cache_creation_tokens = cache_creation;
                                 }
@@ -974,6 +974,38 @@ mod tests {
         assert_eq!(usage.cache_read_tokens, 120_000);
         assert_eq!(usage.cache_creation_tokens, 500);
         assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_rejected_delta_does_not_fill_start_cache() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "claude-sonnet-4-20250514",
+                    "usage": {
+                        "input_tokens": 200_000,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 80_000,
+                    "output_tokens": 1_000,
+                    "cache_read_input_tokens": 10_000
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 200_000);
+        assert_eq!(usage.output_tokens, 1_000);
+        assert_eq!(usage.cache_read_tokens, 0);
+        assert_eq!(usage.cache_creation_tokens, 0);
+        assert_eq!(usage.model, Some("claude-sonnet-4-20250514".to_string()));
     }
 
     #[test]

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -219,14 +219,14 @@ impl TokenUsage {
                                 }
                             }
                             // 从 message_delta 中处理缓存命中(cache_read_input_tokens)
-                            if start_input_tokens == 0 && usage.cache_read_tokens == 0 {
+                            if delta_input.is_none() && usage.cache_read_tokens == 0 {
                                 if let Some(cache_read) = delta_cache_read {
                                     usage.cache_read_tokens = cache_read;
                                 }
                             }
                             // 从 message_delta 中处理缓存创建(cache_creation_input_tokens)
                             // 注: 现在 zhipu 没有返回 cache_creation_input_tokens 字段
-                            if start_input_tokens == 0 && usage.cache_creation_tokens == 0 {
+                            if delta_input.is_none() && usage.cache_creation_tokens == 0 {
                                 if let Some(cache_creation) = delta_cache_creation {
                                     usage.cache_creation_tokens = cache_creation;
                                 }
@@ -970,6 +970,38 @@ mod tests {
 
         let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
         assert_eq!(usage.input_tokens, 80_000);
+        assert_eq!(usage.output_tokens, 1_000);
+        assert_eq!(usage.cache_read_tokens, 120_000);
+        assert_eq!(usage.cache_creation_tokens, 500);
+        assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_accepts_cache_only_delta_with_nonzero_start_input() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "qwen-max",
+                    "usage": {
+                        "input_tokens": 200_000,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "output_tokens": 1_000,
+                    "cache_read_input_tokens": 120_000,
+                    "cache_creation_input_tokens": 500
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 200_000);
         assert_eq!(usage.output_tokens, 1_000);
         assert_eq!(usage.cache_read_tokens, 120_000);
         assert_eq!(usage.cache_creation_tokens, 500);

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -202,8 +202,12 @@ impl TokenUsage {
                                 let corrected_cache_tuple = has_delta_cache
                                     && start_input_tokens > 0
                                     && input < start_input_tokens
-                                    && (fresh_plus_cache_read == Some(start_input_tokens)
-                                        || fresh_plus_all_cache == Some(start_input_tokens));
+                                    && match delta_cache_creation {
+                                        Some(cache_creation) if cache_creation > 0 => {
+                                            fresh_plus_all_cache == Some(start_input_tokens)
+                                        }
+                                        _ => fresh_plus_cache_read == Some(start_input_tokens),
+                                    };
 
                                 let should_use_delta_input =
                                     input > 0 && (start_input_tokens == 0 || corrected_cache_tuple);
@@ -898,6 +902,39 @@ mod tests {
         assert_eq!(usage.output_tokens, 1_000);
         assert_eq!(usage.cache_read_tokens, 120_000);
         assert_eq!(usage.cache_creation_tokens, 500);
+        assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_rejects_overfull_tuple_with_cache_creation() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "qwen-max",
+                    "usage": {
+                        "input_tokens": 200_000,
+                        "cache_read_input_tokens": 180_000,
+                        "cache_creation_input_tokens": 2_000
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 80_000,
+                    "output_tokens": 1_000,
+                    "cache_read_input_tokens": 120_000,
+                    "cache_creation_input_tokens": 10_000
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 200_000);
+        assert_eq!(usage.output_tokens, 1_000);
+        assert_eq!(usage.cache_read_tokens, 180_000);
+        assert_eq!(usage.cache_creation_tokens, 2_000);
         assert_eq!(usage.model, Some("qwen-max".to_string()));
     }
 

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -125,7 +125,7 @@ impl TokenUsage {
         let mut usage = Self::default();
         let mut model: Option<String> = None;
         let mut message_id: Option<String> = None;
-        let mut input_from_delta = false;
+        let mut start_input_tokens = 0u32;
 
         for event in events {
             if let Some(event_type) = event.get("type").and_then(|v| v.as_str()) {
@@ -149,6 +149,7 @@ impl TokenUsage {
                                 msg_usage.get("input_tokens").and_then(|v| v.as_u64())
                             {
                                 usage.input_tokens = input as u32;
+                                start_input_tokens = input as u32;
                             }
                             usage.cache_read_tokens = msg_usage
                                 .get("cache_read_input_tokens")
@@ -199,18 +200,16 @@ impl TokenUsage {
                                         total.checked_add(delta_cache_creation.unwrap_or(0))
                                     });
                                 let corrected_cache_tuple = has_delta_cache
-                                    && input < usage.input_tokens
-                                    && (fresh_plus_cache_read == Some(usage.input_tokens)
-                                        || fresh_plus_all_cache == Some(usage.input_tokens));
+                                    && start_input_tokens > 0
+                                    && input < start_input_tokens
+                                    && (fresh_plus_cache_read == Some(start_input_tokens)
+                                        || fresh_plus_all_cache == Some(start_input_tokens));
 
-                                let should_use_delta_input = input > 0
-                                    && (usage.input_tokens == 0
-                                        || input_from_delta
-                                        || corrected_cache_tuple);
+                                let should_use_delta_input =
+                                    input > 0 && (start_input_tokens == 0 || corrected_cache_tuple);
 
                                 if should_use_delta_input {
                                     usage.input_tokens = input;
-                                    input_from_delta = true;
                                     if let Some(cache_read) = delta_cache_read {
                                         usage.cache_read_tokens = cache_read;
                                     }
@@ -887,6 +886,48 @@ mod tests {
                 "type": "message_delta",
                 "usage": {
                     "input_tokens": 80_000,
+                    "output_tokens": 1_000,
+                    "cache_read_input_tokens": 120_000,
+                    "cache_creation_input_tokens": 500
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 80_000);
+        assert_eq!(usage.output_tokens, 1_000);
+        assert_eq!(usage.cache_read_tokens, 120_000);
+        assert_eq!(usage.cache_creation_tokens, 500);
+        assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_rejects_incoherent_later_delta_after_correction() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "qwen-max",
+                    "usage": {
+                        "input_tokens": 200_000,
+                        "cache_read_input_tokens": 180_000,
+                        "cache_creation_input_tokens": 2_000
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 80_000,
+                    "output_tokens": 100,
+                    "cache_read_input_tokens": 120_000,
+                    "cache_creation_input_tokens": 500
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 200_000,
                     "output_tokens": 1_000,
                     "cache_read_input_tokens": 120_000,
                     "cache_creation_input_tokens": 500

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -214,12 +214,8 @@ impl TokenUsage {
 
                                 if should_use_delta_input {
                                     usage.input_tokens = input;
-                                    if let Some(cache_read) = delta_cache_read {
-                                        usage.cache_read_tokens = cache_read;
-                                    }
-                                    if let Some(cache_creation) = delta_cache_creation {
-                                        usage.cache_creation_tokens = cache_creation;
-                                    }
+                                    usage.cache_read_tokens = delta_cache_read.unwrap_or(0);
+                                    usage.cache_creation_tokens = delta_cache_creation.unwrap_or(0);
                                 }
                             }
                             // 从 message_delta 中处理缓存命中(cache_read_input_tokens)
@@ -977,6 +973,47 @@ mod tests {
         assert_eq!(usage.output_tokens, 1_000);
         assert_eq!(usage.cache_read_tokens, 120_000);
         assert_eq!(usage.cache_creation_tokens, 500);
+        assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_clears_omitted_cache_bucket_on_later_correction() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "qwen-max",
+                    "usage": {
+                        "input_tokens": 200,
+                        "cache_read_input_tokens": 150,
+                        "cache_creation_input_tokens": 10
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 80,
+                    "output_tokens": 100,
+                    "cache_read_input_tokens": 119,
+                    "cache_creation_input_tokens": 1
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 1_000,
+                    "cache_read_input_tokens": 100
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 100);
+        assert_eq!(usage.output_tokens, 1_000);
+        assert_eq!(usage.cache_read_tokens, 100);
+        assert_eq!(usage.cache_creation_tokens, 0);
         assert_eq!(usage.model, Some("qwen-max".to_string()));
     }
 

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -214,8 +214,18 @@ impl TokenUsage {
 
                                 if should_use_delta_input {
                                     usage.input_tokens = input;
-                                    usage.cache_read_tokens = delta_cache_read.unwrap_or(0);
-                                    usage.cache_creation_tokens = delta_cache_creation.unwrap_or(0);
+                                    if start_input_tokens == 0 {
+                                        if let Some(cache_read) = delta_cache_read {
+                                            usage.cache_read_tokens = cache_read;
+                                        }
+                                        if let Some(cache_creation) = delta_cache_creation {
+                                            usage.cache_creation_tokens = cache_creation;
+                                        }
+                                    } else {
+                                        usage.cache_read_tokens = delta_cache_read.unwrap_or(0);
+                                        usage.cache_creation_tokens =
+                                            delta_cache_creation.unwrap_or(0);
+                                    }
                                 }
                             }
                             let allow_cache_fallback = delta_input.is_none()
@@ -1176,6 +1186,45 @@ mod tests {
         assert_eq!(usage.input_tokens, 100);
         assert_eq!(usage.output_tokens, 1_000);
         assert_eq!(usage.cache_read_tokens, 100);
+        assert_eq!(usage.cache_creation_tokens, 0);
+        assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_delta_only_preserves_omitted_cache_bucket() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "qwen-max",
+                    "usage": {
+                        "input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 90_000,
+                    "output_tokens": 100,
+                    "cache_read_input_tokens": 110_000
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 80_000,
+                    "output_tokens": 1_000
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 80_000);
+        assert_eq!(usage.output_tokens, 1_000);
+        assert_eq!(usage.cache_read_tokens, 110_000);
         assert_eq!(usage.cache_creation_tokens, 0);
         assert_eq!(usage.model, Some("qwen-max".to_string()));
     }

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -219,14 +219,14 @@ impl TokenUsage {
                                 }
                             }
                             // 从 message_delta 中处理缓存命中(cache_read_input_tokens)
-                            if delta_input.is_none() && usage.cache_read_tokens == 0 {
+                            if delta_input.unwrap_or(0) == 0 && usage.cache_read_tokens == 0 {
                                 if let Some(cache_read) = delta_cache_read {
                                     usage.cache_read_tokens = cache_read;
                                 }
                             }
                             // 从 message_delta 中处理缓存创建(cache_creation_input_tokens)
                             // 注: 现在 zhipu 没有返回 cache_creation_input_tokens 字段
-                            if delta_input.is_none() && usage.cache_creation_tokens == 0 {
+                            if delta_input.unwrap_or(0) == 0 && usage.cache_creation_tokens == 0 {
                                 if let Some(cache_creation) = delta_cache_creation {
                                     usage.cache_creation_tokens = cache_creation;
                                 }
@@ -1003,6 +1003,39 @@ mod tests {
         let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
         assert_eq!(usage.input_tokens, 200_000);
         assert_eq!(usage.output_tokens, 1_000);
+        assert_eq!(usage.cache_read_tokens, 120_000);
+        assert_eq!(usage.cache_creation_tokens, 500);
+        assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_accepts_zero_input_cache_only_delta() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "model": "qwen-max",
+                    "usage": {
+                        "input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_input_tokens": 120_000,
+                    "cache_creation_input_tokens": 500
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 0);
+        assert_eq!(usage.output_tokens, 0);
         assert_eq!(usage.cache_read_tokens, 120_000);
         assert_eq!(usage.cache_creation_tokens, 500);
         assert_eq!(usage.model, Some("qwen-max".to_string()));

--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -184,15 +184,13 @@ impl TokenUsage {
                                 .and_then(|v| v.as_u64())
                                 .map(|v| v as u32);
 
-                            // 部分 Anthropic-compatible SSE provider 会在 message_start 上报完整上下文，
-                            // 但在 message_delta 上报修正后的 fresh input。遇到更小的正数 delta input
-                            // 时采用 delta；若同一 usage 块带有缓存计数，也同步采用以避免重复计数。
-                            // 若 delta 缺少缓存字段，则保留 start 中已有的缓存值作为 best-effort fallback。
+                            // 原生 Anthropic 语义下，非零 message_start input_tokens 是该请求的
+                            // 权威输入计数，不应仅因为后续 delta 值更小就被覆盖。
+                            // 仅当 start 未提供有效输入（0/缺失）时，才回退到 delta-only provider
+                            // 的 usage；一旦进入 delta 模式，后续 delta 仍可继续更新同一组计数。
                             if let Some(input) = delta_input {
-                                let should_use_delta_input = input > 0
-                                    && (usage.input_tokens == 0
-                                        || input < usage.input_tokens
-                                        || (input_from_delta && input <= usage.input_tokens));
+                                let should_use_delta_input =
+                                    input > 0 && (usage.input_tokens == 0 || input_from_delta);
 
                                 if should_use_delta_input {
                                     usage.input_tokens = input;
@@ -854,9 +852,7 @@ mod tests {
     }
 
     #[test]
-    fn test_claude_stream_prefers_smaller_delta_input_and_cache_pair() {
-        // 部分 Anthropic-compatible provider 会在 message_start 给出包含缓存的总上下文，
-        // 再在 message_delta 给出修正后的 fresh input，需要以 delta usage 为准。
+    fn test_claude_stream_keeps_nonzero_start_when_delta_input_is_smaller() {
         let events = vec![
             json!({
                 "type": "message_start",
@@ -881,33 +877,31 @@ mod tests {
         ];
 
         let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
-        assert_eq!(usage.input_tokens, 80_000);
+        assert_eq!(usage.input_tokens, 200_000);
         assert_eq!(usage.output_tokens, 1_000);
-        assert_eq!(usage.cache_read_tokens, 120_000);
-        assert_eq!(usage.cache_creation_tokens, 500);
+        assert_eq!(usage.cache_read_tokens, 180_000);
+        assert_eq!(usage.cache_creation_tokens, 2_000);
         assert_eq!(usage.model, Some("qwen-max".to_string()));
     }
 
     #[test]
-    fn test_claude_stream_updates_cache_pair_from_later_delta_input() {
-        // 有些 provider 会多次发送带 input 的 message_delta；一旦采用过 delta input，
-        // 后续相同/更小 input 的 delta 应继续更新同一块里的缓存计数。
+    fn test_claude_stream_updates_delta_only_usage_from_later_delta() {
         let events = vec![
             json!({
                 "type": "message_start",
                 "message": {
                     "model": "qwen-max",
                     "usage": {
-                        "input_tokens": 200_000,
-                        "cache_read_input_tokens": 180_000,
-                        "cache_creation_input_tokens": 2_000
+                        "input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                        "cache_creation_input_tokens": 0
                     }
                 }
             }),
             json!({
                 "type": "message_delta",
                 "usage": {
-                    "input_tokens": 80_000,
+                    "input_tokens": 90_000,
                     "output_tokens": 100,
                     "cache_read_input_tokens": 110_000,
                     "cache_creation_input_tokens": 300
@@ -930,6 +924,34 @@ mod tests {
         assert_eq!(usage.cache_read_tokens, 120_000);
         assert_eq!(usage.cache_creation_tokens, 500);
         assert_eq!(usage.model, Some("qwen-max".to_string()));
+    }
+
+    #[test]
+    fn test_claude_stream_preserves_start_usage_for_reported_regression() {
+        let events = vec![
+            json!({
+                "type": "message_start",
+                "message": {
+                    "usage": {
+                        "input_tokens": 233_535,
+                        "cache_read_input_tokens": 10_240
+                    }
+                }
+            }),
+            json!({
+                "type": "message_delta",
+                "usage": {
+                    "input_tokens": 89_828,
+                    "output_tokens": 176,
+                    "cache_read_input_tokens": 10_240
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_claude_stream_events(&events).unwrap();
+        assert_eq!(usage.input_tokens, 233_535);
+        assert_eq!(usage.output_tokens, 176);
+        assert_eq!(usage.cache_read_tokens, 10_240);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

Claude streaming usage parsing could replace a valid non-zero `message_start.usage.input_tokens` value with a smaller positive `message_delta.usage.input_tokens` value, causing input tokens to be undercounted for some Claude Code requests.

This change preserves the non-zero `message_start` value unless a later delta clearly forms a coherent corrected usage tuple (fresh input plus cache counts that reconcile with the start total). Delta-only providers remain supported, and regression coverage includes both the reported `233,535` vs `89,828` case and the existing corrected-cache tuple behavior.

## Related Issue / 关联 Issue

Fixes #6649

## Screenshots / 截图

N/A

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件