### PR TITLE
fix(codex): backfill supports_parallel_tool_calls in catalog template

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1791,7 +1791,12 @@ fn codex_vendor_catalog_model_entry(
 /// field ..."). `base_instructions` is the other known required field; the
 /// templates always carry it and `codex_catalog_model_entry` handles it.
 /// When Codex requires a new field, add it here AND to the static templates.
-const CODEX_CATALOG_PARSER_REQUIRED_FIELDS: &[&str] = &["supports_reasoning_summaries"];
+const CODEX_CATALOG_PARSER_REQUIRED_FIELDS: &[&str] = &[
+    "supports_reasoning_summaries",
+    // codex 0.148.0 rejects the catalog without it (#6661); a models_cache.json
+    // written by an older build can lack it.
+    "supports_parallel_tool_calls",
+];
 
 /// `models_cache.json` is shared by every Codex install on the machine (npm
 /// CLI, desktop-bundled binary, ...), and each version serializes its own
@@ -4045,6 +4050,18 @@ base_url = "https://production.api/v1"
         assert!(template.get("supports_search_tool").is_none());
         assert!(template.get("supports_image_detail_original").is_none());
         assert!(template.get("web_search_tool_type").is_none());
+
+        // A cache template missing supports_parallel_tool_calls gets the
+        // static gpt-5.5 default backfilled (codex 0.148.0 rejects the
+        // catalog without it, #6661).
+        let mut stale = json!({ "slug": "gpt-5.5" });
+        fill_template_fields_from_static(&mut stale);
+        assert_eq!(
+            stale
+                .get("supports_parallel_tool_calls")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
     }
 
     #[test]
@@ -4072,6 +4089,12 @@ base_url = "https://production.api/v1"
         assert_eq!(
             catalog["models"][0]
                 .get("supports_reasoning_summaries")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            catalog["models"][0]
+                .get("supports_parallel_tool_calls")
                 .and_then(Value::as_bool),
             Some(true)
         );


### PR DESCRIPTION
## 问题

Issue #6661: Codex 桌面版 0.148.0 读取 `cc-switch-model-catalog.json` 时报错并拒绝加载：

```
failed to parse model_catalog_json ... missing field `supports_parallel_tool_calls`
```

Kimi For Coding 等 ProxyChat provider 生成的 catalog 条目缺少该字段。

## 根因

Codex 0.148.0 的 external-catalog parser 把 `supports_parallel_tool_calls` 作为**必填字段**（无 serde default），缺一个就拒绝整个 catalog 文件。

cc-switch 的 ProxyChat catalog 模板克隆自本机 `models_cache.json`（`load_codex_model_catalog_template_uncached`），而该缓存的字段集合取决于最后写它的 Codex 版本——旧版本写的缓存可能没有这个字段。`fill_template_fields_from_static` 的必填字段回填白名单 `CODEX_CATALOG_PARSER_REQUIRED_FIELDS` 只列了 `supports_reasoning_summaries`，没有 `supports_parallel_tool_calls`，于是生成的条目缺字段。

## 修复

把 `supports_parallel_tool_calls` 加入 `CODEX_CATALOG_PARSER_REQUIRED_FIELDS`，回填来源是内置 gpt-5.5 静态模板（本身就是 `true`，与 ProxyChat profile 的既有默认一致）；已有值仍然优先、不被覆盖。两个静态模板（gpt-5.5 / native-responses）本来就带这个字段，无需改模板。

## 验证

- `cargo test catalog` 全绿（49 tests）
- 扩展 `dynamic_template_backfills_parser_required_fields_from_static`：缺字段时回填 `true`，已有值（`false`）不被覆盖
- `proxy_chat_catalog_entries_carry_reasoning_summaries_flag` 端到端断言条目携带 `supports_parallel_tool_calls: true`
