### PR TITLE
fix(proxy): normalize GLM-5.3 family forced thinking

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1516,8 +1516,8 @@ impl RequestForwarder {
 
         // Capture the client-side reasoning intent before a generic protocol
         // converter can collapse a tiered control into a plain on/off switch.
-        // The intent is only consumed when the final outbound model is exactly
-        // a GLM-5.3-family model on a direct Zhipu gateway.
+        // The intent is consumed only after body overrides establish the final
+        // outbound model, and only for the GLM-5.3 family on direct Zhipu.
         let glm_5_3_reasoning_intent =
             if super::providers::glm_reasoning::is_direct_zhipu_gateway(&base_url) {
                 super::providers::glm_reasoning::capture_glm_5_3_reasoning_intent(&mapped_body)
@@ -1632,17 +1632,6 @@ impl RequestForwarder {
             mapped_body
         };
 
-        if super::providers::glm_reasoning::normalize_direct_zhipu_glm_5_3_request(
-            &base_url,
-            &mut request_body,
-            glm_5_3_reasoning_intent,
-        ) {
-            log::debug!(
-                "[GLM-5.3 family] Normalized reasoning controls for direct Zhipu upstream (provider={})",
-                provider.id
-            );
-        }
-
         // Native Responses passthrough to a strict third-party gateway (xAI):
         // flatten Codex's private `namespace`/plugin tool declarations into
         // top-level function tools so the upstream's strict serde parser does
@@ -1689,31 +1678,23 @@ impl RequestForwarder {
             self.apply_media_prevention(&mut request_body, provider);
         }
 
-        // 过滤私有参数（以 `_` 开头的字段），防止内部信息泄露到上游
-        // 默认使用空白名单，过滤所有 _ 前缀字段
-        let mut filtered_body = prepare_upstream_request_body(request_body);
-        if !is_copilot {
-            if let Some(overrides) = provider
+        // Filter private fields, apply body overrides, then normalize against
+        // the actual final model. This ordering prevents a model override away
+        // from GLM from inheriting GLM-only fields and lets an override to GLM
+        // recover reasoning intent that a protocol converter discarded.
+        let (filtered_body, glm_5_3_reasoning_normalized) = prepare_final_upstream_request_body(
+            request_body,
+            provider
                 .meta
                 .as_ref()
-                .and_then(|meta| meta.local_proxy_request_overrides.as_ref())
-            {
-                if apply_local_proxy_body_overrides(&mut filtered_body, overrides) {
-                    filtered_body = prepare_upstream_request_body(filtered_body);
-                }
-            }
-        }
-        // Overrides are intentionally applied before this final capability
-        // guard: even an explicit body override cannot ask a thinking-only
-        // GLM-5.3-family endpoint to disable reasoning. No original-intent
-        // fallback is used here, so a valid override tier remains authoritative.
-        if super::providers::glm_reasoning::normalize_direct_zhipu_glm_5_3_request(
+                .and_then(|meta| meta.local_proxy_request_overrides.as_ref()),
+            is_copilot,
             &base_url,
-            &mut filtered_body,
-            None,
-        ) {
+            glm_5_3_reasoning_intent,
+        );
+        if glm_5_3_reasoning_normalized {
             log::debug!(
-                "[GLM-5.3 family] Normalized overridden reasoning controls for direct Zhipu upstream (provider={})",
+                "[GLM-5.3 family] Normalized final reasoning controls for direct Zhipu upstream (provider={})",
                 provider.id
             );
         }
@@ -3527,6 +3508,37 @@ fn summarize_text_for_log(text: &str, max_chars: usize) -> String {
     format!("{truncated}...")
 }
 
+fn prepare_final_upstream_request_body(
+    request_body: Value,
+    overrides: Option<&LocalProxyRequestOverrides>,
+    is_copilot: bool,
+    base_url: &str,
+    glm_5_3_reasoning_intent: Option<super::providers::glm_reasoning::Glm53ReasoningIntent>,
+) -> (Value, bool) {
+    // Model is an allowed local body override, so the final capability guard
+    // must run after overrides rather than mutating an intermediate model.
+    let mut filtered_body = prepare_upstream_request_body(request_body);
+    if !is_copilot {
+        if let Some(overrides) = overrides {
+            if apply_local_proxy_body_overrides(&mut filtered_body, overrides) {
+                filtered_body = prepare_upstream_request_body(filtered_body);
+            }
+        }
+    }
+
+    let normalized = super::providers::glm_reasoning::normalize_direct_zhipu_glm_5_3_request(
+        base_url,
+        &mut filtered_body,
+        glm_5_3_reasoning_intent,
+    );
+    if normalized {
+        // Keep the same deterministic ordering guarantee after the normalizer
+        // inserts or removes fields from the final body.
+        filtered_body = prepare_upstream_request_body(filtered_body);
+    }
+    (filtered_body, normalized)
+}
+
 fn apply_local_proxy_body_overrides(
     body: &mut Value,
     overrides: &LocalProxyRequestOverrides,
@@ -4000,6 +4012,65 @@ mod tests {
         assert_eq!(body["metadata"]["temperature"], 0.2);
         assert_eq!(body["metadata"]["top_p"], 0.9);
         assert_eq!(body["messages"], json!([]));
+    }
+
+    #[test]
+    fn final_model_override_away_from_glm_does_not_leak_glm_reasoning_fields() {
+        let intent = crate::proxy::providers::glm_reasoning::capture_glm_5_3_reasoning_intent(
+            &json!({ "thinking": { "type": "disabled" } }),
+        );
+        let request_body = json!({
+            "model": "glm-5.3",
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+        let overrides = LocalProxyRequestOverrides {
+            headers: HashMap::new(),
+            body: Some(json!({ "model": "glm-5.2" })),
+        };
+
+        let (body, normalized) = prepare_final_upstream_request_body(
+            request_body,
+            Some(&overrides),
+            false,
+            "https://open.bigmodel.cn/api/anthropic",
+            intent,
+        );
+
+        assert!(!normalized);
+        assert_eq!(body["model"], "glm-5.2");
+        assert!(body.get("thinking").is_none());
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn final_model_override_to_glm_restores_preconversion_disabled_intent() {
+        let intent = crate::proxy::providers::glm_reasoning::capture_glm_5_3_reasoning_intent(
+            &json!({ "thinking": { "type": "disabled" } }),
+        );
+        // Simulate a converter that retained only the on/off shape and lost the
+        // original disabled tier before the final model override is applied.
+        let request_body = json!({
+            "model": "glm-5.2",
+            "messages": [{ "role": "user", "content": "hi" }],
+            "thinking": { "type": "enabled" }
+        });
+        let overrides = LocalProxyRequestOverrides {
+            headers: HashMap::new(),
+            body: Some(json!({ "model": "glm-5.3-flash" })),
+        };
+
+        let (body, normalized) = prepare_final_upstream_request_body(
+            request_body,
+            Some(&overrides),
+            false,
+            "https://open.bigmodel.cn/api/anthropic",
+            intent,
+        );
+
+        assert!(normalized);
+        assert_eq!(body["model"], "glm-5.3-flash");
+        assert_eq!(body["thinking"], json!({ "type": "enabled" }));
+        assert_eq!(body["reasoning_effort"], "low");
     }
 
     #[test]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1517,7 +1517,7 @@ impl RequestForwarder {
         // Capture the client-side reasoning intent before a generic protocol
         // converter can collapse a tiered control into a plain on/off switch.
         // The intent is only consumed when the final outbound model is exactly
-        // GLM-5.3 on a direct Zhipu gateway.
+        // a GLM-5.3-family model on a direct Zhipu gateway.
         let glm_5_3_reasoning_intent =
             if super::providers::glm_reasoning::is_direct_zhipu_gateway(&base_url) {
                 super::providers::glm_reasoning::capture_glm_5_3_reasoning_intent(&mapped_body)
@@ -1638,7 +1638,7 @@ impl RequestForwarder {
             glm_5_3_reasoning_intent,
         ) {
             log::debug!(
-                "[GLM-5.3] Normalized reasoning controls for direct Zhipu upstream (provider={})",
+                "[GLM-5.3 family] Normalized reasoning controls for direct Zhipu upstream (provider={})",
                 provider.id
             );
         }
@@ -1705,15 +1705,15 @@ impl RequestForwarder {
         }
         // Overrides are intentionally applied before this final capability
         // guard: even an explicit body override cannot ask a thinking-only
-        // GLM-5.3 endpoint to disable reasoning. No original-intent fallback is
-        // used here, so a valid override tier remains authoritative.
+        // GLM-5.3-family endpoint to disable reasoning. No original-intent
+        // fallback is used here, so a valid override tier remains authoritative.
         if super::providers::glm_reasoning::normalize_direct_zhipu_glm_5_3_request(
             &base_url,
             &mut filtered_body,
             None,
         ) {
             log::debug!(
-                "[GLM-5.3] Normalized overridden reasoning controls for direct Zhipu upstream (provider={})",
+                "[GLM-5.3 family] Normalized overridden reasoning controls for direct Zhipu upstream (provider={})",
                 provider.id
             );
         }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -3518,6 +3518,13 @@ fn prepare_final_upstream_request_body(
     // Model is an allowed local body override, so the final capability guard
     // must run after overrides rather than mutating an intermediate model.
     let mut filtered_body = prepare_upstream_request_body(request_body);
+    let final_override_body = if is_copilot {
+        None
+    } else {
+        overrides
+            .and_then(|overrides| overrides.body.as_ref())
+            .filter(|body| body.is_object())
+    };
     if !is_copilot {
         if let Some(overrides) = overrides {
             if apply_local_proxy_body_overrides(&mut filtered_body, overrides) {
@@ -3526,11 +3533,20 @@ fn prepare_final_upstream_request_body(
         }
     }
 
-    let normalized = super::providers::glm_reasoning::normalize_direct_zhipu_glm_5_3_request(
-        base_url,
-        &mut filtered_body,
-        glm_5_3_reasoning_intent,
-    );
+    let normalized = if let Some(final_override_body) = final_override_body {
+        super::providers::glm_reasoning::normalize_direct_zhipu_glm_5_3_request_with_override(
+            base_url,
+            &mut filtered_body,
+            glm_5_3_reasoning_intent,
+            Some(final_override_body),
+        )
+    } else {
+        super::providers::glm_reasoning::normalize_direct_zhipu_glm_5_3_request(
+            base_url,
+            &mut filtered_body,
+            glm_5_3_reasoning_intent,
+        )
+    };
     if normalized {
         // Keep the same deterministic ordering guarantee after the normalizer
         // inserts or removes fields from the final body.
@@ -4071,6 +4087,33 @@ mod tests {
         assert_eq!(body["model"], "glm-5.3-flash");
         assert_eq!(body["thinking"], json!({ "type": "enabled" }));
         assert_eq!(body["reasoning_effort"], "low");
+    }
+
+    #[test]
+    fn final_glm_effort_override_wins_over_stale_disabled_toggle() {
+        let request_body = json!({
+            "model": "glm-5.3-flash",
+            "messages": [{ "role": "user", "content": "hi" }],
+            "thinking": { "type": "disabled" }
+        });
+        let intent =
+            crate::proxy::providers::glm_reasoning::capture_glm_5_3_reasoning_intent(&request_body);
+        let overrides = LocalProxyRequestOverrides {
+            headers: HashMap::new(),
+            body: Some(json!({ "reasoning_effort": "max" })),
+        };
+
+        let (body, normalized) = prepare_final_upstream_request_body(
+            request_body,
+            Some(&overrides),
+            false,
+            "https://open.bigmodel.cn/api/anthropic",
+            intent,
+        );
+
+        assert!(normalized);
+        assert_eq!(body["thinking"], json!({ "type": "enabled" }));
+        assert_eq!(body["reasoning_effort"], "max");
     }
 
     #[test]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1514,6 +1514,17 @@ impl RequestForwarder {
         // suffix and add the context-1m beta header.
         let mut codex_anthropic_one_m = false;
 
+        // Capture the client-side reasoning intent before a generic protocol
+        // converter can collapse a tiered control into a plain on/off switch.
+        // The intent is only consumed when the final outbound model is exactly
+        // GLM-5.3 on a direct Zhipu gateway.
+        let glm_5_3_reasoning_intent =
+            if super::providers::glm_reasoning::is_direct_zhipu_gateway(&base_url) {
+                super::providers::glm_reasoning::capture_glm_5_3_reasoning_intent(&mapped_body)
+            } else {
+                None
+            };
+
         // 转换请求体（如果需要）
         let mut request_body = if codex_responses_to_chat {
             let mut mapped_body = mapped_body;
@@ -1621,6 +1632,17 @@ impl RequestForwarder {
             mapped_body
         };
 
+        if super::providers::glm_reasoning::normalize_direct_zhipu_glm_5_3_request(
+            &base_url,
+            &mut request_body,
+            glm_5_3_reasoning_intent,
+        ) {
+            log::debug!(
+                "[GLM-5.3] Normalized reasoning controls for direct Zhipu upstream (provider={})",
+                provider.id
+            );
+        }
+
         // Native Responses passthrough to a strict third-party gateway (xAI):
         // flatten Codex's private `namespace`/plugin tool declarations into
         // top-level function tools so the upstream's strict serde parser does
@@ -1680,6 +1702,20 @@ impl RequestForwarder {
                     filtered_body = prepare_upstream_request_body(filtered_body);
                 }
             }
+        }
+        // Overrides are intentionally applied before this final capability
+        // guard: even an explicit body override cannot ask a thinking-only
+        // GLM-5.3 endpoint to disable reasoning. No original-intent fallback is
+        // used here, so a valid override tier remains authoritative.
+        if super::providers::glm_reasoning::normalize_direct_zhipu_glm_5_3_request(
+            &base_url,
+            &mut filtered_body,
+            None,
+        ) {
+            log::debug!(
+                "[GLM-5.3] Normalized overridden reasoning controls for direct Zhipu upstream (provider={})",
+                provider.id
+            );
         }
         // 出站 body 定稿后刷新真值（覆盖 Codex chat 上游模型覆写、转换层模型改写）
         if let Some(m) = filtered_body

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -1195,6 +1195,32 @@ mod tests {
     }
 
     #[test]
+    fn glm_53_flash_preserves_multimodal_image_input() {
+        // Official GLM-5.3-Flash is natively multimodal. It must remain outside
+        // the confirmed text-only registry so proactive media fallback leaves
+        // Chat image_url blocks intact.
+        assert!(!confirmed_text_only_model("glm-5.3-flash"));
+        assert!(!confirmed_text_only_model("zhipu/GLM-5.3-Flash[1M]"));
+
+        let provider = provider(json!({}));
+        let mut body = json!({
+            "model": "glm-5.3-flash",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    { "type": "text", "text": "describe" },
+                    { "type": "image_url", "image_url": { "url": "https://example.com/image.png" } }
+                ]
+            }]
+        });
+
+        let count = replace_images_for_text_only_model(&mut body, &provider, true);
+
+        assert_eq!(count, 0);
+        assert_eq!(body["messages"][0]["content"][1]["type"], "image_url");
+    }
+
+    #[test]
     fn ignores_non_image_errors() {
         let error = ProxyError::UpstreamError {
             status: 400,

--- a/src-tauri/src/proxy/providers/glm_reasoning.rs
+++ b/src-tauri/src/proxy/providers/glm_reasoning.rs
@@ -1,0 +1,629 @@
+//! GLM reasoning capability normalization.
+//!
+//! GLM-5.3 is a thinking-only model. Zhipu's API accepts only
+//! `thinking.type = "enabled"` and the `low | high | max` effort domain.
+//! Claude/Codex clients expose wider, provider-neutral controls, so direct
+//! Zhipu routes need a model-scoped semantic translation before forwarding.
+//!
+//! Vendor references:
+//! - <https://z.ai/blog/glm-5.3>
+//! - <https://docs.z.ai/api-reference/llm/chat-completion>
+//!
+//! The same `enabled + reasoning_effort` shape is accepted by Zhipu's
+//! Anthropic-compatible endpoint (verified against the direct endpoint).
+
+use crate::claude_desktop_config::ONE_M_CONTEXT_MARKER;
+use serde_json::{json, Value};
+use url::Url;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Glm53Effort {
+    Low,
+    High,
+    Max,
+}
+
+impl Glm53Effort {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::High => "high",
+            Self::Max => "max",
+        }
+    }
+}
+
+/// Provider-neutral reasoning intent captured before a format converter can
+/// collapse a tiered request into a plain on/off switch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Glm53ReasoningIntent {
+    effort: Option<Glm53Effort>,
+}
+
+impl Glm53ReasoningIntent {
+    fn new(effort: Option<Glm53Effort>) -> Self {
+        Self { effort }
+    }
+}
+
+/// Exact GLM-5.3 detection after the model-name forms CC Switch accepts are
+/// normalized. Deliberately fail open for unverified variants such as 5.30 or
+/// 5.3v instead of inheriting capabilities by prefix.
+pub(crate) fn is_glm_5_3_model(model: &str) -> bool {
+    let mut normalized = model.trim().to_ascii_lowercase();
+    if normalized
+        .as_bytes()
+        .ends_with(ONE_M_CONTEXT_MARKER.as_bytes())
+    {
+        let keep = normalized.len() - ONE_M_CONTEXT_MARKER.len();
+        normalized.truncate(keep);
+        normalized = normalized.trim_end().to_string();
+    }
+    let normalized = normalized.strip_prefix("models/").unwrap_or(&normalized);
+    normalized.rsplit('/').next() == Some("glm-5.3")
+}
+
+/// Only Zhipu's own endpoints are known to use the `thinking` plus top-level
+/// `reasoning_effort` dialect documented for GLM-5.3. Hosted platforms are
+/// intentionally excluded because their reasoning interface is platform-owned.
+pub(crate) fn is_direct_zhipu_gateway(base_url: &str) -> bool {
+    let Ok(url) = Url::parse(base_url.trim()) else {
+        return false;
+    };
+    matches!(
+        url.host_str().map(str::to_ascii_lowercase).as_deref(),
+        Some("api.z.ai" | "open.bigmodel.cn")
+    )
+}
+
+fn map_effort(value: &str) -> Option<Glm53Effort> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        // GLM-5.3 cannot honor an off/minimal tier. Zhipu's migration guide
+        // explicitly maps disabled thinking to the lowest supported tier.
+        "none" | "off" | "disabled" | "minimal" | "low" => Some(Glm53Effort::Low),
+        "medium" | "high" => Some(Glm53Effort::High),
+        "xhigh" | "max" | "ultra" => Some(Glm53Effort::Max),
+        _ => None,
+    }
+}
+
+fn budget_to_effort(budget: u64) -> Glm53Effort {
+    // Preserve the ordering used by CC Switch's existing Codex→Anthropic
+    // converter, then collapse the provider-neutral middle/high buckets into
+    // GLM-5.3's documented three-level domain.
+    match budget {
+        0..=2_048 => Glm53Effort::Low,
+        2_049..=16_384 => Glm53Effort::High,
+        _ => Glm53Effort::Max,
+    }
+}
+
+/// Capture reasoning intent from either Anthropic/Chat-shaped or
+/// Responses-shaped input. `Some(intent-without-tier)` records an explicit but
+/// unknown/on-with-default control so an illegal field can be removed without
+/// inventing a tier; absence remains `None` and preserves GLM-5.3's max default.
+pub(crate) fn capture_glm_5_3_reasoning_intent(body: &Value) -> Option<Glm53ReasoningIntent> {
+    let thinking_type = body
+        .pointer("/thinking/type")
+        .and_then(Value::as_str)
+        .map(str::to_ascii_lowercase);
+    if thinking_type.as_deref() == Some("disabled") {
+        return Some(Glm53ReasoningIntent::new(Some(Glm53Effort::Low)));
+    }
+
+    if let Some(effort) = body.get("reasoning_effort").and_then(Value::as_str) {
+        return Some(Glm53ReasoningIntent::new(map_effort(effort)));
+    }
+    if let Some(effort) = body.pointer("/reasoning/effort").and_then(Value::as_str) {
+        return Some(Glm53ReasoningIntent::new(map_effort(effort)));
+    }
+    if body.get("reasoning").is_some_and(Value::is_null) {
+        return Some(Glm53ReasoningIntent::new(Some(Glm53Effort::Low)));
+    }
+    if let Some(effort) = body
+        .pointer("/output_config/effort")
+        .and_then(Value::as_str)
+    {
+        return Some(Glm53ReasoningIntent::new(map_effort(effort)));
+    }
+
+    match thinking_type.as_deref() {
+        Some("adaptive") => Some(Glm53ReasoningIntent::new(Some(Glm53Effort::Max))),
+        Some("enabled") => Some(Glm53ReasoningIntent::new(
+            body.pointer("/thinking/budget_tokens")
+                .and_then(Value::as_u64)
+                .map(budget_to_effort),
+        )),
+        Some(_) => Some(Glm53ReasoningIntent::new(None)),
+        None if body.get("reasoning").is_some() => Some(Glm53ReasoningIntent::new(None)),
+        None => None,
+    }
+}
+
+fn merge_intent(
+    outbound: Option<Glm53ReasoningIntent>,
+    original: Option<Glm53ReasoningIntent>,
+) -> Option<Glm53ReasoningIntent> {
+    match (outbound, original) {
+        (Some(current), Some(fallback)) if current.effort.is_none() => {
+            Some(Glm53ReasoningIntent::new(fallback.effort))
+        }
+        (Some(current), _) => Some(current),
+        (None, fallback) => fallback,
+    }
+}
+
+fn remove_output_config_effort(body: &mut Value) -> bool {
+    let mut changed = false;
+    let empty_after = body
+        .get_mut("output_config")
+        .and_then(Value::as_object_mut)
+        .map(|config| {
+            changed |= config.remove("effort").is_some();
+            config.is_empty()
+        })
+        .unwrap_or(false);
+    if empty_after {
+        body.as_object_mut().unwrap().remove("output_config");
+    }
+    changed
+}
+
+fn apply_messages_intent(body: &mut Value, intent: Glm53ReasoningIntent) -> bool {
+    let mut changed = false;
+
+    match body.get_mut("thinking").and_then(Value::as_object_mut) {
+        Some(thinking) => {
+            if thinking.get("type").and_then(Value::as_str) != Some("enabled") {
+                thinking.insert("type".to_string(), json!("enabled"));
+                changed = true;
+            }
+            // GLM-5.3 exposes discrete effort tiers, not Anthropic token budgets.
+            changed |= thinking.remove("budget_tokens").is_some();
+        }
+        None => {
+            body["thinking"] = json!({ "type": "enabled" });
+            changed = true;
+        }
+    }
+
+    let desired_effort = intent.effort.map(Glm53Effort::as_str);
+    let existing_effort = body.get("reasoning_effort").and_then(Value::as_str);
+    match desired_effort {
+        Some(effort) if existing_effort != Some(effort) => {
+            body["reasoning_effort"] = json!(effort);
+            changed = true;
+        }
+        None if body.get("reasoning_effort").is_some() => {
+            body.as_object_mut().unwrap().remove("reasoning_effort");
+            changed = true;
+        }
+        _ => {}
+    }
+    if let Some(object) = body.as_object_mut() {
+        // Messages/Chat routes use Zhipu's top-level reasoning_effort dialect,
+        // never the OpenAI Responses reasoning object.
+        changed |= object.remove("reasoning").is_some();
+    }
+    changed |= remove_output_config_effort(body);
+
+    changed
+}
+
+fn apply_responses_intent(body: &mut Value, intent: Glm53ReasoningIntent) -> bool {
+    let mut changed = false;
+
+    if let Some(object) = body.as_object_mut() {
+        changed |= object.remove("thinking").is_some();
+        changed |= object.remove("reasoning_effort").is_some();
+    }
+    changed |= remove_output_config_effort(body);
+
+    if let Some(effort) = intent.effort {
+        match body.get_mut("reasoning").and_then(Value::as_object_mut) {
+            Some(reasoning) => {
+                if reasoning.get("effort").and_then(Value::as_str) != Some(effort.as_str()) {
+                    reasoning.insert("effort".to_string(), json!(effort.as_str()));
+                    changed = true;
+                }
+            }
+            None => {
+                body["reasoning"] = json!({ "effort": effort.as_str() });
+                changed = true;
+            }
+        }
+    } else {
+        let remove_reasoning = match body.get_mut("reasoning") {
+            Some(Value::Object(reasoning)) => {
+                changed |= reasoning.remove("effort").is_some();
+                reasoning.is_empty()
+            }
+            Some(Value::Null) => true,
+            _ => false,
+        };
+        if remove_reasoning {
+            body.as_object_mut().unwrap().remove("reasoning");
+            changed = true;
+        }
+    }
+
+    changed
+}
+
+/// Normalize the final outbound request for a direct Zhipu GLM-5.3 route.
+///
+/// `original_intent` is captured before protocol conversion. It restores tier
+/// information that an on/off-only generic converter may otherwise discard.
+pub(crate) fn normalize_direct_zhipu_glm_5_3_request(
+    base_url: &str,
+    body: &mut Value,
+    original_intent: Option<Glm53ReasoningIntent>,
+) -> bool {
+    if !is_direct_zhipu_gateway(base_url)
+        || !body
+            .get("model")
+            .and_then(Value::as_str)
+            .is_some_and(is_glm_5_3_model)
+    {
+        return false;
+    }
+
+    let Some(intent) = merge_intent(capture_glm_5_3_reasoning_intent(body), original_intent) else {
+        // No client reasoning control: preserve the documented enabled+max default.
+        return false;
+    };
+
+    if body.get("messages").is_some() {
+        apply_messages_intent(body, intent)
+    } else if body.get("input").is_some()
+        || body.get("instructions").is_some()
+        || body.get("reasoning").is_some()
+    {
+        apply_responses_intent(body, intent)
+    } else {
+        // A future or misconfigured wire format (for example Gemini native)
+        // must fail open rather than receive OpenAI Responses-only fields.
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::CodexChatReasoningConfig;
+    use crate::proxy::providers::transform_responses;
+    use crate::proxy::providers::{transform, transform_codex_anthropic, transform_codex_chat};
+
+    #[test]
+    fn model_detection_is_exact_and_normalizes_supported_wrappers() {
+        for model in [
+            "glm-5.3",
+            "GLM-5.3",
+            "glm-5.3[1M]",
+            "zhipu/glm-5.3",
+            "models/zai-org/GLM-5.3[1m]",
+        ] {
+            assert!(is_glm_5_3_model(model), "{model}");
+        }
+        for model in ["glm-5.2", "glm-5.30", "glm-5.3v", "glm-5.3-air"] {
+            assert!(!is_glm_5_3_model(model), "{model}");
+        }
+    }
+
+    #[test]
+    fn direct_gateway_detection_rejects_host_lookalikes_and_aggregators() {
+        for url in [
+            "https://api.z.ai/api/anthropic",
+            "https://open.bigmodel.cn/api/coding/paas/v4",
+        ] {
+            assert!(is_direct_zhipu_gateway(url), "{url}");
+        }
+        for url in [
+            "https://api.z.ai.evil.example/v1",
+            "https://openrouter.ai/api/v1",
+            "https://api.siliconflow.cn/v1",
+            "not-a-url",
+        ] {
+            assert!(!is_direct_zhipu_gateway(url), "{url}");
+        }
+    }
+
+    #[test]
+    fn effort_mapping_covers_the_client_superset() {
+        for (input, expected) in [
+            ("none", Glm53Effort::Low),
+            ("off", Glm53Effort::Low),
+            ("disabled", Glm53Effort::Low),
+            ("minimal", Glm53Effort::Low),
+            ("low", Glm53Effort::Low),
+            ("medium", Glm53Effort::High),
+            ("high", Glm53Effort::High),
+            ("xhigh", Glm53Effort::Max),
+            ("max", Glm53Effort::Max),
+            ("ultra", Glm53Effort::Max),
+        ] {
+            assert_eq!(map_effort(input), Some(expected), "{input}");
+        }
+        assert_eq!(map_effort("unknown"), None);
+    }
+
+    #[test]
+    fn messages_disabled_becomes_enabled_low_and_preserves_siblings() {
+        let mut body = json!({
+            "model": "glm-5.3",
+            "messages": [{ "role": "user", "content": "hi" }],
+            "thinking": {
+                "type": "disabled",
+                "budget_tokens": 8192,
+                "clear_thinking": false
+            },
+            "output_config": { "effort": "max", "verbosity": "low" }
+        });
+
+        assert!(normalize_direct_zhipu_glm_5_3_request(
+            "https://api.z.ai/api/anthropic",
+            &mut body,
+            None,
+        ));
+        assert_eq!(
+            body["thinking"],
+            json!({ "type": "enabled", "clear_thinking": false })
+        );
+        assert_eq!(body["reasoning_effort"], "low");
+        assert_eq!(body["output_config"], json!({ "verbosity": "low" }));
+    }
+
+    #[test]
+    fn adaptive_claude_controls_become_enabled_max() {
+        let mut body = json!({
+            "model": "zhipu/GLM-5.3[1M]",
+            "messages": [{ "role": "user", "content": "hi" }],
+            "thinking": { "type": "adaptive" },
+            "output_config": { "effort": "max" }
+        });
+
+        normalize_direct_zhipu_glm_5_3_request(
+            "https://open.bigmodel.cn/api/anthropic",
+            &mut body,
+            None,
+        );
+        assert_eq!(body["thinking"], json!({ "type": "enabled" }));
+        assert_eq!(body["reasoning_effort"], "max");
+        assert!(body.get("output_config").is_none());
+    }
+
+    #[test]
+    fn legacy_budget_controls_collapse_to_legal_effort_tiers() {
+        for (budget, expected) in [(2_048, "low"), (8_192, "high"), (24_576, "max")] {
+            let mut body = json!({
+                "model": "glm-5.3",
+                "messages": [{ "role": "user", "content": "hi" }],
+                "thinking": { "type": "enabled", "budget_tokens": budget }
+            });
+
+            normalize_direct_zhipu_glm_5_3_request(
+                "https://api.z.ai/api/anthropic",
+                &mut body,
+                None,
+            );
+            assert_eq!(body["thinking"], json!({ "type": "enabled" }));
+            assert_eq!(body["reasoning_effort"], expected, "budget={budget}");
+        }
+    }
+
+    #[test]
+    fn converted_chat_restores_original_effort_when_converter_kept_only_on_off() {
+        let original = json!({
+            "reasoning": { "effort": "medium" },
+            "input": "hi"
+        });
+        let intent = capture_glm_5_3_reasoning_intent(&original);
+        let mut converted = json!({
+            "model": "glm-5.3",
+            "messages": [{ "role": "user", "content": "hi" }],
+            "thinking": { "type": "enabled" }
+        });
+
+        assert!(normalize_direct_zhipu_glm_5_3_request(
+            "https://open.bigmodel.cn/api/coding/paas/v4",
+            &mut converted,
+            intent,
+        ));
+        assert_eq!(converted["thinking"]["type"], "enabled");
+        assert_eq!(converted["reasoning_effort"], "high");
+    }
+
+    #[test]
+    fn converted_messages_disable_wins_over_a_stronger_original_tier() {
+        let original = capture_glm_5_3_reasoning_intent(&json!({
+            "reasoning": { "effort": "max" }
+        }));
+        let mut converted = json!({
+            "model": "glm-5.3",
+            "messages": [{ "role": "user", "content": "hi" }],
+            "thinking": { "type": "disabled" }
+        });
+
+        normalize_direct_zhipu_glm_5_3_request(
+            "https://api.z.ai/api/anthropic",
+            &mut converted,
+            original,
+        );
+        assert_eq!(converted["thinking"]["type"], "enabled");
+        assert_eq!(converted["reasoning_effort"], "low");
+    }
+
+    #[test]
+    fn responses_none_becomes_low_and_preserves_reasoning_siblings() {
+        let mut body = json!({
+            "model": "glm-5.3",
+            "input": "hi",
+            "reasoning": { "effort": "none", "summary": "auto" }
+        });
+
+        normalize_direct_zhipu_glm_5_3_request("https://api.z.ai/api/v1", &mut body, None);
+        assert_eq!(body["reasoning"]["effort"], "low");
+        assert_eq!(body["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn responses_unknown_effort_is_dropped_without_losing_siblings() {
+        let mut body = json!({
+            "model": "glm-5.3",
+            "input": "hi",
+            "reasoning": { "effort": "bogus", "summary": "auto" }
+        });
+
+        normalize_direct_zhipu_glm_5_3_request("https://api.z.ai/api/v1", &mut body, None);
+        assert!(body["reasoning"].get("effort").is_none());
+        assert_eq!(body["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn responses_conversion_restores_disabled_intent_after_field_loss() {
+        let original = capture_glm_5_3_reasoning_intent(&json!({
+            "thinking": { "type": "disabled" }
+        }));
+        let mut converted = json!({ "model": "glm-5.3", "input": "hi" });
+
+        normalize_direct_zhipu_glm_5_3_request("https://api.z.ai/api/v1", &mut converted, original);
+        assert_eq!(converted["reasoning"], json!({ "effort": "low" }));
+    }
+
+    #[test]
+    fn claude_to_chat_and_responses_restore_disabled_as_low() {
+        let input = json!({
+            "model": "glm-5.3",
+            "max_tokens": 128,
+            "thinking": { "type": "disabled" },
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+        let intent = capture_glm_5_3_reasoning_intent(&input);
+
+        let mut chat = transform::anthropic_to_openai_with_reasoning_content(input.clone(), false)
+            .expect("Claude→Chat conversion");
+        assert!(chat.get("thinking").is_none());
+        normalize_direct_zhipu_glm_5_3_request(
+            "https://open.bigmodel.cn/api/coding/paas/v4",
+            &mut chat,
+            intent,
+        );
+        assert_eq!(chat["thinking"]["type"], "enabled");
+        assert_eq!(chat["reasoning_effort"], "low");
+
+        let mut responses = transform_responses::anthropic_to_responses(input, None, false, false)
+            .expect("Claude→Responses conversion");
+        assert!(responses.get("reasoning").is_none());
+        normalize_direct_zhipu_glm_5_3_request("https://api.z.ai/api/v1", &mut responses, intent);
+        assert_eq!(responses["reasoning"], json!({ "effort": "low" }));
+    }
+
+    #[test]
+    fn codex_to_chat_and_anthropic_never_forward_disabled() {
+        let input = json!({
+            "model": "glm-5.3",
+            "max_output_tokens": 128,
+            "reasoning": null,
+            "input": [{ "role": "user", "content": "hi" }]
+        });
+        let intent = capture_glm_5_3_reasoning_intent(&input);
+        let toggle_only_zhipu = CodexChatReasoningConfig {
+            supports_thinking: Some(true),
+            supports_effort: Some(false),
+            thinking_param: Some("thinking".to_string()),
+            effort_param: Some("none".to_string()),
+            effort_value_mode: None,
+            output_format: Some("reasoning_content".to_string()),
+            effort_levels: None,
+        };
+
+        let mut chat = transform_codex_chat::responses_to_chat_completions_with_reasoning(
+            input.clone(),
+            Some(&toggle_only_zhipu),
+        )
+        .expect("Codex→Chat conversion");
+        assert_eq!(chat["thinking"]["type"], "disabled");
+        normalize_direct_zhipu_glm_5_3_request(
+            "https://open.bigmodel.cn/api/coding/paas/v4",
+            &mut chat,
+            intent,
+        );
+        assert_eq!(chat["thinking"]["type"], "enabled");
+        assert_eq!(chat["reasoning_effort"], "low");
+
+        let mut anthropic = transform_codex_anthropic::responses_request_to_anthropic(input, 128)
+            .expect("Codex→Anthropic conversion");
+        assert!(anthropic.get("thinking").is_none());
+        normalize_direct_zhipu_glm_5_3_request(
+            "https://api.z.ai/api/anthropic",
+            &mut anthropic,
+            intent,
+        );
+        assert_eq!(anthropic["thinking"]["type"], "enabled");
+        assert_eq!(anthropic["reasoning_effort"], "low");
+    }
+
+    #[test]
+    fn absent_controls_and_neighboring_models_remain_byte_identical() {
+        let cases = [
+            json!({ "model": "glm-5.3", "messages": [{ "role": "user", "content": "hi" }] }),
+            json!({ "model": "glm-5.2", "messages": [], "thinking": { "type": "disabled" } }),
+            json!({ "model": "glm-5.3", "messages": [], "thinking": { "type": "disabled" } }),
+        ];
+        let urls = [
+            "https://api.z.ai/api/anthropic",
+            "https://api.z.ai/api/anthropic",
+            "https://openrouter.ai/api/v1",
+        ];
+
+        for (mut body, url) in cases.into_iter().zip(urls) {
+            let original = body.clone();
+            assert!(!normalize_direct_zhipu_glm_5_3_request(
+                url, &mut body, None
+            ));
+            assert_eq!(body, original);
+        }
+    }
+
+    #[test]
+    fn unknown_wire_shapes_fail_open_even_with_a_captured_intent() {
+        let intent = capture_glm_5_3_reasoning_intent(&json!({
+            "thinking": { "type": "disabled" }
+        }));
+        let mut gemini = json!({
+            "model": "glm-5.3",
+            "contents": [{ "role": "user", "parts": [{ "text": "hi" }] }],
+            "generationConfig": {}
+        });
+        let original = gemini.clone();
+
+        assert!(!normalize_direct_zhipu_glm_5_3_request(
+            "https://api.z.ai/api/anthropic",
+            &mut gemini,
+            intent,
+        ));
+        assert_eq!(gemini, original);
+    }
+
+    #[test]
+    fn final_override_tier_wins_on_the_second_normalization_pass() {
+        let original = capture_glm_5_3_reasoning_intent(&json!({
+            "thinking": { "type": "disabled" }
+        }));
+        let mut body = json!({
+            "model": "glm-5.3",
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+        normalize_direct_zhipu_glm_5_3_request(
+            "https://api.z.ai/api/anthropic",
+            &mut body,
+            original,
+        );
+        assert_eq!(body["reasoning_effort"], "low");
+
+        body["reasoning_effort"] = json!("max");
+        normalize_direct_zhipu_glm_5_3_request("https://api.z.ai/api/anthropic", &mut body, None);
+        assert_eq!(body["thinking"]["type"], "enabled");
+        assert_eq!(body["reasoning_effort"], "max");
+    }
+}

--- a/src-tauri/src/proxy/providers/glm_reasoning.rs
+++ b/src-tauri/src/proxy/providers/glm_reasoning.rs
@@ -147,6 +147,25 @@ pub(crate) fn capture_glm_5_3_reasoning_intent(body: &Value) -> Option<Glm53Reas
     }
 }
 
+fn capture_glm_5_3_override_intent(body: &Value) -> Option<Glm53ReasoningIntent> {
+    // An override object may contain neighboring fields such as
+    // `reasoning.summary` or `thinking.clear_thinking` without overriding the
+    // reasoning tier. Only the actual control fields establish a new intent.
+    let has_explicit_control = body.pointer("/thinking/type").is_some()
+        || body.get("reasoning_effort").is_some()
+        || body.pointer("/reasoning/effort").is_some()
+        || body.get("reasoning").is_some_and(Value::is_null)
+        || body.pointer("/output_config/effort").is_some();
+    if !has_explicit_control {
+        return None;
+    }
+
+    // Preserve the ordinary capture precedence when the override itself
+    // contains conflicting controls. A present but malformed control remains
+    // authoritative as intent-without-tier so the illegal value is removed.
+    Some(capture_glm_5_3_reasoning_intent(body).unwrap_or_else(|| Glm53ReasoningIntent::new(None)))
+}
+
 fn merge_intent(
     outbound: Option<Glm53ReasoningIntent>,
     original: Option<Glm53ReasoningIntent>,
@@ -266,6 +285,18 @@ pub(crate) fn normalize_direct_zhipu_glm_5_3_request(
     body: &mut Value,
     original_intent: Option<Glm53ReasoningIntent>,
 ) -> bool {
+    normalize_direct_zhipu_glm_5_3_request_with_override(base_url, body, original_intent, None)
+}
+
+/// Normalize with an optional local body-override layer. Explicit reasoning
+/// controls in that layer outrank both the merged final body and the original
+/// pre-conversion intent, regardless of which stale sibling fields remain.
+pub(crate) fn normalize_direct_zhipu_glm_5_3_request_with_override(
+    base_url: &str,
+    body: &mut Value,
+    original_intent: Option<Glm53ReasoningIntent>,
+    final_override_body: Option<&Value>,
+) -> bool {
     if !is_direct_zhipu_gateway(base_url)
         || !body
             .get("model")
@@ -275,7 +306,9 @@ pub(crate) fn normalize_direct_zhipu_glm_5_3_request(
         return false;
     }
 
-    let Some(intent) = merge_intent(capture_glm_5_3_reasoning_intent(body), original_intent) else {
+    let override_intent = final_override_body.and_then(capture_glm_5_3_override_intent);
+    let merged_intent = merge_intent(capture_glm_5_3_reasoning_intent(body), original_intent);
+    let Some(intent) = override_intent.or(merged_intent) else {
         // No client reasoning control: preserve the upstream-enabled default
         // and its provider-selected effort rather than inventing a tier.
         return false;
@@ -390,6 +423,69 @@ mod tests {
         );
         assert_eq!(body["reasoning_effort"], "low");
         assert_eq!(body["output_config"], json!({ "verbosity": "low" }));
+    }
+
+    #[test]
+    fn final_override_layer_resolves_stale_control_conflicts_symmetrically() {
+        for sibling_only in [
+            json!({ "thinking": { "clear_thinking": false } }),
+            json!({ "reasoning": { "summary": "auto" } }),
+        ] {
+            assert_eq!(capture_glm_5_3_override_intent(&sibling_only), None);
+        }
+        assert_eq!(
+            capture_glm_5_3_override_intent(&json!({ "reasoning_effort": null })),
+            Some(Glm53ReasoningIntent::new(None))
+        );
+
+        for (override_body, expected_effort) in [
+            (json!({ "reasoning_effort": "max" }), "max"),
+            (json!({ "thinking": { "type": "disabled" } }), "low"),
+        ] {
+            // The merged body is deliberately identical in both cases. The
+            // explicit override layer determines which of the stale siblings
+            // is authoritative.
+            let mut body = json!({
+                "model": "glm-5.3-flash",
+                "messages": [{ "role": "user", "content": "hi" }],
+                "thinking": { "type": "disabled", "clear_thinking": false },
+                "reasoning_effort": "max"
+            });
+
+            assert!(normalize_direct_zhipu_glm_5_3_request_with_override(
+                "https://open.bigmodel.cn/api/anthropic",
+                &mut body,
+                None,
+                Some(&override_body),
+            ));
+            assert_eq!(
+                body["thinking"],
+                json!({ "type": "enabled", "clear_thinking": false })
+            );
+            assert_eq!(body["reasoning_effort"], expected_effort);
+        }
+
+        for (override_body, expected_effort) in [
+            (json!({ "reasoning": { "effort": "max" } }), "max"),
+            (json!({ "thinking": { "type": "disabled" } }), "low"),
+        ] {
+            let mut body = json!({
+                "model": "glm-5.3-flash",
+                "input": "hi",
+                "thinking": { "type": "disabled" },
+                "reasoning": { "effort": "max", "summary": "auto" }
+            });
+
+            assert!(normalize_direct_zhipu_glm_5_3_request_with_override(
+                "https://api.z.ai/api/v1",
+                &mut body,
+                None,
+                Some(&override_body),
+            ));
+            assert!(body.get("thinking").is_none());
+            assert_eq!(body["reasoning"]["effort"], expected_effort);
+            assert_eq!(body["reasoning"]["summary"], "auto");
+        }
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/glm_reasoning.rs
+++ b/src-tauri/src/proxy/providers/glm_reasoning.rs
@@ -1,13 +1,14 @@
 //! GLM reasoning capability normalization.
 //!
-//! GLM-5.3 is a thinking-only model. Zhipu's API accepts only
-//! `thinking.type = "enabled"` and the `low | high | max` effort domain.
+//! GLM-5.3 and GLM-5.3-Flash are thinking-only models. Zhipu's API accepts
+//! only `thinking.type = "enabled"` and the `low | high | max` effort domain.
 //! Claude/Codex clients expose wider, provider-neutral controls, so direct
 //! Zhipu routes need a model-scoped semantic translation before forwarding.
 //!
 //! Vendor references:
 //! - <https://z.ai/blog/glm-5.3>
 //! - <https://docs.z.ai/api-reference/llm/chat-completion>
+//! - <https://docs.bigmodel.cn/cn/guide/models/vlm/glm-5.3-flash>
 //!
 //! The same `enabled + reasoning_effort` shape is accepted by Zhipu's
 //! Anthropic-compatible endpoint (verified against the direct endpoint).
@@ -15,6 +16,8 @@
 use crate::claude_desktop_config::ONE_M_CONTEXT_MARKER;
 use serde_json::{json, Value};
 use url::Url;
+
+const THINKING_ONLY_GLM_5_3_MODEL_TAILS: &[&str] = &["glm-5.3", "glm-5.3-flash"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Glm53Effort {
@@ -46,10 +49,11 @@ impl Glm53ReasoningIntent {
     }
 }
 
-/// Exact GLM-5.3 detection after the model-name forms CC Switch accepts are
-/// normalized. Deliberately fail open for unverified variants such as 5.30 or
-/// 5.3v instead of inheriting capabilities by prefix.
-pub(crate) fn is_glm_5_3_model(model: &str) -> bool {
+/// Exact GLM-5.3 forced-thinking-family detection after the model-name forms
+/// CC Switch accepts are normalized. Deliberately fail open for unverified
+/// variants such as 5.30, 5.3v, or flashx instead of inheriting capabilities
+/// by prefix.
+pub(crate) fn is_thinking_only_glm_5_3_family_model(model: &str) -> bool {
     let mut normalized = model.trim().to_ascii_lowercase();
     if normalized
         .as_bytes()
@@ -60,7 +64,10 @@ pub(crate) fn is_glm_5_3_model(model: &str) -> bool {
         normalized = normalized.trim_end().to_string();
     }
     let normalized = normalized.strip_prefix("models/").unwrap_or(&normalized);
-    normalized.rsplit('/').next() == Some("glm-5.3")
+    normalized
+        .rsplit('/')
+        .next()
+        .is_some_and(|tail| THINKING_ONLY_GLM_5_3_MODEL_TAILS.contains(&tail))
 }
 
 /// Only Zhipu's own endpoints are known to use the `thinking` plus top-level
@@ -101,7 +108,7 @@ fn budget_to_effort(budget: u64) -> Glm53Effort {
 /// Capture reasoning intent from either Anthropic/Chat-shaped or
 /// Responses-shaped input. `Some(intent-without-tier)` records an explicit but
 /// unknown/on-with-default control so an illegal field can be removed without
-/// inventing a tier; absence remains `None` and preserves GLM-5.3's max default.
+/// inventing a tier; absence remains `None` and preserves the upstream default.
 pub(crate) fn capture_glm_5_3_reasoning_intent(body: &Value) -> Option<Glm53ReasoningIntent> {
     let thinking_type = body
         .pointer("/thinking/type")
@@ -250,7 +257,7 @@ fn apply_responses_intent(body: &mut Value, intent: Glm53ReasoningIntent) -> boo
     changed
 }
 
-/// Normalize the final outbound request for a direct Zhipu GLM-5.3 route.
+/// Normalize the final outbound request for a direct Zhipu GLM-5.3-family route.
 ///
 /// `original_intent` is captured before protocol conversion. It restores tier
 /// information that an on/off-only generic converter may otherwise discard.
@@ -263,13 +270,14 @@ pub(crate) fn normalize_direct_zhipu_glm_5_3_request(
         || !body
             .get("model")
             .and_then(Value::as_str)
-            .is_some_and(is_glm_5_3_model)
+            .is_some_and(is_thinking_only_glm_5_3_family_model)
     {
         return false;
     }
 
     let Some(intent) = merge_intent(capture_glm_5_3_reasoning_intent(body), original_intent) else {
-        // No client reasoning control: preserve the documented enabled+max default.
+        // No client reasoning control: preserve the upstream-enabled default
+        // and its provider-selected effort rather than inventing a tier.
         return false;
     };
 
@@ -302,11 +310,22 @@ mod tests {
             "glm-5.3[1M]",
             "zhipu/glm-5.3",
             "models/zai-org/GLM-5.3[1m]",
+            "glm-5.3-flash",
+            "GLM-5.3-FLASH[1M]",
+            "zhipu/glm-5.3-flash",
+            "models/zai-org/GLM-5.3-Flash[1m]",
         ] {
-            assert!(is_glm_5_3_model(model), "{model}");
+            assert!(is_thinking_only_glm_5_3_family_model(model), "{model}");
         }
-        for model in ["glm-5.2", "glm-5.30", "glm-5.3v", "glm-5.3-air"] {
-            assert!(!is_glm_5_3_model(model), "{model}");
+        for model in [
+            "glm-5.2",
+            "glm-5.30",
+            "glm-5.3v",
+            "glm-5.3-air",
+            "glm-5.3-flashx",
+            "glm-5.3-flash-vision",
+        ] {
+            assert!(!is_thinking_only_glm_5_3_family_model(model), "{model}");
         }
     }
 
@@ -350,7 +369,7 @@ mod tests {
     #[test]
     fn messages_disabled_becomes_enabled_low_and_preserves_siblings() {
         let mut body = json!({
-            "model": "glm-5.3",
+            "model": "glm-5.3-flash",
             "messages": [{ "role": "user", "content": "hi" }],
             "thinking": {
                 "type": "disabled",
@@ -419,7 +438,7 @@ mod tests {
         });
         let intent = capture_glm_5_3_reasoning_intent(&original);
         let mut converted = json!({
-            "model": "glm-5.3",
+            "model": "glm-5.3-flash",
             "messages": [{ "role": "user", "content": "hi" }],
             "thinking": { "type": "enabled" }
         });
@@ -456,7 +475,7 @@ mod tests {
     #[test]
     fn responses_none_becomes_low_and_preserves_reasoning_siblings() {
         let mut body = json!({
-            "model": "glm-5.3",
+            "model": "glm-5.3-flash",
             "input": "hi",
             "reasoning": { "effort": "none", "summary": "auto" }
         });
@@ -567,10 +586,12 @@ mod tests {
     fn absent_controls_and_neighboring_models_remain_byte_identical() {
         let cases = [
             json!({ "model": "glm-5.3", "messages": [{ "role": "user", "content": "hi" }] }),
+            json!({ "model": "glm-5.3-flash", "messages": [{ "role": "user", "content": "hi" }] }),
             json!({ "model": "glm-5.2", "messages": [], "thinking": { "type": "disabled" } }),
             json!({ "model": "glm-5.3", "messages": [], "thinking": { "type": "disabled" } }),
         ];
         let urls = [
+            "https://api.z.ai/api/anthropic",
             "https://api.z.ai/api/anthropic",
             "https://api.z.ai/api/anthropic",
             "https://openrouter.ai/api/v1",

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -24,6 +24,7 @@ pub mod copilot_model_map;
 mod gemini;
 pub(crate) mod gemini_schema;
 pub mod gemini_shadow;
+pub(crate) mod glm_reasoning;
 pub mod models;
 pub(crate) mod reasoning_bridge;
 pub mod streaming;


### PR DESCRIPTION
## Summary / 概述

GLM-5.3 and GLM-5.3-Flash are thinking-only models, but Claude Code intentionally sends `thinking.type: "disabled"` for some auxiliary/workflow requests. CC Switch currently forwards that control unchanged, and the direct Zhipu endpoints reject it with HTTP 400 / business code 1210.

This PR adds one model-scoped, direct-Zhipu normalization layer that:

- recognizes the exact final upstream models `glm-5.3` and `glm-5.3-flash` after case, vendor-prefix, `models/`, and `[1m]` normalization;
- translates off/minimal intent to Zhipu's supported `enabled + low` contract;
- clamps provider-neutral effort values to the legal `low | high | max` set;
- preserves reasoning intent across Anthropic, Chat Completions, and Responses conversions, including converters that collapse tiers to on/off;
- revalidates final local body overrides so they cannot reintroduce an impossible disabled state;
- fails open for neighboring/unverified model names, hosted aggregators, host lookalikes, and unknown wire formats;
- preserves GLM-5.3-Flash image input as native multimodal content instead of applying the text-only media fallback.

The normalizer runs once, after final model mapping/protocol conversion and local request overrides establish the actual outbound model. One shared capability rule therefore covers:

1. Claude -> Anthropic passthrough
2. Claude -> OpenAI Chat
3. Claude -> OpenAI Responses
4. Codex/Grok Build Responses -> Chat
5. Codex/Grok Build Responses -> Anthropic
6. native Responses passthrough

## Related Issue / 关联 Issue

Fixes #6737.

Related but intentionally separate work:

- #6522 adds GLM-5.3 to OpenClaw presets.
- #6591 adds GLM-5.3 pricing.

Preset/catalog and pricing work are not duplicated here. This PR stays focused on protocol compatibility and verified media behavior.

## Official contract and live verification

Authoritative Zhipu sources:

- GLM-5.3 release/migration note: https://z.ai/blog/glm-5.3
- GLM-5.3-Flash model guide: https://docs.bigmodel.cn/cn/guide/models/vlm/glm-5.3-flash
- Thinking-mode guide: https://docs.bigmodel.cn/cn/guide/capabilities/thinking-mode
- Chat Completions API reference: https://docs.z.ai/api-reference/llm/chat-completion

The Flash guide documents model code `glm-5.3-flash`, text parameters matching GLM-5.3, a 1M context window, `thinking.type` accepting only `enabled`, and native image/video/file input. The thinking guide explicitly lists both GLM-5.3 and GLM-5.3-Flash as forced-thinking models.

| Client intent | Direct Zhipu wire value |
|---|---|
| none / off / disabled / minimal | enabled + low |
| low | low |
| medium / high | high |
| xhigh / max / ultra | max |
| no reasoning control | leave unchanged; preserve upstream defaults |

Live A/B against the configured direct Zhipu endpoints:

| Model and request | Result |
|---|---|
| GLM-5.3, Anthropic `thinking.type: disabled` | HTTP 400 / code 1210 |
| GLM-5.3, Anthropic `enabled` + top-level `reasoning_effort: low` | HTTP 200 |
| GLM-5.3-Flash, Anthropic `thinking.type: disabled` | HTTP 400 / code 1210: model always thinks; use low/high/max |
| GLM-5.3-Flash, Anthropic `enabled` + top-level `reasoning_effort: low` | HTTP 200, response model `glm-5.3-flash` |
| GLM-5.3-Flash, Chat request with an official public URL `image_url` block | HTTP 200 with an image description |

## Implementation notes

- The capability is an explicit exact-model set: `{glm-5.3, glm-5.3-flash}`. Prefix matching is deliberately avoided; tests reject `glm-5.30`, `glm-5.3v`, `glm-5.3-flashx`, and `glm-5.3-flash-vision`.
- The capability is exact-host gated; OpenRouter, SiliconFlow, ModelScope, neutral relays, and URL host lookalikes are untouched.
- The original client reasoning intent is captured before conversion, then applied to the final outbound dialect.
- Local body overrides run before the capability guard: overriding away from GLM cannot leak GLM-only fields, while overriding to GLM can still recover a tier lost by conversion.
- Explicit override reasoning controls have their own highest-priority intent layer. This makes effort and disabled overrides authoritative in both directions even when deep merge leaves a stale conflicting sibling. A present but malformed override control is stripped without falling back to an older tier.
- Messages/Chat uses Zhipu's `thinking + reasoning_effort` shape.
- Responses uses the standard `reasoning.effort` object and preserves siblings such as `summary`.
- Unknown effort values are removed rather than forwarded to a strict upstream.
- Flash remains outside the confirmed text-only registry. A behavior-level media test verifies that `image_url` content is not replaced.
- Requests with no reasoning control remain byte-identical, including Flash; the normalizer does not invent a default tier.
- No user-facing text or i18n changes.

## Screenshots / 截图

Not applicable - proxy protocol fix only.

## Validation / 验证

- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::providers::glm_reasoning` - **17 passed**
- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::media_sanitizer::tests::glm_53_flash_preserves_multimodal_image_input` - **1 passed**
- `cargo test --manifest-path src-tauri/Cargo.toml --lib proxy::forwarder::tests::final_` - **3 passed**
- `cargo test --manifest-path src-tauri/Cargo.toml --lib -- --skip services::provider::tests::update_current_claude_desktop_provider_syncs_profile_when_proxy_takeover_is_active` - **2746 passed, 5 ignored, 1 filtered**
  - The skipped existing test binds default port 15721, which is occupied by the locally running CC Switch instance.
- `pnpm test:unit` - **133 files / 1012 tests passed**
- `pnpm typecheck` - passed
- `pnpm format:check` - passed
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml` - passed
- Strict Clippy for the final Rust tree passed with only the current-main baseline allowances required by local Rust 1.98.
- `git diff --check` - passed
- After addressing the GitHub Codex model-override ordering and stale-control precedence comments, an independent read-only review found no remaining P0/P1/P2 across protocol correctness, path coverage, model overmatching, media preservation, override semantics, or test strength.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] Changed Rust code passes strict Clippy
- [x] Updated i18n files if user-facing text changed / 无用户可见文本变更
