### PR TITLE
feat(usage): add DSH session usage importer

### DIFF
--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -19,6 +19,7 @@ pub mod s3_auto_sync;
 pub mod s3_sync;
 pub mod session_usage;
 pub mod session_usage_codex;
+pub mod session_usage_dsh;
 pub mod session_usage_gemini;
 pub mod session_usage_grokbuild;
 pub mod session_usage_opencode;

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -96,6 +96,11 @@ pub fn sync_all_unlocked(db: &Database) -> SessionSyncResult {
         "Pi",
         crate::services::session_usage_pi::sync_pi_usage(db),
     );
+    merge_sync_step(
+        &mut result,
+        "DSH",
+        crate::services::session_usage_dsh::sync_dsh_usage(db),
+    );
     notify_sync_result(&result);
     result
 }

--- a/src-tauri/src/services/session_usage_dsh.rs
+++ b/src-tauri/src/services/session_usage_dsh.rs
@@ -1,0 +1,685 @@
+//! DSH coding-agent session usage importer.
+//!
+//! DSH persists each session as a zstd-compressed JSONL file under
+//! `~/.dsh/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`. Assistant
+//! messages carry normalized Anthropic-style usage (fresh input tokens, no
+//! cache-write bucket). This importer replays those files into the shared
+//! dashboard; the durable `session_usage_dedup` ledger keyed by
+//! `dsh:session-<id>:<seq>` makes full reparses idempotent and recognizes rows
+//! written by earlier tooling with the same identity scheme.
+
+use crate::database::{lock_conn, Database};
+use crate::error::AppError;
+use crate::proxy::usage::calculator::CostCalculator;
+use crate::proxy::usage::parser::TokenUsage;
+use crate::services::session_usage::{
+    metadata_modified_nanos, update_sync_state_on_conn, SessionSyncResult,
+};
+use crate::services::sql_helpers::INPUT_TOKEN_SEMANTICS_FRESH;
+use crate::services::usage_stats::find_model_pricing;
+use rusqlite::OptionalExtension;
+use rust_decimal::Decimal;
+use serde_json::Value;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+const APP_TYPE: &str = "dsh";
+const DATA_SOURCE: &str = "dsh_session";
+const PROVIDER_PLACEHOLDER: &str = "_dsh_session";
+const UNKNOWN_MODEL: &str = "unknown";
+const MAX_USAGE_LABEL_BYTES: usize = 512;
+const MAX_SESSION_BYTES: u64 = 256 * 1024 * 1024;
+const MIN_SQLITE_UNIX_SECONDS: i64 = -62_167_219_200;
+const MAX_SQLITE_UNIX_SECONDS: i64 = 253_402_300_799;
+const REQUEST_ID_PREFIX: &str = "dsh:";
+const DSH_REQUEST_DEDUP_SQL: &str = "SELECT EXISTS(
+         SELECT 1 FROM session_usage_dedup
+         WHERE data_source = ?1 AND request_id = ?2
+     )";
+
+#[derive(Debug)]
+struct DshUsageRecord {
+    request_id: String,
+    provider_id: String,
+    model: String,
+    input_tokens: u32,
+    output_tokens: u32,
+    cache_read_tokens: u32,
+    created_at: i64,
+    session_id: String,
+}
+
+#[derive(Debug, Default)]
+struct ParsedDshFile {
+    session_id: Option<String>,
+    records: Vec<DshUsageRecord>,
+    incomplete_tail: bool,
+}
+
+/// Import usage from every DSH session log discoverable under the sessions
+/// root. A missing root simply means there is nothing to import yet.
+pub fn sync_dsh_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    let root = dsh_sessions_root();
+    Ok(sync_dsh_files(db, &dsh_session_files(&root)))
+}
+
+fn dsh_sessions_root() -> PathBuf {
+    if let Some(custom) = std::env::var_os("DSH_SESSIONS_DIR") {
+        let trimmed = custom.to_string_lossy().trim().to_string();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    crate::config::get_home_dir().join(".dsh").join("sessions")
+}
+
+fn dsh_session_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let Ok(cwd_dirs) = fs::read_dir(root) else {
+        return files;
+    };
+    for cwd_dir in cwd_dirs.flatten() {
+        let Ok(session_dirs) = fs::read_dir(cwd_dir.path()) else {
+            continue;
+        };
+        for session_dir in session_dirs.flatten() {
+            let candidate = session_dir.path().join("session.jsonl.zstd");
+            if candidate.is_file() {
+                files.push(candidate);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+fn sync_dsh_files(db: &Database, files: &[PathBuf]) -> SessionSyncResult {
+    let mut result = SessionSyncResult {
+        files_scanned: files.len().min(u32::MAX as usize) as u32,
+        ..Default::default()
+    };
+
+    for file_path in files {
+        match sync_single_dsh_file(db, file_path) {
+            Ok(file_result) => result.merge(file_result),
+            Err(error) => {
+                let message = format!("{}: {error}", file_path.display());
+                log::warn!("[DSH-SYNC] 会话文件解析失败: {message}");
+                result.errors.push(message);
+            }
+        }
+    }
+
+    if result.imported > 0 {
+        log::info!(
+            "[DSH-SYNC] 同步完成: 导入 {} 条, 跳过 {} 条, 扫描 {} 个文件",
+            result.imported,
+            result.skipped,
+            result.files_scanned
+        );
+    }
+    result
+}
+
+fn sync_single_dsh_file(db: &Database, file_path: &Path) -> Result<SessionSyncResult, AppError> {
+    let metadata = fs::symlink_metadata(file_path)
+        .map_err(|error| AppError::Config(format!("无法读取 DSH 会话文件元数据: {error}")))?;
+    if !metadata.file_type().is_file() {
+        return Err(AppError::Config("DSH 会话路径不是普通文件".to_string()));
+    }
+    let modified = metadata_modified_nanos(&metadata);
+    let file_path_string = file_path.to_string_lossy().to_string();
+    if dsh_file_unchanged(db, &file_path_string, modified)? {
+        return Ok(SessionSyncResult::default());
+    }
+
+    let parsed = parse_dsh_file(file_path, modified / 1_000_000_000)?;
+    let conn = lock_conn!(db.conn);
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|error| AppError::Database(format!("启动 DSH 用量导入事务失败: {error}")))?;
+    let mut result = SessionSyncResult::default();
+    for record in &parsed.records {
+        if insert_dsh_record(&tx, record)? {
+            result.imported = result.imported.saturating_add(1);
+        } else {
+            result.skipped = result.skipped.saturating_add(1);
+        }
+    }
+
+    update_sync_state_on_conn(
+        &tx,
+        &file_path_string,
+        modified,
+        parsed.records.len().min(i64::MAX as usize) as i64,
+    )?;
+    tx.commit()
+        .map_err(|error| AppError::Database(format!("提交 DSH 用量导入事务失败: {error}")))?;
+    if parsed.incomplete_tail {
+        result.deferred_files = 1;
+    }
+    Ok(result)
+}
+
+/// DSH rewrites its zstd logs in full, so a file whose mtime has not advanced
+/// since the last pass cannot contain new events.
+fn dsh_file_unchanged(db: &Database, file_path: &str, modified: i64) -> Result<bool, AppError> {
+    let conn = lock_conn!(db.conn);
+    let last_modified: Option<i64> = conn
+        .query_row(
+            "SELECT last_modified FROM session_log_sync WHERE file_path = ?1",
+            rusqlite::params![file_path],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| AppError::Database(format!("读取 DSH 会话同步状态失败: {error}")))?;
+    Ok(last_modified.is_some_and(|last| modified <= last))
+}
+
+fn parse_dsh_file(file_path: &Path, file_modified_seconds: i64) -> Result<ParsedDshFile, AppError> {
+    let file = File::open(file_path)
+        .map_err(|error| AppError::Config(format!("无法打开 DSH 会话文件: {error}")))?;
+    let decoder = zstd::stream::read::Decoder::new(file)
+        .map_err(|error| AppError::Config(format!("无法解压 DSH 会话文件: {error}")))?;
+    let mut reader = BufReader::new(decoder);
+    let mut buffer = String::new();
+    let mut parsed = ParsedDshFile::default();
+    let mut decompressed_bytes: u64 = 0;
+
+    loop {
+        buffer.clear();
+        let read = reader
+            .read_line(&mut buffer)
+            .map_err(|error| AppError::Config(format!("无法读取 DSH 会话文件: {error}")))?;
+        if read == 0 {
+            break;
+        }
+        decompressed_bytes = decompressed_bytes.saturating_add(read as u64);
+        if decompressed_bytes > MAX_SESSION_BYTES {
+            return Err(AppError::Config(format!(
+                "DSH 会话解压后超过 {} 字节安全上限",
+                MAX_SESSION_BYTES
+            )));
+        }
+        let has_newline = buffer.ends_with('\n');
+        let line = buffer.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value = match serde_json::from_str::<Value>(line) {
+            Ok(value) => value,
+            Err(_) if !has_newline => {
+                // A torn final line means DSH is mid-rewrite; keep the events
+                // parsed so far and retry the tail on the next pass.
+                parsed.incomplete_tail = true;
+                break;
+            }
+            Err(_) => continue,
+        };
+
+        if parsed.session_id.is_none() {
+            if value.get("type").and_then(Value::as_str) != Some("session") {
+                return Err(AppError::Config(
+                    "DSH 会话的首条有效 JSON 不是 session header".to_string(),
+                ));
+            }
+            let session_id = value
+                .get("id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(truncate_usage_label)
+                .ok_or_else(|| AppError::Config("DSH 会话 header 缺少 id".to_string()))?;
+            parsed.session_id = Some(session_id.to_string());
+            continue;
+        }
+
+        if value.get("type").and_then(Value::as_str) != Some("assistant/message") {
+            continue;
+        }
+        let Some(data) = value.get("data").filter(|data| data.get("usage").is_some()) else {
+            continue;
+        };
+        let Some(record) = parse_usage_record(
+            data,
+            value.get("seq").and_then(Value::as_i64),
+            value.get("time").and_then(Value::as_i64),
+            parsed.session_id.as_deref().unwrap_or_default(),
+            file_modified_seconds,
+        ) else {
+            continue;
+        };
+        parsed.records.push(record);
+    }
+
+    if parsed.session_id.is_none() && !parsed.incomplete_tail {
+        return Err(AppError::Config("DSH 会话没有有效 header".to_string()));
+    }
+    Ok(parsed)
+}
+
+fn parse_usage_record(
+    data: &Value,
+    seq: Option<i64>,
+    time_millis: Option<i64>,
+    session_id: &str,
+    file_modified_seconds: i64,
+) -> Option<DshUsageRecord> {
+    let seq = seq?;
+    let usage = data.get("usage")?;
+    let input_tokens = token_count(usage, "inputTokens");
+    let output_tokens = token_count(usage, "outputTokens");
+    let cache_read_tokens = token_count(usage, "cacheReadTokens");
+
+    let source = data.pointer("/message/source");
+    let provider_id = source
+        .and_then(|source| source.get("provider"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|provider| !provider.is_empty())
+        .map(truncate_usage_label)
+        .unwrap_or(PROVIDER_PLACEHOLDER)
+        .to_string();
+    let model = source
+        .and_then(|source| source.get("model"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(truncate_usage_label)
+        .unwrap_or(UNKNOWN_MODEL)
+        .to_string();
+
+    // DSH reports epoch milliseconds; `time` is absent only for synthetic or
+    // hand-edited logs, where the file mtime is the best available estimate.
+    let created_at = time_millis
+        .map(|time| time.div_euclid(1000))
+        .unwrap_or(file_modified_seconds)
+        .clamp(MIN_SQLITE_UNIX_SECONDS, MAX_SQLITE_UNIX_SECONDS);
+
+    Some(DshUsageRecord {
+        request_id: format!("{REQUEST_ID_PREFIX}{session_id}:{seq}"),
+        provider_id,
+        model,
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        created_at,
+        session_id: session_id.to_string(),
+    })
+}
+
+fn token_count(usage: &Value, key: &str) -> u32 {
+    usage
+        .get(key)
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+        .min(u32::MAX as u64) as u32
+}
+
+fn truncate_usage_label(value: &str) -> &str {
+    if value.len() <= MAX_USAGE_LABEL_BYTES {
+        return value;
+    }
+    let mut end = MAX_USAGE_LABEL_BYTES;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
+}
+
+fn insert_dsh_record(
+    conn: &rusqlite::Connection,
+    record: &DshUsageRecord,
+) -> Result<bool, AppError> {
+    let already_seen: bool = conn
+        .query_row(
+            DSH_REQUEST_DEDUP_SQL,
+            rusqlite::params![DATA_SOURCE, record.request_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| AppError::Database(format!("查询 DSH 用量去重账本失败: {error}")))?;
+    if already_seen {
+        return Ok(false);
+    }
+    conn.execute(
+        "INSERT OR IGNORE INTO session_usage_dedup
+         (data_source, request_id, semantic_id, has_entry_id)
+         VALUES (?1, ?2, ?3, ?4)",
+        rusqlite::params![DATA_SOURCE, record.request_id, record.request_id, 1i64],
+    )
+    .map_err(|error| AppError::Database(format!("写入 DSH 用量去重账本失败: {error}")))?;
+
+    let usage = TokenUsage {
+        input_tokens: record.input_tokens,
+        output_tokens: record.output_tokens,
+        cache_read_tokens: record.cache_read_tokens,
+        cache_creation_tokens: 0,
+        model: Some(record.model.clone()),
+        message_id: None,
+    };
+    let costs = find_model_pricing(conn, &record.model).map(|pricing| {
+        let calculated =
+            CostCalculator::calculate_for_app(APP_TYPE, &usage, &pricing, Decimal::ONE);
+        (
+            calculated.input_cost,
+            calculated.output_cost,
+            calculated.cache_read_cost,
+            calculated.cache_creation_cost,
+            calculated.total_cost,
+        )
+    });
+    let (input_cost, output_cost, cache_read_cost, cache_write_cost, total_cost) =
+        costs.unwrap_or((
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+        ));
+
+    conn.execute(
+        "INSERT OR IGNORE INTO proxy_request_logs (
+            request_id, provider_id, app_type, model, request_model, pricing_model,
+            input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+            input_token_semantics,
+            input_cost_usd, output_cost_usd, cache_read_cost_usd,
+            cache_creation_cost_usd, total_cost_usd,
+            latency_ms, first_token_ms, status_code, error_message, session_id,
+            provider_type, is_streaming, cost_multiplier, created_at, data_source
+        ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
+            ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26
+        )",
+        rusqlite::params![
+            record.request_id,
+            record.provider_id,
+            APP_TYPE,
+            record.model,
+            record.model,
+            record.model,
+            record.input_tokens,
+            record.output_tokens,
+            record.cache_read_tokens,
+            0i64,
+            INPUT_TOKEN_SEMANTICS_FRESH,
+            input_cost.to_string(),
+            output_cost.to_string(),
+            cache_read_cost.to_string(),
+            cache_write_cost.to_string(),
+            total_cost.to_string(),
+            0i64,
+            Option::<i64>::None,
+            200i64,
+            Option::<String>::None,
+            record.session_id,
+            Some(DATA_SOURCE),
+            0i64,
+            "1.0",
+            record.created_at,
+            DATA_SOURCE,
+        ],
+    )
+    .map(|changed| changed > 0)
+    .map_err(|error| AppError::Database(format!("插入 DSH 会话用量失败: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_zstd_session(path: &Path, lines: &[String]) {
+        let jsonl = lines
+            .iter()
+            .map(|line| format!("{line}\n"))
+            .collect::<String>();
+        let compressed = zstd::stream::encode_all(jsonl.as_bytes(), 0).expect("encode session");
+        fs::write(path, compressed).expect("write session");
+    }
+
+    fn session_header(id: &str) -> String {
+        format!(
+            r#"{{"type":"session","version":0,"id":"{id}","createdAt":1786678151825,"cwd":"/work"}}"#
+        )
+    }
+
+    fn assistant_line(seq: i64, time: i64, input: u32, output: u32, cache_read: u32) -> String {
+        format!(
+            r#"{{"type":"assistant/message","seq":{seq},"time":{time},"data":{{"turn":1,"step":1,"message":{{"role":"assistant","content":[{{"type":"text","text":"ok"}}],"source":{{"kind":"model","provider":"stepfun-plan","model":"step-3.7-flash"}}}},"usage":{{"inputTokens":{input},"outputTokens":{output},"cacheReadTokens":{cache_read}}}}}}}"#
+        )
+    }
+
+    fn session_file(root: &Path, encoded_cwd: &str, session_id: &str) -> PathBuf {
+        let path = root
+            .join(encoded_cwd)
+            .join(session_id)
+            .join("session.jsonl.zstd");
+        fs::create_dir_all(path.parent().expect("session dir")).expect("create session dir");
+        path
+    }
+
+    #[test]
+    fn dedup_lookup_uses_complete_identity_index() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let conn = lock_conn!(db.conn);
+        let mut statement = conn.prepare(&format!("EXPLAIN QUERY PLAN {DSH_REQUEST_DEDUP_SQL}"))?;
+        let plan = statement
+            .query_map(rusqlite::params![DATA_SOURCE, "identity"], |row| {
+                row.get::<_, String>(3)
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert!(
+            plan.iter()
+                .any(|step| step.contains("(data_source=? AND request_id=?)")),
+            "lookup does not constrain the complete identity: {plan:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn imports_usage_events_with_fresh_semantics_and_legacy_request_ids() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = session_file(temp.path(), "--work--", "session-abc-123");
+        write_zstd_session(
+            &path,
+            &[
+                session_header("session-abc-123"),
+                r#"{"type":"permission/preset","seq":0,"time":1786678151831,"data":{"preset":"workspace-write"}}"#.to_string(),
+                assistant_line(7, 1786678145825, 7965, 139, 256),
+                assistant_line(8, 1786678148978, 1534, 187, 8128),
+                r#"{"type":"assistant/message","seq":9,"time":1786678149999,"data":{"turn":1,"step":1,"message":{"role":"assistant","content":[]}}}"#.to_string(),
+            ],
+        );
+
+        let db = Database::memory()?;
+        let result = sync_dsh_files(&db, std::slice::from_ref(&path));
+        assert_eq!(result.imported, 2);
+        assert!(result.errors.is_empty());
+
+        {
+            let conn = lock_conn!(db.conn);
+            let identity: (String, String, String, String, String, String, String) = conn
+                .query_row(
+                    "SELECT request_id, provider_id, model, app_type, session_id,
+                            provider_type, data_source
+                     FROM proxy_request_logs WHERE request_id = 'dsh:session-abc-123:7'",
+                    [],
+                    |row| {
+                        Ok((
+                            row.get(0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                            row.get(3)?,
+                            row.get(4)?,
+                            row.get(5)?,
+                            row.get(6)?,
+                        ))
+                    },
+                )?;
+            assert_eq!(identity.0, "dsh:session-abc-123:7");
+            assert_eq!(identity.1, "stepfun-plan");
+            assert_eq!(identity.2, "step-3.7-flash");
+            assert_eq!(identity.3, "dsh");
+            assert_eq!(identity.4, "session-abc-123");
+            assert_eq!(identity.5, "dsh_session");
+            assert_eq!(identity.6, "dsh_session");
+
+            let counters: (i64, i64, i64, i64, i64, i64, i64) = conn.query_row(
+                "SELECT input_tokens, output_tokens, cache_read_tokens,
+                        cache_creation_tokens, input_token_semantics, created_at,
+                        is_streaming
+                 FROM proxy_request_logs WHERE request_id = 'dsh:session-abc-123:7'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                    ))
+                },
+            )?;
+            assert_eq!((counters.0, counters.1, counters.2), (7965, 139, 256));
+            assert_eq!(counters.3, 0);
+            assert_eq!(counters.4, INPUT_TOKEN_SEMANTICS_FRESH);
+            assert_eq!(counters.5, 1_786_678_145);
+            assert_eq!(counters.6, 0);
+
+            let dedup: (String, String, i64) = conn.query_row(
+                "SELECT request_id, semantic_id, has_entry_id FROM session_usage_dedup
+                 WHERE data_source = 'dsh_session' ORDER BY request_id",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )?;
+            assert_eq!(
+                dedup,
+                (
+                    "dsh:session-abc-123:7".to_string(),
+                    "dsh:session-abc-123:7".to_string(),
+                    1
+                )
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_backfill_ledger_rows_are_recognized_and_not_reimported() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = session_file(temp.path(), "--work--", "session-legacy-42");
+        write_zstd_session(
+            &path,
+            &[
+                session_header("session-legacy-42"),
+                assistant_line(70473, 1786776034999, 6, 1107, 148864),
+                assistant_line(70480, 1786776041000, 12, 34, 56),
+            ],
+        );
+
+        // Rows written by the pre-upstream backfill tool use the same
+        // `dsh:session-<id>:<seq>` identity; replaying must add nothing.
+        let db = Database::memory()?;
+        {
+            let conn = lock_conn!(db.conn);
+            for request_id in ["dsh:session-legacy-42:70473", "dsh:session-legacy-42:70480"] {
+                conn.execute(
+                    "INSERT OR IGNORE INTO session_usage_dedup
+                     (data_source, request_id, semantic_id, has_entry_id)
+                     VALUES ('dsh_session', ?1, ?1, 1)",
+                    rusqlite::params![request_id],
+                )?;
+            }
+        }
+        let result = sync_dsh_files(&db, std::slice::from_ref(&path));
+        assert_eq!((result.imported, result.skipped), (0, 2));
+        let count: i64 = lock_conn!(db.conn).query_row(
+            "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'dsh_session'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn missing_provider_falls_back_to_named_placeholder() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = session_file(temp.path(), "--work--", "session-anon-1");
+        let event = r#"{"type":"assistant/message","seq":3,"time":1786678145825,"data":{"turn":1,"step":1,"message":{"role":"assistant","content":[]},"usage":{"inputTokens":10,"outputTokens":5,"cacheReadTokens":2}}}"#;
+        write_zstd_session(
+            &path,
+            &[session_header("session-anon-1"), event.to_string()],
+        );
+
+        let db = Database::memory()?;
+        assert_eq!(sync_dsh_files(&db, std::slice::from_ref(&path)).imported, 1);
+
+        let conn = lock_conn!(db.conn);
+        let (provider_id, model): (String, String) = conn.query_row(
+            "SELECT provider_id, model FROM proxy_request_logs
+             WHERE data_source = 'dsh_session'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(provider_id, PROVIDER_PLACEHOLDER);
+        assert_eq!(model, UNKNOWN_MODEL);
+        drop(conn);
+
+        let providers = db.get_provider_stats(None, None, Some(APP_TYPE), None, None)?;
+        assert!(providers.iter().any(|provider| {
+            provider.provider_id == PROVIDER_PLACEHOLDER
+                && provider.provider_name == "DSH (Session)"
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn rewritten_file_reimports_only_new_events() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = session_file(temp.path(), "--work--", "session-grow-9");
+        write_zstd_session(
+            &path,
+            &[
+                session_header("session-grow-9"),
+                assistant_line(1, 1786678145825, 100, 10, 1000),
+            ],
+        );
+
+        let db = Database::memory()?;
+        assert_eq!(sync_dsh_files(&db, std::slice::from_ref(&path)).imported, 1);
+        // Unchanged mtime: the file is skipped entirely.
+        let unchanged = sync_dsh_files(&db, std::slice::from_ref(&path));
+        assert_eq!((unchanged.imported, unchanged.skipped), (0, 0));
+
+        write_zstd_session(
+            &path,
+            &[
+                session_header("session-grow-9"),
+                assistant_line(1, 1786678145825, 100, 10, 1000),
+                assistant_line(2, 1786678148978, 200, 20, 2000),
+            ],
+        );
+        // Same-size rewrites can keep the mtime; force a bump to model DSH's
+        // full-rewrite behaviour and rely on the ledger for the old event.
+        let later = std::time::SystemTime::now() + std::time::Duration::from_secs(5);
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .expect("open session for timestamp bump")
+            .set_times(std::fs::FileTimes::new().set_modified(later))
+            .expect("bump mtime");
+        let grown = sync_dsh_files(&db, std::slice::from_ref(&path));
+        assert_eq!((grown.imported, grown.skipped), (1, 1));
+
+        let count: i64 = lock_conn!(db.conn).query_row(
+            "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'dsh_session'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 2);
+        Ok(())
+    }
+}

--- a/src-tauri/src/services/session_usage_dsh.rs
+++ b/src-tauri/src/services/session_usage_dsh.rs
@@ -16,12 +16,12 @@ use crate::services::session_usage::{
     metadata_modified_nanos, update_sync_state_on_conn, SessionSyncResult,
 };
 use crate::services::sql_helpers::INPUT_TOKEN_SEMANTICS_FRESH;
-use crate::services::usage_stats::find_model_pricing;
+use crate::services::usage_stats::{find_model_pricing, should_skip_session_insert, DedupKey};
 use rusqlite::OptionalExtension;
 use rust_decimal::Decimal;
 use serde_json::Value;
 use std::fs::{self, File};
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 
 const APP_TYPE: &str = "dsh";
@@ -189,20 +189,28 @@ fn parse_dsh_file(file_path: &Path, file_modified_seconds: i64) -> Result<Parsed
 
     loop {
         buffer.clear();
-        let read = reader
+        // Bound each read_line with the remaining byte allowance so a single
+        // decompressed line without a newline cannot exhaust memory before the
+        // total check below runs. `Take` caps the bytes read from the
+        // underlying BufReader, preventing a decompression-bomb allocation.
+        let remaining = MAX_SESSION_BYTES.saturating_sub(decompressed_bytes);
+        let mut limited = reader.by_ref().take(remaining);
+        let read = limited
             .read_line(&mut buffer)
             .map_err(|error| AppError::Config(format!("无法读取 DSH 会话文件: {error}")))?;
         if read == 0 {
             break;
         }
         decompressed_bytes = decompressed_bytes.saturating_add(read as u64);
-        if decompressed_bytes > MAX_SESSION_BYTES {
+        let has_newline = buffer.ends_with('\n');
+        // The Take budget was exhausted mid-line — the decompressed content
+        // exceeds the safety allowance within a single line.
+        if !has_newline && limited.limit() == 0 {
             return Err(AppError::Config(format!(
                 "DSH 会话解压后超过 {} 字节安全上限",
                 MAX_SESSION_BYTES
             )));
         }
-        let has_newline = buffer.ends_with('\n');
         let line = buffer.trim();
         if line.is_empty() {
             continue;
@@ -342,6 +350,24 @@ fn insert_dsh_record(
     if already_seen {
         return Ok(false);
     }
+
+    // Cross-source dedup: when DSH sends requests through CC Switch's
+    // Claude/Codex proxy endpoint, the proxy already recorded the same
+    // usage under that endpoint's app type with a different request ID.
+    // Skip the session insert so the dashboard does not double-count.
+    let dedup_key = DedupKey {
+        app_type: APP_TYPE,
+        model: &record.model,
+        input_tokens: record.input_tokens,
+        output_tokens: record.output_tokens,
+        cache_read_tokens: record.cache_read_tokens,
+        cache_creation_tokens: 0,
+        created_at: record.created_at,
+    };
+    if should_skip_session_insert(conn, &record.request_id, &dedup_key)? {
+        return Ok(false);
+    }
+
     conn.execute(
         "INSERT OR IGNORE INTO session_usage_dedup
          (data_source, request_id, semantic_id, has_entry_id)
@@ -680,6 +706,90 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(count, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn decompression_bomb_line_is_rejected_by_bounded_reader() -> Result<(), AppError> {
+        // A single line without a newline that exceeds MAX_SESSION_BYTES must
+        // be rejected by the Take-bounded reader, not allocated in full.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = session_file(temp.path(), "--work--", "session-bomb");
+        let bomb_line = "A".repeat(MAX_SESSION_BYTES as usize + 1024);
+        let jsonl = format!("{}\n{}\n", session_header("session-bomb"), bomb_line);
+        let compressed = zstd::stream::encode_all(jsonl.as_bytes(), 0).expect("encode bomb");
+        fs::write(&path, compressed).expect("write bomb");
+
+        let db = Database::memory()?;
+        let result = sync_dsh_files(&db, std::slice::from_ref(&path));
+        assert_eq!(result.imported, 0);
+        assert!(!result.errors.is_empty());
+        // The error must mention the safety limit, and no rows should be written.
+        assert!(result.errors[0].contains("安全上限"));
+        let count: i64 = lock_conn!(db.conn).query_row(
+            "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'dsh_session'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn dsh_session_row_is_skipped_when_proxy_already_recorded() -> Result<(), AppError> {
+        // DSH sends through CC Switch's Claude proxy: the proxy logs the
+        // request as app_type='claude'. The session importer must detect the
+        // fingerprint match and skip the session insert.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = session_file(temp.path(), "--work--", "session-proxy-dup");
+        write_zstd_session(
+            &path,
+            &[
+                session_header("session-proxy-dup"),
+                assistant_line(5, 1786678145825, 5000, 200, 500),
+            ],
+        );
+
+        let db = Database::memory()?;
+        // Simulate the proxy row: same tokens, same model, within the dedup
+        // window (±10 min), app_type='claude'.
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model, request_model,
+                    input_tokens, output_tokens, cache_read_tokens,
+                    cache_creation_tokens, latency_ms, status_code, created_at, data_source
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                rusqlite::params![
+                    "proxy-req-1",
+                    "anthropic",
+                    "claude",
+                    "step-3.7-flash",
+                    "step-3.7-flash",
+                    5000,
+                    200,
+                    500,
+                    7, // proxy may have non-zero cache_creation; DSH reports 0
+                    100,
+                    200,
+                    1_786_678_145, // ±60s of the session row's created_at
+                    "proxy",
+                ],
+            )?;
+        }
+
+        let result = sync_dsh_files(&db, std::slice::from_ref(&path));
+        // The session row is skipped because the proxy already recorded it.
+        assert_eq!(result.imported, 0);
+        assert_eq!(result.skipped, 1);
+
+        let count: i64 = lock_conn!(db.conn).query_row(
+            "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'dsh_session'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 0);
         Ok(())
     }
 }

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -217,6 +217,7 @@ fn provider_name_coalesce(log_alias: &str, provider_alias: &str) -> String {
          WHEN '_opencode_session' THEN 'OpenCode (Session)' \
          WHEN '_grok_session' THEN 'Grok Build (Session)' \
          WHEN '_pi_session' THEN 'Pi (Session)' \
+         WHEN '_dsh_session' THEN 'DSH (Session)' \
          ELSE {log_alias}.provider_id END)"
     )
 }

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -234,8 +234,15 @@ fn data_source_expr(log_alias: &str) -> String {
 }
 
 fn dedup_app_type_match_sql(left: &str, right: &str) -> String {
+    // DSH sessions route through CC Switch's Claude or Codex proxy endpoints,
+    // so a `dsh` session row must cross-match `claude` and `codex` proxy rows.
     format!(
-        "{left} IN ({right}, CASE WHEN {right} = 'claude' THEN 'claude-desktop' ELSE {right} END)"
+        "{left} IN (
+            {right},
+            CASE WHEN {right} = 'claude' THEN 'claude-desktop' ELSE {right} END,
+            CASE WHEN {right} = 'dsh' THEN 'claude' ELSE {right} END,
+            CASE WHEN {right} = 'dsh' THEN 'codex' ELSE {right} END
+        )"
     )
 }
 
@@ -311,7 +318,7 @@ pub(crate) fn effective_usage_log_filter(log_alias: &str) -> String {
         dedup_app_type_match_sql("proxy_dedup.app_type", &format!("{log_alias}.app_type"));
     format!(
         "NOT (
-            {data_source} IN ('session_log', 'codex_session', 'gemini_session', 'opencode_session')
+            {data_source} IN ('session_log', 'codex_session', 'gemini_session', 'opencode_session', 'dsh_session')
             AND EXISTS (
                 SELECT 1
                 FROM proxy_request_logs proxy_dedup
@@ -410,7 +417,8 @@ pub(crate) fn has_matching_proxy_usage_log(
     key: &DedupKey,
 ) -> Result<bool, AppError> {
     let allow_missing_cache_creation =
-        matches!(key.app_type, "codex" | "gemini" | "opencode") && key.cache_creation_tokens == 0;
+        matches!(key.app_type, "codex" | "gemini" | "opencode" | "dsh")
+            && key.cache_creation_tokens == 0;
 
     conn.prepare_cached(&MATCHING_PROXY_USAGE_LOG_SQL)
         .and_then(|mut stmt| {

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -68,6 +68,7 @@ const normalizeRefreshInterval = (value: number | undefined) =>
 const APP_FILTER_ICON: Record<AppType, string> = {
   claude: "claude",
   codex: "openai",
+  dsh: "deepseek",
   gemini: "gemini",
   grokbuild: "grok",
   opencode: "opencode",

--- a/src/components/usage/UsageHero.tsx
+++ b/src/components/usage/UsageHero.tsx
@@ -73,6 +73,10 @@ const TITLE_THEMES: Record<AppType | "all", TitleTheme> = {
     accent: "text-fuchsia-600 dark:text-fuchsia-400",
     iconBg: "bg-fuchsia-500/10",
   },
+  dsh: {
+    accent: "text-teal-600 dark:text-teal-400",
+    iconBg: "bg-teal-500/10",
+  },
 };
 
 /**

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -910,7 +910,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "dsh": "DSH"
   },
   "pi": {
     "empty": {
@@ -1716,7 +1717,8 @@
       "gemini": "Gemini",
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
-      "pi": "Pi"
+      "pi": "Pi",
+      "dsh": "DSH"
     },
     "rawInputLabel": "Raw",
     "rebuildCodex": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -910,7 +910,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "dsh": "DSH"
   },
   "pi": {
     "empty": {
@@ -1716,7 +1717,8 @@
       "gemini": "Gemini",
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
-      "pi": "Pi"
+      "pi": "Pi",
+      "dsh": "DSH"
     },
     "rawInputLabel": "原始",
     "rebuildCodex": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -911,7 +911,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "dsh": "DSH"
   },
   "pi": {
     "empty": {
@@ -1717,7 +1718,8 @@
       "gemini": "Gemini",
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
-      "pi": "Pi"
+      "pi": "Pi",
+      "dsh": "DSH"
     },
     "rawInputLabel": "原始",
     "rebuildCodex": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -910,7 +910,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "dsh": "DSH"
   },
   "pi": {
     "empty": {
@@ -1716,7 +1717,8 @@
       "gemini": "Gemini",
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
-      "pi": "Pi"
+      "pi": "Pi",
+      "dsh": "DSH"
     },
     "rawInputLabel": "原始",
     "rebuildCodex": {

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -192,6 +192,7 @@ export interface UsageRangeSelection {
 export type AppType =
   | "claude"
   | "codex"
+  | "dsh"
   | "gemini"
   | "grokbuild"
   | "opencode"
@@ -202,6 +203,7 @@ export type AppTypeFilter = "all" | AppType;
 export const KNOWN_APP_TYPES: ReadonlyArray<AppType> = [
   "claude",
   "codex",
+  "dsh",
   "gemini",
   "grokbuild",
   "opencode",
@@ -228,8 +230,11 @@ export const CACHE_INCLUSIVE_APP_TYPES: ReadonlySet<string> = new Set([
 
 // Pi sessions can mix Anthropic and OpenAI APIs, but the dashboard aggregates
 // only by app type. Treat cache-write coverage as partial without changing
-// Pi's fresh-input token semantics.
-const PARTIAL_CACHE_WRITE_APP_TYPES: ReadonlySet<string> = new Set(["pi"]);
+// Pi's fresh-input token semantics. DSH logs never report cache writes.
+const PARTIAL_CACHE_WRITE_APP_TYPES: ReadonlySet<string> = new Set([
+  "pi",
+  "dsh",
+]);
 
 export type CacheWriteAvailability = "ok" | "partial" | "na";
 


### PR DESCRIPTION
# PR: feat(usage): add DSH session usage importer

## Title

feat(usage): add DSH session usage importer

## Body

### Background

DSH (DeepSeek Harness) is a coding-agent CLI that keeps a local session
ledger: every session is persisted as a zstd-compressed JSONL file under
`~/.dsh/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`, and each
`assistant/message` event carries normalized Anthropic-style usage
(fresh `inputTokens`, `outputTokens`, `cacheReadTokens`; no cache-write
bucket). That usage is currently invisible to the cc-switch dashboard
unless it flows through the proxy.

This PR adds a first-class session importer for DSH, mirroring the
existing Pi/Codex/Gemini/OpenCode/Grok Build importers, so direct
(non-proxy) DSH usage shows up in the shared usage dashboard with its
own filter. Related dashboard-extension discussions: #6430, #6525.

### Implementation

- New `src-tauri/src/services/session_usage_dsh.rs`:
  - Discovers `session.jsonl.zstd` files under the sessions root
    (`DSH_SESSIONS_DIR` env override, `~/.dsh/sessions` by default).
  - Decompresses with the existing `zstd` dependency and replays every
    `assistant/message` event that reports usage.
  - Identity: `dsh:session-<id>:<seq>` request ids recorded in the
    durable `session_usage_dedup` ledger, so full reparses stay
    idempotent and rows previously written by external tooling with the
    same identity are recognized instead of double-counted.
  - Rows use fresh-input semantics (`input_token_semantics = 2`),
    second-precision `created_at` from the event's epoch-millisecond
    timestamp, and cost estimation from `model_pricing` (like the Pi
    importer; zero when the model is unknown).
  - Files whose mtime has not advanced since the last pass are skipped;
    DSH rewrites its logs in full, so any change triggers a safe
    reparse guarded by the dedup ledger.
- Registered in `session_usage.rs` `sync_all_unlocked` (startup +
  periodic + manual sync) and wired into the `_dsh_session` →
  `DSH (Session)` provider-name mapping.
- Frontend: `dsh` added to `AppType` / `KNOWN_APP_TYPES` /
  partial-cache-write set, filter icon, hero theme, and the `apps` /
  `appFilter` labels in zh / zh-TW / en / ja.

### Testing

- Five new unit tests in `session_usage_dsh.rs`: row values and request
  id format from a synthetic zstd log (built with
  `zstd::stream::encode_all`), legacy-ledger rows are recognized with
  zero re-imports, provider placeholder mapping, mtime-skip plus
  rewrite idempotency, and dedup index usage.
- `cargo test` (2685 passed / 0 failed), `cargo clippy --all-targets`
  and `cargo fmt --check` clean, `pnpm typecheck` and
  `pnpm test:unit` (987 tests) green.
- Verified end-to-end on macOS against a real `~/.dsh` sessions tree
  containing data pre-written by an external importer: after startup
  the dashboard's DSH aggregates match a full raw-log census key-for-
  key, with no duplicate rows and stable counts across re-syncs.
