### PR TITLE
fix(codex): stamp commentary/final_answer on Chat→Responses messages

### DIFF
--- a/src-tauri/src/proxy/providers/codex_responses_sse.rs
+++ b/src-tauri/src/proxy/providers/codex_responses_sse.rs
@@ -150,7 +150,21 @@ pub(crate) fn message_item(item_id: &str, text: &str) -> Value {
 /// Close an assistant message: emits `output_text.done` → `content_part.done` →
 /// `output_item.done`, and returns the completed item so the caller can record it.
 pub(crate) fn message_close(output_index: u32, item_id: &str, text: &str) -> (Vec<Bytes>, Value) {
-    let item = message_item(item_id, text);
+    message_close_with_phase(output_index, item_id, text, None)
+}
+
+/// Close an assistant message and optionally copy a Responses message `phase`
+/// (`commentary` / `final_answer`) onto the completed item.
+pub(crate) fn message_close_with_phase(
+    output_index: u32,
+    item_id: &str,
+    text: &str,
+    phase: Option<&str>,
+) -> (Vec<Bytes>, Value) {
+    let mut item = message_item(item_id, text);
+    if let Some(phase) = phase {
+        item["phase"] = Value::String(phase.to_string());
+    }
     let events = vec![
         sse_event(
             "response.output_text.done",
@@ -367,6 +381,16 @@ mod tests {
         assert_eq!(item["type"], "message");
         assert_eq!(item["status"], "completed");
         assert_eq!(item["content"][0]["text"], "hi");
+        assert!(item.get("phase").is_none());
+    }
+
+    #[test]
+    fn optional_phase_is_copied_onto_done_item() {
+        let (events, item) =
+            message_close_with_phase(1, "msg_phase", "listing", Some("commentary"));
+        assert_eq!(item["content"][0]["text"], "listing");
+        assert_eq!(item["phase"], "commentary");
+        assert!(body(&events[2]).contains("\"phase\":\"commentary\""));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -17,7 +17,7 @@ use crate::proxy::sse::{strip_sse_field, take_sse_block};
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
 use serde_json::{json, Value};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 #[derive(Debug, Default)]
 struct TextItemState {
@@ -26,6 +26,8 @@ struct TextItemState {
     text: String,
     added: bool,
     done: bool,
+    /// Chat `tool_calls` indexes that first appeared while this text item was open.
+    tools_started_after_text: BTreeSet<usize>,
 }
 
 #[derive(Debug, Default)]
@@ -158,6 +160,15 @@ impl ChatToResponsesState {
 
             if let Some(tool_calls) = delta.get("tool_calls").and_then(|v| v.as_array()) {
                 events.extend(self.flush_inline_think_at_boundary());
+                if !tool_calls.is_empty() && self.text.added && !self.text.done {
+                    for tool_call in tool_calls {
+                        let chat_index =
+                            tool_call.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
+                        if !self.tools.contains_key(&chat_index) {
+                            self.text.tools_started_after_text.insert(chat_index);
+                        }
+                    }
+                }
                 let reasoning_for_tool_call = self.current_reasoning_text();
                 events.extend(self.finalize_reasoning());
                 for tool_call in tool_calls {
@@ -588,6 +599,21 @@ impl ChatToResponsesState {
         events
     }
 
+    fn text_item_phase(&self) -> Option<&'static str> {
+        let named_tool_after_text = self.text.tools_started_after_text.iter().any(|index| {
+            self.tools
+                .get(index)
+                .is_some_and(|tool| !tool.name.trim().is_empty())
+        });
+        if named_tool_after_text {
+            Some("commentary")
+        } else if self.finish_reason.as_deref() == Some("stop") {
+            Some("final_answer")
+        } else {
+            None
+        }
+    }
+
     fn finalize_text(&mut self) -> Vec<Bytes> {
         if !self.text.added || self.text.done {
             return Vec::new();
@@ -596,7 +622,8 @@ impl ChatToResponsesState {
         let output_index = self.text.output_index.unwrap_or(0);
         let item_id = self.text.item_id.clone();
         let text = self.text.text.clone();
-        let (events, item) = sse::message_close(output_index, &item_id, &text);
+        let (events, item) =
+            sse::message_close_with_phase(output_index, &item_id, &text, self.text_item_phase());
         self.output_items.push((output_index, item));
         self.text.done = true;
         events
@@ -1037,6 +1064,97 @@ mod tests {
         assert!(output.contains("event: response.function_call_arguments.done"));
         assert!(output.contains("\"type\":\"function_call\""));
         assert!(output.contains("\"call_id\":\"call_1\""));
+    }
+
+    fn message_done_item(events: &[Value]) -> &Value {
+        events
+            .iter()
+            .find(|event| {
+                event["type"] == "response.output_item.done" && event["item"]["type"] == "message"
+            })
+            .expect("message done event")
+    }
+
+    fn completed_output(events: &[Value]) -> &[Value] {
+        events
+            .iter()
+            .find(|event| event["type"] == "response.completed")
+            .and_then(|event| event["response"]["output"].as_array())
+            .map(Vec::as_slice)
+            .expect("completed output")
+    }
+
+    #[tokio::test]
+    async fn progress_text_then_named_tool_uses_commentary_phase() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_progress_then_tool\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":\"Listing files in src next.\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_progress_then_tool\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_ls_1\",\"type\":\"function\",\"function\":{\"name\":\"list_dir\",\"arguments\":\"{\\\"path\\\":\\\"src\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+        let events = parse_sse_events(&output);
+        let added = events
+            .iter()
+            .find(|event| {
+                event["type"] == "response.output_item.added" && event["item"]["type"] == "message"
+            })
+            .expect("message added event");
+        assert_eq!(added["item"].get("phase"), None);
+
+        assert_eq!(message_done_item(&events)["item"]["phase"], "commentary");
+        let items = completed_output(&events);
+        assert_eq!(items[0]["content"][0]["text"], "Listing files in src next.");
+        assert_eq!(items[0]["phase"], "commentary");
+        assert_eq!(items[1]["name"], "list_dir");
+        assert_eq!(items[1].get("phase"), None);
+    }
+
+    #[tokio::test]
+    async fn stop_reason_plain_text_uses_final_answer_phase() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_plain_stop\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":\"Ready to continue.\"},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+        let events = parse_sse_events(&output);
+        assert_eq!(message_done_item(&events)["item"]["phase"], "final_answer");
+        assert_eq!(completed_output(&events)[0]["phase"], "final_answer");
+    }
+
+    #[tokio::test]
+    async fn tool_opened_before_text_does_not_switch_to_commentary() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_tool_then_text\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_sh_9\",\"type\":\"function\",\"function\":{\"name\":\"exec_command\",\"arguments\":\"{\"}}]}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_tool_then_text\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":\"Command finished.\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_tool_then_text\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"}\"}}]},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+        let events = parse_sse_events(&output);
+        let items = completed_output(&events);
+        let message = items
+            .iter()
+            .find(|item| item["type"] == "message")
+            .expect("assistant message");
+        assert_eq!(message["content"][0]["text"], "Command finished.");
+        assert_eq!(message["phase"], "final_answer");
+    }
+
+    #[tokio::test]
+    async fn truncated_stream_does_not_set_a_message_phase() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_truncated\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":\"Working on the patch\"},\"finish_reason\":\"length\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+        let events = parse_sse_events(&output);
+        assert_eq!(message_done_item(&events)["item"].get("phase"), None);
+        let completed = events
+            .iter()
+            .find(|event| event["type"] == "response.completed")
+            .expect("completed event");
+        assert_eq!(completed["response"]["status"], "incomplete");
+        assert_eq!(completed["response"]["output"][0].get("phase"), None);
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -162,8 +162,7 @@ impl ChatToResponsesState {
                 events.extend(self.flush_inline_think_at_boundary());
                 if !tool_calls.is_empty() && self.text.added && !self.text.done {
                     for tool_call in tool_calls {
-                        let chat_index =
-                            tool_call.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
+                        let chat_index = self.resolve_tool_key(tool_call);
                         if !self.tools.contains_key(&chat_index) {
                             self.text.tools_started_after_text.insert(chat_index);
                         }
@@ -353,6 +352,13 @@ impl ChatToResponsesState {
     /// 所以这里只在**能确证是新调用**时才分配新 key：delta 带非空 `id`，且该 id 与
     /// 所有已知调用都不同。其余情况一律归入最后一个已知 key（空 map 时为 0），保持
     /// 既有行为——宁可两个并行调用坍缩成一个，也不能把一个调用的续帧炸成多个 item。
+    fn resolve_tool_key(&self, tool_call: &Value) -> usize {
+        match tool_call.get("index").and_then(Value::as_u64) {
+            Some(index) => index as usize,
+            None => self.resolve_tool_key_without_index(tool_call),
+        }
+    }
+
     fn resolve_tool_key_without_index(&self, tool_call: &Value) -> usize {
         let last_key = self.tools.keys().next_back().copied();
 
@@ -379,10 +385,7 @@ impl ChatToResponsesState {
     }
 
     fn push_tool_call_delta(&mut self, tool_call: &Value, reasoning: Option<&str>) -> Vec<Bytes> {
-        let chat_index = match tool_call.get("index").and_then(|v| v.as_u64()) {
-            Some(index) => index as usize,
-            None => self.resolve_tool_key_without_index(tool_call),
-        };
+        let chat_index = self.resolve_tool_key(tool_call);
         let id_delta = tool_call
             .get("id")
             .and_then(|v| v.as_str())
@@ -1138,6 +1141,32 @@ mod tests {
             .expect("assistant message");
         assert_eq!(message["content"][0]["text"], "Command finished.");
         assert_eq!(message["phase"], "final_answer");
+    }
+
+    #[tokio::test]
+    async fn omitted_index_after_open_text_still_marks_commentary() {
+        let output = collect(vec![
+            "data: {\"id\":\"chatcmpl_omit_index\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_a\",\"type\":\"function\",\"function\":{\"name\":\"exec_command\",\"arguments\":\"{}\"}}]}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_omit_index\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"content\":\"Listing files next.\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_omit_index\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_b\",\"type\":\"function\",\"function\":{\"name\":\"list_dir\",\"arguments\":\"{\\\"path\\\":\\\"src\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: [DONE]\n\n",
+        ])
+        .await;
+        let events = parse_sse_events(&output);
+        let items = completed_output(&events);
+        let message = items
+            .iter()
+            .find(|item| item["type"] == "message")
+            .expect("assistant message");
+        assert_eq!(message["content"][0]["text"], "Listing files next.");
+        assert_eq!(message["phase"], "commentary");
+        let calls: Vec<&Value> = items
+            .iter()
+            .filter(|item| item["type"] == "function_call")
+            .collect();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0]["call_id"], "call_a");
+        assert_eq!(calls[1]["call_id"], "call_b");
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1453,17 +1453,26 @@ pub(crate) fn chat_completion_to_response_with_context(
     let finish_reason = choice.get("finish_reason").and_then(|v| v.as_str());
 
     let reasoning = chat_reasoning_text(message);
+    let projected_tools =
+        chat_tool_calls_to_response_output_items(message, reasoning.as_deref(), tool_context);
+    let message_phase = if !projected_tools.items.is_empty() {
+        Some("commentary")
+    } else if finish_reason == Some("stop") {
+        Some("final_answer")
+    } else {
+        None
+    };
     let mut output = Vec::new();
     if let Some(reasoning_item) =
         chat_reasoning_to_response_output_item(reasoning.as_deref(), &response_id)
     {
         output.push(reasoning_item);
     }
-    if let Some(message_item) = chat_message_to_response_output_item(message, &response_id) {
+    if let Some(message_item) =
+        chat_message_to_response_output_item(message, &response_id, message_phase)
+    {
         output.push(message_item);
     }
-    let tool_calls =
-        chat_tool_calls_to_response_output_items(message, reasoning.as_deref(), tool_context);
 
     // 丢弃过工具调用、且最终一个工具调用都没剩下时，Codex 会收到一个
     // "status=completed 但 output 里没有任何工具调用" 的回合，agent loop 必然静默
@@ -1474,16 +1483,16 @@ pub(crate) fn chat_completion_to_response_with_context(
     // 是截断，工具调用缺 name 是截断的后果而非上游发了畸形数据，报成
     // tool_call_dropped 会给出错误的归因。
     if response_status_from_finish_reason(finish_reason) == "completed"
-        && tool_calls.dropped > 0
-        && tool_calls.items.is_empty()
+        && projected_tools.dropped > 0
+        && projected_tools.items.is_empty()
     {
         return Err(ProxyError::TransformError(format!(
             "Upstream returned {} tool call(s) without a function name, \
              leaving no usable tool call in this turn",
-            tool_calls.dropped
+            projected_tools.dropped
         )));
     }
-    output.extend(tool_calls.items);
+    output.extend(projected_tools.items);
 
     let mut response = json!({
         "id": response_id,
@@ -1537,7 +1546,11 @@ fn chat_reasoning_text(message: &Value) -> Option<String> {
     None
 }
 
-fn chat_message_to_response_output_item(message: &Value, response_id: &str) -> Option<Value> {
+fn chat_message_to_response_output_item(
+    message: &Value,
+    response_id: &str,
+    phase: Option<&str>,
+) -> Option<Value> {
     let mut content = Vec::new();
 
     if let Some(text) = message.get("content").and_then(|v| v.as_str()) {
@@ -1594,13 +1607,17 @@ fn chat_message_to_response_output_item(message: &Value, response_id: &str) -> O
         return None;
     }
 
-    Some(json!({
+    let mut item = json!({
         "id": format!("{response_id}_msg"),
         "type": "message",
         "status": "completed",
         "role": "assistant",
         "content": content
-    }))
+    });
+    if let Some(phase) = phase {
+        item["phase"] = Value::String(phase.to_string());
+    }
+    Some(item)
 }
 
 /// 非流式工具调用转换结果。`dropped` 记录因缺少合法函数名而被丢弃的条数，
@@ -4553,6 +4570,72 @@ mod tests {
 
         assert_eq!(result["status"], "incomplete");
         assert_eq!(result["incomplete_details"]["reason"], "max_output_tokens");
+        assert_eq!(result["output"][0].get("phase"), None);
+    }
+
+    #[test]
+    fn only_stop_reason_assigns_final_answer_phase() {
+        let cases = [
+            ("stop", Some("final_answer")),
+            ("length", None),
+            ("content_filter", None),
+        ];
+        for (reason, expected) in cases {
+            let converted = chat_completion_to_response(json!({
+                "id": format!("chatcmpl_phase_{reason}"),
+                "model": "gpt-5.4",
+                "choices": [{
+                    "message": {"role": "assistant", "content": "All finished."},
+                    "finish_reason": reason
+                }]
+            }))
+            .unwrap();
+            assert_eq!(converted["output"][0]["type"], "message");
+            assert_eq!(
+                converted["output"][0].get("phase").and_then(Value::as_str),
+                expected,
+                "finish_reason={reason}"
+            );
+        }
+
+        let missing_reason = chat_completion_to_response(json!({
+            "id": "chatcmpl_phase_missing",
+            "model": "gpt-5.4",
+            "choices": [{
+                "message": {"role": "assistant", "content": "All finished."}
+            }]
+        }))
+        .unwrap();
+        assert_eq!(missing_reason["output"][0].get("phase"), None);
+    }
+
+    #[test]
+    fn text_and_tool_calls_share_commentary_phase() {
+        let converted = chat_completion_to_response(json!({
+            "id": "chatcmpl_text_and_tools",
+            "model": "gpt-5.4",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Opening the project tree.",
+                    "tool_calls": [{
+                        "id": "call_ls_1",
+                        "type": "function",
+                        "function": {
+                            "name": "list_dir",
+                            "arguments": "{\"path\":\"src\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        }))
+        .unwrap();
+        let items = converted["output"].as_array().unwrap();
+        assert_eq!(items[0]["content"][0]["text"], "Opening the project tree.");
+        assert_eq!(items[0]["phase"], "commentary");
+        assert_eq!(items[1]["name"], "list_dir");
+        assert_eq!(items[1].get("phase"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

Stamp Codex `model_messages` phases on Chat Completions → Responses assistant messages so the client can tell a progress update from a final answer. After completing one round of conversation, the Codex desktop client will automatically fold the operation process.

中文概述：Chat 上游回程转 Responses 时，给紧跟工具调用的进度文本标 `commentary`，给 `finish_reason=stop` 的收尾文本标 `final_answer`。完成一轮对话后，Codex桌面客户端将自动折叠操作过程。

## What changed

- When streamed assistant text is still open and a **new, named** tool call arrives, close that message with `phase: "commentary"`.
- When there is no such following tool call and `finish_reason` is `stop`, close it with `phase: "final_answer"`.
- Leave `phase` off for truncated/`length` text and for tool-only turns.
- Apply the same rule on the non-streaming Chat → Responses path.
- Do not put `phase` on `response.output_item.added`; the converter cannot know yet whether tools will follow.

## Root cause

Codex’s catalog `model_messages` maps assistant `message.phase` onto the commentary / final channels. The Chat → Responses translator currently emits a plain `message` item with no `phase`, so the client cannot classify the text.


Before:
<img width="189" height="70" alt="image" src="https://github.com/user-attachments/assets/b9a8ec23-f213-407c-af6f-2740b0b6f99f" />

After:
<img width="127" height="76" alt="image" src="https://github.com/user-attachments/assets/43d2508d-88a1-446c-8010-bde68c9792bc" />
 
After completing one round of conversation, the Codex desktop client will automatically fold the operation process.

This is the return path. The outbound bug in #6529 is the inverse shape: Responses commentary + `function_call` becoming two Chat assistant messages. That is already covered by #6530.

## Scope

This PR only labels the **return** Chat → Responses message item.

It does **not**:

- coalesce outbound commentary with `tool_calls` (see #6530)
- inject Chat channel-compatibility instructions into the system prompt
- change Anthropic → Responses streaming (`message_close` stays unphased)

## Related Issue / 关联 Issue

Related to #6529 (complementary return-path labeling; does not close that issue).

See also #6530.

## Screenshots / 截图

N/A — wire-format change, no UI.

## Validation

- RED/GREEN: new regressions for commentary, `final_answer`, prior-tool continuation, and `length` with no phase
- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::providers::streaming_codex_chat` — passed
- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::providers::transform_codex_chat` — 91 passed
- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::providers::codex_responses_sse` — 6 passed
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib --tests -- -D warnings`

## Checklist / 检查清单

- [x] `pnpm typecheck` — N/A, no frontend changes
- [x] `pnpm format:check` — N/A, no frontend changes
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed — N/A