### PR TITLE
docs: correct i18n guidance to four locales and current paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ There are many ways to contribute:
 - **Suggest features** — Have an idea? [Submit a feature request](https://github.com/farion1231/cc-switch/issues/new?template=feature_request.yml).
 - **Improve docs** — Spot a typo or missing info? [Report a doc issue](https://github.com/farion1231/cc-switch/issues/new?template=doc_issue.yml).
 - **Contribute code** — Fix bugs or implement features via pull requests.
-- **Translate** — Help us improve translations for English, Chinese, and Japanese.
+- **Translate** — Help us improve translations for English, Simplified Chinese, Traditional Chinese, and Japanese.
 
 > **Security vulnerabilities**: Please do NOT use public issues. See our [Security Policy](./SECURITY.md) instead.
 
@@ -118,14 +118,16 @@ By submitting a PR, you agree to the following:
 
 ## Internationalization (i18n)
 
-CC Switch supports three languages. When modifying user-facing text:
+CC Switch supports four languages. When modifying user-facing text:
 
-1. Update **all three** locale files:
-   - `src/locales/en/translation.json`
-   - `src/locales/zh/translation.json`
-   - `src/locales/ja/translation.json`
-2. Use the `t()` function from i18next for all UI text.
-3. Never hardcode user-facing strings.
+1. Update **all four** locale files:
+   - `src/i18n/locales/en.json`
+   - `src/i18n/locales/zh.json`
+   - `src/i18n/locales/zh-TW.json`
+   - `src/i18n/locales/ja.json`
+2. A parity test enforces the required key paths — `tests/config/managementListLocales.test.ts` enumerates the keys every locale file must provide.
+3. Use the `t()` function from i18next for all UI text.
+4. Never hardcode user-facing strings.
 
 ## Questions?
 
@@ -148,7 +150,7 @@ CC Switch supports three languages. When modifying user-facing text:
 - **建议功能** — 有想法？[提交功能请求](https://github.com/farion1231/cc-switch/issues/new?template=feature_request.yml)。
 - **改进文档** — 发现错误或缺失？[报告文档问题](https://github.com/farion1231/cc-switch/issues/new?template=doc_issue.yml)。
 - **贡献代码** — 通过 Pull Request 修复 Bug 或实现新功能。
-- **翻译** — 帮助改进英文、中文和日文的翻译。
+- **翻译** — 帮助改进英文、简体中文、繁体中文和日文的翻译。
 
 > **安全漏洞**：请不要使用公开 Issue 报告。请参阅我们的[安全策略](./SECURITY.md)。
 
@@ -252,14 +254,16 @@ chore(deps): update dependencies
 
 ## 国际化（i18n）
 
-CC Switch 支持三种语言。修改用户可见文本时：
+CC Switch 支持四种语言。修改用户可见文本时：
 
-1. **同时更新三个**语言文件：
-   - `src/locales/en/translation.json`
-   - `src/locales/zh/translation.json`
-   - `src/locales/ja/translation.json`
-2. 所有 UI 文本使用 i18next 的 `t()` 函数。
-3. 不要硬编码用户可见的字符串。
+1. **同时更新四个**语言文件：
+   - `src/i18n/locales/en.json`
+   - `src/i18n/locales/zh.json`
+   - `src/i18n/locales/zh-TW.json`
+   - `src/i18n/locales/ja.json`
+2. 必需键路径由 parity 测试强制——`tests/config/managementListLocales.test.ts` 枚举每个 locale 文件必须提供的键路径。
+3. 所有 UI 文本使用 i18next 的 `t()` 函数。
+4. 不要硬编码用户可见的字符串。
 
 ## 有疑问？
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ CC Switch supports four languages. When modifying user-facing text:
    - `src/i18n/locales/zh.json`
    - `src/i18n/locales/zh-TW.json`
    - `src/i18n/locales/ja.json`
-2. A parity test enforces the required key paths — `tests/config/managementListLocales.test.ts` enumerates the keys every locale file must provide.
+2. Locale parity is enforced by slice tests, not a whole-file guard — e.g. `tests/config/managementListLocales.test.ts` enumerates the management-list key paths every locale file must provide; keys outside such lists are not automatically checked.
 3. Use the `t()` function from i18next for all UI text.
 4. Never hardcode user-facing strings.
 
@@ -261,7 +261,7 @@ CC Switch 支持四种语言。修改用户可见文本时：
    - `src/i18n/locales/zh.json`
    - `src/i18n/locales/zh-TW.json`
    - `src/i18n/locales/ja.json`
-2. 必需键路径由 parity 测试强制——`tests/config/managementListLocales.test.ts` 枚举每个 locale 文件必须提供的键路径。
+2. locale parity 由分片测试强制，并非全量守卫——例如 `tests/config/managementListLocales.test.ts` 枚举每个 locale 文件必须提供的 management 列表键路径；此类清单之外的键不会被自动检查。
 3. 所有 UI 文本使用 i18next 的 `t()` 函数。
 4. 不要硬编码用户可见的字符串。
 


### PR DESCRIPTION
## Summary / 概述

The i18n guidance in CONTRIBUTING.md still describes the three-locale era: it points contributors to `src/locales/{en,zh,ja}/translation.json` (paths that no longer exist) and asks them to update "all three" locale files. The app now ships four locales at `src/i18n/locales/{en,zh,zh-TW,ja}.json`.

Corrected in both the English and Chinese sections:

- The two "Translate" bullets in the contribution list now name English, Simplified Chinese, Traditional Chinese, and Japanese.
- The two Internationalization sections: three → four locales, stale file paths replaced with the current `src/i18n/locales/*.json` files, and a pointer to the parity test (`tests/config/managementListLocales.test.ts`) that enumerates required key paths.

Docs-only change; no code touched.

CONTRIBUTING.md 的 i18n 指引仍停留在三语时代：让贡献者去改 `src/locales/{en,zh,ja}/translation.json`（该路径已不存在），并要求"同时更新三个"语言文件。而应用目前是四语，文件位于 `src/i18n/locales/{en,zh,zh-TW,ja}.json`。

已在英文与中文两个章节中修正：

- 贡献方式列表里的两条"Translate / 翻译"条目，改为英文、简体中文、繁体中文、日文。
- Internationalization / 国际化两节：三语 → 四语，过时路径替换为当前的 `src/i18n/locales/*.json`，并补充 parity 测试提示（`tests/config/managementListLocales.test.ts` 枚举了必需键路径）。

纯文档改动，未触碰任何代码。

## Related Issue / 关联 Issue

None — docs-only correction, spotted while reading CONTRIBUTING.md in preparation for #6730. Happy to file a doc issue first if preferred.

无 —— 纯文档修正，是在为 #6730 做准备、通读 CONTRIBUTING.md 时发现的。如希望先有一个 doc issue，我可以补开。

## Screenshots / 截图

Docs-only change; text excerpts instead of screenshots / 纯文档改动，以文字摘录代替截图：

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| "Update **all three** locale files: `src/locales/en/translation.json` …" | "Update **all four** locale files: `src/i18n/locales/en.json` …" |
| "Translate — Help us improve translations for English, Chinese, and Japanese." | "Translate — Help us improve translations for English, Simplified Chinese, Traditional Chinese, and Japanese." |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查 — N/A: docs-only, no code changed
- [x] `pnpm format:check` passes / 通过代码格式检查 — N/A: docs-only, no code changed
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）— N/A: no Rust changes
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — N/A: no user-facing text changed