### PR TITLE
fix(provider-form): prevent config editors from overwriting each other

### DIFF
--- a/src/components/JsonEditor.tsx
+++ b/src/components/JsonEditor.tsx
@@ -3,13 +3,16 @@ import { EditorView, basicSetup } from "codemirror";
 import { json } from "@codemirror/lang-json";
 import { javascript } from "@codemirror/lang-javascript";
 import { oneDark } from "@codemirror/theme-one-dark";
-import { EditorSelection, EditorState } from "@codemirror/state";
+import { Annotation, EditorSelection, EditorState } from "@codemirror/state";
 import { placeholder } from "@codemirror/view";
 import { linter, Diagnostic } from "@codemirror/lint";
 import { useTranslation } from "react-i18next";
 import { Wand2 } from "lucide-react";
 import { toast } from "sonner";
 import { formatJSON } from "@/utils/formatters";
+
+/** 标记把 value 属性推进编辑器的事务，避免回吐为 onChange。 */
+const ExternalSync = Annotation.define<boolean>();
 
 interface JsonEditorProps {
   id?: string;
@@ -210,8 +213,13 @@ const JsonEditor: React.FC<JsonEditorProps> = ({
       ),
       EditorView.updateListener.of((update) => {
         if (!readOnly && update.docChanged) {
-          const newValue = update.state.doc.toString();
-          onChangeRef.current(newValue);
+          // CodeMirror 会把外部同步 dispatch 也标记为 docChanged。只有当
+          // 本次 ViewUpdate 中的事务全部来自外部同步时才跳过；使用 every
+          // 保证与用户输入合并的更新不会被误吞。
+          if (update.transactions.every((tr) => tr.annotation(ExternalSync))) {
+            return;
+          }
+          onChangeRef.current(update.state.doc.toString());
         }
       }),
     ];
@@ -316,6 +324,7 @@ const JsonEditor: React.FC<JsonEditorProps> = ({
           contextualRanges,
           viewRef.current.state.selection.mainIndex,
         ),
+        annotations: ExternalSync.of(true),
       });
       viewRef.current.dispatch(transaction);
     }

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -61,6 +61,7 @@ import { HermesFormFields } from "./HermesFormFields";
 import type { UniversalProviderPreset } from "@/config/universalProviderPresets";
 import {
   applyTemplateValues,
+  getApiKeyFromConfig,
   hasApiKeyField,
 } from "@/utils/providerConfigUtils";
 import { mergeProviderMeta } from "@/utils/providerMetaUtils";
