### PR TITLE
fix(codex): keep same-team ChatGPT OAuth accounts distinct

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1,6 +1,9 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+use crate::codex_oauth_identity::{
+    extract_identity_from_jwt, live_auth_matches_managed_account, workspace_id_from_tokens,
+};
 use crate::config::{
     atomic_write, delete_file, get_home_dir, path_is_within, read_json_file,
     sanitize_provider_name, write_json_file, write_text_file,
@@ -283,12 +286,23 @@ impl CodexLiveStateSnapshot {
         if auth.get("auth_mode").and_then(Value::as_str) != Some("chatgpt") {
             return None;
         }
-        let account_id = auth
-            .pointer("/tokens/account_id")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|account_id| !account_id.is_empty())?
-            .to_string();
+        let tokens = auth.get("tokens")?;
+        let account_id = ["id_token", "access_token"]
+            .into_iter()
+            .filter_map(|key| tokens.get(key).and_then(Value::as_str))
+            .find_map(|token| {
+                extract_identity_from_jwt(token)
+                    .map(|identity| identity.storage_id)
+                    .filter(|id| !id.is_empty())
+            })
+            .or_else(|| {
+                tokens
+                    .get("account_id")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .map(str::to_string)
+            })?;
         let last_refresh_ms = auth
             .get("last_refresh")
             .and_then(Value::as_str)
@@ -413,18 +427,31 @@ fn extract_codex_managed_oauth_account_id(auth: &Value) -> Option<String> {
         return None;
     }
 
-    let account_id = tokens
-        .get("account_id")
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        .filter(|id| !id.is_empty())?;
     tokens
         .get("access_token")
         .and_then(|value| value.as_str())
         .map(str::trim)
         .filter(|token| !token.is_empty())?;
 
-    Some(account_id.to_string())
+    // Prefer the user-scoped JWT identity. `tokens.account_id` is the Team
+    // workspace id and would collapse every member onto one marker key.
+    for token in ["id_token", "access_token"]
+        .into_iter()
+        .filter_map(|key| tokens.get(key).and_then(Value::as_str))
+    {
+        if let Some(identity) = extract_identity_from_jwt(token) {
+            if !identity.storage_id.is_empty() {
+                return Some(identity.storage_id);
+            }
+        }
+    }
+
+    tokens
+        .get("account_id")
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
 }
 
 /// Build the native-shaped ChatGPT auth bundle shared by cc-switch and Codex CLI.
