### PR TITLE
fix(proxy): correct Codex stream latency metrics

### DIFF
--- a/src-tauri/src/database/dao/usage_rollup.rs
+++ b/src-tauri/src/database/dao/usage_rollup.rs
@@ -4,7 +4,9 @@
 
 use crate::database::{lock_conn, Database};
 use crate::error::AppError;
-use crate::services::sql_helpers::{fresh_input_sql, INPUT_TOKEN_SEMANTICS_FRESH};
+use crate::services::sql_helpers::{
+    fresh_input_sql, perceived_latency_sql, INPUT_TOKEN_SEMANTICS_FRESH,
+};
 use crate::services::usage_stats::effective_usage_log_filter;
 use chrono::{Duration, Local, TimeZone};
 
@@ -118,6 +120,7 @@ impl Database {
         let effective_filter = effective_usage_log_filter("l");
         let fresh_detail_input = fresh_input_sql("l");
         let fresh_old_input = fresh_input_sql("old");
+        let detail_latency = perceived_latency_sql("l");
         // request_model 维度保留路由接管的「客户端别名 → 真实模型」映射，
         // pricing_model 维度保留写入时的计价基准（request 计价模式下与 model 分叉）；
         // 明细行的这两列可能为 NULL（历史/手工数据），归一为 ''。
@@ -156,7 +159,7 @@ impl Database {
                     COALESCE(SUM(l.cache_read_tokens), 0) as new_cr,
                     COALESCE(SUM(l.cache_creation_tokens), 0) as new_cc,
                     COALESCE(SUM(CAST(l.total_cost_usd AS REAL)), 0) as new_cost,
-                    COALESCE(AVG(l.latency_ms), 0) as new_lat
+                    COALESCE(AVG({detail_latency}), 0) as new_lat
                 FROM proxy_request_logs l
                 WHERE l.created_at < ?1 AND {effective_filter}
                 GROUP BY d, a, p, m, rm, pm
@@ -340,6 +343,47 @@ mod tests {
                 row.get(0)
             })?;
         assert_eq!(remaining, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rollup_uses_first_token_latency_for_streaming_requests() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let old_ts = chrono::Utc::now().timestamp() - 40 * 86400;
+
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model,
+                    latency_ms, first_token_ms, is_streaming,
+                    status_code, created_at
+                ) VALUES ('stream-latency', 'p1', 'codex', 'gpt-5.6-sol',
+                          60000, 1000, 1, 200, ?1)",
+                [old_ts],
+            )?;
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model,
+                    latency_ms, first_token_ms, is_streaming,
+                    status_code, created_at
+                ) VALUES ('non-stream-latency', 'p1', 'codex', 'gpt-5.6-sol',
+                          2000, 500, 0, 200, ?1)",
+                [old_ts + 1],
+            )?;
+        }
+
+        assert_eq!(db.rollup_and_prune(30)?, 2);
+
+        let conn = crate::database::lock_conn!(db.conn);
+        let avg_latency: f64 = conn.query_row(
+            "SELECT avg_latency_ms FROM usage_daily_rollups
+             WHERE provider_id = 'p1' AND model = 'gpt-5.6-sol'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(avg_latency, 1500.0);
 
         Ok(())
     }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1640,8 +1640,14 @@ impl RequestForwarder {
             &filtered_body,
             self.session_client_provided,
         );
-        let request_is_streaming =
-            is_streaming_request(&effective_endpoint, &filtered_body, headers);
+        let codex_oauth_responses_forces_sse = provider.is_codex_oauth()
+            && split_endpoint_and_query(&effective_endpoint).0 == "/responses";
+        let request_is_streaming = is_streaming_request_for_upstream(
+            &effective_endpoint,
+            &filtered_body,
+            headers,
+            codex_oauth_responses_forces_sse,
+        );
         let force_identity_encoding = needs_transform
             || codex_responses_to_chat
             || codex_responses_to_anthropic
@@ -3387,6 +3393,15 @@ fn is_streaming_request(endpoint: &str, body: &Value, headers: &axum::http::Head
         .unwrap_or(false)
 }
 
