### PR TITLE
fix: models.dev 定价同步改走后端全局代理客户端，修复代理环境同步失败

### DIFF
--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -228,6 +228,12 @@ pub fn record_models_dev_sync_result(
     crate::services::model_pricing::record_models_dev_sync_result(&state.db, synced_at, error)
 }
 
+/// 拉取 models.dev 定价数据，走后端代理感知 HTTP 客户端，避免 WebView 直连在代理环境下超时
+#[tauri::command]
+pub async fn fetch_models_dev_pricing() -> Result<String, String> {
+    crate::services::model_pricing::fetch_models_dev_pricing().await
+}
+
 /// 检查 Provider 使用限额
 #[tauri::command]
 pub fn check_provider_limits(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1593,6 +1593,7 @@ pub fn run() {
             commands::get_models_dev_sync_config,
             commands::save_models_dev_sync_config,
             commands::record_models_dev_sync_result,
+            commands::fetch_models_dev_pricing,
             commands::check_provider_limits,
             // Session usage sync
             commands::sync_session_usage,

--- a/src-tauri/src/services/model_pricing.rs
+++ b/src-tauri/src/services/model_pricing.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 
 const MODEL_PRICING_FILE_NAME: &str = "model-pricing.json";
 const MODEL_PRICING_FILE_VERSION: u32 = 1;
@@ -471,6 +472,56 @@ pub fn delete_model_pricing(db: &Database, model_id: &str) -> Result<(), AppErro
     Ok(())
 }
 
+const MODELS_DEV_API_URL: &str = "https://models.dev/api.json";
+const MODELS_DEV_FETCH_TIMEOUT_SECS: u64 = 15;
+/// 响应大小上限：models.dev api.json 实际几 MB，超限视为异常响应
+const MODELS_DEV_MAX_RESPONSE_BYTES: usize = 32 * 1024 * 1024;
+
+/// 校验 models.dev 响应大小是否超限
+fn is_models_dev_response_too_large(len: usize) -> bool {
+    len > MODELS_DEV_MAX_RESPONSE_BYTES
+}
+
+/// 拉取 models.dev 定价数据（api.json）
+///
+/// 使用全局代理感知 HTTP 客户端，WebView 直连在代理环境下会超时。
+/// 返回原始 JSON 字符串，由前端解析为 ModelsDevResponse。
+pub async fn fetch_models_dev_pricing() -> Result<String, String> {
+    let client = crate::proxy::http_client::get();
+    let response = client
+        .get(MODELS_DEV_API_URL)
+        .timeout(Duration::from_secs(MODELS_DEV_FETCH_TIMEOUT_SECS))
+        .send()
+        .await
+        .map_err(|e| format!("Request to models.dev failed: {e}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("models.dev returned HTTP {status}"));
+    }
+
+    if let Some(len) = response.content_length() {
+        if is_models_dev_response_too_large(len as usize) {
+            return Err(format!(
+                "models.dev response too large: {len} bytes (max {MODELS_DEV_MAX_RESPONSE_BYTES})"
+            ));
+        }
+    }
+
+    let body = response
+        .bytes()
+        .await
+        .map_err(|e| format!("Failed to read models.dev response: {e}"))?;
+    if is_models_dev_response_too_large(body.len()) {
+        return Err(format!(
+            "models.dev response too large: {} bytes (max {MODELS_DEV_MAX_RESPONSE_BYTES})",
+            body.len()
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&body).into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -757,5 +808,16 @@ mod tests {
             assert_eq!(state.config.last_sync_at, Some(456));
             assert_eq!(state.config.last_sync_error.as_deref(), Some("offline"));
         });
+    }
+
+    #[test]
+    fn response_size_limit_rejects_oversized_payloads() {
+        assert!(!is_models_dev_response_too_large(0));
+        assert!(!is_models_dev_response_too_large(
+            MODELS_DEV_MAX_RESPONSE_BYTES
+        ));
+        assert!(is_models_dev_response_too_large(
+            MODELS_DEV_MAX_RESPONSE_BYTES + 1
+        ));
     }
 }

--- a/src-tauri/src/services/model_pricing.rs
+++ b/src-tauri/src/services/model_pricing.rs
@@ -488,7 +488,7 @@ fn is_models_dev_response_too_large(len: usize) -> bool {
 /// 返回原始 JSON 字符串，由前端解析为 ModelsDevResponse。
 pub async fn fetch_models_dev_pricing() -> Result<String, String> {
     let client = crate::proxy::http_client::get();
-    let response = client
+    let mut response = client
         .get(MODELS_DEV_API_URL)
         .timeout(Duration::from_secs(MODELS_DEV_FETCH_TIMEOUT_SECS))
         .send()
@@ -508,18 +508,32 @@ pub async fn fetch_models_dev_pricing() -> Result<String, String> {
         }
     }
 
-    let body = response
-        .bytes()
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
         .await
-        .map_err(|e| format!("Failed to read models.dev response: {e}"))?;
-    if is_models_dev_response_too_large(body.len()) {
-        return Err(format!(
-            "models.dev response too large: {} bytes (max {MODELS_DEV_MAX_RESPONSE_BYTES})",
-            body.len()
-        ));
+        .map_err(|e| format!("Failed to read models.dev response: {e}"))?
+    {
+        if append_models_dev_chunk(&mut buf, &chunk).is_err() {
+            return Err(format!(
+                "models.dev response too large: {} bytes (max {MODELS_DEV_MAX_RESPONSE_BYTES})",
+                buf.len()
+            ));
+        }
     }
 
-    Ok(String::from_utf8_lossy(&body).into_owned())
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// 追加一个 chunk 并判断累计大小是否超限（读取过程中即时生效，避免 chunked 响应被整体缓冲）
+fn append_models_dev_chunk(buf: &mut Vec<u8>, chunk: &[u8]) -> Result<(), ()> {
+    if buf.len() > MODELS_DEV_MAX_RESPONSE_BYTES || chunk.len() > MODELS_DEV_MAX_RESPONSE_BYTES - buf.len() {
+        // 超限时仍追加 chunk，便于调用方报告真实累计字节数
+        buf.extend_from_slice(chunk);
+        return Err(());
+    }
+    buf.extend_from_slice(chunk);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -819,5 +833,28 @@ mod tests {
         assert!(is_models_dev_response_too_large(
             MODELS_DEV_MAX_RESPONSE_BYTES + 1
         ));
+    }
+
+    #[test]
+    fn append_chunk_accumulates_within_limit() {
+        let mut buf = Vec::new();
+        append_models_dev_chunk(&mut buf, b"hello").expect("within limit");
+        append_models_dev_chunk(&mut buf, b" world").expect("within limit");
+        assert_eq!(buf, b"hello world");
+    }
+
+    #[test]
+    fn append_chunk_accepts_exactly_limit() {
+        let mut buf = vec![0u8; MODELS_DEV_MAX_RESPONSE_BYTES - 1];
+        append_models_dev_chunk(&mut buf, &[1u8])
+            .expect("exactly at limit should not overflow");
+        assert_eq!(buf.len(), MODELS_DEV_MAX_RESPONSE_BYTES);
+    }
+
+    #[test]
+    fn append_chunk_rejects_over_limit() {
+        let mut buf = vec![0u8; MODELS_DEV_MAX_RESPONSE_BYTES];
+        assert!(append_models_dev_chunk(&mut buf, &[1u8; 1024]).is_err());
+        assert_eq!(buf.len(), MODELS_DEV_MAX_RESPONSE_BYTES + 1024);
     }
 }

--- a/src-tauri/src/services/model_pricing.rs
+++ b/src-tauri/src/services/model_pricing.rs
@@ -527,7 +527,9 @@ pub async fn fetch_models_dev_pricing() -> Result<String, String> {
 
 /// 追加一个 chunk 并判断累计大小是否超限（读取过程中即时生效，避免 chunked 响应被整体缓冲）
 fn append_models_dev_chunk(buf: &mut Vec<u8>, chunk: &[u8]) -> Result<(), ()> {
-    if buf.len() > MODELS_DEV_MAX_RESPONSE_BYTES || chunk.len() > MODELS_DEV_MAX_RESPONSE_BYTES - buf.len() {
+    if buf.len() > MODELS_DEV_MAX_RESPONSE_BYTES
+        || chunk.len() > MODELS_DEV_MAX_RESPONSE_BYTES - buf.len()
+    {
         // 超限时仍追加 chunk，便于调用方报告真实累计字节数
         buf.extend_from_slice(chunk);
         return Err(());
@@ -846,8 +848,7 @@ mod tests {
     #[test]
     fn append_chunk_accepts_exactly_limit() {
         let mut buf = vec![0u8; MODELS_DEV_MAX_RESPONSE_BYTES - 1];
-        append_models_dev_chunk(&mut buf, &[1u8])
-            .expect("exactly at limit should not overflow");
+        append_models_dev_chunk(&mut buf, &[1u8]).expect("exactly at limit should not overflow");
         assert_eq!(buf.len(), MODELS_DEV_MAX_RESPONSE_BYTES);
     }
 

--- a/src/lib/modelsDevPricing.ts
+++ b/src/lib/modelsDevPricing.ts
@@ -1,9 +1,9 @@
+import { invoke } from "@tauri-apps/api/core";
+
 import type { ModelPricing, ModelsDevSyncConfig } from "@/types/usage";
 
-export const MODELS_DEV_API_URL = "https://models.dev/api.json";
 export const MODELS_DEV_QUERY_KEY = ["models-dev-pricing"] as const;
 export const MODELS_DEV_STALE_TIME_MS = 60 * 60 * 1000;
-const MODELS_DEV_FETCH_TIMEOUT_MS = 15_000;
 
 export interface ModelsDevCost {
   input?: number;
@@ -139,22 +139,9 @@ export function flattenModels(data: ModelsDevResponse): ModelsDevEntry[] {
 }
 
 export async function fetchModelsDevPricing(): Promise<ModelsDevResponse> {
-  const controller = new AbortController();
-  const timeout = window.setTimeout(
-    () => controller.abort(),
-    MODELS_DEV_FETCH_TIMEOUT_MS,
-  );
-  try {
-    const response = await fetch(MODELS_DEV_API_URL, {
-      signal: controller.signal,
-    });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-    return (await response.json()) as ModelsDevResponse;
-  } finally {
-    window.clearTimeout(timeout);
-  }
+  // WebView 不读终端代理环境变量，改走 Rust 后端的全局代理感知 HTTP 客户端
+  const raw = await invoke<string>("fetch_models_dev_pricing");
+  return JSON.parse(raw) as ModelsDevResponse;
 }
 
 const COMMON_MODEL_LIMIT_PER_FAMILY = 6;

--- a/tests/components/ModelsDevAutoSyncPanel.test.tsx
+++ b/tests/components/ModelsDevAutoSyncPanel.test.tsx
@@ -2,6 +2,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
 const {
   getModelsDevSyncConfig,
   saveModelsDevSyncConfig,
@@ -84,11 +90,11 @@ describe("ModelsDevAutoSyncPanel", () => {
       changed: 1,
       syncedAt: Date.now(),
     });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command !== "fetch_models_dev_pricing") {
+        throw new Error(`Unexpected command: ${command}`);
+      }
+      return JSON.stringify({
           openai: {
             name: "OpenAI",
             models: {
@@ -109,9 +115,8 @@ describe("ModelsDevAutoSyncPanel", () => {
               },
             },
           },
-        }),
-      }),
-    );
+        });
+    });
   });
 
   it("loads automatic sync as disabled by default", async () => {

--- a/tests/lib/modelsDevAutoSync.test.ts
+++ b/tests/lib/modelsDevAutoSync.test.ts
@@ -18,6 +18,12 @@ vi.mock("@/lib/api/usage", () => ({
   },
 }));
 
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
 import {
   MODELS_DEV_STARTUP_SYNC_INTERVAL_MS,
   syncModelsDevPricing,
@@ -40,11 +46,11 @@ describe("syncModelsDevPricing", () => {
     vi.clearAllMocks();
     updateModelPricingBatch.mockResolvedValue(2);
     recordModelsDevSyncResult.mockResolvedValue(undefined);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({
+    invokeMock.mockImplementation(async (command: string) => {
+      if (command !== "fetch_models_dev_pricing") {
+        throw new Error(`Unexpected command: ${command}`);
+      }
+      return JSON.stringify({
           openai: {
             models: {
               "gpt-5": {
@@ -63,9 +69,8 @@ describe("syncModelsDevPricing", () => {
               },
             },
           },
-        }),
-      }),
-    );
+        });
+    });
   });
 
   it("skips network access when automatic sync is disabled", async () => {
@@ -77,7 +82,7 @@ describe("syncModelsDevPricing", () => {
     const result = await syncModelsDevPricing();
 
     expect(result.skipped).toBe(true);
-    expect(fetch).not.toHaveBeenCalled();
+    expect(invokeMock).not.toHaveBeenCalled();
     expect(updateModelPricingBatch).not.toHaveBeenCalled();
   });
 
@@ -100,7 +105,7 @@ describe("syncModelsDevPricing", () => {
       changed: 0,
       syncedAt: lastSyncAt,
     });
-    expect(fetch).not.toHaveBeenCalled();
+    expect(invokeMock).not.toHaveBeenCalled();
     expect(updateModelPricingBatch).not.toHaveBeenCalled();
   });
 
@@ -127,9 +132,7 @@ describe("syncModelsDevPricing", () => {
       expect.any(Number),
       null,
     );
-    const fetchOptions = vi.mocked(fetch).mock.calls[0]?.[1];
-    expect(fetchOptions).toEqual({ signal: expect.any(AbortSignal) });
-    expect(fetchOptions).not.toHaveProperty("cache");
+    expect(invokeMock).toHaveBeenCalledWith("fetch_models_dev_pricing");
   });
 
   it("stops a startup sync when automatic sync is disabled during download", async () => {
@@ -191,7 +194,7 @@ describe("syncModelsDevPricing", () => {
   it("persists the last error without replacing the previous success time", async () => {
     const previous = { ...state, config: { ...state.config, lastSyncAt: 123 } };
     getModelsDevSyncConfig.mockResolvedValue(previous);
-    vi.mocked(fetch).mockRejectedValueOnce(new Error("offline"));
+    invokeMock.mockRejectedValueOnce(new Error("offline"));
 
     await expect(syncModelsDevPricing()).rejects.toThrow("offline");
     expect(recordModelsDevSyncResult).toHaveBeenCalledWith(null, "offline");

--- a/tests/lib/modelsDevPricing.test.ts
+++ b/tests/lib/modelsDevPricing.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: invokeMock,
+}));
+
+import { fetchModelsDevPricing } from "@/lib/modelsDevPricing";
+
+const fixture = {
+  openai: {
+    models: {
+      "gpt-5": {
+        name: "GPT-5",
+        release_date: "2025-08-01",
+        cost: { input: 1, output: 2 },
+      },
+    },
+  },
+};
+
+describe("fetchModelsDevPricing", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("fetches via the backend command and parses the JSON payload", async () => {
+    invokeMock.mockResolvedValueOnce(JSON.stringify(fixture));
+
+    const result = await fetchModelsDevPricing();
+
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith("fetch_models_dev_pricing");
+    expect(result).toEqual(fixture);
+  });
+
+  it("propagates backend errors", async () => {
+    invokeMock.mockRejectedValueOnce(new Error("HTTP 503"));
+
+    await expect(fetchModelsDevPricing()).rejects.toThrow("HTTP 503");
+  });
+});

--- a/tests/msw/handlers.ts
+++ b/tests/msw/handlers.ts
@@ -1,6 +1,5 @@
 import { http, HttpResponse } from "msw";
 import type { AppId } from "@/lib/api/types";
-import { MODELS_DEV_API_URL } from "@/lib/modelsDevPricing";
 import type { McpServer, Provider, Settings } from "@/types";
 import {
   addProvider,
@@ -41,7 +40,7 @@ const withJson = async <T>(request: Request): Promise<T> => {
 const success = <T>(payload: T) => HttpResponse.json(payload as any);
 
 export const handlers = [
-  http.get(MODELS_DEV_API_URL, () => success({})),
+  http.post(`${TAURI_ENDPOINT}/fetch_models_dev_pricing`, () => success({})),
   http.post(`${TAURI_ENDPOINT}/get_migration_result`, () => success(false)),
   http.post(`${TAURI_ENDPOINT}/get_skills_migration_result`, () =>
     success(null),


### PR DESCRIPTION
## Summary / 概述

开启「自动同步 models.dev 定价」后，在仅通过本地代理（终端环境变量 / 应用内代理）出网的环境下，同步永远失败，UI 显示：

> 上次自动同步失败：Fetch is aborted

「从 models.dev 导入」定价对话框同样不可用（共用同一 fetch 路径）。直连可达 models.dev 的环境不受影响。

### 根因

`src/lib/modelsDevPricing.ts` 的 `fetchModelsDevPricing()` 在 WebView 内用浏览器原生 `fetch` 直连 `https://models.dev/api.json`（15s `AbortController` 超时）。该请求不经过 Rust 后端，因此：

- 不使用 `proxy/http_client.rs` 的全局代理客户端（该文件头注释明确要求「所有需要发送 HTTP 请求的模块都应使用此模块提供的客户端」，此处是漏网之鱼）；
- WKWebView 只跟随系统代理，不读取应用内代理配置与终端环境变量。

代理环境下请求直连 models.dev 挂起 → 15s 超时 abort → WebKit 错误消息 `Fetch is aborted` 被记录为 `lastSyncError`。

### 修复

- 新增 Tauri command `fetch_models_dev_pricing`：经 `http_client::get()`（全局代理感知客户端）请求 api.json，15s per-request 超时、32MB 响应大小上限（content_length 与实际 body 双重校验），非 200 / 网络错误返回带 `models.dev` 上下文的错误字符串。
- 前端 `fetchModelsDevPricing()` 改为 `invoke("fetch_models_dev_pricing")` + `JSON.parse`，函数签名与返回类型不变，`modelsDevAutoSync.ts` 与 `ModelsDevPickerDialog.tsx` 等调用方零改动。
- 不引入新依赖；数据库 schema、`model-pricing.json` 文件格式、`http_client.rs` 均未改动。

## Related Issue / 关联 Issue

Fixes #6696（该 issue 由本 PR 作者先行创建，因为搜索后未发现已有报告）

## Screenshots / 截图

不适用（无 UI 变化）。

## 测试

- TDD：新增 `tests/lib/modelsDevPricing.test.ts`（RED 2 failed → GREEN），断言 invoke 的具体 command 名而非空 mock。
- 相关测试从 mock `window.fetch`（MSW）迁移为 mock Tauri `invoke`：`modelsDevAutoSync.test.ts`、`ModelsDevAutoSyncPanel.test.tsx`、`tests/msw/handlers.ts`。
- `pnpm vitest run` 全量 989 tests 通过；`cargo test model_pricing` 11 passed。
- 真实环境人工验证（macOS，仅本地代理、未设系统代理）：debug 构建下自动同步成功，`lastSyncError` 清空，成功同步 56 个模型价格。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（本次无用户可见文本变更）

## 已知限制

- Rust 侧非 200 / 超时分支为简单 status 判断 + 错误拼接，未打真网单测；大小上限校验已抽纯函数 `is_models_dev_response_too_large` 并有单测。