### PR TITLE
fix(codex): inject experimental_bearer_token for third-party providers (Codex >= 0.149 auth change)

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -2811,15 +2811,34 @@ pub fn write_codex_live_for_provider(
         };
     let config_text = unified_official_config.as_deref().or(config_text);
 
-    let should_write_auth = (category == Some("official") && codex_auth_has_login_material(auth))
-        || (category != Some("official")
-            && !crate::settings::preserve_codex_official_auth_on_switch());
+    let is_official = category == Some("official");
+    let should_write_auth = (is_official && codex_auth_has_login_material(auth))
+        || (!is_official && !crate::settings::preserve_codex_official_auth_on_switch());
+
+    // Since Codex 0.149 (openai/codex#39214) custom providers no longer inherit
+    // ambient auth: with `requires_openai_auth = false` the CLI stops sending the
+    // `auth.json` `OPENAI_API_KEY` as a bearer token, so third-party providers
+    // that only wrote their key into `auth.json` fail with `401 Missing API key`.
+    // Always carry the API key as a provider-scoped `experimental_bearer_token`
+    // in `config.toml` for third-party writes; `auth.json` is still written when
+    // preservation is off so older Codex releases keep working.
+    let prepared_config = if is_official {
+        config_text.map(str::to_string)
+    } else {
+        match config_text {
+            // An empty config has no provider table to attach a token to; keep
+            // the historical behavior of writing it as-is.
+            Some(text) if !text.trim().is_empty() => {
+                Some(prepare_codex_provider_live_config(auth, text)?)
+            }
+            other => other.map(str::to_string),
+        }
+    };
 
     if should_write_auth {
-        write_codex_live_atomic(auth, config_text)
+        write_codex_live_atomic(auth, prepared_config.as_deref())
     } else {
-        let live_config = prepare_codex_provider_live_config(auth, config_text.unwrap_or(""))?;
-        write_codex_live_config_atomic(Some(&live_config))
+        write_codex_live_config_atomic(prepared_config.as_deref())
     }
 }
 

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -6387,8 +6387,9 @@ wire_api = "responses"
         let live_config = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
             .expect("read live config");
         assert!(
-            !live_config.contains("experimental_bearer_token"),
-            "provider token should stay in auth.json when preservation is disabled"
+            live_config.contains(&format!("experimental_bearer_token = \"{PROXY_TOKEN_PLACEHOLDER}\"")),
+            "since Codex 0.149 (openai/codex#39214) custom providers no longer read \
+             auth.json keys, so the placeholder token must be carried in config.toml"
         );
 
         crate::settings::update_settings(crate::settings::AppSettings::default())

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -6387,7 +6387,9 @@ wire_api = "responses"
         let live_config = std::fs::read_to_string(crate::codex_config::get_codex_config_path())
             .expect("read live config");
         assert!(
-            live_config.contains(&format!("experimental_bearer_token = \"{PROXY_TOKEN_PLACEHOLDER}\"")),
+            live_config.contains(&format!(
+                "experimental_bearer_token = \"{PROXY_TOKEN_PLACEHOLDER}\""
+            )),
             "since Codex 0.149 (openai/codex#39214) custom providers no longer read \
              auth.json keys, so the placeholder token must be carried in config.toml"
         );

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -794,6 +794,69 @@ requires_openai_auth = true
 }
 
 #[test]
