### PR TITLE
fix(codex): backfill required supports_parallel_tool_calls into generated model catalog

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1791,7 +1791,14 @@ fn codex_vendor_catalog_model_entry(
 /// field ..."). `base_instructions` is the other known required field; the
 /// templates always carry it and `codex_catalog_model_entry` handles it.
 /// When Codex requires a new field, add it here AND to the static templates.
-const CODEX_CATALOG_PARSER_REQUIRED_FIELDS: &[&str] = &["supports_reasoning_summaries"];
+/// `supports_parallel_tool_calls` was added to the required set after newer
+/// Codex builds started rejecting catalogs whose entries omit it (the very
+/// same `models_cache.json` drift scenario documented below for
+/// `supports_reasoning_summaries`).
+const CODEX_CATALOG_PARSER_REQUIRED_FIELDS: &[&str] = &[
+    "supports_reasoning_summaries",
+    "supports_parallel_tool_calls",
+];
 
 /// `models_cache.json` is shared by every Codex install on the machine (npm
 /// CLI, desktop-bundled binary, ...), and each version serializes its own
@@ -4072,6 +4079,15 @@ base_url = "https://production.api/v1"
         assert_eq!(
             catalog["models"][0]
                 .get("supports_reasoning_summaries")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        // Newer Codex (post-0.144.5 line) also requires
+        // `supports_parallel_tool_calls`; a stale dynamic template that omits it
+        // must be backfilled so the generated catalog parses at startup.
+        assert_eq!(
+            catalog["models"][0]
+                .get("supports_parallel_tool_calls")
                 .and_then(Value::as_bool),
             Some(true)
         );


### PR DESCRIPTION
## 概述 / Summary

新版 Codex 在启动时会拒绝整个外部 model catalog，只要其中任意条目缺少 `supports_parallel_tool_calls`，报错：

```
failed to parse model_catalog_json ... as JSON: missing field `supports_parallel_tool_calls`
```

cc-switch 生成的 `~/.codex/cc-switch-model-catalog.json` 在走 ProxyChat 路径、且 `models_cache.json` 由旧版 Codex 写入（其 `gpt-5.5` 模板不含该字段）时，会缺这个字段，导致 ChatGPT/Codex 桌面端无法加载配置、对话串中断。

## 根因 / Root cause

`src-tauri/src/codex_config.rs` 的 `CODEX_CATALOG_PARSER_REQUIRED_FIELDS` 只列了 `supports_reasoning_summaries`。catalog 从 `models_cache.json`（旧模板）克隆而来后，`fill_template_fields_from_static` 只回填列表中的字段，因此 `supports_parallel_tool_calls` 永远不会被补回。

bundled 静态模板 `resources/gpt5_5_template.json` 已经声明了 `supports_parallel_tool_calls: true`，所以修复只需把它加入回填集合，与现有的 `supports_reasoning_summaries` 处理保持一致。

## 改动 / Changes

- 将 `supports_parallel_tool_calls` 加入 `CODEX_CATALOG_PARSER_REQUIRED_FIELDS` 回填集合。
- 无模板文件改动（静态模板已含该字段，现有值优先、不被覆盖）。
- 在 `proxy_chat_catalog_entries_carry_reasoning_summaries_flag` 测试中增补断言，确认生成的 catalog 条目确实携带 `supports_parallel_tool_calls`。

## 验证 / Verification

- `cargo check --lib` 通过。
- `cargo test --lib codex_config` 全部通过（86 passed），新增断言覆盖回填后该字段存在。

## 关联 / Related

Closes #6709

🤖 Generated with [Claude Code](https://claude.com/claude-code)