### PR TITLE
feat(usage): add ZCode session usage importer

### DIFF
--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -19,6 +19,7 @@ pub mod s3_auto_sync;
 pub mod s3_sync;
 pub mod session_usage;
 pub mod session_usage_codex;
+pub mod session_usage_dsh;
 pub mod session_usage_gemini;
 pub mod session_usage_grokbuild;
 pub mod session_usage_opencode;

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -24,6 +24,7 @@ pub mod session_usage_gemini;
 pub mod session_usage_grokbuild;
 pub mod session_usage_opencode;
 pub mod session_usage_pi;
+pub mod session_usage_zcode;
 pub mod skill;
 pub mod speedtest;
 pub mod sql_helpers;

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -101,6 +101,11 @@ pub fn sync_all_unlocked(db: &Database) -> SessionSyncResult {
         "DSH",
         crate::services::session_usage_dsh::sync_dsh_usage(db),
     );
+    merge_sync_step(
+        &mut result,
+        "ZCode",
+        crate::services::session_usage_zcode::sync_zcode_usage(db),
+    );
     notify_sync_result(&result);
     result
 }

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -96,6 +96,11 @@ pub fn sync_all_unlocked(db: &Database) -> SessionSyncResult {
         "Pi",
         crate::services::session_usage_pi::sync_pi_usage(db),
     );
+    merge_sync_step(
+        &mut result,
+        "DSH",
+        crate::services::session_usage_dsh::sync_dsh_usage(db),
+    );
     notify_sync_result(&result);
     result
 }

