### PR TITLE
fix(i18n): add the missing pi.form.providerKeyDuplicate and common.collapse keys

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -42,7 +42,8 @@
     "deleting": "Deleting...",
     "auto": "Auto",
     "enabled": "Enabled",
-    "notSet": "Not Set"
+    "notSet": "Not Set",
+    "collapse": "Collapse"
   },
   "firstRunNotice": {
     "title": "Welcome to CC Switch",
@@ -978,7 +979,8 @@
       "effectiveApiRequired": "Model {{id}} needs an API, either directly or from the provider",
       "effectiveBaseUrlRequired": "Model {{id}} needs a base URL, either directly or from the provider",
       "duplicateModel": "Model ID {{id}} is duplicated",
-      "modelRequired": "Add at least one model"
+      "modelRequired": "Add at least one model",
+      "providerKeyDuplicate": "This provider key already exists"
     },
     "current": {
       "readFailed": "Could not read Pi's provider configuration",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -42,7 +42,8 @@
     "deleting": "削除中...",
     "auto": "自動",
     "enabled": "有効",
-    "notSet": "未設定"
+    "notSet": "未設定",
+    "collapse": "折りたたむ"
   },
   "firstRunNotice": {
     "title": "CC Switch へようこそ",
@@ -978,7 +979,8 @@
       "effectiveApiRequired": "モデル {{id}} には、直接またはプロバイダーから継承した API が必要です",
       "effectiveBaseUrlRequired": "モデル {{id}} には、直接またはプロバイダーから継承したベース URL が必要です",
       "duplicateModel": "モデル ID {{id}} が重複しています",
-      "modelRequired": "モデルを 1 つ以上追加してください"
+      "modelRequired": "モデルを 1 つ以上追加してください",
+      "providerKeyDuplicate": "このプロバイダーキーは既に存在します"
     },
     "current": {
       "readFailed": "Pi のプロバイダー設定を読み込めません",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -42,7 +42,8 @@
     "deleting": "刪除中...",
     "auto": "自動",
     "enabled": "已啟用",
-    "notSet": "未設定"
+    "notSet": "未設定",
+    "collapse": "收合"
   },
   "firstRunNotice": {
     "title": "歡迎使用 CC Switch",
@@ -979,7 +980,8 @@
       "effectiveApiRequired": "模型 {{id}} 必須直接設定或從供應商繼承 API",
       "effectiveBaseUrlRequired": "模型 {{id}} 必須直接設定或從供應商繼承基礎 URL",
       "duplicateModel": "模型 ID {{id}} 重複",
-      "modelRequired": "請至少新增一個模型"
+      "modelRequired": "請至少新增一個模型",
+      "providerKeyDuplicate": "該供應商標識已存在"
     },
     "current": {
       "readFailed": "無法讀取 Pi 供應商設定",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -42,7 +42,8 @@
     "deleting": "删除中...",
     "auto": "自动",
     "enabled": "已开启",
-    "notSet": "未设置"
+    "notSet": "未设置",
+    "collapse": "收起"
   },
   "firstRunNotice": {
     "title": "欢迎使用 CC Switch",
@@ -978,7 +979,8 @@
       "effectiveApiRequired": "模型 {{id}} 必须直接配置或继承一个 API",
       "effectiveBaseUrlRequired": "模型 {{id}} 必须直接配置或继承一个基础地址",
       "duplicateModel": "模型 ID {{id}} 重复",
-      "modelRequired": "请至少添加一个模型"
+      "modelRequired": "请至少添加一个模型",
+      "providerKeyDuplicate": "该供应商标识已存在"
     },
     "current": {
       "readFailed": "无法读取 Pi 供应商配置",

--- a/tests/config/managementListLocales.test.ts
+++ b/tests/config/managementListLocales.test.ts
@@ -17,6 +17,12 @@ const requiredPaths = [
   "prompts.searchPlaceholder",
   "prompts.searchAriaLabel",
   "prompts.noSearchResults",
+  // `translatePiProviderMutationError` returns this key for the duplicate-key error
+  // the Pi backend raises, and it existed in no locale -- so the toast showed the raw
+  // key. Its own test mocks `t` as identity, so it stayed green throughout.
+  "pi.form.providerKeyDuplicate",
+  // Rendered as the aria-label of the thinking-map toggle in PiProviderForm.
+  "common.collapse",
 ] as const;
 
 type Locale = Record<string, unknown>;


### PR DESCRIPTION
## The defect

`translatePiProviderMutationError` returns a translation key for the duplicate-key error the Pi backend raises (`src/utils/errorUtils.ts:55-57`):

```ts
if (message.includes("Pi provider") && message.includes("already exists")) {
  return t("pi.form.providerKeyDuplicate");
}
```

That key exists in **none** of the four locale files. `fallbackLng: "en"` cannot rescue it, because `en` lacks it too, so `mutations.ts:144` renders the raw key into the toast:

```
Failed to add provider: pi.form.providerKeyDuplicate
```

Resolved against the real JSON, before this change:

```
en     pi.form.providerKeyDuplicate = MISSING    pi.provider.writeConflict = OK
zh     pi.form.providerKeyDuplicate = MISSING    pi.provider.writeConflict = OK
zh-TW  pi.form.providerKeyDuplicate = MISSING    pi.provider.writeConflict = OK
ja     pi.form.providerKeyDuplicate = MISSING    pi.provider.writeConflict = OK
```

`common.collapse` — the aria-label of the thinking-map toggle at `PiProviderForm.tsx:1747` — was missing in all four the same way, so it rides along.

The backend really does emit the matching string: `src-tauri/src/services/provider/pi.rs:51` and `:58`.

## Why it is a one-key omission, not a missing namespace

The branch one line above resolves everywhere, and the same duplicate-key message already exists for three other providers:

```
opencode.providerKeyDuplicate      OK in all four
openclaw.providerKeyDuplicate      OK in all four
hermes.form.providerKeyDuplicate   OK in all four
```

The wording follows Hermes', which is the closest match — *"This provider key already exists"* / 该供应商标识已存在 / 該供應商標識已存在 / このプロバイダーキーは既に存在します.

## Why the existing test did not catch it

`tests/utils/errorUtils.test.ts:22-32` mocks `t` as the identity function and asserts the return **is** the string `"pi.form.providerKeyDuplicate"`. It passes whether or not the key resolves, which is exactly how this survived.

So the guard belongs where keys are resolved against the real files: both paths are added to `requiredPaths` in `tests/config/managementListLocales.test.ts`, which already walks that list across all four locales.

## Verification

```
tests/config/managementListLocales.test.ts + tests/utils/errorUtils.test.ts   10 passed, 0 failed
tests/config/managementListLocales.test.ts (after adding the two paths)        7 passed
```

Reverting only the locale files, with the new guard in place, fails all four locale cases with `expected [ Array(2) ] to deeply equal []` — so the guard pins the keys rather than passing incidentally.

The diff is additive: 4 insertions / 2 deletions per locale file, the two deletions being the trailing-comma lines the insertions follow. No reformatting.