+fn provider_service_switch_codex_default_injects_bearer_token_into_config() {
+    let _guard = test_mutex().lock().expect("acquire test mutex");
+    reset_test_fs();
+    // Preservation stays OFF (default). Since Codex 0.149 (openai/codex#39214)
+    // custom providers no longer inherit ambient auth, so the API key written
+    // into auth.json alone is not sent as a bearer token and the provider
+    // fails with `401 Missing API key`. The live config.toml must therefore
+    // carry the key as a provider-scoped `experimental_bearer_token` even on
+    // the auth-writing default path.
+    let _home = ensure_test_home();
+
+    let third_party_config = r#"model_provider = "aihubmix"
+model = "gpt-5.4"
+
+[model_providers.aihubmix]
+name = "AiHubMix"
+base_url = "https://aihubmix.example/v1"
+wire_api = "responses"
+requires_openai_auth = false
+"#;
+
+    let mut initial_config = MultiAppConfig::default();
+    {
+        let manager = initial_config
+            .get_manager_mut(&AppType::Codex)
+            .expect("codex manager");
+        manager.providers.insert(
+            "third-party".to_string(),
+            Provider::with_id(
+                "third-party".to_string(),
+                "AiHubMix".to_string(),
+                json!({
+                    "auth": {"OPENAI_API_KEY": "third-party-key"},
+                    "config": third_party_config
+                }),
+                None,
+            ),
+        );
+    }
+
+    let state = create_test_state_with_config(&initial_config).expect("create test state");
+
+    ProviderService::switch(&state, AppType::Codex, "third-party")
+        .expect("switch to third-party provider should succeed");
+
+    let auth_value: serde_json::Value =
+        read_json_file(&cc_switch_lib::get_codex_auth_path()).expect("read auth.json");
+    assert_eq!(
+        auth_value.get("OPENAI_API_KEY").and_then(|v| v.as_str()),
+        Some("third-party-key"),
+        "default (preservation off) keeps writing auth.json for older Codex releases"
+    );
+
+    let live_config =
+        std::fs::read_to_string(cc_switch_lib::get_codex_config_path()).expect("read config.toml");
+    assert!(
+        live_config.contains("experimental_bearer_token = \"third-party-key\""),
+        "default switch must inject the API key into config.toml so Codex >= 0.149 \
+         custom providers authenticate (openai/codex#39214); got:\n{live_config}"
+    );
+}
+
+#[test]
 fn provider_service_switch_codex_supports_official_login_provider_without_auth_write() {
     let _guard = test_mutex().lock().expect("acquire test mutex");
     reset_test_fs();


### PR DESCRIPTION
## Summary

Fixes #6744.

Since **Codex CLI 0.149** ([openai/codex#39214](https://github.com/openai/codex/pull/39214), merged 2026-08-18), custom providers no longer inherit ambient auth: with `requires_openai_auth = false` the CLI **stops sending the `auth.json` `OPENAI_API_KEY` as a bearer token**. Only the OpenAI official provider keeps ambient auth; explicit `experimental_bearer_token` / provider auth config is still honored.

CC Switch's default third-party switch path (auth-preservation OFF) wrote the API key **only** into `~/.codex/auth.json`, so on Codex ≥ 0.149 every request fails with:

```
ERROR: unexpected status 401 Unauthorized: {"error":"Missing API key"}, url: .../v1/responses
```

Verified by capturing the actual HTTP headers codex sends:

| Codex version | `requires_openai_auth = false`, key only in auth.json |
|---|---|
| 0.148.0 | sends `Authorization: Bearer <key>` ✅ |
| 0.149.0 | sends no Authorization header at all ❌ |

## Changes

- `write_codex_live_for_provider` (src-tauri/src/codex_config.rs): for every **third-party** live write, inject the provider API key as a provider-scoped `experimental_bearer_token` into `config.toml` via the existing `prepare_codex_provider_live_config`, regardless of the preservation setting. `auth.json` is still written when preservation is off, so **older Codex releases keep working** (belt and suspenders).
  - Official providers are untouched.
  - Empty configs keep the historical write-as-is behavior (no provider table to attach a token to).
- Updated one proxy-takeover unit test whose assertion encoded the old behavior (the placeholder-token path at `proxy.rs:3574` already injected `experimental_bearer_token = "PROXY_MANAGED"`, so this makes the two paths consistent).
- Added a regression test: default (preservation OFF) third-party switch must produce `experimental_bearer_token = "<key>"` in live `config.toml` while still writing `auth.json`.

## Why `experimental_bearer_token`

It is the explicit auth mechanism that openai/codex#39214 keeps working ("Continue to honor an explicit `experimental_bearer_token`"), needs no environment variables (GUI launches don't load shell profiles, so `env_key` is fragile), and is scoped to the provider table.

## Testing

- `cargo test`: all suites green (2680 lib tests + integration tests, including the new regression test)
- `cargo clippy --lib`: no new warnings from this change

## Backward compatibility with older Codex versions

Verified this change is safe for users on older Codex releases:

- `experimental_bearer_token` was introduced in **Codex 0.48.0** (openai/codex#5467, 2025-10-23). On versions below that, the key is unknown.
- Checked the 0.30.0 and 0.47.0 sources: neither `ConfigToml` nor `ModelProviderInfo` uses `deny_unknown_fields`, so serde **silently ignores** the unknown key — no error, no warning, config parsing unaffected.
- Old Codex (< 0.149) still inherits ambient auth, i.e. it reads `auth.json`'s `OPENAI_API_KEY` for custom providers. This PR keeps writing `auth.json` on the default (preservation-OFF) path, so old versions authenticate exactly as before.
- When both are present (0.48–0.148), the token and the auth.json key carry the **same value**, so precedence between them is irrelevant.

Net effect per Codex version:

| Codex version | Before this PR | After this PR |
|---|---|---|
| < 0.48 | works via auth.json | works via auth.json (extra key ignored) |
| 0.48 – 0.148 | works via auth.json | works via both (same key) |
| ≥ 0.149 | ❌ 401 Missing API key | ✅ works via experimental_bearer_token |