@@ -467,8 +468,19 @@ function ProviderFormFull({
 
   const handleSettingsConfigChange = useCallback(
     (config: string) => {
+      if (form.getValues("settingsConfig") === config) {
+        return;
+      }
       form.setValue("settingsConfig", config);
     },
+    [form],
+  );
+
+  // settingsConfig is not subscribed through register/Controller, so writes do
+  // not trigger a render. Event handlers must read the current value instead of
+  // rebuilding JSON from a render-time snapshot.
+  const getSettingsConfig = useCallback(
+    () => form.getValues("settingsConfig"),
     [form],
   );
 
@@ -506,6 +518,7 @@ function ProviderFormFull({
   } = useApiKeyState({
     initialConfig: form.getValues("settingsConfig"),
     onConfigChange: handleSettingsConfigChange,
+    getConfig: getSettingsConfig,
     selectedPresetId,
     category,
     appType: appId,
@@ -519,6 +532,7 @@ function ProviderFormFull({
     codexConfig: "",
     onSettingsConfigChange: handleSettingsConfigChange,
     onCodexConfigChange: () => {},
+    getSettingsConfig,
   });
 
   const {
@@ -536,7 +550,31 @@ function ProviderFormFull({
   } = useModelState({
     settingsConfig: form.getValues("settingsConfig"),
     onConfigChange: handleSettingsConfigChange,
+    getSettingsConfig,
   });
+
+  // Values used for submit-time validation/identity detection must come from
+  // the current JSON editor contents, not stale hook state from the last render.
+  const readSubmitTimeCredentials = useCallback(() => {
+    const raw = getSettingsConfig() || "{}";
+    let parsedBaseUrl: string | null = null;
+    try {
+      const parsed = JSON.parse(raw) as { env?: Record<string, unknown> };
+      const candidate =
+        appId === "gemini"
+          ? parsed.env?.GOOGLE_GEMINI_BASE_URL
+          : parsed.env?.ANTHROPIC_BASE_URL;
+      parsedBaseUrl = typeof candidate === "string" ? candidate.trim() : "";
+    } catch {
+      // The JSON validator will report malformed input; retain hook state for
+      // the auxiliary checks until the user fixes it.
+      parsedBaseUrl = null;
+    }
+    return {
+      baseUrl: parsedBaseUrl ?? baseUrl,
+      apiKey: parsedBaseUrl === null ? apiKey : getApiKeyFromConfig(raw, appId),
+    };
+  }, [apiKey, appId, baseUrl, getSettingsConfig]);
 
   const [localApiFormat, setLocalApiFormat] = useState<ClaudeApiFormat>(() => {
     if (appId !== "claude") return "anthropic";
@@ -561,7 +599,6 @@ function ProviderFormFull({
           delete config.env[prev];
           config.env[field] = value;
           const updated = JSON.stringify(config, null, 2);
-          form.setValue("settingsConfig", updated);
           handleSettingsConfigChange(updated);
         }
       } catch {
@@ -830,6 +867,7 @@ function ProviderFormFull({
     selectedPresetId: appId === "claude" ? selectedPresetId : null,
     presetEntries: appId === "claude" ? presetEntries : [],
     settingsConfig: form.getValues("settingsConfig"),
+    getSettingsConfig,
     onConfigChange: handleSettingsConfigChange,
   });
 
@@ -843,6 +881,7 @@ function ProviderFormFull({
     handleExtract: handleClaudeExtract,
   } = useCommonConfigSnippet({
     settingsConfig: form.getValues("settingsConfig"),
+    getSettingsConfig,
     onConfigChange: handleSettingsConfigChange,
     initialData: appId === "claude" ? initialData : undefined,
     initialEnabled:
@@ -902,10 +941,10 @@ function ProviderFormFull({
           config.env = {};
         }
         config.env[key] = value;
-        form.setValue("settingsConfig", JSON.stringify(config, null, 2));
+        handleSettingsConfigChange(JSON.stringify(config, null, 2));
       } catch {}
     },
-    [form],
+    [form, handleSettingsConfigChange],
   );
 
   const handleGeminiApiKeyChange = useCallback(
@@ -977,8 +1016,8 @@ function ProviderFormFull({
     initialData,
     appId,
     providerId,
-    onSettingsConfigChange: (config) => form.setValue("settingsConfig", config),
-    getSettingsConfig: () => form.getValues("settingsConfig"),
+    onSettingsConfigChange: handleSettingsConfigChange,
+    getSettingsConfig,
   });
 
   const initialOmoSettings =
@@ -998,8 +1037,8 @@ function ProviderFormFull({
     initialData,
     appId,
     providerId,
-    onSettingsConfigChange: (config) => form.setValue("settingsConfig", config),
-    getSettingsConfig: () => form.getValues("settingsConfig"),
+    onSettingsConfigChange: handleSettingsConfigChange,
+    getSettingsConfig,
   });
   const {
     data: openclawLiveProviderIds = [],
@@ -1010,8 +1049,8 @@ function ProviderFormFull({
     initialData,
     appId,
     providerId,
-    onSettingsConfigChange: (config) => form.setValue("settingsConfig", config),
-    getSettingsConfig: () => form.getValues("settingsConfig"),
+    onSettingsConfigChange: handleSettingsConfigChange,
+    getSettingsConfig,
   });
   const {
     data: hermesLiveProviderIds = [],
@@ -1254,8 +1293,16 @@ function ProviderFormFull({
       }
     }
 
+    const { baseUrl: submitBaseUrl, apiKey: submitApiKey } =
+      readSubmitTimeCredentials();
+    const isCopilotProviderAtSubmit =
+      appId === "claude" &&
+      (presetProviderType === "github_copilot" ||
+        initialProviderType === "github_copilot" ||
+        submitBaseUrl.includes("githubcopilot.com"));
+
     // OAuth 未登录：B 类（token 根本不存在，保存了也没法建立）
-    if (isCopilotProvider && isCopilotStatusError) {
+    if (isCopilotProviderAtSubmit && isCopilotStatusError) {
       toast.error(
         t("copilot.statusLoadFailed", {
           defaultValue: "无法加载 GitHub Copilot 账号状态，请重试。",
@@ -1263,7 +1310,7 @@ function ProviderFormFull({
       );
       return;
     }
-    if (isCopilotProvider && !isCopilotStatusSuccess) {
+    if (isCopilotProviderAtSubmit && !isCopilotStatusSuccess) {
       toast.error(
         t("copilot.statusLoading", {
           defaultValue: "正在加载 GitHub Copilot 账号状态，请稍后再试。",
@@ -1271,7 +1318,7 @@ function ProviderFormFull({
       );
       return;
     }
-    if (isCopilotProvider && !isCopilotAuthenticated) {
+    if (isCopilotProviderAtSubmit && !isCopilotAuthenticated) {
       toast.error(
         t("copilot.loginRequired", {
           defaultValue: "请先登录 GitHub Copilot",
@@ -1346,7 +1393,7 @@ function ProviderFormFull({
         (account) => account.id === accountId && !account.requires_reauth,
       );
     if (
-      isCopilotProvider &&
+      isCopilotProviderAtSubmit &&
       !selectedAccountExists(selectedGitHubAccountId, copilotAccounts)
     ) {
       toast.error(
@@ -1417,7 +1464,7 @@ function ProviderFormFull({
         if (
           !isClaudeCodexOauthProvider &&
           !isXaiOauthProvider &&
-          !baseUrl.trim()
+          !submitBaseUrl.trim()
         ) {
           issues.push(
             t("providerForm.endpointRequired", {
@@ -1426,10 +1473,10 @@ function ProviderFormFull({
           );
         }
         if (
-          !isCopilotProvider &&
+          !isCopilotProviderAtSubmit &&
           !isClaudeCodexOauthProvider &&
           !isXaiOauthProvider &&
-          !apiKey.trim()
+          !submitApiKey.trim()
         ) {
           issues.push(
             t("providerForm.apiKeyRequired", {
@@ -1703,7 +1750,12 @@ function ProviderFormFull({
       delete baseMeta.custom_endpoints;
     }
 
-    const providerType = isCopilotProvider
+    const isCopilotProviderForSubmit =
+      appId === "claude" &&
+      (presetProviderType === "github_copilot" ||
+        initialProviderType === "github_copilot" ||
+        readSubmitTimeCredentials().baseUrl.includes("githubcopilot.com"));
+    const providerType = isCopilotProviderForSubmit
       ? "github_copilot"
       : isClaudeCodexOauthProvider || isCodexOfficialManagedOauthBound
         ? "codex_oauth"
@@ -1725,7 +1777,7 @@ function ProviderFormFull({
       claudeDesktopMode: undefined,
       // 保存 providerType（用于识别 Copilot / Codex OAuth 等特殊供应商）
       providerType,
-      authBinding: isCopilotProvider
+      authBinding: isCopilotProviderForSubmit
         ? {
             source: "managed_account",
             authProvider: "github_copilot",
@@ -1752,7 +1804,7 @@ function ProviderFormFull({
               : undefined,
       // GitHub Copilot 多账号：保存关联的账号 ID
       githubAccountId:
-        isCopilotProvider && selectedGitHubAccountId
+        isCopilotProviderForSubmit && selectedGitHubAccountId
           ? selectedGitHubAccountId
           : undefined,
       codexFastMode: isClaudeCodexOauthProvider ? codexFastMode : undefined,
@@ -2700,7 +2752,7 @@ function ProviderFormFull({
                 </Label>
                 <JsonEditor
                   value={form.getValues("settingsConfig")}
-                  onChange={(config) => form.setValue("settingsConfig", config)}
+                  onChange={handleSettingsConfigChange}
                   placeholder={`{
   "npm": "@ai-sdk/openai-compatible",
   "options": {
@@ -2725,7 +2777,7 @@ function ProviderFormFull({
                 </Label>
                 <JsonEditor
                   value={form.getValues("settingsConfig")}
-                  onChange={(config) => form.setValue("settingsConfig", config)}
+                  onChange={handleSettingsConfigChange}
                   placeholder={
                     appId === "hermes"
                       ? `{
@@ -2760,7 +2812,7 @@ function ProviderFormFull({
             <>
               <CommonConfigEditor
                 value={form.getValues("settingsConfig")}
-                onChange={(value) => form.setValue("settingsConfig", value)}
+                onChange={handleSettingsConfigChange}
                 useCommonConfig={useCommonConfig}
                 onCommonConfigToggle={handleCommonConfigToggle}
                 commonConfigSnippet={commonConfigSnippet}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -560,10 +560,7 @@ function ProviderFormFull({
     let parsedBaseUrl: string | null = null;
     try {
       const parsed = JSON.parse(raw) as { env?: Record<string, unknown> };
-      const candidate =
-        appId === "gemini"
-          ? parsed.env?.GOOGLE_GEMINI_BASE_URL
-          : parsed.env?.ANTHROPIC_BASE_URL;
+      const candidate = parsed.env?.ANTHROPIC_BASE_URL;
       parsedBaseUrl = typeof candidate === "string" ? candidate.trim() : "";
     } catch {
       // The JSON validator will report malformed input; retain hook state for

--- a/src/components/providers/forms/hooks/useApiKeyState.ts
+++ b/src/components/providers/forms/hooks/useApiKeyState.ts
@@ -9,6 +9,11 @@ import {
 interface UseApiKeyStateProps {
   initialConfig?: string;
   onConfigChange: (config: string) => void;
+  /**
+   * 现读当前配置。`initialConfig` 是调用方渲染期取的快照，而写 settingsConfig
+   * 不触发重渲染，改 API Key 时若基于旧快照重建整份 JSON 会覆盖别处的改动。
+   */
+  getConfig?: () => string;
   selectedPresetId: string | null;
   category?: ProviderCategory;
   appType?: string;
@@ -22,6 +27,7 @@ interface UseApiKeyStateProps {
 export function useApiKeyState({
   initialConfig,
   onConfigChange,
+  getConfig,
   selectedPresetId,
   category,
   appType,
@@ -57,7 +63,7 @@ export function useApiKeyState({
       setApiKey(key);
 
       const configString = setApiKeyInConfig(
-        initialConfig || "{}",
+        getConfig?.() || initialConfig || "{}",
         key.trim(),
         {
           // 最佳实践：仅在"非官方/非云厂商类别"时补齐缺失字段
@@ -74,6 +80,7 @@ export function useApiKeyState({
       onConfigChange(configString);
     },
     [
+      getConfig,
       initialConfig,
       selectedPresetId,
       category,

--- a/src/components/providers/forms/hooks/useApiKeyState.ts
+++ b/src/components/providers/forms/hooks/useApiKeyState.ts
@@ -63,7 +63,7 @@ export function useApiKeyState({
       setApiKey(key);
 
       const configString = setApiKeyInConfig(
-        getConfig?.() || initialConfig || "{}",
+        getConfig ? getConfig() || "{}" : initialConfig || "{}",
         key.trim(),
         {
           // 最佳实践：仅在"非官方/非云厂商类别"时补齐缺失字段

--- a/src/components/providers/forms/hooks/useBaseUrlState.ts
+++ b/src/components/providers/forms/hooks/useBaseUrlState.ts
@@ -13,6 +13,13 @@ interface UseBaseUrlStateProps {
   codexConfig?: string;
   onSettingsConfigChange: (config: string) => void;
   onCodexConfigChange?: (config: string) => void;
+  /**
+   * 现读当前配置。`settingsConfig` 是调用方在渲染期取的快照，而写入
+   * settingsConfig 不会触发重渲染，所以别处（JSON 编辑器、通用配置片段合并）
+   * 写进去的改动不会反映到那份快照里。改 Base URL 时若基于旧快照重建整份
+   * JSON，就会把那些改动覆盖回去。传入本 getter 即可在事件发生时现读。
+   */
+  getSettingsConfig?: () => string;
 }
 
 /**
@@ -26,11 +33,18 @@ export function useBaseUrlState({
   codexConfig,
   onSettingsConfigChange,
   onCodexConfigChange,
+  getSettingsConfig,
 }: UseBaseUrlStateProps) {
   const [baseUrl, setBaseUrl] = useState("");
   const [codexBaseUrl, setCodexBaseUrl] = useState("");
   const [geminiBaseUrl, setGeminiBaseUrl] = useState("");
   const isUpdatingRef = useRef(false);
+
+  // 事件处理里一律走这里取配置：有 getter 用 getter（当前值），否则退回快照。
+  const readSettingsConfig = useCallback(
+    () => getSettingsConfig?.() ?? settingsConfig,
+    [getSettingsConfig, settingsConfig],
+  );
 
   // 从配置同步到 state（Claude / Claude Desktop）
   useEffect(() => {
@@ -91,7 +105,7 @@ export function useBaseUrlState({
       isUpdatingRef.current = true;
 
       try {
-        const config = JSON.parse(settingsConfig || "{}");
+        const config = JSON.parse(readSettingsConfig() || "{}");
         if (!config.env) {
           config.env = {};
         }
@@ -105,7 +119,7 @@ export function useBaseUrlState({
         }, 0);
       }
     },
-    [settingsConfig, onSettingsConfigChange],
+    [readSettingsConfig, onSettingsConfigChange],
   );
 
   // 处理 Codex Base URL 变化
@@ -141,7 +155,7 @@ export function useBaseUrlState({
       isUpdatingRef.current = true;
 
       try {
-        const config = JSON.parse(settingsConfig || "{}");
+        const config = JSON.parse(readSettingsConfig() || "{}");
         if (!config.env) {
           config.env = {};
         }
@@ -155,7 +169,7 @@ export function useBaseUrlState({
         }, 0);
       }
     },
-    [settingsConfig, onSettingsConfigChange],
+    [readSettingsConfig, onSettingsConfigChange],
   );
 
   return {

--- a/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
+++ b/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
@@ -14,6 +14,12 @@ const DEFAULT_COMMON_CONFIG_SNIPPET = `{
 
 interface UseCommonConfigSnippetProps {
   settingsConfig: string;
+  /**
+   * 现读当前配置。`settingsConfig` 是调用方渲染期取的快照，而写 settingsConfig
+   * 不触发重渲染，勾选/取消"使用公共配置"或改片段时若基于旧快照重建整份配置，
+   * 会把 JSON 编辑器里刚输入的内容覆盖掉。
+   */
+  getSettingsConfig?: () => string;
   onConfigChange: (config: string) => void;
   initialData?: {
     settingsConfig?: Record<string, unknown>;
@@ -30,6 +36,7 @@ interface UseCommonConfigSnippetProps {
  */
 export function useCommonConfigSnippet({
   settingsConfig,
+  getSettingsConfig,
   onConfigChange,
   initialData,
   initialEnabled,
@@ -203,7 +210,7 @@ export function useCommonConfigSnippet({
   const handleCommonConfigToggle = useCallback(
     (checked: boolean) => {
       const { updatedConfig, error: snippetError } = updateCommonConfigSnippet(
-        settingsConfig,
+        getSettingsConfig?.() ?? settingsConfig,
         commonConfigSnippet,
         checked,
       );
@@ -224,7 +231,7 @@ export function useCommonConfigSnippet({
         isUpdatingFromCommonConfig.current = false;
       }, 0);
     },
-    [settingsConfig, commonConfigSnippet, onConfigChange],
+    [getSettingsConfig, settingsConfig, commonConfigSnippet, onConfigChange],
   );
 
   // 处理通用配置片段变化
@@ -247,7 +254,7 @@ export function useCommonConfigSnippet({
 
         if (useCommonConfig) {
           const { updatedConfig } = updateCommonConfigSnippet(
-            settingsConfig,
+            getSettingsConfig?.() ?? settingsConfig,
             previousSnippet,
             false,
           );
@@ -277,7 +284,7 @@ export function useCommonConfigSnippet({
       // 若当前启用通用配置且格式正确，需要替换为最新片段
       if (useCommonConfig && !validationError) {
         const removeResult = updateCommonConfigSnippet(
-          settingsConfig,
+          getSettingsConfig?.() ?? settingsConfig,
           previousSnippet,
           false,
         );
@@ -305,7 +312,13 @@ export function useCommonConfigSnippet({
         }, 0);
       }
     },
-    [commonConfigSnippet, settingsConfig, useCommonConfig, onConfigChange],
+    [
+      commonConfigSnippet,
+      getSettingsConfig,
+      settingsConfig,
+      useCommonConfig,
+      onConfigChange,
+    ],
   );
 
   // 当配置变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）

--- a/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
+++ b/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
@@ -341,7 +341,7 @@ export function useCommonConfigSnippet({
 
     try {
       const extracted = await configApi.extractCommonConfigSnippet("claude", {
-        settingsConfig,
+        settingsConfig: getSettingsConfig?.() ?? settingsConfig,
       });
 
       if (!extracted || extracted === "{}") {
@@ -369,7 +369,7 @@ export function useCommonConfigSnippet({
     } finally {
       setIsExtracting(false);
     }
-  }, [settingsConfig, t]);
+  }, [getSettingsConfig, settingsConfig, t]);
 
   return {
     useCommonConfig,

--- a/src/components/providers/forms/hooks/useModelState.ts
+++ b/src/components/providers/forms/hooks/useModelState.ts
@@ -3,6 +3,12 @@ import { useState, useCallback, useEffect, useRef } from "react";
 interface UseModelStateProps {
   settingsConfig: string;
   onConfigChange: (config: string) => void;
+  /**
+   * 现读当前配置。latestConfigRef 只在渲染期从 settingsConfig 快照赋值，而写
+   * settingsConfig 不触发重渲染，所以别处（JSON 编辑器、通用配置合并）的改动
+   * 不会进入那个 ref。改模型时若基于它重建整份 JSON 会把那些改动覆盖回去。
+   */
+  getSettingsConfig?: () => string;
 }
 
 export type ClaudeModelEnvField =
@@ -122,6 +128,7 @@ function parseModelsFromConfig(settingsConfig: string) {
 export function useModelState({
   settingsConfig,
   onConfigChange,
+  getSettingsConfig,
 }: UseModelStateProps) {
   const initial = useState(() => parseModelsFromConfig(settingsConfig))[0];
   const [claudeModel, setClaudeModel] = useState(initial.model);
@@ -198,9 +205,8 @@ export function useModelState({
       if (field === "CLAUDE_CODE_SUBAGENT_MODEL") setSubagentModel(value);
 
       try {
-        const currentConfig = latestConfigRef.current
-          ? JSON.parse(latestConfigRef.current)
-          : { env: {} };
+        const currentRaw = getSettingsConfig?.() ?? latestConfigRef.current;
+        const currentConfig = currentRaw ? JSON.parse(currentRaw) : { env: {} };
         if (!currentConfig.env) currentConfig.env = {};
         const env = currentConfig.env as Record<string, unknown>;
 
@@ -221,7 +227,7 @@ export function useModelState({
         console.error("Failed to update model config:", err);
       }
     },
-    [onConfigChange],
+    [getSettingsConfig, onConfigChange],
   );
 
   return {

--- a/src/components/providers/forms/hooks/useTemplateValues.ts
+++ b/src/components/providers/forms/hooks/useTemplateValues.ts
@@ -20,6 +20,11 @@ interface UseTemplateValuesProps {
   presetEntries: PresetEntry[];
   settingsConfig: string;
   onConfigChange: (config: string) => void;
+  /**
+   * 现读当前配置。`settingsConfig` 是调用方渲染期取的快照，而写 settingsConfig
+   * 不触发重渲染，套用模板变量时基于旧快照重建整份配置会覆盖别处的改动。
+   */
+  getSettingsConfig?: () => string;
 }
 
 /**
@@ -168,6 +173,7 @@ export function useTemplateValues({
   presetEntries,
   settingsConfig,
   onConfigChange,
+  getSettingsConfig,
 }: UseTemplateValuesProps) {
   const [templateValues, setTemplateValues] = useState<TemplateValueMap>({});
 
@@ -240,7 +246,7 @@ export function useTemplateValues({
         try {
           const configString = applyTemplateValuesToConfigString(
             selectedPreset.settingsConfig,
-            settingsConfig,
+            getSettingsConfig?.() ?? settingsConfig,
             nextValues,
           );
           onConfigChange(configString);
@@ -251,7 +257,7 @@ export function useTemplateValues({
         return nextValues;
       });
     },
-    [selectedPreset, settingsConfig, onConfigChange],
+    [selectedPreset, getSettingsConfig, settingsConfig, onConfigChange],
   );
 
   // 验证所有模板值是否已填写

--- a/tests/components/JsonEditorExternalSync.test.tsx
+++ b/tests/components/JsonEditorExternalSync.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import JsonEditor from "@/components/JsonEditor";
+
+/**
+ * 锁住 JsonEditor 的一条不变量：把 value 属性同步进编辑器的那次程序化替换，
+ * 不得被当成用户输入回吐给 onChange。
+ *
+ * 回吐会让调用方分不清"用户改了"和"我刚把值推进来"。两个持有不同文档的编辑器
+ * 实例因此互相回吐、各自把对方的值盖掉，表现为编辑弹窗在两份配置之间无休止地
+ * 闪 —— 这是线上真实发生过的故障。
+ *
+ * 这里用真实的 CodeMirror 编辑器，不做 mock：mock 掉就等于把被测的那段逻辑
+ * 换掉，测试会在有 bug 的代码上照样通过。
+ */
+const CONFIG_A = JSON.stringify({ env: { A: "1" } }, null, 2);
+const CONFIG_B = JSON.stringify({ env: { B: "2", C: "3" } }, null, 2);
+
+function Harness({ onChange }: { onChange: (value: string) => void }) {
+  const [value, setValue] = useState(CONFIG_A);
+  return (
+    <div>
+      <button type="button" onClick={() => setValue(CONFIG_B)}>
+        push-b
+      </button>
+      <JsonEditor
+        value={value}
+        onChange={(next) => {
+          onChange(next);
+          setValue(next);
+        }}
+      />
+    </div>
+  );
+}
+
+describe("JsonEditor 外部同步不得回吐成用户输入", () => {
+  it("把新 value 推进编辑器时不触发 onChange", async () => {
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    // 挂载本身不算用户输入
+    await waitFor(() =>
+      expect(document.querySelector(".cm-content")).toBeTruthy(),
+    );
+    expect(onChange).not.toHaveBeenCalled();
+
+    screen.getByText("push-b").click();
+
+    // 外部推入新值后，文档要更新，但 onChange 必须一次都不响
+    await waitFor(() =>
+      expect(document.querySelector(".cm-content")?.textContent).toContain("C"),
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("onChange 换成新的闭包后，监听器必须用最新那个", async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    function SwapHarness() {
+      const [useSecond, setUseSecond] = useState(false);
+      const [value, setValue] = useState(CONFIG_A);
+      return (
+        <div>
+          <button type="button" onClick={() => setUseSecond(true)}>
+            swap
+          </button>
+          <JsonEditor
+            value={value}
+            onChange={(next) => {
+              (useSecond ? second : first)(next);
+              setValue(next);
+            }}
+          />
+        </div>
+      );
+    }
+
+    render(<SwapHarness />);
+    await waitFor(() =>
+      expect(document.querySelector(".cm-content")).toBeTruthy(),
+    );
+
+    screen.getByText("swap").click();
+
+    // 模拟用户输入：直接改 CodeMirror 文档（非外部同步事务）
+    const view = (
+      document.querySelector(".cm-editor") as HTMLElement & {
+        cmView?: { view: { dispatch: (spec: unknown) => void } };
+      }
+    )?.cmView?.view;
+    if (!view) {
+      // 拿不到内部实例时跳过断言，避免测试依赖 CodeMirror 私有属性而变脆
+      return;
+    }
+    view.dispatch({ changes: { from: 0, to: 0, insert: " " } });
+
+    await waitFor(() => expect(second).toHaveBeenCalled());
+    expect(first).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/JsonEditorExternalSync.test.tsx
+++ b/tests/components/JsonEditorExternalSync.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { useState } from "react";
 import JsonEditor from "@/components/JsonEditor";
@@ -83,17 +83,17 @@ describe("JsonEditor 外部同步不得回吐成用户输入", () => {
       expect(document.querySelector(".cm-content")).toBeTruthy(),
     );
 
-    screen.getByText("swap").click();
+    fireEvent.click(screen.getByText("swap"));
 
     // 模拟用户输入：直接改 CodeMirror 文档（非外部同步事务）
     const view = (
-      document.querySelector(".cm-editor") as HTMLElement & {
+      document.querySelector(".cm-content") as HTMLElement & {
         cmView?: { view: { dispatch: (spec: unknown) => void } };
       }
     )?.cmView?.view;
+    expect(view).toBeTruthy();
     if (!view) {
-      // 拿不到内部实例时跳过断言，避免测试依赖 CodeMirror 私有属性而变脆
-      return;
+      throw new Error("CodeMirror view was not attached to .cm-content");
     }
     view.dispatch({ changes: { from: 0, to: 0, insert: " " } });
 

--- a/tests/components/ProviderFormSettingsConfigSnapshot.test.tsx
+++ b/tests/components/ProviderFormSettingsConfigSnapshot.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useCallback } from "react";
+import { useForm } from "react-hook-form";
+import { useBaseUrlState } from "@/components/providers/forms/hooks";
+
+/**
+ * 复刻 ProviderForm 对 settingsConfig 的接线方式：
+ * - settingsConfig 没有通过 register/Controller 订阅，只能用 form.setValue 写，
+ *   写入不会触发重渲染；
+ * - 派生状态（这里是 Base URL）在渲染期用 form.getValues 取快照，那份快照因此
+ *   会停在改动之前。
+ *
+ * 修法是给 hook 传 getSettingsConfig，让它在事件发生时现读当前值。绝不能改成
+ * "写入时强制重渲染"来刷新快照：那会让表单初始值回填与通用配置片段自动合并
+ * 两个写入方互相覆盖，编辑弹窗在两份配置之间来回跳。
+ *
+ * 本测试锁住的不变量：后一次结构化字段改动不得覆盖前一次的改动。
+ */
+const INITIAL_CONFIG = JSON.stringify(
+  { env: { ANTHROPIC_BASE_URL: "https://api.old.example" } },
+  null,
+  2,
+);
+
+const CONFIG_FROM_JSON_EDITOR = JSON.stringify(
+  {
+    env: {
+      ANTHROPIC_BASE_URL: "https://api.old.example",
+      ANTHROPIC_AUTH_TOKEN: "token-typed-in-json-editor",
+    },
+  },
+  null,
+  2,
+);
+
+function Harness({ onReadConfig }: { onReadConfig: (config: string) => void }) {
+  const form = useForm<{ settingsConfig: string }>({
+    defaultValues: { settingsConfig: INITIAL_CONFIG },
+    mode: "onSubmit",
+  });
+
+  const handleSettingsConfigChange = useCallback(
+    (config: string) => {
+      if (form.getValues("settingsConfig") === config) {
+        return;
+      }
+      form.setValue("settingsConfig", config);
+    },
+    [form],
+  );
+
+  const getSettingsConfig = useCallback(
+    () => form.getValues("settingsConfig"),
+    [form],
+  );
+
+  const { handleClaudeBaseUrlChange } = useBaseUrlState({
+    appType: "claude",
+    category: "custom",
+    settingsConfig: form.getValues("settingsConfig"),
+    codexConfig: "",
+    onSettingsConfigChange: handleSettingsConfigChange,
+    onCodexConfigChange: () => {},
+    getSettingsConfig,
+  });
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => handleSettingsConfigChange(CONFIG_FROM_JSON_EDITOR)}
+      >
+        edit-json
+      </button>
+      <button
+        type="button"
+        onClick={() => handleClaudeBaseUrlChange("https://api.new.example")}
+      >
+        edit-base-url
+      </button>
+      <button type="button" onClick={() => onReadConfig(getSettingsConfig())}>
+        read
+      </button>
+    </div>
+  );
+}
+
+// 不能从渲染结果里读：写 settingsConfig 不触发重渲染（这正是本测试要保护的
+// 设计），渲染出来的文本会是旧值。改为按需从表单里现读。
+let lastRead = "{}";
+const renderHarness = () =>
+  render(<Harness onReadConfig={(config) => (lastRead = config)} />);
+const readConfig = () => {
+  fireEvent.click(screen.getByText("read"));
+  return JSON.parse(lastRead) as { env?: Record<string, string> };
+};
+
+describe("ProviderForm settingsConfig 写入不能丢失前一次改动", () => {
+  it("JSON 编辑器改完再改请求地址，两处改动都要保留", () => {
+    renderHarness();
+
+    fireEvent.click(screen.getByText("edit-json"));
+    expect(readConfig().env?.ANTHROPIC_AUTH_TOKEN).toBe(
+      "token-typed-in-json-editor",
+    );
+
+    fireEvent.click(screen.getByText("edit-base-url"));
+
+    const config = readConfig();
+    expect(config.env?.ANTHROPIC_BASE_URL).toBe("https://api.new.example");
+    expect(config.env?.ANTHROPIC_AUTH_TOKEN).toBe("token-typed-in-json-editor");
+  });
+
+  it("改请求地址后再改 JSON，请求地址不被旧快照覆盖", () => {
+    renderHarness();
+
+    fireEvent.click(screen.getByText("edit-base-url"));
+    expect(readConfig().env?.ANTHROPIC_BASE_URL).toBe(
+      "https://api.new.example",
+    );
+
+    fireEvent.click(screen.getByText("edit-json"));
+    fireEvent.click(screen.getByText("edit-base-url"));
+
+    const config = readConfig();
+    expect(config.env?.ANTHROPIC_BASE_URL).toBe("https://api.new.example");
+    expect(config.env?.ANTHROPIC_AUTH_TOKEN).toBe("token-typed-in-json-editor");
+  });
+});


### PR DESCRIPTION
## Summary

Split the frontend portion of #6187 into its own PR. This fixes the two `ProviderForm` JSON editors overwriting each other when an external `value` synchronization was echoed back as user input.

## Changes

- Mark CodeMirror value-to-document updates with an `ExternalSync` annotation and ignore only updates made entirely of external-sync transactions.
- Read `onChange` through a ref so the editor keeps the latest form closure without rebuilding the editor on every render.
- Read `settingsConfig` at event time throughout the structured provider-form hooks, preserving edits made in the JSON editor and common-config editor.
- Use the current config for submit-time endpoint/API-key validation and provider identity detection.
- Add regression tests for the CodeMirror no-echo invariant and the settings snapshot invariant.

## Review follow-up

This is the frontend half of closed PR #6187 by BingZi-233. The original author is retained as a co-author in the commit (`Co-authored-by: BingZi-233 <lhby233@outlook.com>`).

## Verification

- `pnpm exec vitest run tests/components/JsonEditorExternalSync.test.tsx tests/components/ProviderFormSettingsConfigSnapshot.test.tsx`
- `pnpm run typecheck`
