### PR TITLE
fix(codex-oauth): route official logins through their own custom upstream

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1105,6 +1105,27 @@ pub fn extract_codex_api_key(auth: Option<&Value>, config_text: Option<&str>) ->
 /// `[model_providers.*]` section — the frontend `extractCodexBaseUrl`
 /// (`getRecoverableBaseUrlAssignments`) excludes those too, and a leftover
 /// section unrelated to the active provider must not leak into `{{baseUrl}}`.
+/// The `base_url` of the table `model_provider` selects — without the
+/// top-level fallback `extract_codex_base_url` accepts, and rejecting a blank
+/// value.
+///
+/// Callers that forward a first-party credential need this stricter form. A
+/// top-level `base_url` can linger from an earlier third-party setup and is not
+/// reachable from the official card UI, so honouring it would send the
+/// credential to a host the active provider never named.
+pub fn extract_active_codex_provider_base_url(config_text: &str) -> Option<String> {
+    let doc = config_text.parse::<toml::Value>().ok()?;
+    let active = doc.get("model_provider")?.as_str()?;
+    let base_url = doc
+        .get("model_providers")?
+        .get(active)?
+        .get("base_url")?
+        .as_str()?
+        .trim();
+
+    (!base_url.is_empty()).then(|| base_url.to_string())
+}
+
 pub fn extract_codex_base_url(config_text: &str) -> Option<String> {
     let doc = config_text.parse::<toml::Value>().ok()?;
 

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1098,6 +1098,36 @@ pub fn extract_codex_api_key(auth: Option<&Value>, config_text: Option<&str>) ->
         .or_else(|| config_text.and_then(extract_codex_experimental_bearer_token))
 }
 
+/// The `base_url` of the table `model_provider` selects, but only when that
+/// table opts into the official login the way Codex CLI itself reads it —
+/// `requires_openai_auth = true` with no `env_key` /
+/// `experimental_bearer_token` short-circuit
+/// (`codex_provider_table_falls_back_to_official_auth`). Without the
+/// top-level fallback `extract_codex_base_url` accepts, and rejecting a blank
+/// value.
+///
+/// Callers that forward a first-party credential need this stricter form. The
+/// takeover route makes Codex hand its ChatGPT authorization to the local
+/// proxy, and the forwarder passes it through unchanged for official cards, so
+/// every host this returns will receive that token. A table that never asked
+/// for OpenAI auth (`requires_openai_auth` absent/false, or carrying its own
+/// credential) must therefore not be returned — Codex CLI would not send the
+/// login there either. A top-level `base_url` can linger from an earlier
+/// third-party setup and is not reachable from the official card UI, so
+/// honouring it would send the credential to a host the active provider never
+/// named.
+pub fn extract_active_codex_provider_base_url(config_text: &str) -> Option<String> {
+    let doc = config_text.parse::<toml_edit::DocumentMut>().ok()?;
+    let active = doc.get("model_provider")?.as_str()?;
+    let table = doc.get("model_providers")?.get(active)?.as_table_like()?;
+    if !codex_provider_table_falls_back_to_official_auth(table) {
+        return None;
+    }
+    let base_url = table.get("base_url")?.as_str()?.trim();
+
+    (!base_url.is_empty()).then(|| base_url.to_string())
+}
+
 /// Extract the upstream base URL from a Codex `config.toml` string.
 ///
 /// Prefers the active `[model_providers.<model_provider>].base_url`, falling
@@ -1105,27 +1135,6 @@ pub fn extract_codex_api_key(auth: Option<&Value>, config_text: Option<&str>) ->
 /// `[model_providers.*]` section — the frontend `extractCodexBaseUrl`
 /// (`getRecoverableBaseUrlAssignments`) excludes those too, and a leftover
 /// section unrelated to the active provider must not leak into `{{baseUrl}}`.
