### PR TITLE
fix(usage): reprice history rows when models.dev sync changes prices

### DIFF
--- a/src-tauri/src/services/model_pricing.rs
+++ b/src-tauri/src/services/model_pricing.rs
@@ -881,6 +881,87 @@ mod tests {
 
     #[test]
     #[serial]
+    fn batch_reprice_preserves_provider_reported_costs() {
+        // Pi and GrokBuild session imports may carry provider-reported costs
+        // (record.costs.reported()). Repricing must not zero and overwrite
+        // those authoritative values with locally-calculated pricing.
+        with_test_home(|db, _path| {
+            {
+                let conn = db.conn.lock().expect("lock test database");
+                // Standard proxy row: locally-calculated costs → repriced.
+                insert_usage_row(&conn, "proxy-target", "custom-model");
+                // Pi session row with provider-reported costs → must be left alone.
+                conn.execute(
+                    "INSERT INTO proxy_request_logs (
+                        request_id, provider_id, app_type, model, request_model,
+                        input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                        input_cost_usd, output_cost_usd, cache_read_cost_usd,
+                        cache_creation_cost_usd, total_cost_usd, latency_ms,
+                        status_code, created_at, data_source
+                    ) VALUES (
+                        'pi-reported', 'pi-provider', 'pi', 'custom-model', 'custom-model',
+                        1000000, 1000000, 500000, 250000,
+                        '0.50', '2.00', '0.10', '0.75', '3.35', 100, 200, 1, 'pi_session'
+                    )",
+                    [],
+                )
+                .expect("insert pi row");
+                // GrokBuild session row with provider-reported total → must be left alone.
+                conn.execute(
+                    "INSERT INTO proxy_request_logs (
+                        request_id, provider_id, app_type, model, request_model,
+                        input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                        input_cost_usd, output_cost_usd, cache_read_cost_usd,
+                        cache_creation_cost_usd, total_cost_usd, latency_ms,
+                        status_code, created_at, data_source
+                    ) VALUES (
+                        'grok-reported', 'xai', 'grokbuild', 'custom-model', 'custom-model',
+                        1000000, 1000000, 500000, 250000,
+                        '0.40', '1.60', '0.08', '0.60', '2.68', 100, 200, 1, 'grok_session'
+                    )",
+                    [],
+                )
+                .expect("insert grok row");
+            }
+
+            // Seed v1 pricing → backfill zero-cost proxy row.
+            update_model_pricing(db, sample_pricing()).expect("seed v1 pricing");
+            {
+                let conn = db.conn.lock().expect("lock test database");
+                assert_eq!(usage_costs(&conn, "proxy-target"), V1_COSTS);
+                // Provider-reported rows keep their original costs.
+                assert_eq!(
+                    usage_costs(&conn, "pi-reported"),
+                    "0.50,2.00,0.10,0.75,3.35"
+                );
+                assert_eq!(
+                    usage_costs(&conn, "grok-reported"),
+                    "0.40,1.60,0.08,0.60,2.68"
+                );
+            }
+
+            // Batch repricing: proxy row gets new price, provider-reported
+            // rows are untouched.
+            assert_eq!(
+                update_model_pricing_batch(db, vec![repriced_pricing()]).expect("batch reprice"),
+                1
+            );
+            let conn = db.conn.lock().expect("lock test database");
+            assert_eq!(usage_costs(&conn, "proxy-target"), V2_COSTS);
+            // Provider-reported costs preserved — not zeroed or recalculated.
+            assert_eq!(
+                usage_costs(&conn, "pi-reported"),
+                "0.50,2.00,0.10,0.75,3.35"
+            );
+            assert_eq!(
+                usage_costs(&conn, "grok-reported"),
+                "0.40,1.60,0.08,0.60,2.68"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
     fn recording_sync_result_preserves_user_selection_and_switches() {
         with_test_home(|db, _path| {
             let config = ModelsDevSyncConfig {

--- a/src-tauri/src/services/model_pricing.rs
+++ b/src-tauri/src/services/model_pricing.rs
@@ -380,7 +380,7 @@ fn update_model_pricing_batch_inner(
         .collect::<Vec<_>>();
 
     sync_local_model_pricing(db)?;
-    let changed = {
+    let (changed, repriced_model_ids) = {
         let _file_guard = file_lock()
             .lock()
             .map_err(|error| AppError::Config(format!("模型定价文件锁失败: {error}")))?;
@@ -404,16 +404,28 @@ fn update_model_pricing_batch_inner(
         let mut conn = lock_conn!(db.conn);
         let transaction = conn.transaction()?;
         let mut changed = 0;
+        let mut repriced_model_ids = Vec::new();
         for entry in &entries {
-            changed += upsert_pricing(&transaction, entry)?;
+            let updated = upsert_pricing(&transaction, entry)?;
+            if updated > 0 {
+                repriced_model_ids.push(entry.model_id.clone());
+            }
+            changed += updated;
         }
         write_file_unlocked(&file)?;
         transaction.commit()?;
-        changed
+        (changed, repriced_model_ids)
     };
 
     if changed > 0 {
         if backfill_all {
+            // models.dev 批量同步改价后，历史行可能仍带着启动回填按旧价固化的
+            // 成本；零成本回填碰不到它们，必须先清零再按新价补回。
+            for model_id in &repriced_model_ids {
+                if let Err(error) = db.reprice_usage_costs_for_model(model_id) {
+                    log::warn!("模型改价后重算历史用量成本失败 (model_id={model_id}): {error}");
+                }
+            }
             if let Err(error) = db.backfill_missing_usage_costs() {
                 log::warn!("批量更新模型定价后回填历史用量成本失败: {error}");
             }
@@ -719,6 +731,151 @@ mod tests {
                 .expect("query pending usage cost");
             assert_eq!(deleted_count, 0);
             assert_eq!(total_cost, 0.0);
+        });
+    }
+
+    fn insert_usage_row(conn: &rusqlite::Connection, request_id: &str, model: &str) -> usize {
+        conn.execute(
+            "INSERT INTO proxy_request_logs (
+                request_id, provider_id, app_type, model, request_model,
+                input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                input_cost_usd, output_cost_usd, cache_read_cost_usd,
+                cache_creation_cost_usd, total_cost_usd, latency_ms,
+                status_code, created_at, data_source
+            ) VALUES (
+                ?1, 'test-provider', 'claude', ?2, ?2,
+                1000000, 1000000, 500000, 250000, '0', '0', '0', '0', '0', 100, 200, 1, 'proxy'
+            )",
+            params![request_id, model],
+        )
+        .expect("insert usage row")
+    }
+
+    fn usage_costs(conn: &rusqlite::Connection, request_id: &str) -> String {
+        conn.query_row(
+            "SELECT input_cost_usd, output_cost_usd, cache_read_cost_usd,
+                    cache_creation_cost_usd, total_cost_usd
+             FROM proxy_request_logs WHERE request_id = ?1",
+            params![request_id],
+            |row| {
+                Ok(format!(
+                    "{},{},{},{},{}",
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?
+                ))
+            },
+        )
+        .expect("query usage costs")
+    }
+
+    fn repriced_pricing() -> ModelPricingInfo {
+        ModelPricingInfo {
+            model_id: "custom-model".to_string(),
+            display_name: "Custom Model".to_string(),
+            input_cost_per_million: "4".to_string(),
+            output_cost_per_million: "8".to_string(),
+            cache_read_cost_per_million: "0.2".to_string(),
+            cache_creation_cost_per_million: "3".to_string(),
+        }
+    }
+
+    const V1_COSTS: &str = "1.250000,5.000000,0.050000,0.375000,6.675000";
+    const V2_COSTS: &str = "4.000000,8.000000,0.100000,0.750000,12.850000";
+
+    #[test]
+    #[serial]
+    fn batch_reprice_recalculates_history_rows_at_new_price() {
+        with_test_home(|db, _path| {
+            {
+                let conn = db.conn.lock().expect("lock test database");
+                insert_usage_row(&conn, "reprice-target", "custom-model");
+            }
+
+            // 启动回填语义：先按旧价把零成本行固化出成本。
+            update_model_pricing(db, sample_pricing()).expect("seed v1 pricing");
+            {
+                let conn = db.conn.lock().expect("lock test database");
+                assert_eq!(usage_costs(&conn, "reprice-target"), V1_COSTS);
+            }
+
+            // models.dev 批量同步改价：历史行必须按新价重算。
+            assert_eq!(
+                update_model_pricing_batch(db, vec![repriced_pricing()]).expect("batch reprice"),
+                1
+            );
+            let conn = db.conn.lock().expect("lock test database");
+            assert_eq!(usage_costs(&conn, "reprice-target"), V2_COSTS);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn batch_reprice_leaves_unchanged_models_untouched() {
+        with_test_home(|db, _path| {
+            {
+                let conn = db.conn.lock().expect("lock test database");
+                insert_usage_row(&conn, "reprice-target", "custom-model");
+                insert_usage_row(&conn, "steady-row", "steady-model");
+            }
+
+            let steady = ModelPricingInfo {
+                model_id: "steady-model".to_string(),
+                display_name: "Steady Model".to_string(),
+                input_cost_per_million: "1.25".to_string(),
+                output_cost_per_million: "5".to_string(),
+                cache_read_cost_per_million: "0.1".to_string(),
+                cache_creation_cost_per_million: "1.5".to_string(),
+            };
+            update_model_pricing_batch(db, vec![sample_pricing(), steady.clone()])
+                .expect("seed batch v1");
+            {
+                let conn = db.conn.lock().expect("lock test database");
+                assert_eq!(usage_costs(&conn, "reprice-target"), V1_COSTS);
+                assert_eq!(usage_costs(&conn, "steady-row"), V1_COSTS);
+            }
+
+            // 批次里 steady 的值原样重发：upsert 判定未变化，不得触发重算。
+            update_model_pricing_batch(db, vec![repriced_pricing(), steady])
+                .expect("batch with unchanged steady");
+            let conn = db.conn.lock().expect("lock test database");
+            assert_eq!(usage_costs(&conn, "reprice-target"), V2_COSTS);
+            assert_eq!(usage_costs(&conn, "steady-row"), V1_COSTS);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn manual_single_price_edit_keeps_existing_costs() {
+        with_test_home(|db, _path| {
+            {
+                let conn = db.conn.lock().expect("lock test database");
+                insert_usage_row(&conn, "manual-target", "custom-model");
+            }
+
+            update_model_pricing(db, sample_pricing()).expect("seed v1 pricing");
+            // 手动单条改价行为不变：只补零成本行，已有成本分毫不动。
+            update_model_pricing(db, repriced_pricing()).expect("manual reprice");
+            let conn = db.conn.lock().expect("lock test database");
+            assert_eq!(usage_costs(&conn, "manual-target"), V1_COSTS);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn deleting_pricing_does_not_touch_existing_costs() {
+        with_test_home(|db, _path| {
+            {
+                let conn = db.conn.lock().expect("lock test database");
+                insert_usage_row(&conn, "delete-target", "custom-model");
+            }
+
+            update_model_pricing(db, sample_pricing()).expect("seed v1 pricing");
+            delete_model_pricing(db, "custom-model").expect("delete pricing");
+            let conn = db.conn.lock().expect("lock test database");
+            assert_eq!(usage_costs(&conn, "delete-target"), V1_COSTS);
         });
     }
 

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -15,6 +15,9 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
+/// 改价重算按 request_id 分块 UPDATE 的块大小（SQLite 变量数上限 999）。
+const REPRICE_UPDATE_CHUNK_SIZE: usize = 500;
+
 /// 使用量汇总
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -1867,6 +1870,64 @@ impl Database {
         }
 
         Ok(updated)
+    }
+
+    /// 改价重算：把该模型作用域内已有成本的明细行五个成本列清零，再复用
+    /// 零成本回填按新价补回。行作用域筛选必须与
+    /// `backfill_missing_usage_costs_for_model` 共用同一套
+    /// model_pricing_candidates＋log_pricing_scope_matches 归一化，另造第二套
+    /// 会漏掉以原始别名落库的行。查不到价的行清零后保持 0，等待下次补价。
+    pub(crate) fn reprice_usage_costs_for_model(&self, model_id: &str) -> Result<u64, AppError> {
+        const PRICED_ROWS_SQL: &str =
+            "SELECT request_id, provider_id, NULL AS provider_name, app_type, model, request_model,
+                        cost_multiplier,
+                        input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                        input_cost_usd, output_cost_usd, cache_read_cost_usd,
+                        cache_creation_cost_usd, total_cost_usd, is_streaming, latency_ms,
+                        first_token_ms, duration_ms, status_code, error_message, created_at,
+                        data_source, pricing_model, input_token_semantics
+             FROM proxy_request_logs
+             WHERE CAST(total_cost_usd AS REAL) > 0
+               AND (input_tokens > 0 OR output_tokens > 0
+                    OR cache_read_tokens > 0 OR cache_creation_tokens > 0)";
+
+        let zeroed = {
+            let conn = lock_conn!(self.conn);
+            let target = model_pricing_candidates(model_id);
+            let request_ids = {
+                let mut stmt = conn.prepare(PRICED_ROWS_SQL)?;
+                let rows = stmt.query_map([], row_to_request_log_detail)?;
+                rows.collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
+                    .filter(|log| log_pricing_scope_matches(log, &target))
+                    .map(|log| log.request_id)
+                    .collect::<Vec<_>>()
+            };
+            if request_ids.is_empty() {
+                return Ok(0);
+            }
+
+            let tx = conn
+                .unchecked_transaction()
+                .map_err(|e| AppError::Database(format!("改价重算清零事务失败: {e}")))?;
+            let mut zeroed = 0u64;
+            for chunk in request_ids.chunks(REPRICE_UPDATE_CHUNK_SIZE) {
+                let placeholders = vec!["?"; chunk.len()].join(",");
+                let sql = format!(
+                    "UPDATE proxy_request_logs
+                     SET input_cost_usd = '0', output_cost_usd = '0', cache_read_cost_usd = '0',
+                         cache_creation_cost_usd = '0', total_cost_usd = '0'
+                     WHERE request_id IN ({placeholders})"
+                );
+                zeroed += tx.execute(&sql, rusqlite::params_from_iter(chunk.iter()))? as u64;
+            }
+            tx.commit()
+                .map_err(|e| AppError::Database(format!("提交改价重算清零事务失败: {e}")))?;
+            zeroed
+        };
+
+        self.backfill_missing_usage_costs_for_model(model_id)?;
+        Ok(zeroed)
     }
 
     /// 尝试为单条 log 回填成本字段。返回是否实际写入（true=已 UPDATE，false=跳过）。

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -1889,7 +1889,8 @@ impl Database {
              FROM proxy_request_logs
              WHERE CAST(total_cost_usd AS REAL) > 0
                AND (input_tokens > 0 OR output_tokens > 0
-                    OR cache_read_tokens > 0 OR cache_creation_tokens > 0)";
+                    OR cache_read_tokens > 0 OR cache_creation_tokens > 0)
+               AND COALESCE(data_source, 'proxy') NOT IN ('pi_session', 'grok_session')";
 
         let zeroed = {
             let conn = lock_conn!(self.conn);

--- a/src/lib/modelsDevPricing.ts
+++ b/src/lib/modelsDevPricing.ts
@@ -225,6 +225,11 @@ const COMMON_FAMILY_RULES: CommonFamilyRule[] = [
     providers: new Set(["zai"]),
     matches: (modelId) => modelId.startsWith("glm-"),
   },
+  {
+    id: "step",
+    providers: new Set(["stepfun"]),
+    matches: (modelId) => modelId.startsWith("step-"),
+  },
 ];
 
 /** Pick a bounded, canonical set of recent chat/coding models per family. */

--- a/tests/components/ModelsDevPickerDialog.test.ts
+++ b/tests/components/ModelsDevPickerDialog.test.ts
@@ -260,6 +260,23 @@ describe("flattenModels", () => {
           },
         },
       },
+      stepfun: {
+        name: "StepFun",
+        models: {
+          "step-3": {
+            release_date: "2026-07-01",
+            cost: { input: 0.6, output: 2.4 },
+          },
+          "step-tts-mini": {
+            release_date: "2026-06-01",
+            cost: { input: 0.1, output: 0.4 },
+          },
+          "step-audio-2": {
+            release_date: "2026-05-01",
+            cost: { input: 0.2, output: 0.8 },
+          },
+        },
+      },
     });
 
     const common = getCommonModelKeys(entries);
@@ -272,6 +289,16 @@ describe("flattenModels", () => {
     expect(common.has("xiaomi/mimo-v2.5")).toBe(true);
     expect(common.has("xiaomi/mimo-v2.5-tts")).toBe(false);
     expect(common.has("longcat/LongCat-2.0")).toBe(true);
+    expect(common.has("stepfun/step-3")).toBe(true);
+    // Audio/TTS models are filtered out before they can join a family bucket.
+    expect(common.has("stepfun/step-tts-mini")).toBe(false);
+    expect(common.has("stepfun/step-audio-2")).toBe(false);
+    expect(entries.some((entry) => entry.key === "stepfun/step-tts-mini")).toBe(
+      false,
+    );
+    expect(entries.some((entry) => entry.key === "stepfun/step-audio-2")).toBe(
+      false,
+    );
   });
 
   it("combines common and explicit selections and deduplicates normalized ids", () => {


### PR DESCRIPTION
### Background

Stale-price pollution timeline (observed in the wild on a real machine, 2.6k+ rows):

1. On startup, `run_session_sync(backfill=true)` calls `backfill_missing_usage_costs()` before the frontend has run anything network-side. Every zero-cost usage row gets priced with whatever the pricing table currently holds — built-in seeds that may lag models.dev.
2. Seconds later, the models.dev auto-sync (when enabled) fetches fresh prices and calls `updateModelPricingBatch`.
3. That batch updated the pricing table and re-ran the zero-cost backfill — but rows already priced in step 1 were never revisited, because the backfill only selects `total_cost_usd <= 0`.
4. Result: usage rows permanently priced with stale costs. The only recovery was manually zeroing the cost columns to make the rows backfill-eligible again.

### Fix

- `update_model_pricing_batch_inner` now records which entries actually changed a value (the pricing upsert already reports per-row change counts).
- After the transaction commits, each changed model goes through the new `reprice_usage_costs_for_model`:
  - zero the five cost columns of detail rows in that model's scope — reusing exactly the `model_pricing_candidates` + `log_pricing_scope_matches` scope of the per-model backfill, so rows stored under raw aliases are covered by the same normalization instead of a second one;
  - chunked `UPDATE ... WHERE request_id IN (...)` (500 per chunk) inside one transaction;
  - then rerun `backfill_missing_usage_costs_for_model` so the rows are recomputed at the new price with all existing semantics preserved (cost multiplier, cache-inclusive input deduction, `pricing_model` resolution).
- The existing full zero-cost backfill after the batch is kept.
- Rows whose pricing cannot be resolved stay at 0 and get picked up by a later backfill, same as any other zero-cost row.

### Scope / non-goals

- Only the batch path changes (its only caller is the models.dev sync). Manual single-price edits keep the current semantics — someone fixing one price by hand should not silently rewrite historical costs. Deletions/tombstones still never touch existing costs.
- Daily rollups freeze summed costs and the rollup table has no `cost_multiplier` column, so they cannot be safely recomputed here; they converge as new days accumulate. Left as a follow-up.

### Also included

- The `stepfun` provider joins the common-model families (`step-` prefix), so the default models.dev selection covers StepFun text models; audio/TTS stay excluded by the existing non-text filters.

### Testing

- 4 new Rust tests in `model_pricing.rs`: reprice recalculates history at the new price (exact amounts asserted on all five cost columns), models whose price did not change in the same batch stay untouched to the cent, manual single edit keeps existing costs, pricing deletion keeps existing costs. Reverse-verified: disabling the reprice call turns the new tests red.
- Extended the picker family test: `stepfun/step-3` enters `getCommonModelKeys`; `step-tts-mini` / `step-audio-2` are excluded at both the flatten level and the family-bucket level.
- `cargo test`: 2805 pass / 0 fail / 5 pre-existing ignored (baseline 2801 + 4 new); `cargo clippy --all-targets` 0 warnings; `cargo fmt --check` clean.
- `pnpm typecheck` and `format:check` green; full `test:unit` passes aside from the pre-existing load-related flaky failures in the PiProviderForm / integration suites, which have no import relationship with the modules touched here (verified by A/B reruns on a clean checkout).