@@ -449,7 +476,11 @@ pub fn codex_managed_oauth_auth_value(
     );
     tokens.insert(
         "account_id".to_string(),
-        Value::String(account_id.to_string()),
+        Value::String(workspace_id_from_tokens(
+            id_token,
+            Some(access_token),
+            account_id,
+        )),
     );
     json!({
         "auth_mode": "chatgpt",
@@ -633,12 +664,7 @@ pub fn codex_live_auth_is_managed_chatgpt_login(auth: &Value, account_id: &str) 
     if !api_key_clearable {
         return false;
     }
-    obj.get("tokens")
-        .and_then(|tokens| tokens.as_object())
-        .and_then(|tokens| tokens.get("account_id"))
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        == Some(account_id)
+    live_auth_matches_managed_account(auth, account_id)
 }
 
 /// 读回 Codex CLI 当前 `~/.codex/auth.json` 中属于 `account_id` 的 refresh_token /

--- a/src-tauri/src/codex_oauth_identity.rs
+++ b/src-tauri/src/codex_oauth_identity.rs
@@ -1,0 +1,192 @@
+//! ChatGPT OAuth identity from Codex JWT claims.
+//!
+//! Official Codex treats `chatgpt_account_id` as the workspace id
+//! (`ChatGPT-Account-Id`). Team members share that value, so account-manager
+//! storage must use a user-scoped id instead.
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde_json::Value;
+
+/// User-scoped storage key plus the workspace id Codex writes to auth.json.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexOAuthIdentity {
+    pub storage_id: String,
+    pub workspace_id: Option<String>,
+    pub email: Option<String>,
+}
+
+fn jwt_payload(token: &str) -> Option<Value> {
+    let mut parts = token.split('.');
+    let (_header, payload, _sig) = (parts.next()?, parts.next()?, parts.next()?);
+    if parts.next().is_some() {
+        return None;
+    }
+    serde_json::from_slice(&URL_SAFE_NO_PAD.decode(payload).ok()?).ok()
+}
+
+fn claim_str(value: &Value, key: &str) -> Option<String> {
+    value.get(key).and_then(Value::as_str).and_then(|raw| {
+        let trimmed = raw.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+fn auth_claim(payload: &Value) -> Option<&Value> {
+    payload.get("https://api.openai.com/auth")
+}
+
+fn profile_claim(payload: &Value) -> Option<&Value> {
+    payload.get("https://api.openai.com/profile")
+}
+
+fn org_workspace_id(payload: &Value) -> Option<String> {
+    payload
+        .get("organizations")
+        .and_then(Value::as_array)
+        .and_then(|orgs| orgs.first())
+        .and_then(|org| claim_str(org, "id"))
+}
+
+fn identity_from_payload(payload: &Value) -> CodexOAuthIdentity {
+    let auth = auth_claim(payload);
+    let profile = profile_claim(payload);
+    let workspace_id = [
+        claim_str(payload, "chatgpt_account_id"),
+        auth.and_then(|auth| claim_str(auth, "chatgpt_account_id")),
+        org_workspace_id(payload),
+    ]
+    .into_iter()
+    .flatten()
+    .next();
+    let storage_id = [
+        claim_str(payload, "chatgpt_user_id"),
+        auth.and_then(|auth| claim_str(auth, "chatgpt_user_id")),
+        claim_str(payload, "email"),
+        auth.and_then(|auth| claim_str(auth, "email")),
+        profile.and_then(|profile| claim_str(profile, "email")),
+        claim_str(payload, "sub"),
+    ]
+    .into_iter()
+    .flatten()
+    .next()
+    .unwrap_or_default();
+    let email = [
+        claim_str(payload, "email"),
+        auth.and_then(|auth| claim_str(auth, "email")),
+        profile.and_then(|profile| claim_str(profile, "email")),
+    ]
+    .into_iter()
+    .flatten()
+    .next();
+    CodexOAuthIdentity {
+        storage_id,
+        workspace_id,
+        email,
+    }
+}
+
+pub fn extract_identity_from_jwt(token: &str) -> Option<CodexOAuthIdentity> {
+    let identity = identity_from_payload(&jwt_payload(token)?);
+    if identity.storage_id.is_empty() && identity.workspace_id.is_none() && identity.email.is_none()
+    {
+        return None;
+    }
+    Some(identity)
+}
+
+/// Prefer `id_token`, then `access_token`. Never key accounts by workspace id.
+pub fn extract_identity_from_oauth_tokens(
+    id_token: Option<&str>,
+    access_token: &str,
+) -> Option<CodexOAuthIdentity> {
+    [id_token, Some(access_token)]
+        .into_iter()
+        .flatten()
+        .find_map(|token| {
+            extract_identity_from_jwt(token).filter(|identity| !identity.storage_id.is_empty())
+        })
+}
+
+/// Workspace id for `tokens.account_id` / `ChatGPT-Account-Id`.
+pub fn workspace_id_from_tokens(
+    id_token: Option<&str>,
+    access_token: Option<&str>,
+    fallback: &str,
+) -> String {
+    [id_token, access_token]
+        .into_iter()
+        .flatten()
+        .find_map(|token| extract_identity_from_jwt(token)?.workspace_id)
+        .filter(|id| !id.is_empty())
+        .unwrap_or_else(|| fallback.trim().to_string())
+}
+
+/// Match live auth.json to a managed user. Team members share `tokens.account_id`.
+pub fn live_auth_matches_managed_account(auth: &Value, storage_id: &str) -> bool {
+    let storage_id = storage_id.trim();
+    if storage_id.is_empty() || auth.get("auth_mode").and_then(Value::as_str) != Some("chatgpt") {
+        return false;
+    }
+    let Some(tokens) = auth.get("tokens").and_then(Value::as_object) else {
+        return false;
+    };
+    for token in ["id_token", "access_token"]
+        .into_iter()
+        .filter_map(|key| tokens.get(key).and_then(Value::as_str))
+    {
+        if extract_identity_from_jwt(token).is_some_and(|id| id.storage_id == storage_id) {
+            return true;
+        }
+    }
+    // Legacy accounts were keyed by the shared workspace id. Keep that match so
+    // existing Team logins can still adopt/clear live auth.json.
+    tokens
+        .get("account_id")
+        .and_then(Value::as_str)
+        .is_some_and(|id| id.trim() == storage_id)
+}
+
+#[cfg(test)]
+pub(crate) fn encode_unsigned_jwt(payload: &str) -> String {
+    let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+    format!("{header}.{}.", URL_SAFE_NO_PAD.encode(payload.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn prefers_user_id_and_keeps_workspace_for_headers() {
+        let jwt = encode_unsigned_jwt(
+            r#"{"https://api.openai.com/auth":{"chatgpt_account_id":"org-team","chatgpt_user_id":"user-a"},"email":"a@example.com"}"#,
+        );
+        let identity = extract_identity_from_oauth_tokens(None, &jwt).unwrap();
+        assert_eq!(identity.storage_id, "user-a");
+        assert_eq!(identity.workspace_id.as_deref(), Some("org-team"));
+        assert_eq!(identity.email.as_deref(), Some("a@example.com"));
+        assert_eq!(
+            workspace_id_from_tokens(Some(&jwt), None, "user-a"),
+            "org-team"
+        );
+    }
+
+    #[test]
+    fn live_auth_does_not_match_teammate_via_shared_workspace() {
+        let jwt_a =
+            encode_unsigned_jwt(r#"{"chatgpt_account_id":"org-team","chatgpt_user_id":"user-a"}"#);
+        let auth = json!({
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "account_id": "org-team",
+                "id_token": jwt_a,
+                "access_token": "access"
+            }
+        });
+        assert!(live_auth_matches_managed_account(&auth, "user-a"));
+        assert!(!live_auth_matches_managed_account(&auth, "user-b"));
+        // Legacy Team accounts were stored under the shared workspace id.
+        assert!(live_auth_matches_managed_account(&auth, "org-team"));
+    }
+}

--- a/src-tauri/src/commands/codex_oauth.rs
+++ b/src-tauri/src/commands/codex_oauth.rs
@@ -52,10 +52,11 @@ pub async fn get_codex_oauth_quota(
         }
     };
 
+    let workspace_id = manager.workspace_id_for_account(&id).await;
     // 瞬时传输失败以 Err 传播（前端 reject → retry + 保留上次成功值）。
     query_codex_quota(
         &token,
-        Some(&id),
+        workspace_id.as_deref(),
         "codex_oauth",
         "Codex OAuth access token expired or rejected. Please re-login via cc-switch.",
     )
@@ -89,6 +90,7 @@ pub async fn get_codex_oauth_models(
         .get_valid_token_for_account(&id)
         .await
         .map_err(|e| format!("Codex OAuth token unavailable: {e}"))?;
+    let workspace_id = manager.workspace_id_for_account(&id).await.unwrap_or(id);
 
-    crate::services::codex_oauth_models::fetch_models_with_token(&token, &id).await
+    crate::services::codex_oauth_models::fetch_models_with_token(&token, &workspace_id).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod claude_mcp;
 mod claude_plugin;
 mod codex_config;
 mod codex_history_migration;
+mod codex_oauth_identity;
 mod codex_state_db;
 mod commands;
 mod config;

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -27,6 +27,7 @@ use crate::proxy::providers::copilot_auth::CopilotAuthManager;
 use crate::proxy::providers::xai_oauth_auth::XaiOAuthManager;
 use crate::{
     app_config::AppType,
+    codex_oauth_identity::extract_identity_from_jwt,
     provider::{LocalProxyRequestOverrides, Provider},
 };
 use bytes::Bytes;
@@ -54,7 +55,7 @@ fn validate_codex_official_authorization(
         Some(value) if value.contains(PROXY_AUTH_PLACEHOLDER) => Err(ProxyError::AuthError(
             "已切换到 OpenAI 官方供应商，请重启 Codex 或新建会话以加载官方登录配置".to_string(),
         )),
-        Some(_) => {
+        Some(value) => {
             let expected_account_id = provider
                 .meta
                 .as_ref()
@@ -62,12 +63,34 @@ fn validate_codex_official_authorization(
                 .map(|account_id| account_id.trim().to_string())
                 .filter(|account_id| !account_id.is_empty());
             if let Some(expected_account_id) = expected_account_id {
-                let request_account_id = headers
-                    .get("chatgpt-account-id")
-                    .and_then(|value| value.to_str().ok())
-                    .map(str::trim)
-                    .filter(|account_id| !account_id.is_empty());
-                if request_account_id != Some(expected_account_id.as_str()) {
+                // ChatGPT-Account-Id is the Team workspace id. Same-team members
+                // share it, so official-session matching prefers the JWT user id.
+                // Legacy bindings still store that workspace id and must keep working.
+                let bearer = value
+                    .strip_prefix("Bearer ")
+                    .or_else(|| value.strip_prefix("bearer "))
+                    .unwrap_or(value)
+                    .trim();
+                let identity = extract_identity_from_jwt(bearer);
+                let request_user_id = identity
+                    .as_ref()
+                    .map(|id| id.storage_id.as_str())
+                    .filter(|id| !id.is_empty());
+                let request_workspace_id = identity
+                    .as_ref()
+                    .and_then(|id| id.workspace_id.as_deref())
+                    .filter(|id| !id.is_empty())
+                    .or_else(|| {
+                        headers
+                            .get("chatgpt-account-id")
+                            .and_then(|value| value.to_str().ok())
+                            .map(str::trim)
+                            .filter(|id| !id.is_empty())
+                    });
+                let matches_selected_account = request_user_id
+                    == Some(expected_account_id.as_str())
+                    || request_workspace_id == Some(expected_account_id.as_str());
+                if !matches_selected_account {
                     return Err(ProxyError::AuthError(
                         "当前 Codex 会话未加载所选 ChatGPT 账号，请重启 Codex 或新建会话后重试"
                             .to_string(),
@@ -1733,10 +1756,14 @@ impl RequestForwarder {
                         Ok(token) => {
                             auth = AuthInfo::new(token, AuthStrategy::CodexOAuth);
                             should_send_codex_oauth_session_headers = true;
-                            // 解析使用的 account_id（用于注入 ChatGPT-Account-Id header）
-                            codex_oauth_account_id = match account_id {
+                            // ChatGPT-Account-Id is the workspace id, not the user key.
+                            let storage_id = match account_id {
                                 Some(id) => Some(id),
                                 None => codex_auth.default_account_id().await,
+                            };
+                            codex_oauth_account_id = match storage_id.as_deref() {
+                                Some(id) => codex_auth.workspace_id_for_account(id).await,
+                                None => None,
                             };
                             log::debug!(
                                 "[CodexOAuth] 成功获取 access_token (account={})",
@@ -4557,20 +4584,30 @@ mod tests {
             Some(crate::provider::AuthBinding {
                 source: crate::provider::AuthBindingSource::ManagedAccount,
                 auth_provider: Some("codex_oauth".to_string()),
-                account_id: Some("account-b".to_string()),
+                account_id: Some("user-b".to_string()),
             });
 
+        let token_a = crate::codex_oauth_identity::encode_unsigned_jwt(
+            r#"{"https://api.openai.com/auth":{"chatgpt_account_id":"org-team","chatgpt_user_id":"user-a"}}"#,
+        );
+        let token_b = crate::codex_oauth_identity::encode_unsigned_jwt(
+            r#"{"https://api.openai.com/auth":{"chatgpt_account_id":"org-team","chatgpt_user_id":"user-b"}}"#,
+        );
         let mut headers = HeaderMap::new();
         headers.insert(
             http::header::AUTHORIZATION,
-            HeaderValue::from_static("Bearer account-a-token"),
+            HeaderValue::from_str(&format!("Bearer {token_a}")).unwrap(),
         );
-        headers.insert("chatgpt-account-id", HeaderValue::from_static("account-a"));
+        // Team members share the workspace header; the JWT user must still match.
+        headers.insert("chatgpt-account-id", HeaderValue::from_static("org-team"));
         let error = validate_codex_official_authorization(&headers, &provider)
             .expect_err("a stale Codex session must not cross the account boundary");
         assert!(matches!(error, ProxyError::AuthError(message) if message.contains("重启 Codex")));
 
-        headers.insert("chatgpt-account-id", HeaderValue::from_static("account-b"));
+        headers.insert(
+            http::header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token_b}")).unwrap(),
+        );
         validate_codex_official_authorization(&headers, &provider)
             .expect("the selected account may pass through");
     }

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -13,9 +13,10 @@
 //! ## 多账号支持
 //! - 每个 ChatGPT 账号独立存储 refresh_token
 //! - Provider 通过 meta.authBinding 关联账号（auth_provider = "codex_oauth"）
-//! - 通过 JWT id_token 提取 chatgpt_account_id 作为账号唯一标识
+//! - 通过 JWT 提取 chatgpt_user_id / email 作为账号唯一标识
+//! - chatgpt_account_id 是工作区 ID，同一 Team 成员共享，不能作为存储键
 
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use crate::codex_oauth_identity::extract_identity_from_oauth_tokens;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -137,31 +138,6 @@ struct OAuthTokenResponse {
     expires_in: Option<i64>,
 }
 
-/// 解析后的 JWT claims（仅关心 chatgpt_account_id 等字段）
-#[derive(Debug, Clone, Default, Deserialize)]
-struct IdTokenClaims {
-    #[serde(default)]
-    chatgpt_account_id: Option<String>,
-    #[serde(default)]
-    email: Option<String>,
-    #[serde(default)]
-    organizations: Vec<OrgClaim>,
-    #[serde(default, rename = "https://api.openai.com/auth")]
-    openai_auth: Option<OpenAiAuthClaim>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-struct OrgClaim {
-    #[serde(default)]
-    id: Option<String>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-struct OpenAiAuthClaim {
-    #[serde(default)]
-    chatgpt_account_id: Option<String>,
-}
-
 /// 缓存的 access_token（含过期时间）
 #[derive(Debug, Clone)]
 struct CachedAccessToken {
@@ -231,7 +207,7 @@ struct PendingDeviceCode {
 /// 持久化的账号数据
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CodexAccountData {
-    /// chatgpt_account_id（同时作为 HashMap 的 key）
+    /// 用户级账号 ID（同时作为 HashMap 的 key）。不是 Team 工作区 ID。
     pub account_id: String,
     /// 账号邮箱（如果可获取）
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1133,6 +1109,27 @@ impl CodexOAuthManager {
         self.resolve_default_account_id().await
     }
 
+    /// Workspace id for `ChatGPT-Account-Id`. Team members share this value.
+    pub async fn workspace_id_for_account(&self, account_id: &str) -> Option<String> {
+        let (id_token, fallback) = {
+            let accounts = self.accounts.read().await;
+            let account = accounts.get(account_id)?;
+            (account.id_token.clone(), account.account_id.clone())
+        };
+        let access_token = self
+            .access_tokens
+            .read()
+            .await
+            .get(account_id)
+            .map(|cached| cached.token.clone());
+        let workspace_id = crate::codex_oauth_identity::workspace_id_from_tokens(
+            id_token.as_deref(),
+            access_token.as_deref(),
+            &fallback,
+        );
+        (!workspace_id.is_empty()).then_some(workspace_id)
+    }
+
     // ==================== 多账号管理 ====================
 
     pub async fn list_accounts(&self) -> Vec<GitHubAccount> {
@@ -1600,56 +1597,12 @@ fn extract_refresh_error_code(body: &str) -> Option<String> {
         .map(|code| code.to_ascii_lowercase())
 }
 
-/// 解析 JWT 中的 claims
-fn parse_jwt_claims(token: &str) -> Option<IdTokenClaims> {
-    let parts: Vec<&str> = token.split('.').collect();
-    if parts.len() != 3 {
-        return None;
-    }
-    let decoded = URL_SAFE_NO_PAD.decode(parts[1]).ok()?;
-    serde_json::from_slice(&decoded).ok()
-}
-
-/// 从 token 响应中提取 (account_id, email)
+/// 从 token 响应中提取用户级 (account_id, email)。
+/// 不会把同一 Team 共享的 workspace / org id 当成账号键。
 fn extract_identity_from_tokens(tokens: &OAuthTokenResponse) -> (Option<String>, Option<String>) {
-    let mut account_id: Option<String> = None;
-    let mut email: Option<String> = None;
-
-    if let Some(id_token) = tokens.id_token.as_deref() {
-        if let Some(claims) = parse_jwt_claims(id_token) {
-            account_id = claims
-                .chatgpt_account_id
-                .clone()
-                .or_else(|| {
-                    claims
-                        .openai_auth
-                        .as_ref()
-                        .and_then(|a| a.chatgpt_account_id.clone())
-                })
-                .or_else(|| claims.organizations.first().and_then(|o| o.id.clone()));
-            email = claims.email.clone();
-        }
-    }
-
-    if account_id.is_none() {
-        if let Some(claims) = parse_jwt_claims(&tokens.access_token) {
-            account_id = claims
-                .chatgpt_account_id
-                .clone()
-                .or_else(|| {
-                    claims
-                        .openai_auth
-                        .as_ref()
-                        .and_then(|a| a.chatgpt_account_id.clone())
-                })
-                .or_else(|| claims.organizations.first().and_then(|o| o.id.clone()));
-            if email.is_none() {
-                email = claims.email.clone();
-            }
-        }
-    }
-
-    (account_id, email)
+    extract_identity_from_oauth_tokens(tokens.id_token.as_deref(), &tokens.access_token)
+        .map(|identity| (Some(identity.storage_id), identity.email))
+        .unwrap_or((None, None))
 }
 
 #[cfg(test)]
@@ -1716,40 +1669,99 @@ mod tests {
         assert!(!valid.is_expiring_soon());
     }
 
-    #[test]
-    fn test_parse_jwt_claims_invalid() {
-        assert!(parse_jwt_claims("not-a-jwt").is_none());
-        assert!(parse_jwt_claims("only.two").is_none());
+    fn unsigned_jwt(payload: &str) -> String {
+        crate::codex_oauth_identity::encode_unsigned_jwt(payload)
     }
 
     #[test]
-    fn test_parse_jwt_claims_valid() {
-        // Header: {"alg":"none"}
-        // Payload: {"chatgpt_account_id":"acc-123","email":"test@example.com"}
-        // Signature: empty
-        let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
-        let payload = URL_SAFE_NO_PAD
-            .encode(b"{\"chatgpt_account_id\":\"acc-123\",\"email\":\"test@example.com\"}");
-        let jwt = format!("{header}.{payload}.");
-        let claims = parse_jwt_claims(&jwt).unwrap();
-        assert_eq!(claims.chatgpt_account_id.as_deref(), Some("acc-123"));
-        assert_eq!(claims.email.as_deref(), Some("test@example.com"));
-    }
-
-    #[test]
-    fn test_parse_jwt_claims_organizations_fallback() {
-        let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
-        let payload = URL_SAFE_NO_PAD.encode(b"{\"organizations\":[{\"id\":\"org-456\"}]}");
-        let jwt = format!("{header}.{payload}.");
-        let claims = parse_jwt_claims(&jwt).unwrap();
-        assert_eq!(
-            claims
-                .organizations
-                .first()
-                .and_then(|o| o.id.clone())
-                .as_deref(),
-            Some("org-456")
+    fn extract_identity_prefers_user_id_over_shared_workspace() {
+        let jwt = unsigned_jwt(
+            r#"{"chatgpt_account_id":"org-team","chatgpt_user_id":"user-a","email":"a@example.com"}"#,
         );
+        let tokens = OAuthTokenResponse {
+            access_token: jwt,
+            refresh_token: Some("rt".into()),
+            id_token: None,
+            expires_in: None,
+        };
+        let (account_id, email) = extract_identity_from_tokens(&tokens);
+        assert_eq!(account_id.as_deref(), Some("user-a"));
+        assert_eq!(email.as_deref(), Some("a@example.com"));
+    }
+
+    #[test]
+    fn extract_identity_keeps_same_team_members_distinct() {
+        let workspace = r#"https://api.openai.com/auth"#;
+        let jwt_a = unsigned_jwt(&format!(
+            r#"{{"{workspace}":{{"chatgpt_account_id":"org-team","chatgpt_user_id":"user-a"}},"email":"a@example.com"}}"#
+        ));
+        let jwt_b = unsigned_jwt(&format!(
+            r#"{{"{workspace}":{{"chatgpt_account_id":"org-team","chatgpt_user_id":"user-b"}},"email":"b@example.com"}}"#
+        ));
+        let id_a = extract_identity_from_tokens(&OAuthTokenResponse {
+            access_token: jwt_a,
+            refresh_token: Some("rt-a".into()),
+            id_token: None,
+            expires_in: None,
+        })
+        .0;
+        let id_b = extract_identity_from_tokens(&OAuthTokenResponse {
+            access_token: jwt_b,
+            refresh_token: Some("rt-b".into()),
+            id_token: None,
+            expires_in: None,
+        })
+        .0;
+        assert_eq!(id_a.as_deref(), Some("user-a"));
+        assert_eq!(id_b.as_deref(), Some("user-b"));
+        assert_ne!(id_a, id_b);
+    }
+
+    #[test]
+    fn extract_identity_does_not_key_accounts_by_organization_id() {
+        let jwt = unsigned_jwt(r#"{"organizations":[{"id":"org-456"}]}"#);
+        let tokens = OAuthTokenResponse {
+            access_token: jwt,
+            refresh_token: Some("rt".into()),
+            id_token: None,
+            expires_in: None,
+        };
+        let (account_id, email) = extract_identity_from_tokens(&tokens);
+        assert_eq!(account_id, None);
+        assert_eq!(email, None);
+    }
+
+    #[tokio::test]
+    async fn same_team_members_are_stored_as_separate_accounts() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        manager
+            .add_account_internal(
+                "user-a".into(),
+                "rt-a".into(),
+                Some("a@example.com".into()),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        manager
+            .add_account_internal(
+                "user-b".into(),
+                "rt-b".into(),
+                Some("b@example.com".into()),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let accounts = manager.list_accounts().await;
+        assert_eq!(accounts.len(), 2);
+        let mut ids: Vec<_> = accounts.iter().map(|account| account.id.as_str()).collect();
+        ids.sort_unstable();
+        assert_eq!(ids, ["user-a", "user-b"]);
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -2661,6 +2661,25 @@ base_url = "https://a.example/v1"
     }
 
     #[test]
+    fn codex_managed_oauth_live_auth_writes_workspace_id_not_user_key() {
+        let id_token = crate::codex_oauth_identity::encode_unsigned_jwt(
+            r#"{"chatgpt_account_id":"org-team","chatgpt_user_id":"user-a"}"#,
+        );
+        let auth = codex_managed_oauth_live_auth(
+            "user-a",
+            "access-token",
+            Some(&id_token),
+            "refresh-token",
+            "2026-01-02T03:04:05.000000000Z",
+        );
+        assert_eq!(
+            auth.pointer("/tokens/account_id").and_then(|v| v.as_str()),
+            Some("org-team"),
+            "auth.json must keep the official Codex workspace id"
+        );
+    }
+
+    #[test]
     fn codex_managed_oauth_live_auth_matches_codex_cli_shape() {
         assert_eq!(
             codex_managed_oauth_live_auth(


### PR DESCRIPTION
## 变更类型

- [x] 🐛 Bug 修复

## 变更说明

官方 Codex 把 JWT 里的 `chatgpt_account_id` 当作 **workspace id**，写入 `~/.codex/auth.json` 的 `tokens.account_id` 和 `ChatGPT-Account-Id`。同一 ChatGPT Team 的成员会共享这个值。

之前账号管理器直接拿它当存储键，导致 Team 成员登录时互相覆盖。本次把用户身份和工作区 ID 拆开：

- 存储 / 账号卡片 / live 匹配 / 官方会话校验：使用 `chatgpt_user_id`（回退 email / `sub`）
- `auth.json` / `ChatGPT-Account-Id` / 额度 / 模型列表：继续写 workspace id

旧账号如果仍按 workspace id 存储，live `auth.json` 匹配和官方会话校验仍可回退到该值，避免已登录 Team 账号失效。

## 相关 Issue

Closes #6738
Closes #5885
Closes #2245

## 测试情况

- [x] 已在本地测试通过
- [ ] 已添加/更新测试用例
- [ ] 不需要测试

本地已跑：

```bash
cd src-tauri
cargo fmt --all
cargo clippy --offline --all-targets -- -D warnings
cargo test --lib --offline extract_identity prefers_user_id live_auth same_team_members writes_workspace_id managed_codex_official extract_codex_managed chatgpt_auth_generation official
```

## 检查清单

- [x] 代码遵循项目规范
- [x] 已自我审查代码
- [x] 已添加必要的注释
- [x] 文档已更新（如需要）
- [x] 没有引入新的警告
- [x] 相关测试已通过