-/// The `base_url` of the table `model_provider` selects — without the
-/// top-level fallback `extract_codex_base_url` accepts, and rejecting a blank
-/// value.
-///
-/// Callers that forward a first-party credential need this stricter form. A
-/// top-level `base_url` can linger from an earlier third-party setup and is not
-/// reachable from the official card UI, so honouring it would send the
-/// credential to a host the active provider never named.
-pub fn extract_active_codex_provider_base_url(config_text: &str) -> Option<String> {
-    let doc = config_text.parse::<toml::Value>().ok()?;
-    let active = doc.get("model_provider")?.as_str()?;
-    let base_url = doc
-        .get("model_providers")?
-        .get(active)?
-        .get("base_url")?
-        .as_str()?
-        .trim();
-
-    (!base_url.is_empty()).then(|| base_url.to_string())
-}
-
 pub fn extract_codex_base_url(config_text: &str) -> Option<String> {
     let doc = config_text.parse::<toml::Value>().ok()?;
 

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -903,10 +903,13 @@ impl ProviderAdapter for CodexAdapter {
         // forwarder passes through. Either the active `model_provider` names an
         // upstream we can resolve, or the card keeps targeting ChatGPT.
         //
-        // Only the active table counts. `extract_codex_base_url` would also
-        // accept a top-level `base_url`, which the official card UI cannot even
-        // set and which typically survives from an earlier third-party setup —
-        // the same leak by another route.
+        // Only the active table counts, and only if it opted into the official
+        // login (`requires_openai_auth = true` with no credential of its own) —
+        // the same condition under which Codex CLI itself would send the login
+        // there. `extract_codex_base_url` would also accept a top-level
+        // `base_url`, which the official card UI cannot even set and which
+        // typically survives from an earlier third-party setup — the same leak
+        // by another route.
         if is_codex_official_provider(provider) {
             let upstream = provider
                 .settings_config
@@ -1385,6 +1388,63 @@ base_url = "https://old.example.com/v1"
                 super::super::CHATGPT_CODEX_BASE_URL,
                 "nothing here is an upstream the active `model_provider` named"
             );
+        }
+    }
+
+    /// The forwarder passes the ChatGPT bearer token through for official
+    /// cards, so the active table must have opted into receiving it the way
+    /// Codex CLI reads it: `requires_openai_auth = true` and no credential of
+    /// its own. A table that left the flag off, or that carries an
+    /// `env_key` / `experimental_bearer_token`, would never be handed the
+    /// login by Codex either — routing there would leak it.
+    #[test]
+    fn only_a_table_that_opts_into_openai_auth_can_receive_the_login() {
+        let adapter = CodexAdapter::new();
+
+        for config in [
+            // Flag explicitly off.
+            r#"model_provider = "gateway"
+
+[model_providers.gateway]
+base_url = "https://untrusted.example/v1"
+wire_api = "responses"
+requires_openai_auth = false
+"#,
+            // Flag absent.
+            r#"model_provider = "gateway"
+
+[model_providers.gateway]
+base_url = "https://untrusted.example/v1"
+"#,
+            // Opted in, but short-circuited by its own credential.
+            r#"model_provider = "gateway"
+
+[model_providers.gateway]
+base_url = "https://untrusted.example/v1"
+requires_openai_auth = true
+experimental_bearer_token = "sk-own"
+"#,
+            r#"model_provider = "gateway"
+
+[model_providers.gateway]
+base_url = "https://untrusted.example/v1"
+requires_openai_auth = true
+env_key = "GATEWAY_KEY"
+"#,
+        ] {
+            for provider in [
+                managed_oauth_provider(config),
+                fixed_official_provider(config),
+            ] {
+                assert_eq!(
+                    adapter
+                        .extract_base_url(&provider)
+                        .expect("official base url"),
+                    super::super::CHATGPT_CODEX_BASE_URL,
+                    "a table that never asked for OpenAI auth must not receive \
+                     the ChatGPT bearer token"
+                );
+            }
         }
     }
 

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -307,10 +307,6 @@ pub fn is_codex_official_provider(provider: &Provider) -> bool {
         return false;
     }
 
-    if has_explicit_codex_third_party_upstream(provider) {
-        return false;
-    }
-
     let has_managed_account = provider
         .meta
         .as_ref()
