### PR TITLE
fix(terminal): show provider-terminal toast at launch, not at window close

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -4384,27 +4384,37 @@ fn escape_windows_batch_value(value: &str) -> String {
         .replace('(', "^(")
         .replace(')', "^)")
 }
-/// Windows: Run a start command with common error handling
+/// Windows: Run a start command with common error handling.
+///
+/// stdio must be pointed at NUL instead of captured with `output()`: `start`
+/// lets the spawned console inherit the wrapper's std handles, so a captured
+/// pipe stays open until that window (and everything running inside it)
+/// exits. Waiting for the pipe's EOF kept the calling Tauri command pending
+/// for the entire terminal session, so the frontend "Terminal opened" toast
+/// only fired when the window was closed (issue #6712). Waiting on the
+/// wrapper's exit status via `status()` still surfaces launch failures
+/// without tying this call to the window's lifetime.
 #[cfg(target_os = "windows")]
 fn run_windows_start_command(args: &[&str], terminal_name: &str) -> Result<(), String> {
-    use std::process::Command;
+    use std::process::{Command, Stdio};
 
     let mut full_args = vec!["/C", "start"];
     full_args.extend(args);
 
-    let output = Command::new("cmd")
+    let status = Command::new("cmd")
         .args(&full_args)
         .creation_flags(CREATE_NO_WINDOW)
-        .output()
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
         .map_err(|e| format!("启动 {} 失败: {e}", terminal_name))?;
 
-    if !output.status.success() {
-        let stderr = decode_command_output(&output.stderr);
+    if !status.success() {
         return Err(format!(
-            "{} 启动失败 (exit code: {:?}): {}",
+            "{} 启动失败 (exit code: {:?})",
             terminal_name,
-            output.status.code(),
-            stderr
+            status.code(),
         ));
     }
 


### PR DESCRIPTION
## Summary / 概述

 On Windows, `run_windows_start_command` captured the `cmd /C start` wrapper's output via `Command::output()`. The console spawned
  by `start` inherits the wrapper's stdout/stderr pipe handles, and that pipe only reaches EOF once the window and everything
  running inside it exits. As a result, `open_provider_terminal` resolved only when the user closed the terminal: the frontend
  "Terminal opened" toast fired at close time instead of open time, and an async worker thread stayed blocked for the whole session.

  This PR points stdio at NUL and waits on the wrapper's exit status instead, so the command resolves as soon as the terminal
  launches. Launch failures are still detected via the exit code.

  Windows 下，`run_windows_start_command` 之前用 `Command::output()` 捕获 `cmd /C start` 的输出。`start`
  打开的控制台会继承外层进程的 stdout/stderr 管道句柄，管道只有在窗口及其内部所有进程退出后才到达 EOF。因此 `open_provider_terminal`
  只在用户关闭终端时才返回，前端的 "Terminal opened" 提示在关窗时才弹出，且整个会话期间都有一个异步工作线程被阻塞。本 PR 将 stdio
  指向 NUL 并改为等待包装进程的退出码，命令在终端启动后立即返回；启动失败仍可通过退出码发现。

  ## Related Issue / 关联 Issue

  Fixes #6712

  ## Screenshots / 截图

  Not applicable — backend timing fix, no UI change. / 不适用——后端时序修复，无界面变化。

  ## Verification / 验证

  - Standalone reproduction of the exact call semantics on Windows 11: the old `.output()` form blocked for the entire lifetime of
  the spawned window (measured until window close), while the new form returns in ~90 ms with the window still open.
  - `cargo fmt --check`, `cargo clippy`, `pnpm typecheck`, `pnpm format:check` all pass.
  - `cargo test`: 2661 passed. The 2 failing tests
  (`services::model_pricing::tests::reloads_manual_file_edits_and_deletion_tombstones`,
  `services::skill::tests::migrate_storage_safely_leaves_an_existing_pi_ssot_alias`) fail identically on clean `main` in this
  environment (verified by stashing this change), unrelated to this PR.
  - `pnpm test:unit`: 983 passed. The 4 failing tests in `tests/components/UnifiedSkillsPanel.test.tsx` are frontend-only; this PR
  touches no frontend code.

  ## Checklist / 检查清单

  - [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
  - [x] `pnpm format:check` passes / 通过代码格式检查
  - [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
  - [x] No user-facing text changed, i18n files untouched / 未修改用户可见文本，无需更新国际化文件