### PR TITLE
fix(theme): dynamic system theme synchronization on Linux/KDE via Portal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ copilot-api
 .history
 CODEBUDDY.md
 mainWindow.js
+.pnpm-store/

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -769,6 +769,7 @@ dependencies = [
  "brotli 7.0.0",
  "bytes",
  "chrono",
+ "dark-light",
  "dirs 5.0.1",
  "flate2",
  "futures",
@@ -1163,6 +1164,23 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dark-light"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f66b71ac6b73812b0bf51cda8dd646a268fbb38623f45b2b7907593c323f745"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "wasm-bindgen",
+ "web-sys",
+ "windows-sys 0.61.2",
+ "winreg 0.56.0",
+ "zbus",
 ]
 
 [[package]]
@@ -4687,7 +4705,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5414,6 +5432,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7513,6 +7542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7539,6 +7577,16 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7770,9 +7818,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.14.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -7797,7 +7845,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 0.7.15",
+ "winnow 1.0.4",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -7805,14 +7853,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.14.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -7820,13 +7868,22 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.1"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow 1.0.4",
  "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -8028,40 +8085,41 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.10.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 0.7.15",
+ "winnow 1.0.4",
+ "zcheapstr",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
- "winnow 0.7.15",
+ "syn 3.0.3",
+ "winnow 1.0.4",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -82,6 +82,7 @@ hmac = "0.12"
 json5 = "0.4"
 json-five = "0.3.1"
 sys-locale = "0.3"
+dark-light = "3.0.0"
 
 [target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -4738,6 +4738,42 @@ pub async fn set_window_theme(window: tauri::Window, theme: String) -> Result<()
     window.set_theme(tauri_theme).map_err(|e| e.to_string())
 }
 