@@ -318,6 +314,10 @@ pub fn is_codex_official_provider(provider: &Provider) -> bool {
         .is_some_and(|account_id| !account_id.trim().is_empty());
     if has_managed_account {
         return true;
+    }
+
+    if has_explicit_codex_third_party_upstream(provider) {
+        return false;
     }
 
     let has_stored_api_key = provider
@@ -344,7 +344,22 @@ pub fn resolve_codex_catalog_tool_profile(
     provider: &Provider,
 ) -> crate::codex_config::CodexCatalogToolProfile {
     use crate::codex_config::CodexCatalogToolProfile;
+    // Keyed on the credential source, not the upstream host. An official login
+    // with no upstream of its own is a Responses passthrough. Once it does carry
+    // a custom gateway (see `extract_base_url`), that gateway's declared
+    // protocol picks the profile, read through the very functions the router
+    // consults in `should_convert_codex_responses_to_chat`/`_to_anthropic` — so
+    // the catalog cannot disagree with the transform actually applied. Official
+    // cards have no `meta.api_format`, but their TOML `wire_api` is signal
+    // enough, and both helpers fall through to `NativeResponses` when the card
+    // declares neither.
     if is_codex_official_provider(provider) {
+        if codex_provider_uses_anthropic(provider) {
+            return CodexCatalogToolProfile::Anthropic;
+        }
+        if codex_provider_uses_chat_completions(provider) {
+            return CodexCatalogToolProfile::ProxyChat;
+        }
         return CodexCatalogToolProfile::NativeResponses;
     }
     // xAI OAuth pins the native Responses profile regardless of editable
@@ -874,8 +889,37 @@ impl ProviderAdapter for CodexAdapter {
     }
 
     fn extract_base_url(&self, provider: &Provider) -> Result<String, ProxyError> {
+        // `is_codex_official_provider` answers where the credentials come from,
+        // not where the request goes. A card can hold an official ChatGPT login
+        // and still route through a self-hosted gateway — Codex CLI supports
+        // exactly that via `model_providers.<id>.requires_openai_auth = true`
+        // next to a custom `base_url`. Only an official login *without* an
+        // explicit upstream of its own targets the ChatGPT backend.
+        //
+        // An official card never falls through to the generic resolution below:
+        // that path scans for the first literal `base_url = "` in the text, so a
+        // leftover `[model_providers.*]` the active provider does not point at
+        // would receive the request — and with it the ChatGPT bearer token the
+        // forwarder passes through. Either the active `model_provider` names an
+        // upstream we can resolve, or the card keeps targeting ChatGPT.
+        //
+        // Only the active table counts. `extract_codex_base_url` would also
+        // accept a top-level `base_url`, which the official card UI cannot even
+        // set and which typically survives from an earlier third-party setup —
+        // the same leak by another route.
         if is_codex_official_provider(provider) {
-            return Ok(super::CHATGPT_CODEX_BASE_URL.to_string());
+            let upstream = provider
+                .settings_config
+                .get("config")
+                .and_then(JsonValue::as_str)
+                .and_then(|text| crate::codex_config::strip_codex_unified_session_bucket(text).ok())
+                .and_then(|text| {
+                    crate::codex_config::extract_active_codex_provider_base_url(&text)
+                });
+
+            return Ok(upstream
+                .map(|url| url.trim_end_matches('/').to_string())
+                .unwrap_or_else(|| super::CHATGPT_CODEX_BASE_URL.to_string()));
         }
 
         // xAI OAuth: ignore editable provider base URLs and always use the xAI
@@ -909,6 +953,14 @@ impl ProviderAdapter for CodexAdapter {
             }
 
             // 尝试解析 TOML 字符串格式
+            //
+            // The literal scans below take the first `base_url` in the text
+            // regardless of which table `model_provider` selects, so a card that
+            // switched upstreams and left the old `[model_providers.*]` behind
+            // can still be routed to it. Official cards return above precisely
+            // to avoid that; third-party cards remain exposed, risking their own
+            // key rather than a ChatGPT token. Fixing it here means auditing
+            // every third-party shape that relies on this scan.
             if let Some(config_str) = config.as_str() {
                 if let Some(url) = crate::grok_config::extract_base_url(config_str) {
                     return Ok(url.trim_end_matches('/').to_string());
@@ -1093,15 +1145,7 @@ context_window = 500000
         assert!(is_codex_official_provider(&native));
 
         provider.id = "managed-official-account".to_string();
-        provider.meta = Some(crate::provider::ProviderMeta {
-            provider_type: Some("codex_oauth".to_string()),
-            auth_binding: Some(crate::provider::AuthBinding {
-                source: crate::provider::AuthBindingSource::ManagedAccount,
-                auth_provider: Some("codex_oauth".to_string()),
-                account_id: Some("acct-managed".to_string()),
-            }),
-            ..Default::default()
-        });
+        provider.meta = managed_codex_oauth_meta();
         let adapter = CodexAdapter::new();
 
         assert!(is_codex_official_provider(&provider));
@@ -1182,6 +1226,272 @@ context_window = 500000
         grok_official.id = crate::database::GROKBUILD_OFFICIAL_PROVIDER_ID.to_string();
         grok_official.category = Some("official".to_string());
         assert!(!is_codex_official_provider(&grok_official));
+    }
+
+    /// A self-hosted gateway that fronts the ChatGPT backend: Codex CLI keeps
+    /// authenticating with the login stored in `auth.json`
+    /// (`requires_openai_auth = true`) while the requests leave for our own
+    /// origin.
+    const WORKER_UPSTREAM_CONFIG: &str = r#"model_provider = "myworker"
+
+[model_providers.myworker]
+name = "My Worker"
+base_url = "https://worker.example.com/backend-api/codex"
+wire_api = "responses"
+requires_openai_auth = true
+"#;
+
+    fn managed_codex_oauth_meta() -> Option<crate::provider::ProviderMeta> {
+        Some(crate::provider::ProviderMeta {
+            provider_type: Some("codex_oauth".to_string()),
+            auth_binding: Some(crate::provider::AuthBinding {
+                source: crate::provider::AuthBindingSource::ManagedAccount,
+                auth_provider: Some("codex_oauth".to_string()),
+                account_id: Some("acct-managed".to_string()),
+            }),
+            ..Default::default()
+        })
+    }
+
+    fn managed_oauth_provider(config: &str) -> Provider {
+        let mut provider = create_provider(json!({ "auth": {}, "config": config }));
+        provider.id = "managed-worker-account".to_string();
+        provider.category = Some("official".to_string());
+        provider.meta = managed_codex_oauth_meta();
+        provider
+    }
+
+    /// The fixed official id short-circuits `is_codex_official_provider` before
+    /// the third-party upstream check, so it reaches `extract_base_url` through
+    /// a different branch than a managed binding does.
+    fn fixed_official_provider(config: &str) -> Provider {
+        let mut provider = create_provider(json!({ "auth": {}, "config": config }));
+        provider.id = crate::database::CODEX_OFFICIAL_PROVIDER_ID.to_string();
+        provider.category = Some("official".to_string());
+        provider
+    }
+
+    #[test]
+    fn managed_oauth_card_with_custom_upstream_keeps_official_credentials() {
+        let provider = managed_oauth_provider(WORKER_UPSTREAM_CONFIG);
+        assert!(
+            is_codex_official_provider(&provider),
+            "a self-hosted upstream must not demote the credential source: the \
+             managed ChatGPT token still has to be synced into ~/.codex/auth.json"
+        );
+    }
+
+    #[test]
+    fn official_cards_with_a_custom_upstream_route_to_that_upstream() {
+        let adapter = CodexAdapter::new();
+        let mut unbound = create_provider(json!({
+            "auth": {},
+            "config": WORKER_UPSTREAM_CONFIG
+        }));
+        unbound.category = Some("official".to_string());
+
+        for provider in [
+            managed_oauth_provider(WORKER_UPSTREAM_CONFIG),
+            fixed_official_provider(WORKER_UPSTREAM_CONFIG),
+            unbound,
+        ] {
+            assert_eq!(
+                adapter
+                    .extract_base_url(&provider)
+                    .expect("worker base url"),
+                "https://worker.example.com/backend-api/codex",
+                "routing an official card to chatgpt.com would silently bypass the \
+                 gateway the user configured, with no error to notice"
+            );
+        }
+    }
+
+    #[test]
+    fn official_cards_without_a_custom_upstream_still_target_chatgpt() {
+        let adapter = CodexAdapter::new();
+        let mut unbound = create_provider(json!({ "auth": {}, "config": "" }));
+        unbound.category = Some("official".to_string());
+
+        for provider in [
+            managed_oauth_provider(""),
+            fixed_official_provider(""),
+            unbound,
+        ] {
+            assert_eq!(
+                adapter
+                    .extract_base_url(&provider)
+                    .expect("official base url"),
+                super::super::CHATGPT_CODEX_BASE_URL,
+                "cards without an upstream of their own keep the pre-existing route"
+            );
+        }
+    }
+
+    #[test]
+    fn official_cards_never_route_to_a_table_the_active_provider_skips() {
+        let adapter = CodexAdapter::new();
+        // These once looked like "has a custom upstream" to the third-party
+        // heuristic while offering no resolvable URL, which is how they reached
+        // the text scan. The official branch no longer consults that heuristic,
+        // so they are kept as regression guards: the `baseUrl` card in
+        // particular must never again be routed by a settings field the branch
+        // deliberately does not read.
+        let mut settings_field = managed_oauth_provider("");
+        settings_field.settings_config["baseUrl"] = json!("https://stale.example.com/v1");
+
+        for provider in [
+            // `model_provider` names a table that is not in the config, next to
+            // a leftover one that is.
+            managed_oauth_provider(
+                r#"model_provider = "ollama"
+
+[model_providers.old]
+base_url = "https://old.example.com/v1"
+"#,
+            ),
+            managed_oauth_provider("experimental_bearer_token = \"sk-legacy\""),
+            settings_field,
+        ] {
+            assert_eq!(
+                adapter
+                    .extract_base_url(&provider)
+                    .expect("official base url"),
+                super::super::CHATGPT_CODEX_BASE_URL,
+                "falling through to the generic text scan would send the request \
+                 — and the ChatGPT bearer token the forwarder passes through — to \
+                 a host the active `model_provider` never selected"
+            );
+        }
+    }
+
+    /// A URL only counts when `model_provider` selects the table holding it.
+    /// The official card UI cannot set a top-level `base_url`, so one that is
+    /// present survived from an earlier third-party setup — honouring it would
+    /// hand the ChatGPT token to a host the active provider never named.
+    #[test]
+    fn only_the_table_the_active_provider_selects_can_take_the_request() {
+        let adapter = CodexAdapter::new();
+
+        for config in [
+            "base_url = \"https://top.example.com/v1\"",
+            "[model_providers.any]\nbase_url = \"https://unselected.example.com/v1\"\n",
+            "model_provider = \"myworker\"\n\n[model_providers.myworker]\nbase_url = \"   \"\n",
+        ] {
+            let provider = managed_oauth_provider(config);
+            assert_eq!(
+                adapter
+                    .extract_base_url(&provider)
+                    .expect("official base url"),
+                super::super::CHATGPT_CODEX_BASE_URL,
+                "nothing here is an upstream the active `model_provider` named"
+            );
+        }
+    }
+
+    /// `validate_config_toml` rejects an unparsable config when the provider is
+    /// saved, so this state is not reachable from the UI. Pinned anyway because
+    /// the parse error is swallowed here rather than surfaced: if that
+    /// validation is ever relaxed, the card stays on the official route instead
+    /// of resolving to something arbitrary.
+    #[test]
+    fn an_unparsable_config_keeps_the_official_route() {
+        let adapter = CodexAdapter::new();
+        let provider = managed_oauth_provider("model_provider = \"myworker\"\n[[[broken");
+        assert_eq!(
+            adapter
+                .extract_base_url(&provider)
+                .expect("official base url"),
+            super::super::CHATGPT_CODEX_BASE_URL
+        );
+    }
+
+    #[test]
+    fn custom_upstream_url_comes_from_the_active_model_provider() {
+        let adapter = CodexAdapter::new();
+        let provider = managed_oauth_provider(
+            r#"model_provider = "second"
+
+[model_providers.first]
+base_url = "https://first.example.com/v1"
+
+[model_providers.second]
+base_url = "https://second.example.com/v1"
+requires_openai_auth = true
+"#,
+        );
+        assert_eq!(
+            adapter
+                .extract_base_url(&provider)
+                .expect("active base url"),
+            "https://second.example.com/v1",
+            "a textual scan would return the first `base_url` in the file rather \
+             than the table `model_provider` actually selects"
+        );
+    }
+
+    /// Once an official card can carry its own gateway, the catalog profile has
+    /// to follow that gateway's protocol: the router reads the same `wire_api`
+    /// in `should_convert_codex_responses_to_chat` and transforms the request,
+    /// so pinning `NativeResponses` here would advertise a tool set the
+    /// converted route does not actually serve.
+    #[test]
+    fn official_card_on_a_chat_gateway_gets_the_chat_catalog() {
+        let provider = managed_oauth_provider(
+            r#"
+model_provider = "gw"
+[model_providers.gw]
+base_url = "https://gw.example.com/v1"
+wire_api = "chat"
+requires_openai_auth = true
+"#,
+        );
+
+        assert!(
+            should_convert_codex_responses_to_chat(&provider, "/v1/responses"),
+            "precondition: the router converts this card to Chat Completions"
+        );
+        assert!(matches!(
+            resolve_codex_catalog_tool_profile(&provider),
+            crate::codex_config::CodexCatalogToolProfile::ProxyChat
+        ));
+    }
+
+    #[test]
+    fn official_card_on_an_anthropic_gateway_gets_the_anthropic_catalog() {
+        let provider = managed_oauth_provider(
+            r#"
+model_provider = "gw"
+[model_providers.gw]
+base_url = "https://gw.example.com/v1"
+wire_api = "anthropic"
+requires_openai_auth = true
+"#,
+        );
+
+        assert!(
+            codex_provider_uses_anthropic(&provider),
+            "precondition: the router treats this card as an Anthropic upstream"
+        );
+        assert!(matches!(
+            resolve_codex_catalog_tool_profile(&provider),
+            crate::codex_config::CodexCatalogToolProfile::Anthropic
+        ));
+    }
+
+    /// The common case must not move: an official card that declares no
+    /// protocol of its own stays a Responses passthrough.
+    #[test]
+    fn official_card_without_a_protocol_signal_keeps_native_responses() {
+        for provider in [
+            managed_oauth_provider(WORKER_UPSTREAM_CONFIG),
+            managed_oauth_provider(""),
+            fixed_official_provider(""),
+        ] {
+            assert!(matches!(
+                resolve_codex_catalog_tool_profile(&provider),
+                crate::codex_config::CodexCatalogToolProfile::NativeResponses
+            ));
+        }
     }
 
     #[test]

--- a/src/utils/providerCapabilities.test.ts
+++ b/src/utils/providerCapabilities.test.ts
@@ -381,3 +381,49 @@ describe("providerNeedsRouting", () => {
     );
   });
 });
+
+describe("resolveCodexOfficialIdentity 与后端判定顺序对齐", () => {
+  // 自建网关代理 ChatGPT backend：认证仍取 auth.json 里的登录态
+  // （requires_openai_auth = true），请求出口换成自己的 origin。
+  const workerConfig = `model_provider = "myworker"\n\n[model_providers.myworker]\nname = "My Worker"\nbase_url = "https://worker.example.com/backend-api/codex"\nwire_api = "responses"\nrequires_openai_auth = true\n`;
+
+  const managedWithCustomUpstream = mkProvider({
+    id: "managed-worker-account",
+    category: "official",
+    settingsConfig: { auth: {}, config: workerConfig },
+    meta: {
+      authBinding: {
+        source: "managed_account",
+        authProvider: "codex_oauth",
+        accountId: "acct-managed",
+      },
+    },
+  });
+
+  it("托管绑定指向自建上游时仍是官方身份", () => {
+    // 后端 is_codex_official_provider 先认托管绑定再看上游。这里若回 null，
+    // 后端会注入 OAuth token 而前端在接管期间拒绝切换，两边打架。
+    expect(
+      resolveCodexOfficialIdentity("codex" as AppId, managedWithCustomUpstream),
+    ).toBe("managed_account");
+    expect(
+      supportsOfficialProxyTakeover(
+        "codex" as AppId,
+        managedWithCustomUpstream,
+      ),
+    ).toBe(true);
+  });
+
+  it("未绑定却声明第三方上游的卡仍判为非官方", () => {
+    expect(
+      resolveCodexOfficialIdentity(
+        "codex" as AppId,
+        mkProvider({
+          id: "plain-third-party",
+          category: "official",
+          settingsConfig: { auth: {}, config: workerConfig },
+        }),
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/utils/providerCapabilities.ts
+++ b/src/utils/providerCapabilities.ts
@@ -69,13 +69,21 @@ export function resolveCodexOfficialIdentity(
     return null;
   }
 
+  // Checked before the third-party upstream test, matching
+  // `is_codex_official_provider` (`proxy/providers/codex.rs`): a managed
+  // binding decides where the credentials come from, and a card may point an
+  // official ChatGPT login at a self-hosted gateway. Testing the upstream
+  // first would report such a card as non-official and strand it — the backend
+  // would inject its OAuth token while `supportsOfficialProxyTakeover` denied
+  // the switch during takeover.
+  if (managedAccountId) {
+    return "managed_account";
+  }
+
   if (hasExplicitCodexThirdPartyUpstream(settings)) {
     return null;
   }
 
-  if (managedAccountId) {
-    return "managed_account";
-  }
   if (hasStoredCodexApiKey(settings)) {
     return provider.category === "official" ? "api_key" : null;
   }


### PR DESCRIPTION
## Summary / 概述

A Codex card can authenticate with a managed ChatGPT account **and** route through a self-hosted gateway. Codex CLI supports this natively — `model_providers.<id>.requires_openai_auth = true` next to a custom `base_url` — and people need it when the official backend is unreachable or an org gateway has to audit the traffic. CC Switch broke both halves of that setup.

The root cause is that `is_codex_official_provider` answers two questions with one boolean:

- **where the credentials come from** — drives the `auth.json` write, failover exclusion, takeover placeholder injection (10 of the 11 call sites)
- **where the request goes** — drives `extract_base_url` (the remaining one)

Those two used to always agree, so one boolean served both. A custom upstream makes them diverge.

**Half 1 — the token never reached `auth.json`.** `is_codex_official_provider` tested for a third-party upstream *before* the managed account binding, so a card with a custom `base_url` was not recognised as official and its OAuth token was never synced. The managed binding is the authoritative signal for the credential source and is now checked first. `resolveCodexOfficialIdentity` on the frontend had the same inversion, which reported the card as non-official and made `supportsOfficialProxyTakeover` deny the switch while the backend was injecting its token; it is now aligned with the backend order.

**Half 2 — the gateway was silently bypassed.** `CodexAdapter::extract_base_url` short-circuited every official card to `chatgpt.com/backend-api/codex`. With proxy takeover enabled the request went to the official backend with no error to notice. An official card now resolves its upstream from `extract_active_codex_provider_base_url`: the `base_url` of the table the active `model_provider` selects, or nothing.

Two deliberate restrictions on that resolution, both of which would otherwise send the ChatGPT bearer token (which the forwarder passes through for official cards) to a host the active `model_provider` never named:

- It never falls through to the generic resolution below, whose literal `base_url = "` scan takes the first match in the text regardless of which table is active. A leftover `[model_providers.*]` would otherwise receive the request.
- It does not accept the top-level `base_url` that the permissive `extract_codex_base_url` allows. The official card UI cannot set that field (`CodexFormFields` gates the Base URL shortcut on a non-official category), so a card carrying one inherited it from an earlier third-party setup.

The unified session bucket is stripped before resolution so an injected bucket table cannot pose as the active upstream.

### Behaviour matrix

Only one card shape changes, and it changes from wrong to right. Every other row is locked down by a test.

| Card shape | Credentials | Upstream before | Upstream after |
|---|---|---|---|
| fixed `codex-official` id, no custom upstream | official | chatgpt.com | chatgpt.com |
| managed OAuth binding, no custom upstream | official | chatgpt.com | chatgpt.com |
| `category: official`, no binding, no key, no custom upstream | official | chatgpt.com | chatgpt.com |
| `category: official` + stored API key | third-party | unchanged | unchanged |
| `category: official` + custom upstream, no binding | third-party | unchanged | unchanged |
| plain third-party card | third-party | unchanged | unchanged |
| **managed OAuth binding + custom upstream** | official | chatgpt.com (wrong) | **the custom upstream** |
| **fixed `codex-official` id + custom upstream** | official | chatgpt.com (wrong) | **the custom upstream** |

### Note for users setting this up

The worker config **must** declare a top-level `model_provider`:

```toml
model_provider = "myworker"

[model_providers.myworker]
name = "My Worker"
base_url = "https://<worker>/backend-api/codex"
wire_api = "responses"
requires_openai_auth = true
```

Without it, `inject_codex_unified_session_bucket` does not short-circuit and the unified session bucket points the route back at the official backend.

### Deliberately not done

- **`requires_openai_auth` as an official-credential signal.** The Codex schema defines it as "requires an OpenAI API Key *or* ChatGPT login token", i.e. "read credentials from `auth.json` instead of `env_key`", which does not distinguish the two. Third-party API-key cards (`Zhipu GLM`, `Kimi For Coding`) set it too, so treating it as an official signal would write a ChatGPT token into their `auth.json` and 401 them.
- **Splitting all 11 call sites.** Only `extract_base_url` asks the second question; re-deciding the semantics of the other 10 is a wide regression surface for zero gain.
- **The Base URL shortcut field for official cards.** The `config.toml` editor already covers the need; unlocking that field pulls in a row of unrelated `category !== "official"` gates.

### Known limitation, left in place

The generic text scan is still what third-party cards resolve through, and `extract_auth` attaches their API key, so a stale `[model_providers.*]` can leak that key. This is pre-existing on `main` and orthogonal to this change; fixing it needs every third-party config shape relying on that scan audited. A pointer comment marks it in the code.

### Verified end to end

On a managed ChatGPT card pointed at a local stub gateway (`http://127.0.0.1:18080/backend-api/codex`), with Codex proxy takeover enabled:

- `~/.codex/config.toml` was rewritten to `model_provider = "cc-switch-official"` → `http://127.0.0.1:15721/v1`, and cc-switch was listening there
- the proxy logged 8 forwarded requests, and the stub recorded the same 8 `POST /backend-api/codex/responses` at identical timestamps — **the requests reached the configured upstream, not `chatgpt.com`**
- the forwarded requests carried the client's `Authorization: Bearer …` through unchanged, confirming the official-card passthrough still applies to a custom upstream
- turning takeover off restored `config.toml` and left `auth.json` intact (`auth_mode: "chatgpt"`, all four token fields, no `PROXY_MANAGED` placeholder)
- switching to a third-party API-key card and back left that card's key untouched and restored the official login

Not covered: a negative control on a pre-fix build. The pre-fix routing is pinned by unit tests rather than re-run by hand.

## Related Issue / 关联 Issue

Fixes #6668

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes on the changed files / 通过 Clippy 检查（如修改了 Rust 代码）— the 3 remaining warnings (`gemini_mcp.rs:52`, `codex_oauth_auth.rs:262`, `tray.rs:785`) are pre-existing on `main` and are what #6678 fixes; none is in this diff
- [x] No user-facing text changed, i18n not applicable / 未修改用户可见文本，国际化不适用
