### PR TITLE
fix(proxy): preserve Gemini thought_signature across Codex chat bridge

### DIFF
--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -163,7 +163,7 @@ pub(crate) fn attach_optional_google_thought_signature(
 ) -> bool {
     if !matches!(
         item.get("type").and_then(Value::as_str),
-        Some("function_call" | "function")
+        Some("function_call" | "function" | "custom_tool_call" | "tool_search_call")
     ) {
         return false;
     }

--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -150,6 +150,49 @@ pub(crate) fn attach_optional_reasoning_content_field(
     attach_reasoning_content_field(item, reasoning)
 }
 
+pub(crate) fn google_thought_signature(value: &Value) -> Option<&str> {
+    value
+        .pointer("/extra_content/google/thought_signature")
+        .and_then(Value::as_str)
+        .filter(|signature| !signature.is_empty())
+}
+
+pub(crate) fn attach_optional_google_thought_signature(
+    item: &mut Value,
+    signature: Option<&str>,
+) -> bool {
+    if !matches!(
+        item.get("type").and_then(Value::as_str),
+        Some("function_call" | "function")
+    ) {
+        return false;
+    }
+    let Some(signature) = signature.filter(|signature| !signature.is_empty()) else {
+        return false;
+    };
+
+    let Some(object) = item.as_object_mut() else {
+        return false;
+    };
+    let extra_content = object
+        .entry("extra_content".to_string())
+        .or_insert_with(|| json!({}));
+    let Some(extra_content) = extra_content.as_object_mut() else {
+        return false;
+    };
+    let google = extra_content
+        .entry("google".to_string())
+        .or_insert_with(|| json!({}));
+    let Some(google) = google.as_object_mut() else {
+        return false;
+    };
+    google.insert(
+        "thought_signature".to_string(),
+        Value::String(signature.to_string()),
+    );
+    true
+}
+
 pub(crate) fn response_function_call_item(
     item_id: &str,
     status: &str,

--- a/src-tauri/src/proxy/providers/codex_chat_history.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_history.rs
@@ -1,4 +1,7 @@
-use super::codex_chat_common::{is_empty_value, response_item_call_id};
+use super::codex_chat_common::{
+    attach_optional_google_thought_signature, google_thought_signature, is_empty_value,
+    response_item_call_id,
+};
 use crate::proxy::sse::{append_utf8_safe, strip_sse_field, take_sse_block};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
@@ -475,6 +478,7 @@ fn enrich_call_item_from_cache(item: &mut Value, cached: &Value) -> bool {
         "input",
         "status",
         "execution",
+        "extra_content",
         "reasoning_content",
         "reasoning",
     ] {
@@ -487,6 +491,11 @@ fn enrich_call_item_from_cache(item: &mut Value, cached: &Value) -> bool {
         if let Some(object) = item.as_object_mut() {
             object.insert(key.to_string(), value.clone());
             changed = true;
+        }
+    }
+    if google_thought_signature(item).is_none() {
+        if let Some(signature) = google_thought_signature(cached) {
+            changed |= attach_optional_google_thought_signature(item, Some(signature));
         }
     }
     changed

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -3,7 +3,8 @@
 use super::codex_responses_sse as sse;
 use super::{
     codex_chat_common::{
-        extract_reasoning_field_text, split_leading_think_block, strip_leading_think_open_tag,
+        attach_optional_google_thought_signature, extract_reasoning_field_text,
+        google_thought_signature, split_leading_think_block, strip_leading_think_open_tag,
     },
     transform_codex_chat::{
         chat_usage_to_responses_usage, custom_tool_input_from_chat_arguments,
@@ -58,6 +59,7 @@ struct ToolCallState {
     call_id: String,
     name: String,
     arguments: String,
+    thought_signature: Option<String>,
     reasoning_content: String,
     added: bool,
     done: bool,
@@ -386,6 +388,7 @@ impl ChatToResponsesState {
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
+        let thought_signature_delta = google_thought_signature(tool_call).map(str::to_string);
 
         let mut output_index = None;
         let mut item_id = String::new();
@@ -405,6 +408,9 @@ impl ChatToResponsesState {
             }
             if !args_delta.is_empty() {
                 state.arguments.push_str(&args_delta);
+            }
+            if let Some(signature) = thought_signature_delta {
+                state.thought_signature = Some(signature);
             }
             if state.reasoning_content.is_empty() {
                 if let Some(reasoning) = reasoning.map(str::trim).filter(|value| !value.is_empty())
@@ -466,7 +472,7 @@ impl ChatToResponsesState {
                 &self.tool_context,
             );
 
-            let item = response_tool_call_item_from_chat_name(
+            let mut item = response_tool_call_item_from_chat_name(
                 &state.item_id,
                 "in_progress",
                 &state.call_id,
@@ -475,6 +481,7 @@ impl ChatToResponsesState {
                 Some(&state.reasoning_content),
                 &self.tool_context,
             );
+            attach_optional_google_thought_signature(&mut item, state.thought_signature.as_deref());
 
             events.push(sse::output_item_added(assigned, &item));
 
@@ -666,7 +673,7 @@ impl ChatToResponsesState {
                     &state.name,
                     &self.tool_context,
                 );
-                let item = response_tool_call_item_from_chat_name(
+                let mut item = response_tool_call_item_from_chat_name(
                     &state.item_id,
                     "in_progress",
                     &state.call_id,
@@ -674,6 +681,10 @@ impl ChatToResponsesState {
                     "",
                     Some(&state.reasoning_content),
                     &self.tool_context,
+                );
+                attach_optional_google_thought_signature(
+                    &mut item,
+                    state.thought_signature.as_deref(),
                 );
                 add_event = Some(sse::output_item_added(assigned, &item));
             }
@@ -688,7 +699,7 @@ impl ChatToResponsesState {
             let output_index = state.output_index.unwrap_or(0);
             let arguments = canonicalize_tool_arguments_str(&state.arguments);
             let is_custom_tool = self.tool_context.is_custom_tool_chat_name(&state.name);
-            let item = response_tool_call_item_from_chat_name(
+            let mut item = response_tool_call_item_from_chat_name(
                 &state.item_id,
                 "completed",
                 &state.call_id,
@@ -697,6 +708,7 @@ impl ChatToResponsesState {
                 Some(&state.reasoning_content),
                 &self.tool_context,
             );
+            attach_optional_google_thought_signature(&mut item, state.thought_signature.as_deref());
             state.done = true;
             self.output_items.push((output_index, item.clone()));
 
@@ -1423,6 +1435,84 @@ mod tests {
         assert!(output.contains("\"execution\":\"client\""));
         assert!(output.contains("\"call_id\":\"call_tool_search_1\""));
         assert!(output.contains("\"query\":\"Gmail search emails\""));
+    }
+
+    #[tokio::test]
+    async fn preserves_google_thought_signature_across_streaming_sequential_tool_call() {
+        let signature = "gemini-stream-thought-signature";
+        let first_chunk = json!({
+            "id": "chatcmpl_gemini_stream",
+            "model": "gemini-3.7-flash",
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_gemini_stream",
+                        "type": "function",
+                        "function": {"name": "read_file"},
+                        "extra_content": {
+                            "google": {"thought_signature": signature}
+                        }
+                    }]
+                }
+            }]
+        });
+        let second_chunk = json!({
+            "id": "chatcmpl_gemini_stream",
+            "model": "gemini-3.7-flash",
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "function": {
+                            "arguments": "{\"path\":\"README.md\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+        let upstream = stream::iter(vec![
+            Ok::<Bytes, std::io::Error>(Bytes::from(format!("data: {first_chunk}\n\n"))),
+            Ok(Bytes::from(format!("data: {second_chunk}\n\n"))),
+            Ok(Bytes::from_static(b"data: [DONE]\n\n")),
+        ]);
+        let history =
+            std::sync::Arc::new(super::super::codex_chat_history::CodexChatHistoryStore::default());
+        let converted = create_responses_sse_stream_from_chat(upstream);
+        let recorded = super::super::codex_chat_history::record_responses_sse_stream(
+            converted,
+            history.clone(),
+        );
+        let bytes: Vec<Bytes> = recorded.map(|item| item.unwrap()).collect().await;
+        let output = String::from_utf8(bytes.concat()).unwrap();
+        let completed = parse_sse_events(&output)
+            .into_iter()
+            .find(|event| event["type"] == "response.completed")
+            .unwrap();
+        assert_eq!(
+            completed["response"]["output"][0]["extra_content"]["google"]["thought_signature"],
+            signature
+        );
+
+        let mut follow_up = json!({
+            "previous_response_id": completed["response"]["id"].clone(),
+            "model": "gemini-3.7-flash",
+            "input": [{
+                "type": "function_call_output",
+                "call_id": "call_gemini_stream",
+                "output": "ok"
+            }]
+        });
+        assert_eq!(history.enrich_request(&mut follow_up).await, 1);
+
+        let rebuilt_chat =
+            super::super::transform_codex_chat::responses_to_chat_completions(follow_up).unwrap();
+        assert_eq!(
+            rebuilt_chat["messages"][0]["tool_calls"][0]["extra_content"]["google"]
+                ["thought_signature"],
+            signature
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -5,7 +5,8 @@
 //! OpenAI-compatible Chat Completions endpoint.
 
 use super::codex_chat_common::{
-    append_reasoning_content, extract_reasoning_field_text, extract_reasoning_summary_text,
+    append_reasoning_content, attach_optional_google_thought_signature,
+    extract_reasoning_field_text, extract_reasoning_summary_text, google_thought_signature,
     response_function_call_item, response_function_call_item_with_namespace,
     split_leading_think_block,
 };
@@ -1340,14 +1341,16 @@ fn responses_function_call_to_chat_tool_call(
     let chat_name = tool_context.chat_name_for_response_function(name, namespace);
     let arguments = canonicalize_tool_arguments(item.get("arguments"));
 
-    json!({
+    let mut tool_call = json!({
         "id": call_id,
         "type": "function",
         "function": {
             "name": chat_name,
             "arguments": arguments
         }
-    })
+    });
+    attach_optional_google_thought_signature(&mut tool_call, google_thought_signature(item));
+    tool_call
 }
 
 fn responses_custom_tool_call_to_chat_tool_call(item: &Value) -> Value {
@@ -1681,7 +1684,7 @@ fn chat_tool_call_to_response_item(
     let arguments = canonicalize_tool_arguments(function.get("arguments"));
 
     let item_id = response_tool_call_item_id_from_chat_name(&call_id, name, tool_context);
-    response_tool_call_item_from_chat_name(
+    let mut item = response_tool_call_item_from_chat_name(
         &item_id,
         "completed",
         &call_id,
@@ -1689,7 +1692,9 @@ fn chat_tool_call_to_response_item(
         &arguments,
         reasoning,
         tool_context,
-    )
+    );
+    attach_optional_google_thought_signature(&mut item, google_thought_signature(tool_call));
+    item
 }
 
 fn chat_legacy_function_call_to_response_item(
@@ -4863,5 +4868,61 @@ mod tests {
             "tools should be present from tool_search_output"
         );
         assert_eq!(result["tools"][0]["function"]["name"], "search_docs");
+    }
+
+    #[tokio::test]
+    async fn preserves_google_thought_signature_across_non_streaming_sequential_tool_call() {
+        let signature = "gemini-thought-signature";
+        let chat_response = json!({
+            "id": "chatcmpl_gemini",
+            "model": "gemini-3.7-flash",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_gemini",
+                        "type": "function",
+                        "function": {
+                            "name": "read_file",
+                            "arguments": "{\"path\":\"README.md\"}"
+                        },
+                        "extra_content": {
+                            "google": {
+                                "thought_signature": signature
+                            }
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let response = chat_completion_to_response(chat_response).unwrap();
+        assert_eq!(
+            response["output"][0]["extra_content"]["google"]["thought_signature"],
+            signature
+        );
+
+        let history = super::super::codex_chat_history::CodexChatHistoryStore::default();
+        history.record_response(&response).await;
+
+        let mut follow_up = json!({
+            "previous_response_id": response["id"].clone(),
+            "model": "gemini-3.7-flash",
+            "input": [{
+                "type": "function_call_output",
+                "call_id": "call_gemini",
+                "output": "ok"
+            }]
+        });
+        assert_eq!(history.enrich_request(&mut follow_up).await, 1);
+
+        let rebuilt_chat = responses_to_chat_completions(follow_up).unwrap();
+        assert_eq!(
+            rebuilt_chat["messages"][0]["tool_calls"][0]["extra_content"]["google"]
+                ["thought_signature"],
+            signature
+        );
     }
 }

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1362,14 +1362,16 @@ fn responses_custom_tool_call_to_chat_tool_call(item: &Value) -> Value {
     let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
     let input = item.get("input").cloned().unwrap_or_else(|| json!(""));
 
-    json!({
+    let mut tool_call = json!({
         "id": call_id,
         "type": "function",
         "function": {
             "name": name,
             "arguments": canonical_json_string(&json!({ CUSTOM_TOOL_INPUT_FIELD: input }))
         }
-    })
+    });
+    attach_optional_google_thought_signature(&mut tool_call, google_thought_signature(item));
+    tool_call
 }
 
 fn responses_tool_search_call_to_chat_tool_call(item: &Value) -> Value {
@@ -1383,14 +1385,16 @@ fn responses_tool_search_call_to_chat_tool_call(item: &Value) -> Value {
         .map(canonical_json_string)
         .unwrap_or_else(|| "{}".to_string());
 
-    json!({
+    let mut tool_call = json!({
         "id": call_id,
         "type": "function",
         "function": {
             "name": TOOL_SEARCH_PROXY_NAME,
             "arguments": arguments
         }
-    })
+    });
+    attach_optional_google_thought_signature(&mut tool_call, google_thought_signature(item));
+    tool_call
 }
 
 fn responses_tool_choice_to_chat(tool_choice: &Value, tool_context: &CodexToolContext) -> Value {
@@ -4914,6 +4918,67 @@ mod tests {
                 "type": "function_call_output",
                 "call_id": "call_gemini",
                 "output": "ok"
+            }]
+        });
+        assert_eq!(history.enrich_request(&mut follow_up).await, 1);
+
+        let rebuilt_chat = responses_to_chat_completions(follow_up).unwrap();
+        assert_eq!(
+            rebuilt_chat["messages"][0]["tool_calls"][0]["extra_content"]["google"]
+                ["thought_signature"],
+            signature
+        );
+    }
+
+    #[tokio::test]
+    async fn preserves_google_thought_signature_across_custom_tool_sequential_call() {
+        let signature = "gemini-custom-tool-thought-signature";
+        let request = json!({
+            "model": "gpt-5.4",
+            "tools": [{"type": "custom", "name": "apply_patch"}],
+            "input": "Patch it."
+        });
+        let context = build_codex_tool_context_from_request(&request);
+        let chat_response = json!({
+            "id": "chatcmpl_gemini_custom",
+            "model": "gemini-3.7-flash",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_patch",
+                        "type": "function",
+                        "function": {
+                            "name": "apply_patch",
+                            "arguments": "{\"input\":\"*** Begin Patch\\n*** End Patch\"}"
+                        },
+                        "extra_content": {
+                            "google": {"thought_signature": signature}
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let response = chat_completion_to_response_with_context(chat_response, &context).unwrap();
+        assert_eq!(response["output"][0]["type"], "custom_tool_call");
+        assert_eq!(
+            response["output"][0]["extra_content"]["google"]["thought_signature"],
+            signature
+        );
+
+        let history = super::super::codex_chat_history::CodexChatHistoryStore::default();
+        history.record_response(&response).await;
+
+        let mut follow_up = json!({
+            "previous_response_id": response["id"].clone(),
+            "model": "gemini-3.7-flash",
+            "input": [{
+                "type": "custom_tool_call_output",
+                "call_id": "call_patch",
+                "output": "patched"
             }]
         });
         assert_eq!(history.enrich_request(&mut follow_up).await, 1);


### PR DESCRIPTION
## Summary / 概述

Preserves Gemini 3.7's `extra_content.google.thought_signature` across the Codex `/responses` ↔ Google OpenAI-compatible `/chat/completions` proxy bridge.

### Root Cause
When Gemini models generate tool calls via the OpenAI-compatible `/chat/completions` endpoint, Google includes a verification signature under `tool_calls[].extra_content.google.thought_signature`. Previously:
1. CC Switch converted the incoming chat tool call into a Codex `function_call` item but dropped `extra_content`.
2. When the tool output was returned (`function_call_output`), CC Switch's history cache reconstructed the previous assistant tool call without the signature.
3. Gemini rejected the follow-up request with `HTTP 400: Function call is missing a thought_signature`.

### Solution
- Added `google_thought_signature` and `attach_optional_google_thought_signature` helpers in `codex_chat_common.rs`.
- Preserved `extra_content.google.thought_signature` in non-streaming response conversion and outbound request reconstruction in `transform_codex_chat.rs`.
- Captured `thought_signature` during SSE streaming in `streaming_codex_chat.rs` and retained it on emitted output items.
- Added `extra_content` to the history cache keys in `codex_chat_history.rs` and enriched missing signatures on follow-ups.
- Kept the behavior strictly conditional so other providers (DeepSeek, MiniMax, Kimi, etc.) without this field remain completely unaffected.
- Added regression tests for sequential tool calls in both streaming and non-streaming modes.

## Related Issue / 关联 Issue

Fixes #

## Checklist / 检查清单

- [x] `cargo fmt -- --check` passes
- [x] `cargo test --lib` passes