+fn is_streaming_request_for_upstream(
+    endpoint: &str,
+    body: &Value,
+    headers: &axum::http::HeaderMap,
+    codex_oauth_responses_forces_sse: bool,
+) -> bool {
+    codex_oauth_responses_forces_sse || is_streaming_request(endpoint, body, headers)
+}
+
 #[cfg(test)]
 fn should_force_identity_encoding(
     endpoint: &str,
@@ -4784,6 +4799,30 @@ mod tests {
             "/v1/responses",
             &json!({ "model": "gpt-5" }),
             &headers
+        ));
+    }
+
+    #[test]
+    fn codex_oauth_responses_are_streaming_without_client_stream_hints() {
+        let headers = HeaderMap::new();
+
+        assert!(is_streaming_request_for_upstream(
+            "/responses",
+            &json!({ "model": "gpt-5.6-sol" }),
+            &headers,
+            true,
+        ));
+    }
+
+    #[test]
+    fn regular_responses_without_stream_hints_remain_non_streaming() {
+        let headers = HeaderMap::new();
+
+        assert!(!is_streaming_request_for_upstream(
+            "/responses",
+            &json!({ "model": "gpt-5.6-sol" }),
+            &headers,
+            false,
         ));
     }
 

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -36,8 +36,9 @@ use super::{
     },
     response_processor::{
         create_logged_passthrough_stream, create_usage_collector, process_response,
-        read_decoded_body, strip_entity_headers_for_rebuilt_body,
-        strip_hop_by_hop_response_headers, usage_logging_enabled, SseUsageCollector,
+        process_response_with_stream_hint, read_decoded_body,
+        strip_entity_headers_for_rebuilt_body, strip_hop_by_hop_response_headers,
+        usage_logging_enabled, SseUsageCollector,
     },
     server::ProxyState,
     sse::{strip_sse_field, take_sse_block},
@@ -950,12 +951,14 @@ async fn handle_responses_for_app(
         .await;
     }
 
-    process_response(
+    let expected_sse = is_stream || ctx.provider.is_codex_oauth();
+    process_response_with_stream_hint(
         response,
         &ctx,
         &state,
         &CODEX_PARSER_CONFIG,
         connection_guard,
+        expected_sse,
     )
     .await
 }

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -147,6 +147,10 @@ pub fn is_sse_response(response: &ProxyResponse) -> bool {
     response.is_sse()
 }
 