+/// 读取当前系统的深浅色模式（Linux 上通过 XDG Desktop Portal 读取）
+#[tauri::command]
+pub async fn get_system_theme() -> Result<Option<&'static str>, String> {
+    const DETECT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(1500);
+    let detect = tauri::async_runtime::spawn_blocking(detect_system_theme_blocking);
+    match tokio::time::timeout(DETECT_TIMEOUT, detect).await {
+        Ok(Ok(mode)) => Ok(mode),
+        Ok(Err(e)) => {
+            log::debug!("System theme detect task failed: {e}");
+            Ok(None)
+        }
+        Err(_) => {
+            log::debug!("System theme detect timed out; falling back to matchMedia");
+            Ok(None)
+        }
+    }
+}
+
+fn map_system_theme_mode(mode: dark_light::Mode) -> Option<&'static str> {
+    match mode {
+        dark_light::Mode::Dark => Some("dark"),
+        dark_light::Mode::Light => Some("light"),
+        dark_light::Mode::Unspecified => None,
+    }
+}
+
+fn detect_system_theme_blocking() -> Option<&'static str> {
+    match dark_light::detect() {
+        Ok(mode) => map_system_theme_mode(mode),
+        Err(e) => {
+            log::debug!("Failed to detect system theme via dark-light: {e}");
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -7190,5 +7226,24 @@ mod tests {
             command,
             "pushd \"\\\\server\\share\\100%%^&^(test^)\" || exit /b 1\r\n"
         );
+    }
+
+    #[test]
+    fn map_system_theme_mode_maps_correctly() {
+        assert_eq!(map_system_theme_mode(dark_light::Mode::Dark), Some("dark"));
+        assert_eq!(
+            map_system_theme_mode(dark_light::Mode::Light),
+            Some("light")
+        );
+        assert_eq!(map_system_theme_mode(dark_light::Mode::Unspecified), None);
+    }
+
+    #[tokio::test]
+    async fn get_system_theme_returns_valid_variant() {
+        let res = get_system_theme().await;
+        assert!(res.is_ok());
+        if let Ok(Some(theme)) = res {
+            assert!(theme == "dark" || theme == "light");
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1666,6 +1666,7 @@ pub fn run() {
             commands::scan_local_proxies,
             // Window theme control
             commands::set_window_theme,
+            commands::get_system_theme,
             // Generic managed auth commands
             commands::auth_start_login,
             commands::auth_poll_for_account,

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { isLinux } from "@/lib/platform";
 
 type Theme = "light" | "dark" | "system";
 
@@ -58,41 +59,66 @@ export function ThemeProvider({
     }
 
     const root = window.document.documentElement;
-    root.classList.remove("light", "dark");
 
-    if (theme === "system") {
-      const isDark =
-        window.matchMedia &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches;
-      root.classList.add(isDark ? "dark" : "light");
+    if (theme !== "system") {
+      root.classList.remove("light", "dark");
+      root.classList.add(theme);
       return;
     }
 
-    root.classList.add(theme);
-  }, [theme]);
+    let isMounted = true;
+    let inFlight = false;
 
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-    const handleChange = () => {
-      if (theme !== "system") {
-        return;
-      }
-
-      const root = window.document.documentElement;
-      root.classList.toggle("dark", mediaQuery.matches);
-      root.classList.toggle("light", !mediaQuery.matches);
+    const applyTheme = (isDark: boolean) => {
+      if (!isMounted) return;
+      root.classList.toggle("dark", isDark);
+      root.classList.toggle("light", !isDark);
     };
 
-    if (theme === "system") {
-      handleChange();
-    }
+    const syncSystemTheme = async () => {
+      if (!isMounted || inFlight) return;
+      inFlight = true;
+      try {
+        const sysTheme = await invoke<string | null>("get_system_theme");
+        if (sysTheme === "dark") {
+          applyTheme(true);
+          return;
+        } else if (sysTheme === "light") {
+          applyTheme(false);
+          return;
+        }
+      } catch (e) {
+        console.debug("Failed to read system theme via get_system_theme:", e);
+      } finally {
+        inFlight = false;
+      }
 
-    mediaQuery.addEventListener("change", handleChange);
-    return () => mediaQuery.removeEventListener("change", handleChange);
+      // Fallback to matchMedia
+      const isDark = Boolean(
+        window.matchMedia &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches,
+      );
+      applyTheme(isDark);
+    };
+
+    // Initial sync
+    void syncSystemTheme();
+
+    const mediaQuery = window.matchMedia?.("(prefers-color-scheme: dark)");
+    const handleMediaChange = () => {
+      void syncSystemTheme();
+    };
+    mediaQuery?.addEventListener("change", handleMediaChange);
+
+    // Fallback periodic polling for Linux/KDE Portal theme changes
+    // which may not emit WebKit mediaQuery events.
+    const intervalId = isLinux() ? setInterval(syncSystemTheme, 2000) : null;
+
+    return () => {
+      isMounted = false;
+      if (intervalId !== null) clearInterval(intervalId);
+      mediaQuery?.removeEventListener("change", handleMediaChange);
+    };
   }, [theme]);
 
   // Sync native window theme (Windows/macOS title bar)

--- a/tests/components/ThemeProvider.test.tsx
+++ b/tests/components/ThemeProvider.test.tsx
@@ -1,0 +1,214 @@
+import { render, waitFor, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ThemeProvider, useTheme } from "@/components/theme-provider";
+import { invoke } from "@tauri-apps/api/core";
+import * as platform from "@/lib/platform";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@/lib/platform", () => ({
+  isLinux: vi.fn(() => true),
+}));
+
+function ThemeConsumer() {
+  const { theme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme-value">{theme}</span>
+      <button onClick={() => setTheme("light")}>Set Light</button>
+      <button onClick={() => setTheme("dark")}>Set Dark</button>
+      <button onClick={() => setTheme("system")}>Set System</button>
+    </div>
+  );
+}
+
+describe("ThemeProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(platform.isLinux).mockReturnValue(true);
+    window.localStorage.clear();
+    document.documentElement.classList.remove("light", "dark");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("syncs system dark theme using get_system_theme command", async () => {
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_system_theme") return "dark";
+      return undefined;
+    });
+
+    render(
+      <ThemeProvider defaultTheme="system" storageKey="test-theme">
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+      expect(document.documentElement.classList.contains("light")).toBe(false);
+    });
+
+    expect(invoke).toHaveBeenCalledWith("get_system_theme");
+  });
+
+  it("syncs system light theme using get_system_theme command", async () => {
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_system_theme") return "light";
+      return undefined;
+    });
+
+    render(
+      <ThemeProvider defaultTheme="system" storageKey="test-theme">
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("light")).toBe(true);
+      expect(document.documentElement.classList.contains("dark")).toBe(false);
+    });
+  });
+
+  it("applies fixed theme when set to light or dark", async () => {
+    render(
+      <ThemeProvider defaultTheme="dark" storageKey="test-theme">
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains("dark")).toBe(true);
+    });
+
+    expect(invoke).toHaveBeenCalledWith("set_window_theme", { theme: "dark" });
+  });
+
+  it("polls periodically every 2s on Linux", async () => {
+    vi.useFakeTimers();
+    vi.mocked(platform.isLinux).mockReturnValue(true);
+    let themeValue = "dark";
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_system_theme") return themeValue;
+      return undefined;
+    });
+
+    render(
+      <ThemeProvider defaultTheme="system" storageKey="test-theme">
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    const getSystemThemeCalls = () =>
+      vi
+        .mocked(invoke)
+        .mock.calls.filter(([cmd]) => cmd === "get_system_theme");
+
+    // Initial mount sync
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getSystemThemeCalls()).toHaveLength(1);
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    // Theme changes on system
+    themeValue = "light";
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(getSystemThemeCalls()).toHaveLength(2);
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("does not poll periodically on non-Linux platforms", async () => {
+    vi.useFakeTimers();
+    vi.mocked(platform.isLinux).mockReturnValue(false);
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_system_theme") return "dark";
+      return undefined;
+    });
+
+    render(
+      <ThemeProvider defaultTheme="system" storageKey="test-theme">
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    const getSystemThemeCalls = () =>
+      vi
+        .mocked(invoke)
+        .mock.calls.filter(([cmd]) => cmd === "get_system_theme");
+
+    // Initial sync
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getSystemThemeCalls()).toHaveLength(1);
+
+    // Advance timers - on non-Linux, setInterval was not scheduled
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(getSystemThemeCalls()).toHaveLength(1);
+  });
+
+  it("prevents overlapping concurrent get_system_theme calls via in-flight guard", async () => {
+    vi.useFakeTimers();
+    vi.mocked(platform.isLinux).mockReturnValue(true);
+
+    let resolveFirstCall: (val: string) => void;
+    const firstCallPromise = new Promise<string>((resolve) => {
+      resolveFirstCall = resolve;
+    });
+
+    let callCount = 0;
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === "get_system_theme") {
+        callCount++;
+        if (callCount === 1) {
+          return firstCallPromise;
+        }
+        return "light";
+      }
+      return undefined;
+    });
+
+    render(
+      <ThemeProvider defaultTheme="system" storageKey="test-theme">
+        <ThemeConsumer />
+      </ThemeProvider>,
+    );
+
+    // First call started but hasn't resolved
+    expect(callCount).toBe(1);
+
+    // Advance 2s while first call is still in flight
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    // in-flight guard should have skipped the tick
+    expect(callCount).toBe(1);
+
+    // Resolve first call
+    await act(async () => {
+      resolveFirstCall!("dark");
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+
+    // Now that in-flight is cleared, next 2s tick should proceed
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(callCount).toBe(2);
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes an issue on Linux (e.g. KDE Plasma / GNOME with XDG Desktop Portal) where CC Switch in "System" theme mode does not dynamically follow desktop theme switches without restarting the application.

### Root Cause
On Wayland, GTK3 has no live settings channel for desktop theme changes, and WebKitGTK reads `gtk-application-prefer-dark-theme` from `GtkSettings`, so WebKit's `prefers-color-scheme` never flips dynamically. Reading the XDG Desktop Portal (`org.freedesktop.appearance/color-scheme`) is the proper live data source.
*(Note: As a pre-existing upstream behavior, `tao` maps `set_theme(None)` on Linux to `gtk-application-prefer-dark-theme = false`. With this PR the page root classes `.dark`/`.light` will synchronize dynamically, though `prefers-color-scheme` inside the webview may still disagree for native controls like scrollbars until a separate follow-up).*

### Changes
1. **Rust Backend (`src-tauri`)**:
   - Added `dark-light = "3.0.0"` dependency.
   - Implemented async `get_system_theme()` command reading the active XDG Desktop Portal theme via `tauri::async_runtime::spawn_blocking` bounded by a 1500ms `tokio::time::timeout` to prevent any D-Bus / portal hangs from blocking the GTK main loop or worker threads.
   - Added `map_system_theme_mode` helper and unit tests for theme mapping and async command execution.
2. **Frontend React (`src/components/theme-provider.tsx`)**:
   - Updated `ThemeProvider` to query `get_system_theme` on initial mount / mode change.
   - Added an `inFlight` guard to prevent stacking concurrent IPC requests.
   - Gated the 2s fallback polling interval on `isLinux()` so macOS/Windows users incur no polling overhead.
   - Wrapped `window.matchMedia` fallback in `Boolean(...)` for safe `classList.toggle` under jsdom / fallback environments.
   - Added unit test suite in `tests/components/ThemeProvider.test.tsx` covering theme detection, Linux 2s polling, non-Linux polling omission, and in-flight request deduplication.
3. **Dependency & Environment Notes**:
   - `.gitignore` tracks `.pnpm-store/`.
   - `Cargo.lock` updates `zbus` family (5.14 → 5.19) and related dependencies (such as `syn 3.0.3`, `winnow 1.0.4`) required by `dark-light 3.0.0`.

### Verification
- Frontend Vitest tests pass (136 test files, 1093 tests passed).
- Backend Rust unit tests pass (`cargo test --lib system_theme`).
- TypeScript typecheck (`pnpm run typecheck`) passes with 0 errors.
- Verified on Fedora KDE Plasma 6: dynamically toggles UI theme between dark and light modes on desktop theme changes.