### PR TITLE
fix(openclaw): sync agents.defaults.models with the provider form's final model list

### DIFF
--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -47,7 +47,7 @@ import {
 } from "@/config/opencodeProviderPresets";
 import {
   openclawProviderPresets,
-  rebaseOpenClawSuggestedDefaults,
+  buildOpenClawSuggestedDefaultsFromForm,
   type OpenClawProviderPreset,
   type OpenClawSuggestedDefaults,
 } from "@/config/openclawProviderPresets";
@@ -1623,13 +1623,16 @@ function ProviderFormFull({
       if (activePreset.isPartner) {
         payload.isPartner = activePreset.isPartner;
       }
-      // OpenClaw: align preset model refs with the actual submitted provider key.
+      // OpenClaw: build suggested defaults from the form's final model list
+      // so agents.defaults.models matches what the user actually configured,
+      // with preset model refs aligned to the submitted provider key.
       if (activePreset.suggestedDefaults) {
         payload.suggestedDefaults =
           appId === "openclaw" && payload.providerKey
-            ? rebaseOpenClawSuggestedDefaults(
+            ? buildOpenClawSuggestedDefaultsFromForm(
                 activePreset.suggestedDefaults,
                 payload.providerKey,
+                openclawForm.openclawModels,
               )
             : activePreset.suggestedDefaults;
       }

--- a/src/config/openclawProviderPresets.ts
+++ b/src/config/openclawProviderPresets.ts
@@ -6,6 +6,7 @@ import type {
   ProviderCategory,
   OpenClawProviderConfig,
   OpenClawDefaultModel,
+  OpenClawModel,
 } from "../types";
 import type { PresetTheme, TemplateValueConfig } from "./claudeProviderPresets";
 
@@ -80,6 +81,46 @@ export function rebaseOpenClawSuggestedDefaults(
           ]),
         )
       : undefined,
+  };
+}
+
+/**
+ * Build suggested defaults from the provider form's final model list, so that
+ * `agents.defaults.models` reflects what the user actually configured instead
+ * of the preset's built-in defaults. Default model refs are kept only when
+ * they still point at a model present in the final list.
+ */
+export function buildOpenClawSuggestedDefaultsFromForm(
+  defaults: OpenClawSuggestedDefaults,
+  providerKey: string,
+  models: OpenClawModel[],
+): OpenClawSuggestedDefaults {
+  const rebased = rebaseOpenClawSuggestedDefaults(defaults, providerKey);
+
+  const catalog: Record<string, { alias?: string }> = {};
+  for (const model of models) {
+    const id = model.id?.trim();
+    if (!id) continue;
+    const alias = model.alias?.trim() || model.name?.trim();
+    catalog[`${providerKey}/${id}`] = alias ? { alias } : {};
+  }
+
+  const validRefs = new Set(Object.keys(catalog));
+  const orderedRefs = rebased.model
+    ? [rebased.model.primary, ...(rebased.model.fallbacks ?? [])].filter(
+        (ref) => validRefs.has(ref),
+      )
+    : [];
+
+  return {
+    model:
+      orderedRefs.length > 0
+        ? {
+            primary: orderedRefs[0],
+            fallbacks: orderedRefs.slice(1),
+          }
+        : undefined,
+    modelCatalog: catalog,
   };
 }
 

--- a/src/hooks/useProviderActions.ts
+++ b/src/hooks/useProviderActions.ts
@@ -161,8 +161,56 @@ export function useProviderActions(
           trayError,
         );
       }
