### PR TITLE
test(env-check): avoid host-specific paths in env-check tests

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -4616,14 +4616,23 @@ mod tests {
     use super::*;
     use std::path::{Path, PathBuf};
 
-    /// 探测 helper 正常路径：spawn（含 pre_exec setsid）能启动、输出能捕获。
-    /// `/bin/echo --version` 在 macOS/Linux 均即刻成功退出。
-    #[cfg(not(target_os = "windows"))]
+    /// 探测 helper 正常路径：以 `--version` 启动 fixture、捕获 stdout 并等到成功退出。
+    #[cfg(unix)]
     #[test]
     fn probe_version_command_captures_healthy_tool_output() {
-        let out = run_probe_version_command(Path::new("/bin/echo"), std::ffi::OsStr::new(""))
-            .expect("probe of /bin/echo should succeed");
+        let temp = tempfile::tempdir().expect("temp dir should be created");
+        let tool = temp.path().join("tool");
+        std::fs::write(
+            &tool,
+            "#!/bin/sh\nif [ \"${1:-}\" != \"--version\" ]; then\n    exit 1\nfi\nprintf healthy-tool\n",
+        )
+            .expect("version fixture should be written");
+        set_test_executable(&tool, true);
+
+        let out = run_probe_version_command(&tool, std::ffi::OsStr::new(""))
+            .expect("probe of version fixture should succeed");
         assert!(out.status.success());
+        assert_eq!(decode_command_output(&out.stdout), "healthy-tool");
     }
 
     /// 超时击杀路径：挂死的子进程到点被整组击杀、wait 返回超时错误而非永等。
@@ -5882,61 +5891,6 @@ mod tests {
             assert_eq!(
                 cmd.as_deref(),
                 Some("PATH='/Users/my name/.nvm/versions/node/v22/bin':\"$PATH\" '/Users/my name/.nvm/versions/node/v22/bin/npm' i -g @openai/codex@latest")
-            );
-        }
-
-        #[test]
-        fn npm_anchor_supplies_sibling_node_to_env_shebang() {
-            use std::os::unix::fs::PermissionsExt;
-            use std::process::Command;
-
-            let temp = tempfile::tempdir().expect("temp dir should be created");
-            let bin = temp.path().join("home dir/.nvm/versions/node/v22.14.0/bin");
-            std::fs::create_dir_all(&bin).expect("node bin should be created");
-
-            let marker = temp.path().join("sibling-node-used");
-            let node = bin.join("node");
-            let npm = bin.join("npm");
-            std::fs::write(
-                &node,
-                format!(
-                    "#!/bin/sh\nprintf sibling-node > {}\n",
-                    shell_single_quote(&marker.to_string_lossy())
-                ),
-            )
-            .expect("fake node should be written");
-            std::fs::write(&npm, "#!/usr/bin/env node\n").expect("fake npm should be written");
-            for executable in [&node, &npm] {
-                let mut permissions = std::fs::metadata(executable)
-                    .expect("fake executable metadata should exist")
-                    .permissions();
-                permissions.set_mode(0o755);
-                std::fs::set_permissions(executable, permissions)
-                    .expect("fake executable should be executable");
-            }
-
-            let codex = bin.join("codex").to_string_lossy().into_owned();
-            let real = temp
-                .path()
-                .join("home dir/.nvm/versions/node/v22.14.0/lib/node_modules/@openai/codex/bin/codex.js")
-                .to_string_lossy()
-                .into_owned();
-            let command = anchored_command_from_paths("codex", &codex, &real)
-                .expect("nvm codex should produce an anchored npm command");
-            let output = Command::new("/bin/bash")
-                .args(["-c", &command])
-                .env("PATH", "/usr/bin:/bin")
-                .output()
-                .expect("anchored npm command should start");
-
-            assert!(
-                output.status.success(),
-                "anchored npm command failed: {}",
-                decode_command_output(&output.stderr)
-            );
-            assert_eq!(
-                std::fs::read_to_string(marker).expect("sibling node should leave a marker"),
-                "sibling-node"
             );
         }
 


### PR DESCRIPTION
<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

将 Unix 版本探测测试从硬编码的宿主机路径改为临时可执行 fixture。fixture 会校验探测命令确实传入 `--version`，并验证 stdout 被捕获、子进程成功退出。

同时移除依赖固定 shell、`/usr/bin/env node` 和固定 PATH 的 anchored npm 端到端测试。其应用层契约已由现有的 nvm/fnm 锚定命令字符串测试覆盖，包括同级 bin 目录注入 `PATH` 和路径含空格时的 POSIX 引号处理。这样默认单测仍保留关键回归保护，同时不再假设宿主机文件布局。

此 PR 的目的是提高近期引入的测试的可移植性和兼容性，起因是最近更新 nixpkgs 中的 cc-switch 打包时发现有测试失败阻塞了构建。调查后发现是有两个近期新增的测试对测试环境中的特定二进制路径（如 /bin/echo）做了强假设和硬编码，这使得部分发行版和构建沙盒不满足测试条件且无法以低成本的方式注入环境。起因虽然如此，但这个改动并非一个“发行版特定”的修复，而是旨在使新测试达到与项目整体测试一致的高可移植性。

我对 cc-switch 的理解不深，如果有考虑不周的地方希望不吝指出！

另外感谢您在这个好用的工具上投入的热情和努力！

### 本地验证

- [x] `rustfmt --check`
- [x] `git diff --check`
- [x] `cargo test`
- [x] `cargo clippy`

```
$ nix-shell -E '
with import <nixpkgs> {};
mkShell {
  packages = [
    rustup
    pkg-config
    cmake
    ninja
    perl
    go
    rustPlatform.bindgenHook
  ];
  buildInputs = [
    openssl
    glib
    gtk3
    webkitgtk_4_1
    libsoup_3
    libappindicator-gtk3
    gdk-pixbuf
    cairo
    pango
    librsvg
  ];
}
' --run '
set -euxo pipefail

rustup toolchain install 1.95 --profile minimal --component clippy --component rustfmt
rustup show active-toolchain
rustc --version
cargo --version

mkdir -p dist
cargo test --lib --manifest-path src-tauri/Cargo.toml commands::misc::tests
cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
'
+ rustup toolchain install 1.95 --profile minimal --component clippy --component rustfmt
info: syncing channel updates for 1.95-x86_64-unknown-linux-gnu
info: latest update on 2026-04-16 for version 1.95.0 (59807616e 2026-04-14)
info: downloading 5 components
        cargo installed                       10.48 MiB
       clippy installed                        4.48 MiB
     rust-std installed                       28.20 MiB
        rustc installed                       76.63 MiB
      rustfmt installed                        2.06 MiB
  1.95-x86_64-unknown-linux-gnu installed - rustc 1.95.0 (59807616e 2026-04-14)

info: default toolchain set to 1.95-x86_64-unknown-linux-gnu
info: self-update is disabled for this build of rustup
info: any updates to rustup will need to be fetched with your system package manager
+ rustup show active-toolchain
1.95-x86_64-unknown-linux-gnu (overridden by '/home/curious/Projects/cc-switch/rust-toolchain.toml')
+ rustc --version
rustc 1.95.0 (59807616e 2026-04-14)
+ cargo --version
cargo 1.95.0 (f2d3ce0bd 2026-03-21)
+ mkdir -p dist
+ cargo test --lib --manifest-path src-tauri/Cargo.toml commands::misc::tests

    Finished `test` profile [unoptimized + debuginfo] target(s) in 2m 43s
     Running unittests src/lib.rs (src-tauri/target/debug/deps/cc_switch_lib-d963d262f2018a2b)

running 85 tests
test commands::misc::tests::anchored_upgrade::brew_formula_extraction ... ok
test commands::misc::tests::anchored_upgrade::claude_native_installer_uses_self_update ... ok
test commands::misc::tests::anchored_upgrade::brew_path_with_space_is_quoted ... ok
test commands::misc::tests::anchored_upgrade::claude_native_path_with_space_is_quoted ... ok
test commands::misc::tests::anchored_upgrade::codex_homebrew_formula_uses_brew_not_self_update ... ok
test commands::misc::tests::anchored_upgrade::codex_broken_volta_uses_volta_install_not_npm_repair ... ok
test commands::misc::tests::anchored_upgrade::codex_nvm_anchors_to_that_npm ... ok
test commands::misc::tests::anchored_upgrade::codex_missing_platform_binary_self_heals_via_uninstall_install ... ok
test commands::misc::tests::anchored_upgrade::bun_uses_bun_add ... ok
test commands::misc::tests::anchored_upgrade::bun_path_with_space_is_quoted ... ok
test commands::misc::tests::anchored_upgrade::codex_volta_anchors_to_volta_install ... ok
test commands::misc::tests::anchored_upgrade::default_install_none_when_ambiguous ... ok
test commands::misc::tests::anchored_upgrade::default_install_prefers_path_default ... ok
test commands::misc::tests::anchored_upgrade::default_install_falls_back_to_sole_entry ... ok
test commands::misc::tests::anchored_upgrade::codex_runnable_uses_plain_npm_not_self_heal ... ok
test commands::misc::tests::anchored_upgrade::first_abs_path_line_skips_shell_noise ... ok
test commands::misc::tests::anchored_upgrade::fnm_install_anchors_to_that_npm ... ok
test commands::misc::tests::anchored_upgrade::gemini_nvm_anchors_to_npm_without_cli_update ... ok
test commands::misc::tests::anchored_upgrade::codex_broken_homebrew_formula_uses_brew_not_npm_repair ... ok
test commands::misc::tests::anchored_upgrade::grok_custom_bin_dir_is_native_when_target_is_official_download ... ok
test commands::misc::tests::anchored_upgrade::grok_native_update_falls_back_to_installer_not_npm ... ok
test commands::misc::tests::anchored_upgrade::go_bin_opencode_uses_cli_upgrade_without_package_fallback ... ok
test commands::misc::tests::anchored_upgrade::grok_nvm_anchors_to_npm_without_cli_update ... ok
test commands::misc::tests::anchored_upgrade::homebrew_npm_global_package_anchors_not_brew ... ok
test commands::misc::tests::anchored_upgrade::hermes_uses_cli_update_anchor ... ok
test commands::misc::tests::anchored_upgrade::grok_native_installer_uses_self_update_with_installer_fallback ... ok
test commands::misc::tests::anchored_upgrade::sibling_bin_returns_none_when_bin_path_has_no_directory ... ok
test commands::misc::tests::anchored_upgrade::path_with_space_is_quoted ... ok
test commands::misc::tests::anchored_upgrade::codex_broken_bun_uses_bun_add_not_phantom_npm ... ok
test commands::misc::tests::anchored_upgrade::volta_path_with_space_is_quoted ... ok
test commands::misc::tests::anchored_upgrade::volta_self_update_chain_anchors_to_volta ... ok
test commands::misc::tests::build_windows_cwd_command_str_uses_pushd_for_unc_paths ... ok
test commands::misc::tests::anchored_upgrade::gemini_homebrew_formula_uses_brew_upgrade ... ok
test commands::misc::tests::anchored_upgrade::opencode_native_install_uses_cli_upgrade_without_package_fallback ... ok
test commands::misc::tests::anchored_upgrade::is_conflicting_thresholds ... ok
test commands::misc::tests::anchored_upgrade::merge_path_segments_dedupes_preserving_login_order ... ok
test commands::misc::tests::build_windows_cwd_command_str_escapes_batch_metacharacters ... ok
test commands::misc::tests::env_child_dir_appends_child_and_dedupes ... ok
test commands::misc::tests::anchored_upgrade::path_line_from_env_output_survives_shell_noise ... ok
test commands::misc::tests::grok_extra_search_paths_deduplicates_default_override ... ok
test commands::misc::tests::grok_extra_search_paths_prefers_override_then_default_native_dir ... ok
test commands::misc::tests::build_windows_cwd_command_str_uses_cd_for_drive_paths ... ok
test commands::misc::tests::install_source_classification::macos_volta_with_dot_prefix ... ok
test commands::misc::tests::install_source_classification::windows_nvm_falls_back_to_system ... ok
test commands::misc::tests::grok_lifecycle_metadata_is_consistent ... ok
test commands::misc::tests::install_source_classification::windows_scoop_still_identified ... ok
test commands::misc::tests::install_source_classification::windows_pnpm_localappdata ... ok
test commands::misc::tests::install_source_classification::windows_volta_localappdata_no_dot ... ok
test commands::misc::tests::install_strategy::claude_install_prefers_native_with_npm_fallback ... ok
test commands::misc::tests::install_strategy::codex_install_keeps_static_npm ... ok
test commands::misc::tests::cli_path_env_search_paths_include_path_entries_and_dedupe ... ok
test commands::misc::tests::install_strategy::gemini_install_keeps_static_npm ... ok
test commands::misc::tests::install_strategy::grok_install_prefers_native_with_npm_fallback ... ok
test commands::misc::tests::child_search_paths_include_existing_children_with_suffix ... ok
test commands::misc::tests::install_strategy::hermes_install_uses_official_installer ... ok
test commands::misc::tests::install_strategy::hermes_update_fallback_uses_cli_update_then_installer ... ok
test commands::misc::tests::install_strategy::openclaw_install_keeps_static_npm ... ok
test commands::misc::tests::install_strategy::opencode_install_prefers_native_with_npm_fallback ... ok
test commands::misc::tests::install_strategy::pi_install_uses_the_verified_pinned_package ... ok
test commands::misc::tests::install_strategy::update_fallbacks_use_official_cli_only_when_supported ... ok
test commands::misc::tests::opencode_extra_search_paths_deduplicates_bun_default_dir ... ok
test commands::misc::tests::opencode_extra_search_paths_deduplicates_repeated_entries ... ok
test commands::misc::tests::opencode_extra_search_paths_includes_install_and_fallback_dirs ... ok
test commands::misc::tests::parent_dir_cases::mixed_separators_takes_rightmost ... ok
test commands::misc::tests::parent_dir_cases::no_separator_returns_empty ... ok
test commands::misc::tests::parent_dir_cases::separator_at_root_returns_empty ... ok
test commands::misc::tests::parent_dir_cases::unix_path ... ok
test commands::misc::tests::parent_dir_cases::windows_backslash ... ok
test commands::misc::tests::pi_lifecycle_metadata_matches_pinned_distribution ... ok
test commands::misc::tests::prepend_search_dir_to_path_preserves_non_utf8_bytes ... ok
test commands::misc::tests::resolve_launch_cwd_accepts_existing_directory ... ok
test commands::misc::tests::test_build_exec_line ... ok
test commands::misc::tests::resolve_launch_cwd_rejects_missing_directory ... ok
test commands::misc::tests::test_build_final_shell_cd_command ... ok
test commands::misc::tests::test_build_provider_command_line_uses_user_shell_environment ... ok
test commands::misc::tests::test_compare_semver ... ok
test commands::misc::tests::test_get_user_shell_fallback ... ok
test commands::misc::tests::mise_node_search_paths_include_shims_and_installed_node_bins ... ok
test commands::misc::tests::test_pick_latest_version_filters_dirty_prerelease ... ok
test commands::misc::tests::test_pick_latest_version ... ok
test commands::misc::tests::tool_executable_candidates_non_windows_uses_plain_binary_name ... ok
test commands::misc::tests::test_valid_user_shell_path ... ok
test commands::misc::tests::test_extract_version ... ok
test commands::misc::tests::probe_version_command_captures_healthy_tool_output ... ok
test commands::misc::tests::isolated_hung_child_is_killed_on_deadline ... ok

test result: ok. 85 passed; 0 failed; 0 ignored; 0 measured; 2587 filtered out; finished in 0.21s

+ cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
 
    Checking tauri-plugin-single-instance v2.4.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 50s
+ exit
+ exitHandler
+ exitCode=0
+ set +e
+ '[' -n '' ']'
+ ((  0 != 0  ))
+ runHook exitHook
+ local hookName=exitHook
+ shift
+ local 'hooksSlice=exitHooks[@]'
+ local hook
+ for hook in "_callImplicitHook 0 $hookName" ${!hooksSlice+"${!hooksSlice}"}
+ _logHook exitHook '_callImplicitHook 0 exitHook'
+ [[ -z 2 ]]
+ local hookKind=exitHook
+ local 'hookExpr=_callImplicitHook 0 exitHook'
+ shift 2
+ declare -F '_callImplicitHook 0 exitHook'
+ type -p '_callImplicitHook 0 exitHook'
+ [[ _callImplicitHook 0 exitHook != _callImplicitHook* ]]
+ _eval '_callImplicitHook 0 exitHook'
+ declare -F '_callImplicitHook 0 exitHook'
+ eval '_callImplicitHook 0 exitHook'
++ _callImplicitHook 0 exitHook
++ local def=0
++ local hookName=exitHook
++ declare -F exitHook
++ type -p exitHook
++ '[' -n '' ']'
++ return 0
+ return 0
+ return 0
```

## Related Issue / 关联 Issue

Fixes #

## Screenshots / 截图

不适用。

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件