### PR TITLE
chore(clippy): satisfy stable 1.98 lint set

### DIFF
--- a/src-tauri/src/gemini_mcp.rs
+++ b/src-tauri/src/gemini_mcp.rs
@@ -49,7 +49,7 @@ pub fn read_mcp_servers_map() -> Result<std::collections::HashMap<String, Value>
         .unwrap_or_default();
 
     // 反向格式转换：Gemini 特有格式 → 统一 MCP 格式
-    for (_, spec) in servers.iter_mut() {
+    for spec in servers.values_mut() {
         if let Some(obj) = spec.as_object_mut() {
             // httpUrl → url + type: "http"
             if let Some(http_url) = obj.remove("httpUrl") {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -367,6 +367,7 @@ impl RequestForwarder {
     /// 出口处都会把 `active_connections` 回收。Per-attempt 维度（成功/失败/熔断
     /// 等）仍由 inner 内自行更新 `success_requests` / `failed_requests`。
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::result_large_err)]
     pub async fn forward_with_retry(
         &self,
         app_type: &AppType,
@@ -407,6 +408,7 @@ impl RequestForwarder {
     /// * `headers` - 请求头
     /// * `providers` - 已选择的 Provider 列表（由 RequestContext 提供，避免重复调用 select_providers）
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::result_large_err)]
     async fn forward_with_retry_inner(
         &self,
         app_type: &AppType,

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -259,7 +259,7 @@ impl From<&CodexAccountData> for GitHubAccount {
             login: data
                 .email
                 .clone()
-                .unwrap_or_else(|| format!("ChatGPT ({})", &data.account_id)),
+                .unwrap_or_else(|| format!("ChatGPT ({})", data.account_id)),
             avatar_url: None,
             authenticated_at: data.authenticated_at,
             github_domain: "github.com".to_string(),

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -782,7 +782,7 @@ pub fn create_tray_menu(
                         provider,
                     );
                 let label = if is_official_blocked {
-                    format!("{} \u{26D4}", &provider.name) // ⛔ emoji
+                    format!("{} \u{26D4}", provider.name) // ⛔ emoji
                 } else {
                     provider.name.clone()
                 };


### PR DESCRIPTION
## Summary

`main`'s Backend Checks are currently failing on the latest stable toolchain (1.98): clippy's newly-added lints flag existing, unrelated code. This is a trivial, mechanical fix set — no behavioral changes:

- `gemini_mcp.rs`: iterate map values via `values_mut()` instead of discarding keys
- `forwarder.rs`: add `#[allow(clippy::result_large_err)]` to `forward_with_retry` / `forward_with_retry_inner`
- `codex_oauth_auth.rs` / `tray.rs`: drop redundant `&` borrows inside `format!`

Verified locally against stable 1.98: `cargo fmt --check` and `cargo clippy -- -D warnings` both pass.

Merging this also unblocks the CI for other open PRs (e.g. #6656).

## Related Issue

No issue (CI toolchain update). Fixes the red Backend Checks on `main` caused by the stable 1.98 rollout.

## Checklist / 检查清单

- [x] `cargo clippy` passes (Rust backend changed) / 通过 Clippy 检查（修改了 Rust 代码）
- [x] No user-facing text changed, i18n not applicable / 未修改用户可见文本，国际化不适用