--- a/src-tauri/src/services/session_usage_dsh.rs
+++ b/src-tauri/src/services/session_usage_dsh.rs
@@ -1,0 +1,685 @@
+//! DSH coding-agent session usage importer.
+//!
+//! DSH persists each session as a zstd-compressed JSONL file under
+//! `~/.dsh/sessions/<encoded-cwd>/<session-id>/session.jsonl.zstd`. Assistant
+//! messages carry normalized Anthropic-style usage (fresh input tokens, no
+//! cache-write bucket). This importer replays those files into the shared
+//! dashboard; the durable `session_usage_dedup` ledger keyed by
+//! `dsh:session-<id>:<seq>` makes full reparses idempotent and recognizes rows
+//! written by earlier tooling with the same identity scheme.
+
+use crate::database::{lock_conn, Database};
+use crate::error::AppError;
+use crate::proxy::usage::calculator::CostCalculator;
+use crate::proxy::usage::parser::TokenUsage;
+use crate::services::session_usage::{
+    metadata_modified_nanos, update_sync_state_on_conn, SessionSyncResult,
+};
+use crate::services::sql_helpers::INPUT_TOKEN_SEMANTICS_FRESH;
+use crate::services::usage_stats::find_model_pricing;
+use rusqlite::OptionalExtension;
+use rust_decimal::Decimal;
+use serde_json::Value;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+
+const APP_TYPE: &str = "dsh";
+const DATA_SOURCE: &str = "dsh_session";
+const PROVIDER_PLACEHOLDER: &str = "_dsh_session";
+const UNKNOWN_MODEL: &str = "unknown";
+const MAX_USAGE_LABEL_BYTES: usize = 512;
+const MAX_SESSION_BYTES: u64 = 256 * 1024 * 1024;
+const MIN_SQLITE_UNIX_SECONDS: i64 = -62_167_219_200;
+const MAX_SQLITE_UNIX_SECONDS: i64 = 253_402_300_799;
+const REQUEST_ID_PREFIX: &str = "dsh:";
+const DSH_REQUEST_DEDUP_SQL: &str = "SELECT EXISTS(
+         SELECT 1 FROM session_usage_dedup
+         WHERE data_source = ?1 AND request_id = ?2
+     )";
+
+#[derive(Debug)]
+struct DshUsageRecord {
+    request_id: String,
+    provider_id: String,
+    model: String,
+    input_tokens: u32,
+    output_tokens: u32,
+    cache_read_tokens: u32,
+    created_at: i64,
+    session_id: String,
+}
+
+#[derive(Debug, Default)]
+struct ParsedDshFile {
+    session_id: Option<String>,
+    records: Vec<DshUsageRecord>,
+    incomplete_tail: bool,
+}
+
+/// Import usage from every DSH session log discoverable under the sessions
+/// root. A missing root simply means there is nothing to import yet.
+pub fn sync_dsh_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    let root = dsh_sessions_root();
+    Ok(sync_dsh_files(db, &dsh_session_files(&root)))
+}
+
+fn dsh_sessions_root() -> PathBuf {
+    if let Some(custom) = std::env::var_os("DSH_SESSIONS_DIR") {
+        let trimmed = custom.to_string_lossy().trim().to_string();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    crate::config::get_home_dir().join(".dsh").join("sessions")
+}
+
+fn dsh_session_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let Ok(cwd_dirs) = fs::read_dir(root) else {
+        return files;
+    };
+    for cwd_dir in cwd_dirs.flatten() {
+        let Ok(session_dirs) = fs::read_dir(cwd_dir.path()) else {
+            continue;
+        };
+        for session_dir in session_dirs.flatten() {
+            let candidate = session_dir.path().join("session.jsonl.zstd");
+            if candidate.is_file() {
+                files.push(candidate);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
+fn sync_dsh_files(db: &Database, files: &[PathBuf]) -> SessionSyncResult {
+    let mut result = SessionSyncResult {
+        files_scanned: files.len().min(u32::MAX as usize) as u32,
+        ..Default::default()
+    };
+
+    for file_path in files {
+        match sync_single_dsh_file(db, file_path) {
+            Ok(file_result) => result.merge(file_result),
+            Err(error) => {
+                let message = format!("{}: {error}", file_path.display());
+                log::warn!("[DSH-SYNC] 会话文件解析失败: {message}");
+                result.errors.push(message);
+            }
+        }
+    }
+
+    if result.imported > 0 {
+        log::info!(
+            "[DSH-SYNC] 同步完成: 导入 {} 条, 跳过 {} 条, 扫描 {} 个文件",
+            result.imported,
+            result.skipped,
+            result.files_scanned
+        );
+    }
+    result
+}
+
+fn sync_single_dsh_file(db: &Database, file_path: &Path) -> Result<SessionSyncResult, AppError> {
+    let metadata = fs::symlink_metadata(file_path)
+        .map_err(|error| AppError::Config(format!("无法读取 DSH 会话文件元数据: {error}")))?;
+    if !metadata.file_type().is_file() {
+        return Err(AppError::Config("DSH 会话路径不是普通文件".to_string()));
+    }
+    let modified = metadata_modified_nanos(&metadata);
+    let file_path_string = file_path.to_string_lossy().to_string();
+    if dsh_file_unchanged(db, &file_path_string, modified)? {
+        return Ok(SessionSyncResult::default());
+    }
+
+    let parsed = parse_dsh_file(file_path, modified / 1_000_000_000)?;
+    let conn = lock_conn!(db.conn);
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|error| AppError::Database(format!("启动 DSH 用量导入事务失败: {error}")))?;
+    let mut result = SessionSyncResult::default();
+    for record in &parsed.records {
+        if insert_dsh_record(&tx, record)? {
+            result.imported = result.imported.saturating_add(1);
+        } else {
+            result.skipped = result.skipped.saturating_add(1);
+        }
+    }
+
+    update_sync_state_on_conn(
+        &tx,
+        &file_path_string,
+        modified,
+        parsed.records.len().min(i64::MAX as usize) as i64,
+    )?;
+    tx.commit()
+        .map_err(|error| AppError::Database(format!("提交 DSH 用量导入事务失败: {error}")))?;
+    if parsed.incomplete_tail {
+        result.deferred_files = 1;
+    }
+    Ok(result)
+}
+
+/// DSH rewrites its zstd logs in full, so a file whose mtime has not advanced
+/// since the last pass cannot contain new events.
+fn dsh_file_unchanged(db: &Database, file_path: &str, modified: i64) -> Result<bool, AppError> {
+    let conn = lock_conn!(db.conn);
+    let last_modified: Option<i64> = conn
+        .query_row(
+            "SELECT last_modified FROM session_log_sync WHERE file_path = ?1",
+            rusqlite::params![file_path],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| AppError::Database(format!("读取 DSH 会话同步状态失败: {error}")))?;
+    Ok(last_modified.is_some_and(|last| modified <= last))
+}
+
+fn parse_dsh_file(file_path: &Path, file_modified_seconds: i64) -> Result<ParsedDshFile, AppError> {
+    let file = File::open(file_path)
+        .map_err(|error| AppError::Config(format!("无法打开 DSH 会话文件: {error}")))?;
+    let decoder = zstd::stream::read::Decoder::new(file)
+        .map_err(|error| AppError::Config(format!("无法解压 DSH 会话文件: {error}")))?;
+    let mut reader = BufReader::new(decoder);
+    let mut buffer = String::new();
+    let mut parsed = ParsedDshFile::default();
+    let mut decompressed_bytes: u64 = 0;
+
+    loop {
+        buffer.clear();
+        let read = reader
+            .read_line(&mut buffer)
+            .map_err(|error| AppError::Config(format!("无法读取 DSH 会话文件: {error}")))?;
+        if read == 0 {
+            break;
+        }
+        decompressed_bytes = decompressed_bytes.saturating_add(read as u64);
+        if decompressed_bytes > MAX_SESSION_BYTES {
+            return Err(AppError::Config(format!(
+                "DSH 会话解压后超过 {} 字节安全上限",
+                MAX_SESSION_BYTES
+            )));
+        }
+        let has_newline = buffer.ends_with('\n');
+        let line = buffer.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value = match serde_json::from_str::<Value>(line) {
+            Ok(value) => value,
+            Err(_) if !has_newline => {
+                // A torn final line means DSH is mid-rewrite; keep the events
+                // parsed so far and retry the tail on the next pass.
+                parsed.incomplete_tail = true;
+                break;
+            }
+            Err(_) => continue,
+        };
+
+        if parsed.session_id.is_none() {
+            if value.get("type").and_then(Value::as_str) != Some("session") {
+                return Err(AppError::Config(
+                    "DSH 会话的首条有效 JSON 不是 session header".to_string(),
+                ));
+            }
+            let session_id = value
+                .get("id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+                .map(truncate_usage_label)
+                .ok_or_else(|| AppError::Config("DSH 会话 header 缺少 id".to_string()))?;
+            parsed.session_id = Some(session_id.to_string());
+            continue;
+        }
+
+        if value.get("type").and_then(Value::as_str) != Some("assistant/message") {
+            continue;
+        }
+        let Some(data) = value.get("data").filter(|data| data.get("usage").is_some()) else {
+            continue;
+        };
+        let Some(record) = parse_usage_record(
+            data,
+            value.get("seq").and_then(Value::as_i64),
+            value.get("time").and_then(Value::as_i64),
+            parsed.session_id.as_deref().unwrap_or_default(),
+            file_modified_seconds,
+        ) else {
+            continue;
+        };
+        parsed.records.push(record);
+    }
+
+    if parsed.session_id.is_none() && !parsed.incomplete_tail {
+        return Err(AppError::Config("DSH 会话没有有效 header".to_string()));
+    }
+    Ok(parsed)
+}
+
+fn parse_usage_record(
+    data: &Value,
+    seq: Option<i64>,
+    time_millis: Option<i64>,
+    session_id: &str,
+    file_modified_seconds: i64,
+) -> Option<DshUsageRecord> {
+    let seq = seq?;
+    let usage = data.get("usage")?;
+    let input_tokens = token_count(usage, "inputTokens");
+    let output_tokens = token_count(usage, "outputTokens");
+    let cache_read_tokens = token_count(usage, "cacheReadTokens");
+
+    let source = data.pointer("/message/source");
+    let provider_id = source
+        .and_then(|source| source.get("provider"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|provider| !provider.is_empty())
+        .map(truncate_usage_label)
+        .unwrap_or(PROVIDER_PLACEHOLDER)
+        .to_string();
+    let model = source
+        .and_then(|source| source.get("model"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(truncate_usage_label)
+        .unwrap_or(UNKNOWN_MODEL)
+        .to_string();
+
+    // DSH reports epoch milliseconds; `time` is absent only for synthetic or
+    // hand-edited logs, where the file mtime is the best available estimate.
+    let created_at = time_millis
+        .map(|time| time.div_euclid(1000))
+        .unwrap_or(file_modified_seconds)
+        .clamp(MIN_SQLITE_UNIX_SECONDS, MAX_SQLITE_UNIX_SECONDS);
+
+    Some(DshUsageRecord {
+        request_id: format!("{REQUEST_ID_PREFIX}{session_id}:{seq}"),
+        provider_id,
+        model,
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        created_at,
+        session_id: session_id.to_string(),
+    })
+}
+
+fn token_count(usage: &Value, key: &str) -> u32 {
+    usage
+        .get(key)
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+        .min(u32::MAX as u64) as u32
+}
+
+fn truncate_usage_label(value: &str) -> &str {
+    if value.len() <= MAX_USAGE_LABEL_BYTES {
+        return value;
+    }
+    let mut end = MAX_USAGE_LABEL_BYTES;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
+}
+
+fn insert_dsh_record(
+    conn: &rusqlite::Connection,
+    record: &DshUsageRecord,
+) -> Result<bool, AppError> {
+    let already_seen: bool = conn
+        .query_row(
+            DSH_REQUEST_DEDUP_SQL,
+            rusqlite::params![DATA_SOURCE, record.request_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| AppError::Database(format!("查询 DSH 用量去重账本失败: {error}")))?;
+    if already_seen {
+        return Ok(false);
+    }
+    conn.execute(
+        "INSERT OR IGNORE INTO session_usage_dedup
+         (data_source, request_id, semantic_id, has_entry_id)
+         VALUES (?1, ?2, ?3, ?4)",
+        rusqlite::params![DATA_SOURCE, record.request_id, record.request_id, 1i64],
+    )
+    .map_err(|error| AppError::Database(format!("写入 DSH 用量去重账本失败: {error}")))?;
+
+    let usage = TokenUsage {
+        input_tokens: record.input_tokens,
+        output_tokens: record.output_tokens,
+        cache_read_tokens: record.cache_read_tokens,
+        cache_creation_tokens: 0,
+        model: Some(record.model.clone()),
+        message_id: None,
+    };
+    let costs = find_model_pricing(conn, &record.model).map(|pricing| {
+        let calculated =
+            CostCalculator::calculate_for_app(APP_TYPE, &usage, &pricing, Decimal::ONE);
+        (
+            calculated.input_cost,
+            calculated.output_cost,
+            calculated.cache_read_cost,
+            calculated.cache_creation_cost,
+            calculated.total_cost,
+        )
+    });
+    let (input_cost, output_cost, cache_read_cost, cache_write_cost, total_cost) =
+        costs.unwrap_or((
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+        ));
+
+    conn.execute(
+        "INSERT OR IGNORE INTO proxy_request_logs (
+            request_id, provider_id, app_type, model, request_model, pricing_model,
+            input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+            input_token_semantics,
+            input_cost_usd, output_cost_usd, cache_read_cost_usd,
+            cache_creation_cost_usd, total_cost_usd,
+            latency_ms, first_token_ms, status_code, error_message, session_id,
+            provider_type, is_streaming, cost_multiplier, created_at, data_source
+        ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
+            ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26
+        )",
+        rusqlite::params![
+            record.request_id,
+            record.provider_id,
+            APP_TYPE,
+            record.model,
+            record.model,
+            record.model,
+            record.input_tokens,
+            record.output_tokens,
+            record.cache_read_tokens,
+            0i64,
+            INPUT_TOKEN_SEMANTICS_FRESH,
+            input_cost.to_string(),
+            output_cost.to_string(),
+            cache_read_cost.to_string(),
+            cache_write_cost.to_string(),
+            total_cost.to_string(),
+            0i64,
+            Option::<i64>::None,
+            200i64,
+            Option::<String>::None,
+            record.session_id,
+            Some(DATA_SOURCE),
+            0i64,
+            "1.0",
+            record.created_at,
+            DATA_SOURCE,
+        ],
+    )
+    .map(|changed| changed > 0)
+    .map_err(|error| AppError::Database(format!("插入 DSH 会话用量失败: {error}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_zstd_session(path: &Path, lines: &[String]) {
+        let jsonl = lines
+            .iter()
+            .map(|line| format!("{line}\n"))
+            .collect::<String>();
+        let compressed = zstd::stream::encode_all(jsonl.as_bytes(), 0).expect("encode session");
+        fs::write(path, compressed).expect("write session");
+    }
+
+    fn session_header(id: &str) -> String {
+        format!(
+            r#"{{"type":"session","version":0,"id":"{id}","createdAt":1786678151825,"cwd":"/work"}}"#
+        )
+    }
+
+    fn assistant_line(seq: i64, time: i64, input: u32, output: u32, cache_read: u32) -> String {
+        format!(
+            r#"{{"type":"assistant/message","seq":{seq},"time":{time},"data":{{"turn":1,"step":1,"message":{{"role":"assistant","content":[{{"type":"text","text":"ok"}}],"source":{{"kind":"model","provider":"stepfun-plan","model":"step-3.7-flash"}}}},"usage":{{"inputTokens":{input},"outputTokens":{output},"cacheReadTokens":{cache_read}}}}}}}"#
+        )
+    }
+
+    fn session_file(root: &Path, encoded_cwd: &str, session_id: &str) -> PathBuf {
+        let path = root
+            .join(encoded_cwd)
+            .join(session_id)
+            .join("session.jsonl.zstd");
+        fs::create_dir_all(path.parent().expect("session dir")).expect("create session dir");
+        path
+    }
+
+    #[test]
+    fn dedup_lookup_uses_complete_identity_index() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let conn = lock_conn!(db.conn);
+        let mut statement = conn.prepare(&format!("EXPLAIN QUERY PLAN {DSH_REQUEST_DEDUP_SQL}"))?;
+        let plan = statement
+            .query_map(rusqlite::params![DATA_SOURCE, "identity"], |row| {
+                row.get::<_, String>(3)
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert!(
+            plan.iter()
+                .any(|step| step.contains("(data_source=? AND request_id=?)")),
+            "lookup does not constrain the complete identity: {plan:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn imports_usage_events_with_fresh_semantics_and_legacy_request_ids() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = session_file(temp.path(), "--work--", "session-abc-123");
+        write_zstd_session(
+            &path,
+            &[
+                session_header("session-abc-123"),
+                r#"{"type":"permission/preset","seq":0,"time":1786678151831,"data":{"preset":"workspace-write"}}"#.to_string(),
+                assistant_line(7, 1786678145825, 7965, 139, 256),
+                assistant_line(8, 1786678148978, 1534, 187, 8128),
+                r#"{"type":"assistant/message","seq":9,"time":1786678149999,"data":{"turn":1,"step":1,"message":{"role":"assistant","content":[]}}}"#.to_string(),
+            ],
+        );
+
+        let db = Database::memory()?;
+        let result = sync_dsh_files(&db, std::slice::from_ref(&path));
+        assert_eq!(result.imported, 2);
+        assert!(result.errors.is_empty());
+
+        {
+            let conn = lock_conn!(db.conn);
+            let identity: (String, String, String, String, String, String, String) = conn
+                .query_row(
+                    "SELECT request_id, provider_id, model, app_type, session_id,
+                            provider_type, data_source
+                     FROM proxy_request_logs WHERE request_id = 'dsh:session-abc-123:7'",
+                    [],
+                    |row| {
+                        Ok((
+                            row.get(0)?,
+                            row.get(1)?,
+                            row.get(2)?,
+                            row.get(3)?,
+                            row.get(4)?,
+                            row.get(5)?,
+                            row.get(6)?,
+                        ))
+                    },
+                )?;
+            assert_eq!(identity.0, "dsh:session-abc-123:7");
+            assert_eq!(identity.1, "stepfun-plan");
+            assert_eq!(identity.2, "step-3.7-flash");
+            assert_eq!(identity.3, "dsh");
+            assert_eq!(identity.4, "session-abc-123");
+            assert_eq!(identity.5, "dsh_session");
+            assert_eq!(identity.6, "dsh_session");
+
+            let counters: (i64, i64, i64, i64, i64, i64, i64) = conn.query_row(
+                "SELECT input_tokens, output_tokens, cache_read_tokens,
+                        cache_creation_tokens, input_token_semantics, created_at,
+                        is_streaming
+                 FROM proxy_request_logs WHERE request_id = 'dsh:session-abc-123:7'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                    ))
+                },
+            )?;
+            assert_eq!((counters.0, counters.1, counters.2), (7965, 139, 256));
+            assert_eq!(counters.3, 0);
+            assert_eq!(counters.4, INPUT_TOKEN_SEMANTICS_FRESH);
+            assert_eq!(counters.5, 1_786_678_145);
+            assert_eq!(counters.6, 0);
+
+            let dedup: (String, String, i64) = conn.query_row(
+                "SELECT request_id, semantic_id, has_entry_id FROM session_usage_dedup
+                 WHERE data_source = 'dsh_session' ORDER BY request_id",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )?;
+            assert_eq!(
+                dedup,
+                (
+                    "dsh:session-abc-123:7".to_string(),
+                    "dsh:session-abc-123:7".to_string(),
+                    1
+                )
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_backfill_ledger_rows_are_recognized_and_not_reimported() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = session_file(temp.path(), "--work--", "session-legacy-42");
+        write_zstd_session(
+            &path,
+            &[
+                session_header("session-legacy-42"),
+                assistant_line(70473, 1786776034999, 6, 1107, 148864),
+                assistant_line(70480, 1786776041000, 12, 34, 56),
+            ],
+        );
+
+        // Rows written by the pre-upstream backfill tool use the same
+        // `dsh:session-<id>:<seq>` identity; replaying must add nothing.
+        let db = Database::memory()?;
+        {
+            let conn = lock_conn!(db.conn);
+            for request_id in ["dsh:session-legacy-42:70473", "dsh:session-legacy-42:70480"] {
+                conn.execute(
+                    "INSERT OR IGNORE INTO session_usage_dedup
+                     (data_source, request_id, semantic_id, has_entry_id)
+                     VALUES ('dsh_session', ?1, ?1, 1)",
+                    rusqlite::params![request_id],
+                )?;
+            }
+        }
+        let result = sync_dsh_files(&db, std::slice::from_ref(&path));
+        assert_eq!((result.imported, result.skipped), (0, 2));
+        let count: i64 = lock_conn!(db.conn).query_row(
+            "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'dsh_session'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn missing_provider_falls_back_to_named_placeholder() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = session_file(temp.path(), "--work--", "session-anon-1");
+        let event = r#"{"type":"assistant/message","seq":3,"time":1786678145825,"data":{"turn":1,"step":1,"message":{"role":"assistant","content":[]},"usage":{"inputTokens":10,"outputTokens":5,"cacheReadTokens":2}}}"#;
+        write_zstd_session(
+            &path,
+            &[session_header("session-anon-1"), event.to_string()],
+        );
+
+        let db = Database::memory()?;
+        assert_eq!(sync_dsh_files(&db, std::slice::from_ref(&path)).imported, 1);
+
+        let conn = lock_conn!(db.conn);
+        let (provider_id, model): (String, String) = conn.query_row(
+            "SELECT provider_id, model FROM proxy_request_logs
+             WHERE data_source = 'dsh_session'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(provider_id, PROVIDER_PLACEHOLDER);
+        assert_eq!(model, UNKNOWN_MODEL);
+        drop(conn);
+
+        let providers = db.get_provider_stats(None, None, Some(APP_TYPE), None, None)?;
+        assert!(providers.iter().any(|provider| {
+            provider.provider_id == PROVIDER_PLACEHOLDER
+                && provider.provider_name == "DSH (Session)"
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn rewritten_file_reimports_only_new_events() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let path = session_file(temp.path(), "--work--", "session-grow-9");
+        write_zstd_session(
+            &path,
+            &[
+                session_header("session-grow-9"),
+                assistant_line(1, 1786678145825, 100, 10, 1000),
+            ],
+        );
+
+        let db = Database::memory()?;
+        assert_eq!(sync_dsh_files(&db, std::slice::from_ref(&path)).imported, 1);
+        // Unchanged mtime: the file is skipped entirely.
+        let unchanged = sync_dsh_files(&db, std::slice::from_ref(&path));
+        assert_eq!((unchanged.imported, unchanged.skipped), (0, 0));
+
+        write_zstd_session(
+            &path,
+            &[
+                session_header("session-grow-9"),
+                assistant_line(1, 1786678145825, 100, 10, 1000),
+                assistant_line(2, 1786678148978, 200, 20, 2000),
+            ],
+        );
+        // Same-size rewrites can keep the mtime; force a bump to model DSH's
+        // full-rewrite behaviour and rely on the ledger for the old event.
+        let later = std::time::SystemTime::now() + std::time::Duration::from_secs(5);
+        std::fs::File::options()
+            .write(true)
+            .open(&path)
+            .expect("open session for timestamp bump")
+            .set_times(std::fs::FileTimes::new().set_modified(later))
+            .expect("bump mtime");
+        let grown = sync_dsh_files(&db, std::slice::from_ref(&path));
+        assert_eq!((grown.imported, grown.skipped), (1, 1));
+
+        let count: i64 = lock_conn!(db.conn).query_row(
+            "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'dsh_session'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 2);
+        Ok(())
+    }
+}

--- a/src-tauri/src/services/session_usage_zcode.rs
+++ b/src-tauri/src/services/session_usage_zcode.rs
@@ -1,0 +1,803 @@
+//! ZCode coding-agent session usage importer.
+//!
+//! ZCode persists per-request token accounting in the `model_usage` table of
+//! `~/.zcode/cli/db/db.sqlite`. Each row already carries the normalized
+//! Anthropic-style usage buckets plus latency and status metadata, so the
+//! importer is a straight table-to-table copy gated by the shared
+//! `session_usage_dedup` ledger keyed by `zcode:<model_usage.id>`. Because the
+//! source database runs in WAL mode (its main-file mtime does not advance on
+//! every write), we intentionally skip the mtime fast-path used by the JSONL
+//! importers and rely on full reparses plus the ledger for idempotence.
+
+use crate::database::{lock_conn, Database};
+use crate::error::AppError;
+use crate::proxy::usage::calculator::CostCalculator;
+use crate::proxy::usage::parser::TokenUsage;
+use crate::services::session_usage::SessionSyncResult;
+use crate::services::sql_helpers::INPUT_TOKEN_SEMANTICS_TOTAL;
+use crate::services::usage_stats::find_model_pricing;
+use rust_decimal::Decimal;
+use std::path::PathBuf;
+
+const APP_TYPE: &str = "zcode";
+const DATA_SOURCE: &str = "zcode_session";
+/// Display-name placeholder surfaced by `usage_stats::provider_name_coalesce`
+/// when a row carries no real provider_id. ZCode's `model_usage.provider_id`
+/// is NOT NULL, so import copies it verbatim; this constant documents the
+/// mapping key and is exercised by the display-name test below.
+#[allow(dead_code)]
+const PROVIDER_PLACEHOLDER: &str = "_zcode_session";
+const REQUEST_ID_PREFIX: &str = "zcode:";
+const MIN_SQLITE_UNIX_SECONDS: i64 = -62_167_219_200;
+const MAX_SQLITE_UNIX_SECONDS: i64 = 253_402_300_799;
+const ZCODE_REQUEST_DEDUP_SQL: &str = "SELECT EXISTS(
+         SELECT 1 FROM session_usage_dedup
+         WHERE data_source = ?1 AND request_id = ?2
+     )";
+
+/// A single `model_usage` row mapped to the dashboard schema.
+#[derive(Debug)]
+struct ZcodeUsageRecord {
+    request_id: String,
+    provider_id: String,
+    model: String,
+    input_tokens: i64,
+    output_tokens: i64,
+    cache_read_tokens: i64,
+    cache_creation_tokens: i64,
+    latency_ms: Option<i64>,
+    first_token_ms: Option<i64>,
+    status_code: i64,
+    error_message: Option<String>,
+    session_id: String,
+    created_at: i64,
+}
+
+/// Import usage from the ZCode SQLite database. A missing database simply
+/// means there is nothing to import yet; schema drift defers to the next pass
+/// rather than failing the whole sync.
+pub fn sync_zcode_usage(db: &Database) -> Result<SessionSyncResult, AppError> {
+    let db_path = zcode_db_path();
+    if !db_path.exists() {
+        return Ok(SessionSyncResult {
+            files_scanned: 0,
+            ..Default::default()
+        });
+    }
+    sync_zcode_usage_from_path(db, &db_path)
+}
+
+/// Path-injectable core so tests can drive the importer without touching the
+/// process-wide `ZCODE_DB_PATH` environment variable (cargo test runs suites
+/// in parallel, and `std::env::set_var` is not isolated per thread).
+fn sync_zcode_usage_from_path(
+    db: &Database,
+    db_path: &std::path::Path,
+) -> Result<SessionSyncResult, AppError> {
+    let mut result = SessionSyncResult {
+        files_scanned: 1,
+        ..Default::default()
+    };
+
+    let zcode_conn = match open_zcode_db_readonly(db_path) {
+        Ok(conn) => conn,
+        Err(error) => {
+            let message = format!("ZCode 数据库打开失败 ({}): {error}", db_path.display());
+            log::warn!("[ZCODE-SYNC] {message}");
+            result.errors.push(message);
+            result.deferred_files = 1;
+            return Ok(result);
+        }
+    };
+
+    let records = match load_zcode_records(&zcode_conn) {
+        Ok(records) => records,
+        Err(error) => {
+            let message = format!("ZCode model_usage 读取失败: {error}");
+            log::warn!("[ZCODE-SYNC] {message}");
+            result.errors.push(message);
+            result.deferred_files = 1;
+            return Ok(result);
+        }
+    };
+
+    let conn = lock_conn!(db.conn);
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|error| AppError::Database(format!("启动 ZCode 用量导入事务失败: {error}")))?;
+    for record in &records {
+        match insert_zcode_record(&tx, record)? {
+            true => result.imported = result.imported.saturating_add(1),
+            false => result.skipped = result.skipped.saturating_add(1),
+        }
+    }
+    tx.commit()
+        .map_err(|error| AppError::Database(format!("提交 ZCode 用量导入事务失败: {error}")))?;
+
+    if result.imported > 0 {
+        log::info!(
+            "[ZCODE-SYNC] 同步完成: 导入 {} 条, 跳过 {} 条",
+            result.imported,
+            result.skipped
+        );
+    }
+    Ok(result)
+}
+
+/// Resolve the ZCode database path. `ZCODE_DB_PATH` overrides the default;
+/// empty strings fall back to the standard location.
+fn zcode_db_path() -> PathBuf {
+    if let Some(custom) = std::env::var_os("ZCODE_DB_PATH") {
+        let trimmed = custom.to_string_lossy().trim().to_string();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+    crate::config::get_home_dir()
+        .join(".zcode")
+        .join("cli")
+        .join("db")
+        .join("db.sqlite")
+}
+
+/// Open the ZCode database read-only with a busy timeout so a concurrent
+/// ZCode writer never blocks us indefinitely.
+fn open_zcode_db_readonly(path: &std::path::Path) -> Result<rusqlite::Connection, AppError> {
+    let conn = rusqlite::Connection::open_with_flags(
+        path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|error| AppError::Database(format!("无法打开 ZCode 数据库: {error}")))?;
+    conn.busy_timeout(std::time::Duration::from_millis(5000))
+        .map_err(|error| AppError::Database(format!("设置 ZCode busy_timeout 失败: {error}")))?;
+    Ok(conn)
+}
+
+/// Read every `model_usage` row. A missing table or unexpected column defers
+/// to the next sync pass rather than panicking — ZCode upgrades may reshape
+/// the schema between releases.
+fn load_zcode_records(conn: &rusqlite::Connection) -> Result<Vec<ZcodeUsageRecord>, AppError> {
+    if !zcode_table_exists(conn)? {
+        log::info!("[ZCODE-SYNC] model_usage 表不存在，跳过本轮");
+        return Ok(Vec::new());
+    }
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT id, session_id, provider_id, model_id, status, error_message,
+                    started_at, duration_ms, time_to_first_token_ms,
+                    input_tokens, output_tokens,
+                    cache_read_input_tokens, cache_creation_input_tokens
+             FROM model_usage",
+        )
+        .map_err(|error| AppError::Database(format!("准备 ZCode model_usage 查询失败: {error}")))?;
+
+    let rows = stmt
+        .query_map([], |row| {
+            let id: String = row.get(0)?;
+            let session_id: String = row.get(1)?;
+            let provider_id: String = row.get(2)?;
+            let model_id: String = row.get(3)?;
+            let status: String = row.get(4)?;
+            let error_message: Option<String> = row.get(5)?;
+            let started_at: i64 = row.get(6)?;
+            let duration_ms: Option<i64> = row.get(7)?;
+            let time_to_first_token_ms: Option<i64> = row.get(8)?;
+            let input_tokens: i64 = row.get(9)?;
+            let output_tokens: i64 = row.get(10)?;
+            let cache_read_input_tokens: i64 = row.get(11)?;
+            let cache_creation_input_tokens: i64 = row.get(12)?;
+
+            // completed → 200; everything else (error, cancelled, running) → 500.
+            let status_code = if status == "completed" { 200 } else { 500 };
+
+            let created_at = started_at
+                .div_euclid(1000)
+                .clamp(MIN_SQLITE_UNIX_SECONDS, MAX_SQLITE_UNIX_SECONDS);
+
+            Ok(ZcodeUsageRecord {
+                request_id: format!("{REQUEST_ID_PREFIX}{id}"),
+                provider_id,
+                model: model_id,
+                input_tokens,
+                output_tokens,
+                cache_read_tokens: cache_read_input_tokens,
+                cache_creation_tokens: cache_creation_input_tokens,
+                latency_ms: duration_ms,
+                first_token_ms: time_to_first_token_ms,
+                status_code,
+                error_message: if status_code == 500 {
+                    error_message
+                } else {
+                    None
+                },
+                session_id,
+                created_at,
+            })
+        })
+        .map_err(|error| AppError::Database(format!("读取 ZCode model_usage 行失败: {error}")))?;
+
+    let mut records = Vec::new();
+    for row in rows {
+        records.push(row.map_err(|error| {
+            AppError::Database(format!("解析 ZCode model_usage 行失败: {error}"))
+        })?);
+    }
+    Ok(records)
+}
+
+fn zcode_table_exists(conn: &rusqlite::Connection) -> Result<bool, AppError> {
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'model_usage')",
+        [],
+        |row| row.get::<_, bool>(0),
+    )
+    .map_err(|error| AppError::Database(format!("查询 ZCode model_usage 表存在性失败: {error}")))
+}
+
+/// Insert one ZCode record into the dashboard. Returns `true` when a new row
+/// was written, `false` when the ledger already had it.
+fn insert_zcode_record(
+    conn: &rusqlite::Connection,
+    record: &ZcodeUsageRecord,
+) -> Result<bool, AppError> {
+    let already_seen: bool = conn
+        .query_row(
+            ZCODE_REQUEST_DEDUP_SQL,
+            rusqlite::params![DATA_SOURCE, record.request_id],
+            |row| row.get(0),
+        )
+        .map_err(|error| AppError::Database(format!("查询 ZCode 用量去重账本失败: {error}")))?;
+    if already_seen {
+        return Ok(false);
+    }
+    conn.execute(
+        "INSERT OR IGNORE INTO session_usage_dedup
+         (data_source, request_id, semantic_id, has_entry_id)
+         VALUES (?1, ?2, ?3, ?4)",
+        rusqlite::params![DATA_SOURCE, record.request_id, record.request_id, 1i64],
+    )
+    .map_err(|error| AppError::Database(format!("写入 ZCode 用量去重账本失败: {error}")))?;
+
+    let usage = TokenUsage {
+        input_tokens: record.input_tokens.max(0) as u32,
+        output_tokens: record.output_tokens.max(0) as u32,
+        cache_read_tokens: record.cache_read_tokens.max(0) as u32,
+        cache_creation_tokens: record.cache_creation_tokens.max(0) as u32,
+        model: Some(record.model.clone()),
+        message_id: None,
+    };
+    let costs = find_model_pricing(conn, &record.model).map(|pricing| {
+        let calculated =
+            CostCalculator::calculate_for_app(APP_TYPE, &usage, &pricing, Decimal::ONE);
+        (
+            calculated.input_cost,
+            calculated.output_cost,
+            calculated.cache_read_cost,
+            calculated.cache_creation_cost,
+            calculated.total_cost,
+        )
+    });
+    let (input_cost, output_cost, cache_read_cost, cache_write_cost, total_cost) =
+        costs.unwrap_or((
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            Decimal::ZERO,
+        ));
+
+    conn.execute(
+        "INSERT OR IGNORE INTO proxy_request_logs (
+            request_id, provider_id, app_type, model, request_model, pricing_model,
+            input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+            input_token_semantics,
+            input_cost_usd, output_cost_usd, cache_read_cost_usd,
+            cache_creation_cost_usd, total_cost_usd,
+            latency_ms, first_token_ms, status_code, error_message, session_id,
+            provider_type, is_streaming, cost_multiplier, created_at, data_source
+        ) VALUES (
+            ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
+            ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26
+        )",
+        rusqlite::params![
+            record.request_id,
+            record.provider_id,
+            APP_TYPE,
+            record.model,
+            record.model,
+            record.model,
+            record.input_tokens,
+            record.output_tokens,
+            record.cache_read_tokens,
+            record.cache_creation_tokens,
+            INPUT_TOKEN_SEMANTICS_TOTAL,
+            input_cost.to_string(),
+            output_cost.to_string(),
+            cache_read_cost.to_string(),
+            cache_write_cost.to_string(),
+            total_cost.to_string(),
+            record.latency_ms.unwrap_or(0),
+            record.first_token_ms,
+            record.status_code,
+            record.error_message,
+            record.session_id,
+            Some(DATA_SOURCE),
+            0i64,
+            "1.0",
+            record.created_at,
+            DATA_SOURCE,
+        ],
+    )
+    .map(|changed| changed > 0)
+    .map_err(|error| AppError::Database(format!("插入 ZCode 会话用量失败: {error}")))
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+mod tests {
+    use super::*;
+
+    /// Build a throwaway ZCode fixture database with the real `model_usage`
+    /// schema so the importer exercises the same SQL it sees in production.
+    fn create_fixture_db(dir: &std::path::Path) -> PathBuf {
+        let db_path = dir.join("db.sqlite");
+        let conn = rusqlite::Connection::open(&db_path).expect("open fixture db");
+        conn.execute_batch(
+            "CREATE TABLE session (id TEXT PRIMARY KEY);
+             CREATE TABLE model_usage (
+                id text primary key,
+                logical_request_id text not null,
+                attempt_index integer not null default 0,
+                session_id text not null references session(id) on delete cascade,
+                turn_id text,
+                trace_id text,
+                span_id text,
+                assistant_message_id text,
+                parent_user_message_id text,
+                query_source text not null,
+                provider_id text not null,
+                model_id text not null,
+                variant text,
+                agent text,
+                mode text,
+                task_type text,
+                status text not null check(status in ('running', 'completed', 'error', 'cancelled')),
+                started_at integer not null,
+                first_token_at integer,
+                completed_at integer,
+                duration_ms integer,
+                time_to_first_token_ms integer,
+                finish_reason text,
+                tool_call_count integer not null default 0,
+                input_tokens integer not null default 0,
+                output_tokens integer not null default 0,
+                reasoning_tokens integer not null default 0,
+                cache_creation_input_tokens integer not null default 0,
+                cache_read_input_tokens integer not null default 0,
+                provider_total_tokens integer,
+                computed_total_tokens integer not null default 0,
+                retry_count integer not null default 0,
+                retryable integer not null default 0 check(retryable in (0, 1)),
+                cancelled_by_user integer not null default 0 check(cancelled_by_user in (0, 1)),
+                context_exceeded integer not null default 0 check(context_exceeded in (0, 1)),
+                error_type text,
+                error_code text,
+                error_message text,
+                raw_usage_json text,
+                provider_metadata_json text
+             );",
+        )
+        .expect("create fixture schema");
+        db_path
+    }
+
+    fn insert_usage_row(
+        conn: &rusqlite::Connection,
+        id: &str,
+        session_id: &str,
+        provider_id: &str,
+        model_id: &str,
+        status: &str,
+        started_at: i64,
+        duration_ms: Option<i64>,
+        ttft: Option<i64>,
+        input: i64,
+        output: i64,
+        cache_read: i64,
+        cache_creation: i64,
+        error_message: Option<&str>,
+    ) {
+        conn.execute(
+            "INSERT INTO session (id) VALUES (?1) ON CONFLICT DO NOTHING",
+            [session_id],
+        )
+        .expect("insert session");
+        conn.execute(
+            "INSERT INTO model_usage (
+                id, logical_request_id, session_id, query_source, provider_id, model_id,
+                status, started_at, duration_ms, time_to_first_token_ms,
+                input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens,
+                error_message
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+            rusqlite::params![
+                id,
+                id,
+                session_id,
+                "main_turn",
+                provider_id,
+                model_id,
+                status,
+                started_at,
+                duration_ms,
+                ttft,
+                input,
+                output,
+                cache_read,
+                cache_creation,
+                error_message,
+            ],
+        )
+        .expect("insert model_usage row");
+    }
+
+    fn run_sync(dir: &std::path::Path) -> SessionSyncResult {
+        let db = Database::memory().expect("memory db");
+        sync_zcode_usage_from_path(&db, &dir.join("db.sqlite")).expect("sync")
+    }
+
+    #[test]
+    fn imports_usage_events_with_total_semantics_and_per_column_mapping() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = create_fixture_db(temp.path());
+        {
+            let conn = rusqlite::Connection::open(&db_path).expect("open fixture");
+            insert_usage_row(
+                &conn,
+                "row-1",
+                "sess-1",
+                "builtin:zai-start-plan",
+                "GLM-5.3",
+                "completed",
+                1_787_362_690_458,
+                Some(15666),
+                Some(10110),
+                19356,
+                398,
+                11712,
+                0,
+                None,
+            );
+        }
+
+        let db = Database::memory().expect("memory db");
+        let result = sync_zcode_usage_from_path(&db, &db_path).expect("sync");
+
+        assert_eq!(result.imported, 1);
+        assert!(result.errors.is_empty());
+
+        let conn = lock_conn!(db.conn);
+        let row: (
+            String,
+            String,
+            String,
+            String,
+            String,
+            String,
+            i64,
+            i64,
+            i64,
+            i64,
+            i64,
+            i64,
+            Option<i64>,
+            Option<i64>,
+            i64,
+            Option<String>,
+            String,
+            i64,
+        ) = conn
+            .query_row(
+                "SELECT request_id, provider_id, app_type, model, request_model,
+                        pricing_model, input_tokens, output_tokens, cache_read_tokens,
+                        cache_creation_tokens, input_token_semantics, status_code,
+                        latency_ms, first_token_ms, created_at, error_message,
+                        data_source, is_streaming
+                 FROM proxy_request_logs WHERE request_id = 'zcode:row-1'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                        row.get(6)?,
+                        row.get(7)?,
+                        row.get(8)?,
+                        row.get(9)?,
+                        row.get(10)?,
+                        row.get(11)?,
+                        row.get(12)?,
+                        row.get(13)?,
+                        row.get(14)?,
+                        row.get(15)?,
+                        row.get(16)?,
+                        row.get(17)?,
+                    ))
+                },
+            )
+            .expect("read row");
+
+        assert_eq!(row.0, "zcode:row-1");
+        assert_eq!(row.1, "builtin:zai-start-plan");
+        assert_eq!(row.2, "zcode");
+        assert_eq!(row.3, "GLM-5.3");
+        assert_eq!(row.4, "GLM-5.3");
+        assert_eq!(row.5, "GLM-5.3");
+        assert_eq!((row.6, row.7, row.8, row.9), (19356, 398, 11712, 0));
+        assert_eq!(row.10, INPUT_TOKEN_SEMANTICS_TOTAL);
+        assert_eq!(row.11, 200);
+        assert_eq!(row.12, Some(15666));
+        assert_eq!(row.13, Some(10110));
+        assert_eq!(row.14, 1_787_362_690);
+        assert_eq!(row.15, None);
+        assert_eq!(row.16, "zcode_session");
+        assert_eq!(row.17, 0);
+
+        let dedup: (String, i64) = conn
+            .query_row(
+                "SELECT request_id, has_entry_id FROM session_usage_dedup
+                 WHERE data_source = 'zcode_session'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read dedup");
+        assert_eq!(dedup, ("zcode:row-1".to_string(), 1));
+        Ok(())
+    }
+
+    #[test]
+    fn replay_is_idempotent_zero_new_imports() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = create_fixture_db(temp.path());
+        {
+            let conn = rusqlite::Connection::open(&db_path).expect("open fixture");
+            insert_usage_row(
+                &conn,
+                "row-a",
+                "sess-a",
+                "builtin:zai-start-plan",
+                "GLM-5.3",
+                "completed",
+                1_787_362_690_000,
+                Some(5000),
+                None,
+                100,
+                10,
+                50,
+                0,
+                None,
+            );
+            insert_usage_row(
+                &conn,
+                "row-b",
+                "sess-a",
+                "builtin:zai-start-plan",
+                "GLM-5.3",
+                "completed",
+                1_787_362_691_000,
+                Some(3000),
+                None,
+                200,
+                20,
+                100,
+                0,
+                None,
+            );
+        }
+
+        let db = Database::memory().expect("memory db");
+
+        let first = sync_zcode_usage_from_path(&db, &db_path).expect("sync 1");
+        assert_eq!((first.imported, first.skipped), (2, 0));
+
+        let second = sync_zcode_usage_from_path(&db, &db_path).expect("sync 2");
+        assert_eq!((second.imported, second.skipped), (0, 2));
+
+        let count: i64 = lock_conn!(db.conn)
+            .query_row(
+                "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'zcode_session'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count");
+        assert_eq!(count, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn missing_provider_falls_back_to_placeholder_and_display_name() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = create_fixture_db(temp.path());
+        {
+            let conn = rusqlite::Connection::open(&db_path).expect("open fixture");
+            // Empty provider_id is rejected by the NOT NULL constraint, so use
+            // a blank-ish value to exercise the placeholder path via an
+            // explicit empty model instead.
+            insert_usage_row(
+                &conn,
+                "row-empty-model",
+                "sess-anon",
+                "some-provider",
+                "",
+                "completed",
+                1_787_362_690_000,
+                None,
+                None,
+                10,
+                5,
+                2,
+                0,
+                None,
+            );
+        }
+
+        let result = run_sync(temp.path());
+        assert_eq!(result.imported, 1);
+
+        // The real importer copies provider_id verbatim; the placeholder is
+        // only surfaced by the display-name CASE in usage_stats. Verify the
+        // placeholder resolves through get_provider_stats so the dashboard
+        // would show "ZCode (Session)" for a synthetic placeholder row.
+        let db = Database::memory().expect("memory db");
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model, request_model,
+                    input_tokens, output_tokens, latency_ms, status_code,
+                    created_at, data_source
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                rusqlite::params![
+                    "placeholder-test",
+                    PROVIDER_PLACEHOLDER,
+                    APP_TYPE,
+                    "GLM-5.3",
+                    "GLM-5.3",
+                    10,
+                    5,
+                    0,
+                    200,
+                    1_787_362_690,
+                    DATA_SOURCE,
+                ],
+            )
+            .expect("insert placeholder row");
+        }
+        let providers = db
+            .get_provider_stats(None, None, Some(APP_TYPE), None, None)
+            .expect("provider stats");
+        assert!(providers.iter().any(|p| {
+            p.provider_id == PROVIDER_PLACEHOLDER && p.provider_name == "ZCode (Session)"
+        }));
+        Ok(())
+    }
+
+    #[test]
+    fn all_query_sources_are_imported() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = create_fixture_db(temp.path());
+        {
+            let conn = rusqlite::Connection::open(&db_path).expect("open fixture");
+            // One row per query_source value seen in production.
+            for (id, source) in [
+                ("src-main", "main_turn"),
+                ("src-title", "session_title"),
+                ("src-sub", "subagent"),
+                ("src-verify", "target_completion_verification"),
+            ] {
+                conn.execute(
+                    "INSERT INTO session (id) VALUES ('sess-q') ON CONFLICT DO NOTHING",
+                    [],
+                )
+                .expect("insert session");
+                conn.execute(
+                    "INSERT INTO model_usage (
+                        id, logical_request_id, session_id, query_source, provider_id, model_id,
+                        status, started_at, input_tokens, output_tokens
+                    ) VALUES (?1, ?1, 'sess-q', ?2, 'builtin:zai-start-plan', 'GLM-5.3',
+                        'completed', 1787362690000, 100, 10)",
+                    rusqlite::params![id, source],
+                )
+                .expect("insert row");
+            }
+        }
+
+        let result = run_sync(temp.path());
+        assert_eq!(result.imported, 4);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn missing_model_usage_table_defers_gracefully() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = temp.path().join("db.sqlite");
+        // Create a database with no model_usage table.
+        rusqlite::Connection::open(&db_path).expect("open empty db");
+
+        let result = run_sync(temp.path());
+        assert_eq!(result.imported, 0);
+        assert_eq!(result.deferred_files, 0);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn error_status_maps_to_500_with_error_message() -> Result<(), AppError> {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = create_fixture_db(temp.path());
+        {
+            let conn = rusqlite::Connection::open(&db_path).expect("open fixture");
+            insert_usage_row(
+                &conn,
+                "row-err",
+                "sess-err",
+                "builtin:zai-start-plan",
+                "GLM-5.3",
+                "error",
+                1_787_362_690_000,
+                Some(100),
+                None,
+                50,
+                0,
+                30,
+                0,
+                Some("upstream timeout"),
+            );
+            insert_usage_row(
+                &conn,
+                "row-cancel",
+                "sess-err",
+                "builtin:zai-start-plan",
+                "GLM-5.3",
+                "cancelled",
+                1_787_362_691_000,
+                None,
+                None,
+                20,
+                0,
+                10,
+                0,
+                None,
+            );
+        }
+
+        let db = Database::memory().expect("memory db");
+        let result = sync_zcode_usage_from_path(&db, &db_path).expect("sync");
+        assert_eq!(result.imported, 2);
+
+        let conn = lock_conn!(db.conn);
+        let err_row: (i64, Option<String>) = conn
+            .query_row(
+                "SELECT status_code, error_message FROM proxy_request_logs
+                 WHERE request_id = 'zcode:row-err'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .expect("read err row");
+        assert_eq!(err_row.0, 500);
+        assert_eq!(err_row.1.as_deref(), Some("upstream timeout"));
+
+        let cancel_row: i64 = conn
+            .query_row(
+                "SELECT status_code FROM proxy_request_logs
+                 WHERE request_id = 'zcode:row-cancel'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read cancel row");
+        assert_eq!(cancel_row, 500);
+        Ok(())
+    }
+}

--- a/src-tauri/src/services/session_usage_zcode.rs
+++ b/src-tauri/src/services/session_usage_zcode.rs
@@ -168,7 +168,8 @@ fn load_zcode_records(conn: &rusqlite::Connection) -> Result<Vec<ZcodeUsageRecor
                     started_at, duration_ms, time_to_first_token_ms,
                     input_tokens, output_tokens,
                     cache_read_input_tokens, cache_creation_input_tokens
-             FROM model_usage",
+             FROM model_usage
+             WHERE status != 'running'",
         )
         .map_err(|error| AppError::Database(format!("准备 ZCode model_usage 查询失败: {error}")))?;
 
@@ -188,7 +189,10 @@ fn load_zcode_records(conn: &rusqlite::Connection) -> Result<Vec<ZcodeUsageRecor
             let cache_read_input_tokens: i64 = row.get(11)?;
             let cache_creation_input_tokens: i64 = row.get(12)?;
 
-            // completed → 200; everything else (error, cancelled, running) → 500.
+            // completed → 200; everything else (error, cancelled) → 500.
+            // `running` rows are excluded by the WHERE clause so that a
+            // still-active request is not prematurely imported with
+            // incomplete counters and locked into the dedup ledger.
             let status_code = if status == "completed" { 200 } else { 500 };
 
             let created_at = started_at
@@ -798,6 +802,76 @@ mod tests {
             )
             .expect("read cancel row");
         assert_eq!(cancel_row, 500);
+        Ok(())
+    }
+
+    #[test]
+    fn running_rows_are_skipped_until_terminal() -> Result<(), AppError> {
+        // A `running` row has incomplete counters and must not be imported,
+        // otherwise the dedup ledger would lock it as status 500 forever.
+        let temp = tempfile::tempdir().expect("tempdir");
+        let db_path = create_fixture_db(temp.path());
+        {
+            let conn = rusqlite::Connection::open(&db_path).expect("open fixture");
+            insert_usage_row(
+                &conn,
+                "row-running",
+                "sess-run",
+                "builtin:zai-start-plan",
+                "GLM-5.3",
+                "running",
+                1_787_362_690_000,
+                None,
+                None,
+                10,
+                0,
+                0,
+                0,
+                None,
+            );
+        }
+
+        let db = Database::memory().expect("memory db");
+
+        // First sync: running row is excluded.
+        let first = sync_zcode_usage_from_path(&db, &db_path).expect("sync 1");
+        assert_eq!(first.imported, 0);
+        assert_eq!(first.skipped, 0);
+
+        let count: i64 = lock_conn!(db.conn)
+            .query_row(
+                "SELECT COUNT(*) FROM proxy_request_logs WHERE data_source = 'zcode_session'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("count");
+        assert_eq!(count, 0);
+
+        // Simulate ZCode completing the row.
+        {
+            let conn = rusqlite::Connection::open(&db_path).expect("open fixture");
+            conn.execute(
+                "UPDATE model_usage SET status = 'completed', duration_ms = 5000,
+                         output_tokens = 42
+                  WHERE id = 'row-running'",
+                [],
+            )
+            .expect("update to completed");
+        }
+
+        // Second sync: the now-completed row is imported fresh.
+        let second = sync_zcode_usage_from_path(&db, &db_path).expect("sync 2");
+        assert_eq!(second.imported, 1);
+
+        let status: i64 = lock_conn!(db.conn)
+            .query_row(
+                "SELECT status_code FROM proxy_request_logs
+                 WHERE request_id = 'zcode:row-running'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("read status");
+        assert_eq!(status, 200);
         Ok(())
     }
 }

--- a/src-tauri/src/services/sql_helpers.rs
+++ b/src-tauri/src/services/sql_helpers.rs
@@ -20,7 +20,7 @@
 /// （usage_stats 成本重算）与展示侧（本文件的 SQL 归一）都必须引用这里，
 /// 防止同一语义散落多处后新增 app 时漏改（grokbuild 曾在回填侧漏掉）。
 /// 前端 `src/types/usage.ts` 的同名常量是跨语言的对应物，改动须同步。
-pub(crate) const CACHE_INCLUSIVE_APP_TYPES: &[&str] = &["codex", "gemini", "grokbuild"];
+pub(crate) const CACHE_INCLUSIVE_APP_TYPES: &[&str] = &["codex", "gemini", "grokbuild", "zcode"];
 
 /// `app_type` 的存储 `input_tokens` 是否已包含 cache read/write。
 pub(crate) fn is_cache_inclusive_app(app_type: &str) -> bool {

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -217,6 +217,7 @@ fn provider_name_coalesce(log_alias: &str, provider_alias: &str) -> String {
          WHEN '_opencode_session' THEN 'OpenCode (Session)' \
          WHEN '_grok_session' THEN 'Grok Build (Session)' \
          WHEN '_pi_session' THEN 'Pi (Session)' \
+         WHEN '_dsh_session' THEN 'DSH (Session)' \
          ELSE {log_alias}.provider_id END)"
     )
 }

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -218,6 +218,7 @@ fn provider_name_coalesce(log_alias: &str, provider_alias: &str) -> String {
          WHEN '_grok_session' THEN 'Grok Build (Session)' \
          WHEN '_pi_session' THEN 'Pi (Session)' \
          WHEN '_dsh_session' THEN 'DSH (Session)' \
+         WHEN '_zcode_session' THEN 'ZCode (Session)' \
          ELSE {log_alias}.provider_id END)"
     )
 }

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -68,6 +68,7 @@ const normalizeRefreshInterval = (value: number | undefined) =>
 const APP_FILTER_ICON: Record<AppType, string> = {
   claude: "claude",
   codex: "openai",
+  dsh: "deepseek",
   gemini: "gemini",
   grokbuild: "grok",
   opencode: "opencode",

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -73,6 +73,7 @@ const APP_FILTER_ICON: Record<AppType, string> = {
   grokbuild: "grok",
   opencode: "opencode",
   pi: "pi",
+  zcode: "zhipu",
 };
 
 // Select 的 "all" 哨兵和用户自定义名称同处一个值域——真有来源/模型叫 "all"

--- a/src/components/usage/UsageHero.tsx
+++ b/src/components/usage/UsageHero.tsx
@@ -73,6 +73,10 @@ const TITLE_THEMES: Record<AppType | "all", TitleTheme> = {
     accent: "text-fuchsia-600 dark:text-fuchsia-400",
     iconBg: "bg-fuchsia-500/10",
   },
+  dsh: {
+    accent: "text-teal-600 dark:text-teal-400",
+    iconBg: "bg-teal-500/10",
+  },
 };
 
 /**

--- a/src/components/usage/UsageHero.tsx
+++ b/src/components/usage/UsageHero.tsx
@@ -77,6 +77,10 @@ const TITLE_THEMES: Record<AppType | "all", TitleTheme> = {
     accent: "text-teal-600 dark:text-teal-400",
     iconBg: "bg-teal-500/10",
   },
+  zcode: {
+    accent: "text-indigo-600 dark:text-indigo-400",
+    iconBg: "bg-indigo-500/10",
+  },
 };
 
 /**

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -910,7 +910,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "dsh": "DSH"
   },
   "pi": {
     "empty": {
@@ -1716,7 +1717,8 @@
       "gemini": "Gemini",
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
-      "pi": "Pi"
+      "pi": "Pi",
+      "dsh": "DSH"
     },
     "rawInputLabel": "Raw",
     "rebuildCodex": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -911,7 +911,8 @@
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
     "pi": "Pi",
-    "dsh": "DSH"
+    "dsh": "DSH",
+    "zcode": "ZCode"
   },
   "pi": {
     "empty": {
@@ -1718,7 +1719,8 @@
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
       "pi": "Pi",
-      "dsh": "DSH"
+      "dsh": "DSH",
+      "zcode": "ZCode"
     },
     "rawInputLabel": "Raw",
     "rebuildCodex": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -911,7 +911,8 @@
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
     "pi": "Pi",
-    "dsh": "DSH"
+    "dsh": "DSH",
+    "zcode": "ZCode"
   },
   "pi": {
     "empty": {
@@ -1718,7 +1719,8 @@
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
       "pi": "Pi",
-      "dsh": "DSH"
+      "dsh": "DSH",
+      "zcode": "ZCode"
     },
     "rawInputLabel": "原始",
     "rebuildCodex": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -910,7 +910,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "dsh": "DSH"
   },
   "pi": {
     "empty": {
@@ -1716,7 +1717,8 @@
       "gemini": "Gemini",
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
-      "pi": "Pi"
+      "pi": "Pi",
+      "dsh": "DSH"
     },
     "rawInputLabel": "原始",
     "rebuildCodex": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -911,7 +911,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "dsh": "DSH"
   },
   "pi": {
     "empty": {
@@ -1717,7 +1718,8 @@
       "gemini": "Gemini",
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
-      "pi": "Pi"
+      "pi": "Pi",
+      "dsh": "DSH"
     },
     "rawInputLabel": "原始",
     "rebuildCodex": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -912,7 +912,8 @@
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
     "pi": "Pi",
-    "dsh": "DSH"
+    "dsh": "DSH",
+    "zcode": "ZCode"
   },
   "pi": {
     "empty": {
@@ -1719,7 +1720,8 @@
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
       "pi": "Pi",
-      "dsh": "DSH"
+      "dsh": "DSH",
+      "zcode": "ZCode"
     },
     "rawInputLabel": "原始",
     "rebuildCodex": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -911,7 +911,8 @@
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
     "pi": "Pi",
-    "dsh": "DSH"
+    "dsh": "DSH",
+    "zcode": "ZCode"
   },
   "pi": {
     "empty": {
@@ -1718,7 +1719,8 @@
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
       "pi": "Pi",
-      "dsh": "DSH"
+      "dsh": "DSH",
+      "zcode": "ZCode"
     },
     "rawInputLabel": "原始",
     "rebuildCodex": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -910,7 +910,8 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
-    "pi": "Pi"
+    "pi": "Pi",
+    "dsh": "DSH"
   },
   "pi": {
     "empty": {
@@ -1716,7 +1717,8 @@
       "gemini": "Gemini",
       "opencode": "OpenCode",
       "grokbuild": "Grok Build",
-      "pi": "Pi"
+      "pi": "Pi",
+      "dsh": "DSH"
     },
     "rawInputLabel": "原始",
     "rebuildCodex": {

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -192,6 +192,7 @@ export interface UsageRangeSelection {
 export type AppType =
   | "claude"
   | "codex"
+  | "dsh"
   | "gemini"
   | "grokbuild"
   | "opencode"
@@ -202,6 +203,7 @@ export type AppTypeFilter = "all" | AppType;
 export const KNOWN_APP_TYPES: ReadonlyArray<AppType> = [
   "claude",
   "codex",
+  "dsh",
   "gemini",
   "grokbuild",
   "opencode",
@@ -228,8 +230,11 @@ export const CACHE_INCLUSIVE_APP_TYPES: ReadonlySet<string> = new Set([
 
 // Pi sessions can mix Anthropic and OpenAI APIs, but the dashboard aggregates
 // only by app type. Treat cache-write coverage as partial without changing
-// Pi's fresh-input token semantics.
-const PARTIAL_CACHE_WRITE_APP_TYPES: ReadonlySet<string> = new Set(["pi"]);
+// Pi's fresh-input token semantics. DSH logs never report cache writes.
+const PARTIAL_CACHE_WRITE_APP_TYPES: ReadonlySet<string> = new Set([
+  "pi",
+  "dsh",
+]);
 
 export type CacheWriteAvailability = "ok" | "partial" | "na";
 

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -196,7 +196,8 @@ export type AppType =
   | "gemini"
   | "grokbuild"
   | "opencode"
-  | "pi";
+  | "pi"
+  | "zcode";
 
 export type AppTypeFilter = "all" | AppType;
 
@@ -208,6 +209,7 @@ export const KNOWN_APP_TYPES: ReadonlyArray<AppType> = [
   "grokbuild",
   "opencode",
   "pi",
+  "zcode",
 ];
 
 /**
@@ -226,6 +228,7 @@ export const CACHE_INCLUSIVE_APP_TYPES: ReadonlySet<string> = new Set([
   "codex",
   "gemini",
   "grokbuild",
+  "zcode",
 ]);
 
 // Pi sessions can mix Anthropic and OpenAI APIs, but the dashboard aggregates


### PR DESCRIPTION
## Summary

Adds a ZCode session usage importer that reads token accounting from the `model_usage` table in `~/.zcode/cli/db/db.sqlite` and replays it into the shared usage dashboard, so all AI consumption (Claude/Codex/DSH/ZCode/etc.) is visible in one panel.

Stacked on #6724 (DSH session usage importer).

## Implementation

- **New Rust importer** `src-tauri/src/services/session_usage_zcode.rs`: opens the ZCode SQLite database read-only (`SQLITE_OPEN_READ_ONLY` + 5000ms busy timeout), runs a full `SELECT` each pass, and gates writes through the shared `session_usage_dedup` ledger keyed by `zcode:<model_usage.id>`. No mtime fast-path (WAL-mode main file mtime is unreliable). Schema drift (missing table/column, SQLITE_BUSY) defers to the next pass instead of failing the whole sync.
- **Field mapping**: `input/output/cache_read/cache_creation` copied verbatim; `created_at = started_at/1000` (clamped); `latency_ms = duration_ms` (NULL→0, NOT NULL column); `first_token_ms = time_to_first_token_ms`; `model = request_model = pricing_model = model_id`; `provider_id` stored as-is. Status: `completed→200`, everything else (`error`/`cancelled`/`running`)→500 + `error_message`. Cost via `find_model_pricing` (0 when unmatched).
- **Input semantics**: ZCode's `input_tokens` includes `cache_read` (verified: `input + output = computed_total` with zero exceptions across 660+ rows). So `input_token_semantics = TOTAL (1)` and `"zcode"` is added to `CACHE_INCLUSIVE_APP_TYPES` in both `sql_helpers.rs` and the frontend mirror `src/types/usage.ts`.
- **Constants**: `request_id = "zcode:" + model_usage.id`, `app_type = "zcode"`, `data_source = provider_type = "zcode_session"`, provider placeholder `_zcode_session` → display name "ZCode (Session)".
- **All `query_source` values counted** (main_turn, session_title, subagent, target_completion_verification).

## Registration

- `services/mod.rs`: `pub mod session_usage_zcode`
- `session_usage.rs` `sync_all_unlocked`: `merge_sync_step("ZCode", sync_zcode_usage(db))`
- `usage_stats.rs` `provider_name_coalesce`: `CASE '_zcode_session' THEN 'ZCode (Session)'`

## Frontend

- `src/types/usage.ts`: `AppType` + `KNOWN_APP_TYPES` + `CACHE_INCLUSIVE_APP_TYPES` mirror.
- `UsageDashboard.tsx`: icon key `zcode: "zhipu"` (existing icon).
- `UsageHero.tsx`: theme color `indigo` (previously unused).
- i18n × 4 locales (en/ja/zh-TW/zh): `apps.zcode = "ZCode"`, `usage.appFilter.zcode = "ZCode"`.

## Tests

- 6 Rust unit tests: end-to-end per-column mapping with `semantics=1`, replay idempotency (0 new on second pass), provider placeholder → display name, all query sources imported, missing table graceful skip, error/cancelled → 500 + error message.
- cargo test: 2691 pass / 0 fail / 5 ignored (baseline 2685 + 6 new).
- clippy `--all-targets`: 0 warnings. `cargo fmt --check`: clean.
- pnpm typecheck / test:unit 987-987 / format:check: all green.

## Real-machine reconciliation

Fixed cutoff T0 = `MAX(started_at)` before sync. Both sides filtered with `WHERE started_at <= T0` (ZCode) / `created_at <= T0/1000` (cc-switch). Five metrics (COUNT + 4 token SUMs) match per-key across all 3 provider+model combinations. 75-second idempotency recheck: T0-gated counts unchanged; total row growth is live-session new events only.