### PR TITLE
fix(windows): switch lifecycle .bat to UTF-8 codepage before anchored commands

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -378,6 +378,16 @@ impl FromStr for ToolLifecycleAction {
     }
 }
 
+/// Windows lifecycle .bat 头部。`@echo off` 之后必须先 `chcp 65001`：脚本以
+/// UTF-8 写入（`fs::write`），而 cmd.exe 默认按 OEM 代码页解析批处理内容——
+/// 锚定路径含非 ASCII 字符（如中文用户名 `C:\Users\张三\...`）时会被错解成
+/// 乱码路径，cmd 报 "The system cannot find the path specified."（#6741）。
+/// 代码页切换必须排在任何携带路径的命令行之前。
+#[cfg(target_os = "windows")]
+fn windows_lifecycle_bat_header() -> Vec<String> {
+    vec!["@echo off".to_string(), "chcp 65001 >nul".to_string()]
+}
+
 fn build_tool_lifecycle_command(
     tools: &[&str],
     action: ToolLifecycleAction,
@@ -395,7 +405,7 @@ fn build_tool_lifecycle_command(
     }
 
     #[cfg(target_os = "windows")]
-    lines.push("@echo off".to_string());
+    lines.extend(windows_lifecycle_bat_header());
 
     for tool in tools {
         let label = tool_display_name(tool);
@@ -6737,6 +6747,41 @@ mod tests {
             decode_command_output(&output.stdout).trim(),
             "codex-cli 0.144.3"
         );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn lifecycle_bat_runs_anchored_command_with_non_ascii_path() {
+        // 非 ASCII 路径（如中文用户名）下的锚定命令：.bat 以 UTF-8 写入，cmd.exe
+        // 默认按 OEM 代码页解析会把路径错解成乱码；头部切到 UTF-8 后必须能跑通。
+        let base = tempfile::tempdir().expect("temp dir should be created");
+        let tool_dir = base.path().join("cc-switch-工具目录");
+        std::fs::create_dir_all(&tool_dir).expect("non-ascii tool dir should be created");
+        let npm = tool_dir.join("npm.cmd");
+        std::fs::write(&npm, "@echo off\r\nexit /b 0\r\n")
+            .expect("fake npm.cmd should be written");
+
+        let command_line = format!(
+            "{header}\r\ncall \"{npm}\"\r\nif errorlevel 1 exit /b %errorlevel%",
+            header = windows_lifecycle_bat_header().join("\r\n"),
+            npm = npm.display(),
+        );
+
+        let result = run_tool_lifecycle_silently(&command_line, "test_non_ascii_path");
+        assert!(
+            result.is_ok(),
+            "anchored command with non-ASCII path should run under the UTF-8 header: {result:?}"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn build_tool_lifecycle_command_emits_utf8_header_first() {
+        let command = build_tool_lifecycle_command(&["claude"], ToolLifecycleAction::Update, None)
+            .expect("lifecycle command should build");
+        let mut lines = command.lines();
+        assert_eq!(lines.next(), Some("@echo off"));
+        assert_eq!(lines.next(), Some("chcp 65001 >nul"));
     }
 
     #[test]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -6758,8 +6758,7 @@ mod tests {
         let tool_dir = base.path().join("cc-switch-工具目录");
         std::fs::create_dir_all(&tool_dir).expect("non-ascii tool dir should be created");
         let npm = tool_dir.join("npm.cmd");
-        std::fs::write(&npm, "@echo off\r\nexit /b 0\r\n")
-            .expect("fake npm.cmd should be written");
+        std::fs::write(&npm, "@echo off\r\nexit /b 0\r\n").expect("fake npm.cmd should be written");
 
         let command_line = format!(
             "{header}\r\ncall \"{npm}\"\r\nif errorlevel 1 exit /b %errorlevel%",


### PR DESCRIPTION
## Root cause

Fixes #6741.

On Windows the upgrade flow (`run_tool_lifecycle_silently`) writes the generated .bat with `std::fs::write` (UTF-8), but `cmd.exe` decodes batch content using the OEM codepage by default. The anchored upgrade command embeds an absolute path — e.g. `C:\Users\<用户名>\AppData\Roaming\fnm\node-versions\v24.16.0\installation\npm.cmd` — and any non-ASCII character in it (a Chinese username is the common case) is mangled into a nonexistent path. cmd then fails with "系统找不到指定的路径" / "The system cannot find the path specified." before npm ever runs.

This also explains the report's asymmetry: version detection works because it passes the path as a command-line argument (CreateProcessW is Unicode-safe), while the upgrade path goes through the .bat file.

Note: the report's own suspicion (the extensionless `where` shim) is already handled on main — `resolve_path_default` resolves `codex` to its `.cmd` sibling via `windows_runnable_sibling_for_extensionless_tool`. The remaining gap is the .bat encoding.

## Change

`build_tool_lifecycle_command` now emits `chcp 65001 >nul` immediately after `@echo off` (extracted into `windows_lifecycle_bat_header`), so cmd parses every subsequent line as UTF-8. The change is harmless for pure-ASCII paths and covers install/update/WSL lines alike.

## Validation

- New Windows behavioral test `lifecycle_bat_runs_anchored_command_with_non_ascii_path`: builds a .bat with the production header that `call`s a fake `npm.cmd` under a non-ASCII directory (`cc-switch-工具目录`) and asserts it runs — fails without the `chcp` line (OEM-codepage decode mangles the UTF-8 path), passes with it.
- Structural test `build_tool_lifecycle_command_emits_utf8_header_first` guards the builder wiring.
- `cargo check` / `cargo test --no-run` clean locally (Windows tests run in CI on windows-latest).