+fn should_handle_as_streaming(response: &ProxyResponse, expected_sse: bool) -> bool {
+    is_sse_response(response) || (expected_sse && !response.is_json())
+}
+
 /// 处理流式响应
 pub async fn handle_streaming(
     response: ProxyResponse,
@@ -173,6 +177,12 @@ pub async fn handle_streaming(
 
     let mut response_headers = response.headers().clone();
     strip_hop_by_hop_response_headers(&mut response_headers);
+    // A protocol hint can recover SSE handling when a compatible upstream
+    // omits or mislabels Content-Type. Normalize the downstream contract too.
+    response_headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("text/event-stream"),
+    );
 
     let mut builder = axum::response::Response::builder().status(status);
 
@@ -330,7 +340,21 @@ pub async fn process_response(
     parser_config: &UsageParserConfig,
     connection_guard: Option<ActiveConnectionGuard>,
 ) -> Result<Response, ProxyError> {
-    if is_sse_response(&response) {
+    process_response_with_stream_hint(response, ctx, state, parser_config, connection_guard, false)
+        .await
+}
+
+/// Process a response whose protocol is known to be streaming even when a
+/// compatible upstream omits the SSE content type.
+pub async fn process_response_with_stream_hint(
+    response: ProxyResponse,
+    ctx: &RequestContext,
+    state: &ProxyState,
+    parser_config: &UsageParserConfig,
+    connection_guard: Option<ActiveConnectionGuard>,
+    expected_sse: bool,
+) -> Result<Response, ProxyError> {
+    if should_handle_as_streaming(&response, expected_sse) {
         Ok(handle_streaming(response, ctx, state, parser_config, connection_guard).await)
     } else {
         handle_non_streaming(response, ctx, state, parser_config, connection_guard).await
@@ -387,8 +411,10 @@ impl SseUsageCollector {
             .unwrap_or(true)
     }
 
-    /// 标记首个被收集的 SSE 事件时间，沿用 `first_token_ms` 的既有近似语义。
-    async fn mark_first_collected_event_time(&self) {
+    /// Observe an SSE data event independently of whether its payload is kept
+    /// for usage parsing. `first_token_ms` retains its existing approximate
+    /// semantics: time to the first usable SSE event.
+    pub async fn observe_stream_event(&self) {
         if self.inner.first_event_set.load(Ordering::Acquire) {
             return;
         }
@@ -401,7 +427,6 @@ impl SseUsageCollector {
 
     /// 推送 SSE 事件
     pub async fn push(&self, event: Value) {
-        self.mark_first_collected_event_time().await;
         let mut events = self.inner.events.lock().await;
         events.push(event);
     }
@@ -755,6 +780,9 @@ pub fn create_logged_passthrough_stream(
                                 for line in event_text.lines() {
                                     if let Some(data) = strip_sse_field(line, "data") {
                                         if data.trim() != "[DONE]" {
+                                            if let Some(c) = &collector {
+                                                c.observe_stream_event().await;
+                                            }
                                             let collected = match &collector {
                                                 Some(c) if c.should_collect(data) => {
                                                     match serde_json::from_str::<Value>(data) {
@@ -887,6 +915,63 @@ mod tests {
         assert!(formatted.contains("cf-ray=abc123-SJC"), "{formatted}");
         assert!(!formatted.contains("super-secret"), "{formatted}");
         assert!(!formatted.contains("cookie-secret"), "{formatted}");
+    }
+
+    #[test]
+    fn expected_sse_recovers_streaming_when_content_type_is_missing() {
+        let response = ProxyResponse::buffered(
+            http::StatusCode::OK,
+            HeaderMap::new(),
+            Bytes::from_static(b"data: {}\n\n"),
+        );
+
+        assert!(should_handle_as_streaming(&response, true));
+    }
+
+    #[test]
+    fn expected_sse_does_not_override_explicit_json() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+        let response = ProxyResponse::buffered(
+            http::StatusCode::OK,
+            headers,
+            Bytes::from_static(br#"{"ok":true}"#),
+        );
+
+        assert!(!should_handle_as_streaming(&response, true));
+    }
+
+    #[test]
+    fn missing_content_type_without_stream_hint_remains_non_streaming() {
+        let response = ProxyResponse::buffered(
+            http::StatusCode::OK,
+            HeaderMap::new(),
+            Bytes::from_static(b"opaque response"),
+        );
+
+        assert!(!should_handle_as_streaming(&response, false));
+    }
+
+    #[tokio::test]
+    async fn first_token_timing_is_not_delayed_until_usage_event() {
+        let start_time = std::time::Instant::now();
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let captured_for_callback = captured.clone();
+        let collector = SseUsageCollector::new(start_time, None, move |_, first_token_ms| {
+            *captured_for_callback.lock().unwrap() = first_token_ms;
+        });
+
+        collector.observe_stream_event().await;
+        let observed_by_ms = start_time.elapsed().as_millis() as u64;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        collector.push(serde_json::json!({"usage": {}})).await;
+        collector.finish().await;
+
+        let first_token_ms = captured.lock().unwrap().expect("first event timing");
+        assert!(
+            first_token_ms <= observed_by_ms + 5,
+            "first event timing {first_token_ms}ms should precede delayed usage; observation completed by {observed_by_ms}ms"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -902,21 +902,144 @@ fn is_productive_sse_data(data: &str) -> bool {
         // Preserve the historical behavior for non-JSON SSE protocols.
         return true;
     };
-    let Some(event_type) = event.get("type").and_then(Value::as_str) else {
-        // OpenAI Chat Completions and several compatible protocols do not use
-        // Responses-style event names. Keep their existing timing semantics.
-        return true;
-    };
-    if !event_type.starts_with("response.") {
-        return true;
+
+    if let Some(event_type) = event.get("type").and_then(Value::as_str) {
+        if event_type.starts_with("response.") {
+            return responses_event_is_productive(&event, event_type);
+        }
+        if matches!(
+            event_type,
+            "message_start"
+                | "message_delta"
+                | "message_stop"
+                | "content_block_start"
+                | "content_block_delta"
+                | "content_block_stop"
+                | "ping"
+        ) {
+            return anthropic_event_is_productive(&event, event_type);
+        }
     }
+
+    if event.get("choices").is_some() {
+        return openai_chat_event_is_productive(&event);
+    }
+    if event.get("candidates").is_some() {
+        return gemini_event_is_productive(&event);
+    }
+
+    // Unknown compatible JSON protocols retain the previous first-event
+    // behavior instead of being silently excluded from TTFT statistics.
+    true
+}
+
+fn responses_event_is_productive(event: &Value, event_type: &str) -> bool {
     if !event_type.ends_with(".delta") {
         return false;
     }
     match event.get("delta") {
         Some(Value::String(delta)) => !delta.is_empty(),
         Some(Value::Null) | None => false,
-        Some(_) => true,
+        Some(delta) => json_value_has_content(delta),
+    }
+}
+
+fn anthropic_event_is_productive(event: &Value, event_type: &str) -> bool {
+    match event_type {
+        "content_block_delta" => event.get("delta").is_some_and(|delta| {
+            ["text", "thinking", "partial_json"]
+                .into_iter()
+                .any(|key| value_has_nonempty_string(delta.get(key)))
+        }),
+        // Standard Anthropic streams send empty block starts. A few compatible
+        // gateways inline complete text, reasoning, or tool input here and emit
+        // no following delta, so count only starts that carry real output.
+        "content_block_start" => event.get("content_block").is_some_and(|block| {
+            ["text", "thinking", "data"]
+                .into_iter()
+                .any(|key| value_has_nonempty_string(block.get(key)))
+                || block.get("input").is_some_and(json_value_has_content)
+        }),
+        _ => false,
+    }
+}
+
+fn openai_chat_event_is_productive(event: &Value) -> bool {
+    event
+        .get("choices")
+        .and_then(Value::as_array)
+        .is_some_and(|choices| {
+            choices.iter().any(|choice| {
+                let Some(delta) = choice.get("delta") else {
+                    return false;
+                };
+                ["content", "reasoning", "reasoning_content", "refusal"]
+                    .into_iter()
+                    .any(|key| delta.get(key).is_some_and(json_value_has_content))
+                    || delta
+                        .get("function_call")
+                        .is_some_and(openai_function_delta_has_content)
+                    || delta
+                        .get("tool_calls")
+                        .and_then(Value::as_array)
+                        .is_some_and(|tool_calls| {
+                            tool_calls.iter().any(|tool_call| {
+                                tool_call
+                                    .get("function")
+                                    .is_some_and(openai_function_delta_has_content)
+                            })
+                        })
+                    || delta.get("audio").is_some_and(json_value_has_content)
+            })
+        })
+}
+
+fn openai_function_delta_has_content(function: &Value) -> bool {
+    ["name", "arguments"]
+        .into_iter()
+        .any(|key| value_has_nonempty_string(function.get(key)))
+}
+
+fn gemini_event_is_productive(event: &Value) -> bool {
+    event
+        .get("candidates")
+        .and_then(Value::as_array)
+        .is_some_and(|candidates| {
+            candidates.iter().any(|candidate| {
+                candidate
+                    .get("content")
+                    .and_then(|content| content.get("parts"))
+                    .and_then(Value::as_array)
+                    .is_some_and(|parts| {
+                        parts.iter().any(|part| {
+                            value_has_nonempty_string(part.get("text"))
+                                || part.get("functionCall").is_some_and(json_value_has_content)
+                                || part.get("inlineData").is_some_and(json_value_has_content)
+                                || part
+                                    .get("executableCode")
+                                    .is_some_and(json_value_has_content)
+                                || part
+                                    .get("codeExecutionResult")
+                                    .is_some_and(json_value_has_content)
+                        })
+                    })
+            })
+        })
+}
+
+fn value_has_nonempty_string(value: Option<&Value>) -> bool {
+    value
+        .and_then(Value::as_str)
+        .is_some_and(|text| !text.is_empty())
+}
+
+fn json_value_has_content(value: &Value) -> bool {
+    match value {
+        Value::Null => false,
+        Value::Bool(_) | Value::Number(_) => true,
+        Value::String(text) => !text.is_empty(),
+        Value::Array(values) => values.iter().any(json_value_has_content),
+        Value::Object(values) => !values.is_empty() && values.values().any(json_value_has_content),
     }
 }
 
@@ -1128,6 +1251,90 @@ mod tests {
             first_token_ms >= 40,
             "lifecycle metadata started the first-token timer at {first_token_ms}ms"
         );
+    }
+
+    #[tokio::test]
+    async fn claude_lifecycle_events_do_not_start_first_token_timer() {
+        let start_time = std::time::Instant::now();
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let captured_for_callback = captured.clone();
+        let collector = SseUsageCollector::new(start_time, None, move |_, first_token_ms| {
+            *captured_for_callback.lock().unwrap() = first_token_ms;
+        });
+        let upstream = async_stream::stream! {
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10}}}\n\n",
+            ));
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"event: content_block_start\ndata: {\"type\":\"content_block_start\",\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+            ));
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n\n",
+            ));
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n",
+            ));
+        };
+        let output = create_logged_passthrough_stream(
+            upstream,
+            "test",
+            Some(collector),
+            StreamingTimeoutConfig {
+                first_byte_timeout: 0,
+                idle_timeout: 0,
+            },
+            None,
+        );
+        tokio::pin!(output);
+        while let Some(chunk) = output.next().await {
+            chunk.unwrap();
+        }
+
+        let first_token_ms = captured.lock().unwrap().expect("productive event timing");
+        assert!(
+            first_token_ms >= 40,
+            "Claude lifecycle metadata started the first-token timer at {first_token_ms}ms"
+        );
+    }
+
+    #[test]
+    fn productive_sse_classifier_ignores_supported_protocol_metadata() {
+        let metadata = [
+            serde_json::json!({"type": "response.created"}),
+            serde_json::json!({"type": "response.in_progress"}),
+            serde_json::json!({"type": "message_start", "message": {"usage": {"input_tokens": 10}}}),
+            serde_json::json!({"type": "content_block_start", "content_block": {"type": "text", "text": ""}}),
+            serde_json::json!({"type": "content_block_delta", "delta": {"type": "signature_delta", "signature": "sig"}}),
+            serde_json::json!({"choices": [{"delta": {"role": "assistant"}}]}),
+            serde_json::json!({"choices": [], "usage": {"completion_tokens": 4}}),
+            serde_json::json!({"candidates": [], "usageMetadata": {"candidatesTokenCount": 4}}),
+        ];
+
+        for event in metadata {
+            let encoded = serde_json::to_string(&event).unwrap();
+            assert!(!is_productive_sse_data(&encoded), "metadata: {encoded}");
+        }
+    }
+
+    #[test]
+    fn productive_sse_classifier_accepts_supported_protocol_output() {
+        let output = [
+            serde_json::json!({"type": "response.output_text.delta", "delta": "hello"}),
+            serde_json::json!({"type": "response.function_call_arguments.delta", "delta": "{"}),
+            serde_json::json!({"type": "content_block_delta", "delta": {"type": "text_delta", "text": "hello"}}),
+            serde_json::json!({"type": "content_block_delta", "delta": {"type": "input_json_delta", "partial_json": "{"}}),
+            serde_json::json!({"type": "content_block_start", "content_block": {"type": "tool_use", "input": {"city": "Tokyo"}}}),
+            serde_json::json!({"choices": [{"delta": {"content": "hello"}}]}),
+            serde_json::json!({"choices": [{"delta": {"tool_calls": [{"function": {"arguments": "{"}}]}}]}),
+            serde_json::json!({"candidates": [{"content": {"parts": [{"text": "hello"}]}}]}),
+            serde_json::json!({"candidates": [{"content": {"parts": [{"functionCall": {"name": "lookup", "args": {"city": "Tokyo"}}}]}}]}),
+        ];
+
+        for event in output {
+            let encoded = serde_json::to_string(&event).unwrap();
+            assert!(is_productive_sse_data(&encoded), "output: {encoded}");
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/response_processor.rs
+++ b/src-tauri/src/proxy/response_processor.rs
@@ -147,8 +147,71 @@ pub fn is_sse_response(response: &ProxyResponse) -> bool {
     response.is_sse()
 }
 
-fn should_handle_as_streaming(response: &ProxyResponse, expected_sse: bool) -> bool {
-    is_sse_response(response) || (expected_sse && !response.is_json())
+fn sniff_unlabelled_body_as_json(bytes: &[u8]) -> Option<bool> {
+    let bytes = if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        &bytes[3..]
+    } else if bytes.len() < 3 && [0xEF, 0xBB, 0xBF].starts_with(bytes) {
+        return None;
+    } else {
+        bytes
+    };
+    bytes
+        .iter()
+        .copied()
+        .find(|byte| !byte.is_ascii_whitespace())
+        .map(|byte| matches!(byte, b'{' | b'['))
+}
+
+/// Classify an expected SSE response without trusting the protocol hint over
+/// the actual payload. Some compatible gateways ignore `stream:true` and send
+/// one complete Responses JSON document without a Content-Type header.
+///
+/// Only enough bytes to identify the first non-whitespace byte are consumed,
+/// then every consumed chunk is replayed before the untouched upstream stream.
+async fn prepare_response_for_handling(
+    response: ProxyResponse,
+    expected_sse: bool,
+) -> (ProxyResponse, bool) {
+    if is_sse_response(&response) {
+        return (response, true);
+    }
+    if response.is_json() || !expected_sse {
+        return (response, false);
+    }
+
+    const MAX_SNIFF_BYTES: usize = 8 * 1024;
+    let status = response.status();
+    let headers = response.headers().clone();
+    let mut upstream = Box::pin(response.bytes_stream());
+    let mut replay = Vec::new();
+    let mut prefix = Vec::new();
+    let is_streaming = loop {
+        match upstream.next().await {
+            Some(Ok(chunk)) => {
+                if prefix.len() < MAX_SNIFF_BYTES {
+                    let remaining = MAX_SNIFF_BYTES - prefix.len();
+                    prefix.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+                }
+                replay.push(Ok(chunk));
+                if let Some(is_json) = sniff_unlabelled_body_as_json(&prefix) {
+                    break !is_json;
+                }
+                if prefix.len() >= MAX_SNIFF_BYTES {
+                    break true;
+                }
+            }
+            Some(Err(error)) => {
+                replay.push(Err(error));
+                break true;
+            }
+            None => break true,
+        }
+    };
+    let replayed = futures::stream::iter(replay).chain(upstream);
+    (
+        ProxyResponse::streamed(status, headers, replayed),
+        is_streaming,
+    )
 }
 
 /// 处理流式响应
@@ -354,7 +417,8 @@ pub async fn process_response_with_stream_hint(
     connection_guard: Option<ActiveConnectionGuard>,
     expected_sse: bool,
 ) -> Result<Response, ProxyError> {
-    if should_handle_as_streaming(&response, expected_sse) {
+    let (response, is_streaming) = prepare_response_for_handling(response, expected_sse).await;
+    if is_streaming {
         Ok(handle_streaming(response, ctx, state, parser_config, connection_guard).await)
     } else {
         handle_non_streaming(response, ctx, state, parser_config, connection_guard).await
@@ -780,8 +844,10 @@ pub fn create_logged_passthrough_stream(
                                 for line in event_text.lines() {
                                     if let Some(data) = strip_sse_field(line, "data") {
                                         if data.trim() != "[DONE]" {
-                                            if let Some(c) = &collector {
-                                                c.observe_stream_event().await;
+                                            if is_productive_sse_data(data) {
+                                                if let Some(c) = &collector {
+                                                    c.observe_stream_event().await;
+                                                }
                                             }
                                             let collected = match &collector {
                                                 Some(c) if c.should_collect(data) => {
@@ -828,6 +894,29 @@ pub fn create_logged_passthrough_stream(
         if let Some(guard) = &mut finish_guard {
             guard.disarm();
         }
+    }
+}
+
+fn is_productive_sse_data(data: &str) -> bool {
+    let Ok(event) = serde_json::from_str::<Value>(data) else {
+        // Preserve the historical behavior for non-JSON SSE protocols.
+        return true;
+    };
+    let Some(event_type) = event.get("type").and_then(Value::as_str) else {
+        // OpenAI Chat Completions and several compatible protocols do not use
+        // Responses-style event names. Keep their existing timing semantics.
+        return true;
+    };
+    if !event_type.starts_with("response.") {
+        return true;
+    }
+    if !event_type.ends_with(".delta") {
+        return false;
+    }
+    match event.get("delta") {
+        Some(Value::String(delta)) => !delta.is_empty(),
+        Some(Value::Null) | None => false,
+        Some(_) => true,
     }
 }
 
@@ -917,19 +1006,20 @@ mod tests {
         assert!(!formatted.contains("cookie-secret"), "{formatted}");
     }
 
-    #[test]
-    fn expected_sse_recovers_streaming_when_content_type_is_missing() {
+    #[tokio::test]
+    async fn expected_sse_recovers_streaming_when_content_type_is_missing() {
         let response = ProxyResponse::buffered(
             http::StatusCode::OK,
             HeaderMap::new(),
             Bytes::from_static(b"data: {}\n\n"),
         );
 
-        assert!(should_handle_as_streaming(&response, true));
+        let (_, is_streaming) = prepare_response_for_handling(response, true).await;
+        assert!(is_streaming);
     }
 
-    #[test]
-    fn expected_sse_does_not_override_explicit_json() {
+    #[tokio::test]
+    async fn expected_sse_does_not_override_explicit_json() {
         let mut headers = HeaderMap::new();
         headers.insert("content-type", "application/json".parse().unwrap());
         let response = ProxyResponse::buffered(
@@ -938,18 +1028,44 @@ mod tests {
             Bytes::from_static(br#"{"ok":true}"#),
         );
 
-        assert!(!should_handle_as_streaming(&response, true));
+        let (_, is_streaming) = prepare_response_for_handling(response, true).await;
+        assert!(!is_streaming);
     }
 
-    #[test]
-    fn missing_content_type_without_stream_hint_remains_non_streaming() {
+    #[tokio::test]
+    async fn expected_sse_does_not_override_unlabelled_complete_json() {
+        let body = Bytes::from_static(br#"{"id":"resp_123","object":"response"}"#);
+        let response = ProxyResponse::streamed(
+            http::StatusCode::OK,
+            HeaderMap::new(),
+            futures::stream::iter([
+                Ok::<_, std::io::Error>(Bytes::from_static(b" \r\n")),
+                Ok(body.clone()),
+            ]),
+        );
+
+        let (response, is_streaming) = prepare_response_for_handling(response, true).await;
+        assert!(!is_streaming);
+        let replayed = response
+            .bytes_with_limit(MAX_RESPONSE_BODY_BYTES)
+            .await
+            .unwrap();
+        assert_eq!(
+            replayed,
+            Bytes::from_static(b" \r\n{\"id\":\"resp_123\",\"object\":\"response\"}")
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_content_type_without_stream_hint_remains_non_streaming() {
         let response = ProxyResponse::buffered(
             http::StatusCode::OK,
             HeaderMap::new(),
             Bytes::from_static(b"opaque response"),
         );
 
-        assert!(!should_handle_as_streaming(&response, false));
+        let (_, is_streaming) = prepare_response_for_handling(response, false).await;
+        assert!(!is_streaming);
     }
 
     #[tokio::test]
@@ -971,6 +1087,46 @@ mod tests {
         assert!(
             first_token_ms <= observed_by_ms + 5,
             "first event timing {first_token_ms}ms should precede delayed usage; observation completed by {observed_by_ms}ms"
+        );
+    }
+
+    #[tokio::test]
+    async fn responses_lifecycle_events_do_not_start_first_token_timer() {
+        let start_time = std::time::Instant::now();
+        let captured = Arc::new(std::sync::Mutex::new(None));
+        let captured_for_callback = captured.clone();
+        let collector = SseUsageCollector::new(start_time, None, move |_, first_token_ms| {
+            *captured_for_callback.lock().unwrap() = first_token_ms;
+        });
+        let upstream = async_stream::stream! {
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"data: {\"type\":\"response.created\"}\n\n",
+            ));
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(
+                b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello\"}\n\n",
+            ));
+            yield Ok::<Bytes, std::io::Error>(Bytes::from_static(b"data: [DONE]\n\n"));
+        };
+        let output = create_logged_passthrough_stream(
+            upstream,
+            "test",
+            Some(collector),
+            StreamingTimeoutConfig {
+                first_byte_timeout: 0,
+                idle_timeout: 0,
+            },
+            None,
+        );
+        tokio::pin!(output);
+        while let Some(chunk) = output.next().await {
+            chunk.unwrap();
+        }
+
+        let first_token_ms = captured.lock().unwrap().expect("productive event timing");
+        assert!(
+            first_token_ms >= 40,
+            "lifecycle metadata started the first-token timer at {first_token_ms}ms"
         );
     }
 

--- a/src-tauri/src/services/sql_helpers.rs
+++ b/src-tauri/src/services/sql_helpers.rs
@@ -66,6 +66,27 @@ pub fn fresh_input_sql(alias: &str) -> String {
     )
 }
 
+/// Build an SQL expression for the latency users perceive before a response
+/// becomes usable.
+///
+/// For streaming responses that is time-to-first-token. Measuring until the
+/// stream closes makes longer, successful generations look artificially slow.
+/// Non-streaming responses still use the full request latency. Legacy or
+/// incomplete streaming rows fall back to the full latency.
+pub fn perceived_latency_sql(alias: &str) -> String {
+    let prefix = if alias.is_empty() {
+        String::new()
+    } else {
+        format!("{alias}.")
+    };
+    format!(
+        "CASE WHEN {prefix}is_streaming = 1 \
+                    AND {prefix}first_token_ms IS NOT NULL \
+              THEN {prefix}first_token_ms \
+              ELSE {prefix}latency_ms END"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -81,7 +102,10 @@ mod tests {
                 output_tokens INTEGER NOT NULL DEFAULT 0,
                 cache_read_tokens INTEGER NOT NULL DEFAULT 0,
                 cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
-                input_token_semantics INTEGER NOT NULL DEFAULT 0
+                input_token_semantics INTEGER NOT NULL DEFAULT 0,
+                latency_ms INTEGER NOT NULL DEFAULT 0,
+                first_token_ms INTEGER,
+                is_streaming INTEGER NOT NULL DEFAULT 0
             );",
         )
         .unwrap();
@@ -193,5 +217,56 @@ mod tests {
         let sql = format!("SELECT {expr} FROM proxy_request_logs l");
         let value: i64 = conn.query_row(&sql, [], |row| row.get(0)).unwrap();
         assert_eq!(value, 500);
+    }
+
+    #[test]
+    fn perceived_latency_uses_first_token_for_streaming_rows() {
+        let conn = setup_conn();
+        conn.execute(
+            "INSERT INTO proxy_request_logs
+                (request_id, app_type, latency_ms, first_token_ms, is_streaming)
+             VALUES ('stream', 'codex', 60000, 1000, 1)",
+            [],
+        )
+        .unwrap();
+
+        let expr = perceived_latency_sql("l");
+        let sql = format!("SELECT {expr} FROM proxy_request_logs l");
+        let value: i64 = conn.query_row(&sql, [], |row| row.get(0)).unwrap();
+        assert_eq!(value, 1000);
+    }
+
+    #[test]
+    fn perceived_latency_uses_full_latency_for_non_streaming_rows() {
+        let conn = setup_conn();
+        conn.execute(
+            "INSERT INTO proxy_request_logs
+                (request_id, app_type, latency_ms, first_token_ms, is_streaming)
+             VALUES ('non-stream', 'codex', 2000, 1000, 0)",
+            [],
+        )
+        .unwrap();
+
+        let expr = perceived_latency_sql("l");
+        let sql = format!("SELECT {expr} FROM proxy_request_logs l");
+        let value: i64 = conn.query_row(&sql, [], |row| row.get(0)).unwrap();
+        assert_eq!(value, 2000);
+    }
+
+    #[test]
+    fn perceived_latency_falls_back_when_first_token_is_missing() {
+        let conn = setup_conn();
+        conn.execute(
+            "INSERT INTO proxy_request_logs
+                (request_id, app_type, latency_ms, is_streaming)
+             VALUES ('legacy-stream', 'codex', 3000, 1)",
+            [],
+        )
+        .unwrap();
+
+        let expr = perceived_latency_sql("l");
+        let sql = format!("SELECT {expr} FROM proxy_request_logs l");
+        let value: i64 = conn.query_row(&sql, [], |row| row.get(0)).unwrap();
+        assert_eq!(value, 3000);
     }
 }

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -6,7 +6,8 @@ use crate::database::{lock_conn, Database};
 use crate::error::AppError;
 use crate::proxy::usage::calculator::ModelPricing;
 use crate::services::sql_helpers::{
-    fresh_input_sql, INPUT_TOKEN_SEMANTICS_FRESH, INPUT_TOKEN_SEMANTICS_TOTAL,
+    fresh_input_sql, perceived_latency_sql, INPUT_TOKEN_SEMANTICS_FRESH,
+    INPUT_TOKEN_SEMANTICS_TOTAL,
 };
 use chrono::{Local, NaiveDate, TimeZone, Timelike};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -1332,6 +1333,7 @@ impl Database {
         let rollup_pname = provider_name_coalesce("r", "p2");
         let fresh_input_detail = fresh_input_sql("l");
         let fresh_input_rollup = fresh_input_sql("r");
+        let detail_latency = perceived_latency_sql("l");
         let sql = format!(
             "SELECT
                 provider_id, app_type, provider_name,
@@ -1349,7 +1351,7 @@ impl Database {
                     COALESCE(SUM({fresh_input_detail} + l.output_tokens), 0) as total_tokens,
                     COALESCE(SUM(CAST(l.total_cost_usd AS REAL)), 0) as total_cost,
                     COALESCE(SUM(CASE WHEN l.status_code >= 200 AND l.status_code < 300 THEN 1 ELSE 0 END), 0) as success_count,
-                    COALESCE(SUM(l.latency_ms), 0) as latency_sum
+                    COALESCE(SUM({detail_latency}), 0) as latency_sum
                 FROM proxy_request_logs l
                 LEFT JOIN providers p ON l.provider_id = p.id AND l.app_type = p.app_type
                 {detail_where}
@@ -3843,6 +3845,64 @@ mod tests {
         assert_eq!(stats[0].provider_id, "p1");
         assert_eq!(stats[0].request_count, 1);
         assert_eq!(stats[0].total_tokens, 275);
+
+        Ok(())
+    }
+
+    #[test]
+    fn provider_stats_use_first_token_latency_for_streaming_requests() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model,
+                    input_tokens, output_tokens, total_cost_usd,
+                    is_streaming, latency_ms, first_token_ms, status_code, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    "streaming",
+                    "p1",
+                    "codex",
+                    "gpt-test",
+                    100,
+                    50,
+                    "0.01",
+                    1,
+                    60_000,
+                    1_000,
+                    200,
+                    1_000
+                ],
+            )?;
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model,
+                    input_tokens, output_tokens, total_cost_usd,
+                    is_streaming, latency_ms, first_token_ms, status_code, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    "non-streaming",
+                    "p1",
+                    "codex",
+                    "gpt-test",
+                    100,
+                    50,
+                    "0.01",
+                    0,
+                    2_000,
+                    Option::<i64>::None,
+                    200,
+                    2_000
+                ],
+            )?;
+        }
+
+        let stats = db.get_provider_stats(None, None, Some("codex"), None, None)?;
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats[0].request_count, 2);
+        assert_eq!(stats[0].avg_latency_ms, 1_500);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary / 概述

This PR fixes two compounding problems in Codex local routing:

- Treat managed Codex OAuth `/responses` requests as streaming even when the client omits `stream: true` or an SSE `Accept` header.
- Recover the SSE processing path when a compatible upstream omits or mislabels `Content-Type`, while preserving explicit JSON responses as non-streaming.
- Capture `first_token_ms` at the first usable SSE data event, independently of the usage-event filter.
- Report perceived latency consistently: first-token latency for streaming rows when available, otherwise full request latency.
- Apply the same latency rule to live Provider Statistics and newly generated daily rollups.

The change keeps ordinary non-streaming Responses calls and legacy rows without first-token timing on their existing full-latency fallback.

## Related Issue / 关联 Issue

Fixes #6637

## Screenshots / 截图

Not applicable. This is a backend streaming-classification and statistics fix with no UI changes.

## Testing / 测试

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --all-targets --manifest-path src-tauri/Cargo.toml -- -D warnings`
- Targeted Rust module tests: 190 passed
- Full Rust library suite: 2671 passed, 6 ignored; 2 unrelated Windows tests require symlink privilege (OS error 1314)
- `tsc --noEmit`
- `prettier --check "src/**/*.{js,jsx,ts,tsx,css,json}"`
- Frontend suite: 985 passed; 2 integration tests were order/timing-sensitive in the full parallel run and passed 7/7 when their file was rerun in isolation

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] No user-facing text changed; no i18n update is required / 未修改用户可见文本，无需更新国际化文件