+
+      // OpenClaw: sync agents.defaults.models with the provider's current
+      // model list — merge entries for current models, drop stale ones that
+      // no longer exist in this provider's config.
+      if (activeApp === "openclaw") {
+        try {
+          const config = provider.settingsConfig as OpenClawProviderConfig;
+          const providerKey = provider.id;
+          const stalePrefixes = [`${providerKey}/`];
+          if (originalId && originalId !== providerKey) {
+            stalePrefixes.push(`${originalId}/`);
+          }
+
+          const existingCatalog = (await openclawApi.getModelCatalog()) || {};
+          const modelIds = new Set(
+            (config.models ?? [])
+              .map((m) => m.id?.trim())
+              .filter((id): id is string => Boolean(id)),
+          );
+
+          const nextCatalog: Record<string, { alias?: string }> = {};
+          // Keep other providers' entries; drop stale refs under this key.
+          for (const [ref, entry] of Object.entries(existingCatalog)) {
+            const isStale =
+              stalePrefixes.some((prefix) => ref.startsWith(prefix)) &&
+              !modelIds.has(ref.slice(ref.indexOf("/") + 1));
+            if (!isStale) nextCatalog[ref] = entry;
+          }
+          // Re-add current models.
+          for (const m of config.models ?? []) {
+            const id = m.id?.trim();
+            if (!id) continue;
+            const alias = m.alias?.trim() || m.name?.trim();
+            nextCatalog[`${providerKey}/${id}`] = alias ? { alias } : {};
+          }
+
+          // Skip the write when nothing changed.
+          if (JSON.stringify(existingCatalog) !== JSON.stringify(nextCatalog)) {
+            await openclawApi.setModelCatalog(nextCatalog);
+            await queryClient.invalidateQueries({
+              queryKey: openclawKeys.health,
+            });
+          }
+        } catch (error) {
+          // Log warning but don't block main flow - provider is already saved
+          console.warn("[OpenClaw] Failed to sync model catalog:", error);
+        }
+      }
     },
-    [updateProviderMutation],
+    [updateProviderMutation, activeApp, queryClient],
   );
 
   // 切换供应商

--- a/src/hooks/useProviderActions.ts
+++ b/src/hooks/useProviderActions.ts
@@ -174,7 +174,28 @@ export function useProviderActions(
             stalePrefixes.push(`${originalId}/`);
           }
 
-          const existingCatalog = (await openclawApi.getModelCatalog()) || {};
+          // Only sync when this provider actually lives in the config,
+          // mirroring the backend's database-only behavior: writing catalog
+          // entries for a provider absent from models.providers would create
+          // selectable refs that cannot resolve.
+          await queryClient.invalidateQueries({
+            queryKey: openclawKeys.liveProviderIds,
+          });
+          const liveProviderIds = await queryClient.ensureQueryData({
+            queryKey: openclawKeys.liveProviderIds,
+            queryFn: () => providersApi.getOpenClawLiveProviderIds(),
+          });
+          if (!liveProviderIds.includes(providerKey)) {
+            return;
+          }
+
+          // Preserve an unset global allowlist: seeding a new catalog from
+          // only this provider's models would hide every other live
+          // provider's models from /model.
+          const existingCatalog = await openclawApi.getModelCatalog();
+          if (!existingCatalog) {
+            return;
+          }
           const modelIds = new Set(
             (config.models ?? [])
               .map((m) => m.id?.trim())


### PR DESCRIPTION
Fixes #6729

### 问题

OpenClaw 供应商保存时,`agents.defaults.models`(模型目录/允许列表)与用户实际配置的模型列表不一致:

1. **新增供应商**:提交时 `suggestedDefaults` 取自预设模板(`activePreset.suggestedDefaults`)。即使用户在"模型配置"里删除了预设默认的 anthropic 模型、添加了自定义模型,注册到 `agents.defaults.models` 的仍是预设默认条目
2. **编辑供应商**:`updateProvider` 完全没有同步 `agents.defaults.models` 的逻辑,改模型列表后会出现漏注册或孤儿引用

### 改动

1. **`src/config/openclawProviderPresets.ts`**:新增 `buildOpenClawSuggestedDefaultsFromForm`,从表单最终模型列表生成 `modelCatalog`;预设的 default model 引用仅在其指向的模型仍存在于最终列表时保留(按原顺序取第一个有效 ref 作为 primary)
2. **`src/components/providers/forms/ProviderForm.tsx`**:openclaw 提交路径改用上述函数替代纯 rebase 预设值
3. **`src/hooks/useProviderActions.ts`**:`updateProvider` 增加目录同步——合并当前模型条目、清理本 provider 键下已失效的引用(含改名前的旧键)、内容无变化时跳过写入;失败仅告警不阻塞主流程,与 `addProvider` 现有行为一致

### 验证

- \`pnpm typecheck\` 通过
- \`pnpm test:unit\`:985+ 通过;唯一失败的 \`PiProviderForm > stores Pi-native request headers...\` 为超时 flake,与本改动无关(stash 后单独跑同样通过,带改动单独跑 46/46 通过)
- \`prettier --check\` 通过