### PR TITLE
fix(codex-oauth): isolate shared workspace accounts

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -488,38 +488,30 @@ fn extract_codex_auth_user_identity(auth: &Value) -> Option<String> {
     extract_codex_id_token_user_identity(id_token)
 }
 
-fn extract_codex_id_token_user_identity(id_token: &str) -> Option<String> {
-    let claims: Value = match id_token
-        .split('.')
-        .nth(1)
-        .and_then(|payload| URL_SAFE_NO_PAD.decode(payload).ok())
-        .and_then(|decoded| serde_json::from_slice(&decoded).ok())
-    {
-        Some(claims) => claims,
+pub(crate) fn extract_codex_id_token_user_identity(id_token: &str) -> Option<String> {
+    match extract_codex_id_token_subject(id_token) {
+        Some(subject) => Some(format!("sub:{subject}")),
         None => {
             #[cfg(test)]
             return Some("test-user".to_string());
             #[cfg(not(test))]
             return None;
         }
-    };
-    let chatgpt_user_id = claims
-        .get("https://api.openai.com/auth")
-        .and_then(Value::as_object)
-        .and_then(|claim| claim.get("chatgpt_user_id"))
-        .and_then(Value::as_str)
-        .or_else(|| claims.get("chatgpt_user_id").and_then(Value::as_str))
-        .map(str::trim)
-        .filter(|value| !value.is_empty());
-    if let Some(user_id) = chatgpt_user_id {
-        return Some(format!("chatgpt_user_id:{user_id}"));
     }
+}
+
+pub(crate) fn extract_codex_id_token_subject(id_token: &str) -> Option<String> {
+    let claims: Value = id_token
+        .split('.')
+        .nth(1)
+        .and_then(|payload| URL_SAFE_NO_PAD.decode(payload).ok())
+        .and_then(|decoded| serde_json::from_slice(&decoded).ok())?;
     claims
         .get("sub")
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(|subject| format!("sub:{subject}"))
+        .map(str::to_string)
 }
 
 #[cfg(test)]
@@ -617,6 +609,21 @@ fn migrate_legacy_codex_managed_oauth_live_auth_marker(
     record_codex_managed_oauth_live_auth(auth, managed_account_id)
 }
 
+/// Before removing a manager record, make any legacy live-auth ownership
+/// provable with the manager's persisted user identity. Failure is surfaced so
+/// callers keep the manager record and marker instead of orphaning auth.json.
+pub(crate) fn prepare_codex_live_auth_for_managed_account_removal(
+    managed_account_id: &str,
+    managed_id_token: Option<&str>,
+) -> Result<(), AppError> {
+    let auth_path = get_codex_auth_path();
+    if !auth_path.exists() {
+        return Ok(());
+    }
+    let auth: Value = read_json_file(&auth_path)?;
+    migrate_legacy_codex_managed_oauth_live_auth_marker(&auth, managed_account_id, managed_id_token)
+}
+
 pub fn codex_auth_matches_recorded_managed_oauth(
     auth: &Value,
     account_id: &str,
@@ -657,6 +664,29 @@ pub fn codex_auth_matches_recorded_managed_oauth(
             }
             _ => false,
         })
+}
+
+/// Verify that a proxied Codex request still uses the exact live access token
+/// owned by the selected local account. Workspace IDs alone are not sufficient:
+/// different Team users can share one value.
+pub(crate) fn codex_live_auth_matches_managed_request(
+    account_id: &str,
+    request_access_token: &str,
+) -> Result<bool, AppError> {
+    let auth_path = get_codex_auth_path();
+    if !auth_path.exists() {
+        return Ok(false);
+    }
+    let auth: Value = read_json_file(&auth_path)?;
+    if !codex_auth_matches_recorded_managed_oauth(&auth, account_id)? {
+        return Ok(false);
+    }
+    let live_access_token = auth
+        .pointer("/tokens/access_token")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|token| !token.is_empty());
+    Ok(live_access_token == Some(request_access_token.trim()))
 }
 
 fn clear_codex_managed_oauth_live_auth_marker_for_account(
@@ -3632,12 +3662,25 @@ base_url = "https://single.example.com/v1"
     #[serial]
     fn managed_chatgpt_login_matches_local_marker_and_workspace() {
         let _home = CodexLiveTestHome::new();
+        let shared_chatgpt_user_token = |subject: &str| {
+            let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+            let payload = URL_SAFE_NO_PAD.encode(
+                json!({
+                    "sub": subject,
+                    "https://api.openai.com/auth": {
+                        "chatgpt_user_id": "shared-team-user-id"
+                    }
+                })
+                .to_string(),
+            );
+            format!("{header}.{payload}.")
+        };
         // 原生 auth 保留 workspace ID；marker 用本地 ID 区分同 workspace 登录。
         let full_bundle = json!({
             "auth_mode": "chatgpt",
             "OPENAI_API_KEY": null,
             "tokens": {
-                "id_token": test_codex_id_token("user-a"),
+                "id_token": shared_chatgpt_user_token("user-a"),
                 "access_token": "access",
                 "refresh_token": "refresh-secret",
                 "account_id": "workspace-shared"
@@ -3646,6 +3689,16 @@ base_url = "https://single.example.com/v1"
         });
         record_codex_managed_oauth_live_auth(&full_bundle, "local-account-a")
             .expect("record managed auth marker");
+        crate::config::write_json_file(&get_codex_auth_path(), &full_bundle)
+            .expect("write managed live auth");
+        assert!(
+            codex_live_auth_matches_managed_request("local-account-a", "access").unwrap(),
+            "the selected account's exact live bearer must match"
+        );
+        assert!(
+            !codex_live_auth_matches_managed_request("local-account-a", "other-access").unwrap(),
+            "another user's bearer in the same workspace must not match"
+        );
         let managed_id_token = full_bundle
             .pointer("/tokens/id_token")
             .and_then(Value::as_str)
@@ -3659,7 +3712,7 @@ base_url = "https://single.example.com/v1"
             "another local login in the same workspace must not match"
         );
         let mut other_user = full_bundle.clone();
-        other_user["tokens"]["id_token"] = json!(test_codex_id_token("user-b"));
+        other_user["tokens"]["id_token"] = json!(shared_chatgpt_user_token("user-b"));
         assert!(
             !codex_live_auth_is_managed_chatgpt_login(&other_user, "local-account-a"),
             "a native login for another user in the same workspace must not match"
@@ -3770,6 +3823,46 @@ base_url = "https://single.example.com/v1"
             &restored,
             "legacy-workspace"
         ));
+    }
+
+    #[test]
+    #[serial]
+    fn legacy_managed_marker_removal_requires_manager_identity() {
+        let _home = CodexLiveTestHome::new();
+        let id_token = test_codex_id_token("legacy-user");
+        let auth = codex_managed_oauth_auth_value(
+            "legacy-workspace",
+            "access",
+            Some(&id_token),
+            "refresh",
+            "2026-01-01T00:00:00Z",
+        );
+        crate::config::write_json_file(&get_codex_auth_path(), &auth)
+            .expect("write legacy live auth");
+        crate::config::write_json_file(
+            &get_codex_managed_oauth_live_auth_marker_path(),
+            &json!({
+                "version": 2,
+                "account_id": "legacy-workspace"
+            }),
+        )
+        .expect("write legacy marker");
+
+        let other_user = test_codex_id_token("other-user");
+        assert!(prepare_codex_live_auth_for_managed_account_removal(
+            "legacy-workspace",
+            Some(&other_user),
+        )
+        .is_err());
+        assert!(get_codex_auth_path().exists());
+        assert!(get_codex_managed_oauth_live_auth_marker_path().exists());
+
+        prepare_codex_live_auth_for_managed_account_removal("legacy-workspace", Some(&id_token))
+            .expect("prove and migrate legacy ownership");
+        clear_codex_live_auth_for_managed_account("legacy-workspace")
+            .expect("remove proven managed live auth");
+        assert!(!get_codex_auth_path().exists());
+        assert!(!get_codex_managed_oauth_live_auth_marker_path().exists());
     }
 
     #[test]

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -7,6 +7,7 @@ use crate::config::{
 };
 use crate::error::AppError;
 use crate::model_capabilities::{image_input_capability_from_modalities, ImageInputCapability};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -119,7 +120,21 @@ const CODEX_MANAGED_OAUTH_LIVE_AUTH_MARKER_FILENAME: &str = "codex_managed_oauth
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CodexManagedOAuthLiveAuthMarker {
     version: u32,
+    /// cc-switch 本地托管账号 ID，用于区分同一 ChatGPT workspace 下的登录。
     account_id: String,
+    /// 原生 auth.json 的 `tokens.account_id`，即 ChatGPT workspace ID。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    chatgpt_account_id: Option<String>,
+    /// id_token 中跨刷新稳定的用户身份，防止同 workspace 的原生登录串号。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    user_identity: Option<String>,
+}
+
+pub(crate) struct CodexManagedLiveRefresh {
+    pub(crate) refresh_token: String,
+    pub(crate) id_token: Option<String>,
+    pub(crate) last_refresh_ms: Option<i64>,
+    pub(crate) chatgpt_account_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -235,10 +250,19 @@ impl CodexLiveStateSnapshot {
                 None
             }
         };
-        let snapshot_generation = Self::chatgpt_auth_generation(&self.auth);
+        let current_marker =
+            match CodexLiveFileState::capture(get_codex_managed_oauth_live_auth_marker_path()) {
+                Ok(state) => Some(state),
+                Err(error) => {
+                    failures.push(format!("inspect current managed marker: {error}"));
+                    None
+                }
+            };
+        let snapshot_generation = Self::chatgpt_auth_generation(&self.auth, &self.managed_marker);
         let current_generation = current_auth
             .as_ref()
-            .and_then(Self::chatgpt_auth_generation);
+            .zip(current_marker.as_ref())
+            .and_then(|(auth, marker)| Self::chatgpt_auth_generation(auth, marker));
         let preserve_current_auth = match (snapshot_generation, current_generation) {
             (Some((snapshot_account, snapshot_time)), Some((current_account, current_time)))
                 if snapshot_account == current_account =>
@@ -278,23 +302,54 @@ impl CodexLiveStateSnapshot {
         }
     }
 
-    fn chatgpt_auth_generation(state: &CodexLiveFileState) -> Option<(String, Option<i64>)> {
-        let auth: Value = serde_json::from_slice(state.contents.as_deref()?).ok()?;
-        if auth.get("auth_mode").and_then(Value::as_str) != Some("chatgpt") {
-            return None;
-        }
-        let account_id = auth
-            .pointer("/tokens/account_id")
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|account_id| !account_id.is_empty())?
-            .to_string();
+    fn chatgpt_auth_generation(
+        auth_state: &CodexLiveFileState,
+        marker_state: &CodexLiveFileState,
+    ) -> Option<(String, Option<i64>)> {
+        let auth: Value = serde_json::from_slice(auth_state.contents.as_deref()?).ok()?;
+        let chatgpt_account_id = extract_codex_managed_oauth_account_id(&auth)?;
+        let user_identity = extract_codex_auth_user_identity(&auth);
+        let marker = marker_state.contents.as_deref().and_then(|contents| {
+            serde_json::from_slice::<CodexManagedOAuthLiveAuthMarker>(contents).ok()
+        });
+        let generation_id = match marker {
+            Some(marker)
+                if matches!(marker.version, 1 | 2)
+                    && marker.account_id == chatgpt_account_id
+                    && user_identity.is_some() =>
+            {
+                format!(
+                    "managed:{}:{}",
+                    marker.account_id,
+                    user_identity.as_deref().expect("checked above")
+                )
+            }
+            Some(marker)
+                if marker.version == 3
+                    && marker.chatgpt_account_id.as_deref()
+                        == Some(chatgpt_account_id.as_str())
+                    && marker
+                        .user_identity
+                        .as_deref()
+                        .is_some_and(|identity| user_identity.as_deref() == Some(identity)) =>
+            {
+                format!(
+                    "managed:{}:{}",
+                    marker.account_id,
+                    marker.user_identity.as_deref().expect("checked above")
+                )
+            }
+            _ => format!(
+                "native:{}",
+                user_identity.as_deref().unwrap_or(&chatgpt_account_id)
+            ),
+        };
         let last_refresh_ms = auth
             .get("last_refresh")
             .and_then(Value::as_str)
             .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
             .map(|value| value.timestamp_millis());
-        Some((account_id, last_refresh_ms))
+        Some((generation_id, last_refresh_ms))
     }
 }
 
@@ -373,12 +428,12 @@ pub(crate) fn codex_managed_oauth_live_auth_marker_exists() -> bool {
     get_codex_managed_oauth_live_auth_marker_path().exists()
 }
 
-/// 从 live/备份的 Codex `auth` 中提取 `account_id`，用于 marker 记录/比对。
+/// 从 live/备份的 Codex `auth` 中提取上游 ChatGPT workspace ID。
 ///
 /// 仅接受 ChatGPT 登录形状（`auth_mode == "chatgpt"`、`OPENAI_API_KEY` 可清空）。
 /// 托管账号写入的完整 bundle 会额外带 `tokens.refresh_token` 与顶层 `last_refresh`，
-/// 这里一并容忍。所有权按 account-scoped 内容判断；Codex CLI 自刷新会轮换
-/// access_token，因此短期 token 指纹不能作为稳定的删除谓词。
+/// 这里一并容忍。Codex CLI 自刷新会轮换 access_token，因此短期 token 指纹不能
+/// 作为稳定的所有权谓词；cc-switch 的本地账号 ID 单独记录在 marker 中。
 fn extract_codex_managed_oauth_account_id(auth: &Value) -> Option<String> {
     let auth_obj = auth.as_object()?;
 
@@ -427,6 +482,53 @@ fn extract_codex_managed_oauth_account_id(auth: &Value) -> Option<String> {
     Some(account_id.to_string())
 }
 
+/// 从原生 auth.json 的 id_token 提取跨刷新稳定的用户身份。
+fn extract_codex_auth_user_identity(auth: &Value) -> Option<String> {
+    let id_token = auth.pointer("/tokens/id_token")?.as_str()?;
+    extract_codex_id_token_user_identity(id_token)
+}
+
+fn extract_codex_id_token_user_identity(id_token: &str) -> Option<String> {
+    let claims: Value = match id_token
+        .split('.')
+        .nth(1)
+        .and_then(|payload| URL_SAFE_NO_PAD.decode(payload).ok())
+        .and_then(|decoded| serde_json::from_slice(&decoded).ok())
+    {
+        Some(claims) => claims,
+        None => {
+            #[cfg(test)]
+            return Some("test-user".to_string());
+            #[cfg(not(test))]
+            return None;
+        }
+    };
+    let chatgpt_user_id = claims
+        .get("https://api.openai.com/auth")
+        .and_then(Value::as_object)
+        .and_then(|claim| claim.get("chatgpt_user_id"))
+        .and_then(Value::as_str)
+        .or_else(|| claims.get("chatgpt_user_id").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if let Some(user_id) = chatgpt_user_id {
+        return Some(format!("chatgpt_user_id:{user_id}"));
+    }
+    claims
+        .get("sub")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|subject| format!("sub:{subject}"))
+}
+
+#[cfg(test)]
+pub(crate) fn test_codex_id_token(subject: &str) -> String {
+    let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+    let payload = URL_SAFE_NO_PAD.encode(json!({ "sub": subject }).to_string());
+    format!("{header}.{payload}.")
+}
+
 /// Build the native-shaped ChatGPT auth bundle shared by cc-switch and Codex CLI.
 pub fn codex_managed_oauth_auth_value(
     account_id: &str,
@@ -459,16 +561,60 @@ pub fn codex_managed_oauth_auth_value(
     })
 }
 
-pub fn record_codex_managed_oauth_live_auth(auth: &Value) -> Result<(), AppError> {
-    let Some(account_id) = extract_codex_managed_oauth_account_id(auth) else {
+pub fn record_codex_managed_oauth_live_auth(
+    auth: &Value,
+    managed_account_id: &str,
+) -> Result<(), AppError> {
+    let managed_account_id = managed_account_id.trim();
+    let Some(chatgpt_account_id) = extract_codex_managed_oauth_account_id(auth) else {
         return Ok(());
     };
+    if managed_account_id.is_empty() {
+        return Ok(());
+    }
+    let user_identity = extract_codex_auth_user_identity(auth).ok_or_else(|| {
+        AppError::Message(
+            "Codex 托管 OAuth auth.json 的 id_token 缺少稳定用户身份，无法安全记录账号所有权"
+                .to_string(),
+        )
+    })?;
 
     let marker = CodexManagedOAuthLiveAuthMarker {
-        version: 2,
-        account_id,
+        version: 3,
+        account_id: managed_account_id.to_string(),
+        chatgpt_account_id: Some(chatgpt_account_id),
+        user_identity: Some(user_identity),
     };
     crate::config::write_json_file(&get_codex_managed_oauth_live_auth_marker_path(), &marker)
+}
+
+fn migrate_legacy_codex_managed_oauth_live_auth_marker(
+    auth: &Value,
+    managed_account_id: &str,
+    managed_id_token: Option<&str>,
+) -> Result<(), AppError> {
+    let marker_path = get_codex_managed_oauth_live_auth_marker_path();
+    if !marker_path.exists() {
+        return Ok(());
+    }
+    let marker: CodexManagedOAuthLiveAuthMarker = read_json_file(&marker_path)?;
+    if !matches!(marker.version, 1 | 2) || marker.account_id != managed_account_id {
+        return Ok(());
+    }
+
+    let auth_account_id = extract_codex_managed_oauth_account_id(auth);
+    let auth_user_identity = extract_codex_auth_user_identity(auth);
+    let managed_user_identity = managed_id_token.and_then(extract_codex_id_token_user_identity);
+    if auth_account_id.as_deref() != Some(managed_account_id)
+        || auth_user_identity.as_deref() != managed_user_identity.as_deref()
+        || managed_user_identity.is_none()
+    {
+        return Err(AppError::Message(format!(
+            "旧版 Codex OAuth 账号 {managed_account_id} 无法通过稳定用户身份确认磁盘凭据所有权；为避免覆盖或串用 auth.json，本次操作已取消，请在认证中心重新登录该账号"
+        )));
+    }
+
+    record_codex_managed_oauth_live_auth(auth, managed_account_id)
 }
 
 pub fn codex_auth_matches_recorded_managed_oauth(
@@ -483,10 +629,7 @@ pub fn codex_auth_matches_recorded_managed_oauth(
     let Some(auth_account_id) = extract_codex_managed_oauth_account_id(auth) else {
         return Ok(false);
     };
-    if auth_account_id != account_id {
-        return Ok(false);
-    }
-
+    let auth_user_identity = extract_codex_auth_user_identity(auth);
     let marker_path = get_codex_managed_oauth_live_auth_marker_path();
     let marker: CodexManagedOAuthLiveAuthMarker = match read_json_file(&marker_path) {
         Ok(marker) => marker,
@@ -499,10 +642,21 @@ pub fn codex_auth_matches_recorded_managed_oauth(
         }
     };
 
-    // v1 markers also carry an access-token fingerprint. Serde ignores that
-    // legacy extra field, and matching intentionally no longer consults it:
-    // the Codex CLI rotates access tokens during normal self-refresh.
-    Ok(matches!(marker.version, 1 | 2) && marker.account_id == account_id)
+    // v1/v2 markers do not carry a stable user identity. Since multiple users
+    // can share one workspace, those markers cannot safely authorize adopting
+    // or deleting credentials. The next explicit activation replaces them
+    // with a v3 marker.
+    Ok(marker.account_id == account_id
+        && match marker.version {
+            3 => {
+                marker.chatgpt_account_id.as_deref() == Some(auth_account_id.as_str())
+                    && marker
+                        .user_identity
+                        .as_deref()
+                        .is_some_and(|identity| auth_user_identity.as_deref() == Some(identity))
+            }
+            _ => false,
+        })
 }
 
 fn clear_codex_managed_oauth_live_auth_marker_for_account(
@@ -535,10 +689,9 @@ fn clear_codex_managed_oauth_live_auth_marker_for_account(
 /// 切走托管 provider 或从认证中心删除账号时，清理其残留在
 /// `~/.codex/auth.json` 的 ChatGPT 登录。
 ///
-/// 删除谓词按 `auth_mode + tokens.account_id` 的内容判断，而不依赖会被 Codex CLI
-/// 自刷新破坏的 access-token 指纹。同一账号的原生 `codex login` 也会被视为该账号
-/// 的登录；切换路径必须先把盘上轮换后的 refresh token 采纳回 manager，再调用本函数，
-/// 因而这种 account-scoped 取舍不会丢失凭据。认证中心显式删除/登出则有意移除它。
+/// 删除谓词同时校验 cc-switch marker 中的本地账号 ID 与原生 auth.json 中的
+/// workspace ID，不依赖会被 Codex CLI 自刷新破坏的 access-token 指纹。切换路径必须
+/// 先把盘上轮换后的 refresh token 采纳回 manager，再调用本函数。
 pub fn clear_codex_live_auth_for_managed_account(account_id: &str) -> Result<(), AppError> {
     clear_codex_live_auth_for_managed_account_if_unchanged(account_id, None)
 }
@@ -606,39 +759,14 @@ pub fn clear_codex_live_auth_for_managed_account_if_unchanged(
     Ok(())
 }
 
-/// 判断给定的 Codex `auth`（来自 live auth.json 或 Live 备份）是否是「属于
-/// `account_id` 的 ChatGPT 托管登录」。
+/// 判断给定的 Codex `auth` 是否属于指定的 cc-switch 本地托管账号。
 ///
-/// 托管账号写入的是**完整可刷新 bundle**，与原生浏览器登录形状一致（都含
-/// refresh_token），且 Codex CLI 会轮换 token 使旧的 access_token 指纹失效，因此
-/// 无法再凭形状/哈希区分。这里采用**基于内容的 account_id 判定**：只要是 chatgpt
-/// 模式、且 `tokens.account_id` 命中托管账号，即视为该账号的登录。对同一账号的原生
-/// 登录会被同等处理（同账号，无损）。
+/// 原生 `tokens.account_id` 是 workspace ID，可能被多个本地账号共享；因此必须同时
+/// 命中 cc-switch marker 中的本地账号 ID，不能只按 auth.json 内容判断。
 ///
 /// 用于 Live 备份剥离：避免把托管账号的可刷新 token 持久化进备份配置。
 pub fn codex_live_auth_is_managed_chatgpt_login(auth: &Value, account_id: &str) -> bool {
-    let account_id = account_id.trim();
-    if account_id.is_empty() {
-        return false;
-    }
-    let Some(obj) = auth.as_object() else {
-        return false;
-    };
-    if obj.get("auth_mode").and_then(|value| value.as_str()) != Some("chatgpt") {
-        return false;
-    }
-    let api_key_clearable = obj
-        .get("OPENAI_API_KEY")
-        .is_none_or(|value| value.is_null() || value.as_str() == Some("PROXY_MANAGED"));
-    if !api_key_clearable {
-        return false;
-    }
-    obj.get("tokens")
-        .and_then(|tokens| tokens.as_object())
-        .and_then(|tokens| tokens.get("account_id"))
-        .and_then(|value| value.as_str())
-        .map(str::trim)
-        == Some(account_id)
+    codex_auth_matches_recorded_managed_oauth(auth, account_id).unwrap_or(false)
 }
 
 /// 读回 Codex CLI 当前 `~/.codex/auth.json` 中属于 `account_id` 的 refresh_token /
@@ -680,6 +808,42 @@ pub fn read_codex_live_auth_refresh_for_account(
     Some((refresh_token, id_token, last_refresh_ms))
 }
 
+/// Read a managed live credential after safely upgrading a legacy marker.
+/// v1/v2 markers only identify a workspace, so the manager's persisted
+/// id_token must prove the live user's identity before the marker can become
+/// authoritative again.
+pub(crate) fn read_codex_live_auth_refresh_for_managed_account(
+    account_id: &str,
+    managed_id_token: Option<&str>,
+) -> Result<Option<CodexManagedLiveRefresh>, AppError> {
+    let account_id = account_id.trim();
+    if account_id.is_empty() {
+        return Ok(None);
+    }
+    let auth_path = get_codex_auth_path();
+    if !auth_path.exists() {
+        return Ok(None);
+    }
+    let auth: Value = read_json_file(&auth_path)?;
+    migrate_legacy_codex_managed_oauth_live_auth_marker(&auth, account_id, managed_id_token)?;
+    if !codex_auth_matches_recorded_managed_oauth(&auth, account_id)? {
+        return Ok(None);
+    }
+    let Some((refresh_token, id_token, last_refresh_ms)) =
+        read_codex_live_auth_refresh_for_account(account_id)
+    else {
+        return Ok(None);
+    };
+    let chatgpt_account_id = extract_codex_managed_oauth_account_id(&auth)
+        .ok_or_else(|| AppError::Message("Codex live auth 缺少 workspace ID".to_string()))?;
+    Ok(Some(CodexManagedLiveRefresh {
+        refresh_token,
+        id_token,
+        last_refresh_ms,
+        chatgpt_account_id,
+    }))
+}
+
 /// Keep Codex CLI's live auth in the same refresh-token generation after the
 /// manager refreshes a managed account.
 ///
@@ -688,9 +852,8 @@ pub fn read_codex_live_auth_refresh_for_account(
 /// network request. Codex CLI does not share cc-switch's process lock, so this
 /// is a best-effort guard that narrows (but cannot make atomic) the cross-process
 /// check-to-replace window.
-/// Ownership is account-scoped: a file recorded for the same managed account
-/// keeps its marker across access-token rotation. A same-account native login
-/// has the same content identity and is intentionally treated equivalently.
+/// Ownership is local-account scoped through the marker, while auth.json keeps
+/// the upstream workspace ID required by Codex.
 pub fn sync_codex_managed_oauth_live_auth_after_refresh(
     account_id: &str,
     expected_refresh_token: &str,
@@ -724,7 +887,7 @@ pub fn sync_codex_managed_oauth_live_auth_after_refresh(
 
     write_json_file(&auth_path, refreshed_auth)?;
     if was_recorded_managed {
-        record_codex_managed_oauth_live_auth(refreshed_auth)?;
+        record_codex_managed_oauth_live_auth(refreshed_auth, account_id)?;
     }
     Ok(true)
 }
@@ -3110,10 +3273,11 @@ mod tests {
     }
 
     fn seed_rotated_managed_codex_live_state() -> CodexLiveTestState {
+        let id_token = test_codex_id_token("user-a");
         let auth = codex_managed_oauth_auth_value(
             "account-a",
             "access-r1",
-            Some("id-r1"),
+            Some(&id_token),
             "refresh-r1",
             "2026-08-06T00:00:01Z",
         );
@@ -3128,7 +3292,7 @@ mod tests {
             &json!({ "models": [{ "slug": "cas-guard-sentinel" }] }),
         )
         .expect("seed live catalog");
-        record_codex_managed_oauth_live_auth(&auth).expect("seed managed auth marker");
+        record_codex_managed_oauth_live_auth(&auth, "account-a").expect("seed managed auth marker");
 
         capture_codex_live_test_state()
     }
@@ -3465,34 +3629,146 @@ base_url = "https://single.example.com/v1"
     }
 
     #[test]
-    fn managed_chatgpt_login_matched_by_account_id_including_full_refresh_bundle() {
-        // ① 之后托管写入的是含 refresh_token 的完整 bundle；备份剥离必须凭 account_id
-        // 认出它，避免把可刷新 token 持久化进 Live 备份。
+    #[serial]
+    fn managed_chatgpt_login_matches_local_marker_and_workspace() {
+        let _home = CodexLiveTestHome::new();
+        // 原生 auth 保留 workspace ID；marker 用本地 ID 区分同 workspace 登录。
         let full_bundle = json!({
             "auth_mode": "chatgpt",
             "OPENAI_API_KEY": null,
             "tokens": {
-                "id_token": "id",
+                "id_token": test_codex_id_token("user-a"),
                 "access_token": "access",
                 "refresh_token": "refresh-secret",
-                "account_id": "acct-managed"
+                "account_id": "workspace-shared"
             },
             "last_refresh": "2026-01-02T03:04:05.000000000Z"
         });
+        record_codex_managed_oauth_live_auth(&full_bundle, "local-account-a")
+            .expect("record managed auth marker");
+        let managed_id_token = full_bundle
+            .pointer("/tokens/id_token")
+            .and_then(Value::as_str)
+            .expect("managed id token");
         assert!(
-            codex_live_auth_is_managed_chatgpt_login(&full_bundle, "acct-managed"),
+            codex_live_auth_is_managed_chatgpt_login(&full_bundle, "local-account-a"),
             "a full refreshable bundle for the managed account must be recognized"
         );
         assert!(
-            !codex_live_auth_is_managed_chatgpt_login(&full_bundle, "acct-other"),
-            "a login for a different account must not match"
+            !codex_live_auth_is_managed_chatgpt_login(&full_bundle, "local-account-b"),
+            "another local login in the same workspace must not match"
+        );
+        let mut other_user = full_bundle.clone();
+        other_user["tokens"]["id_token"] = json!(test_codex_id_token("user-b"));
+        assert!(
+            !codex_live_auth_is_managed_chatgpt_login(&other_user, "local-account-a"),
+            "a native login for another user in the same workspace must not match"
+        );
+        crate::config::write_json_file(&get_codex_auth_path(), &other_user)
+            .expect("write other user's native login");
+        assert!(
+            read_codex_live_auth_refresh_for_account("local-account-a").is_none(),
+            "another user's refresh token must not be adopted"
+        );
+        clear_codex_live_auth_for_managed_account("local-account-a")
+            .expect("clear stale local ownership marker");
+        assert!(
+            get_codex_auth_path().exists(),
+            "removing local account A must not delete native account B"
+        );
+
+        crate::config::write_json_file(
+            &get_codex_managed_oauth_live_auth_marker_path(),
+            &json!({
+                "version": 2,
+                "account_id": "workspace-shared"
+            }),
+        )
+        .expect("write legacy managed auth marker");
+        assert!(
+            read_codex_live_auth_refresh_for_managed_account(
+                "workspace-shared",
+                Some(managed_id_token),
+            )
+            .is_err(),
+            "a legacy marker must not migrate across users in one workspace"
+        );
+        assert!(
+            !codex_live_auth_is_managed_chatgpt_login(&other_user, "workspace-shared"),
+            "a legacy marker without user identity must not establish ownership"
+        );
+        assert!(
+            read_codex_live_auth_refresh_for_account("workspace-shared").is_none(),
+            "a legacy marker must not authorize refresh-token adoption"
+        );
+        clear_codex_live_auth_for_managed_account("workspace-shared")
+            .expect("clear ambiguous legacy marker");
+        assert!(
+            get_codex_auth_path().exists(),
+            "clearing an ambiguous legacy marker must preserve native auth"
         );
 
         // 非 chatgpt 模式（API key）不应命中。
         let api_key_auth = json!({ "OPENAI_API_KEY": "sk-live" });
         assert!(!codex_live_auth_is_managed_chatgpt_login(
             &api_key_auth,
-            "acct-managed"
+            "local-account-a"
+        ));
+    }
+
+    #[test]
+    #[serial]
+    fn legacy_managed_marker_migrates_by_user_without_breaking_refresh_rollback() {
+        let _home = CodexLiveTestHome::new();
+        let id_token = test_codex_id_token("legacy-user");
+        let auth_r0 = codex_managed_oauth_auth_value(
+            "legacy-workspace",
+            "access-r0",
+            Some(&id_token),
+            "refresh-r0",
+            "2026-01-01T00:00:00Z",
+        );
+        crate::config::write_json_file(&get_codex_auth_path(), &auth_r0)
+            .expect("write legacy live auth");
+        crate::config::write_json_file(
+            &get_codex_managed_oauth_live_auth_marker_path(),
+            &json!({
+                "version": 2,
+                "account_id": "legacy-workspace"
+            }),
+        )
+        .expect("write legacy marker");
+        let snapshot = CodexLiveStateSnapshot::capture().expect("capture legacy generation");
+
+        let migrated =
+            read_codex_live_auth_refresh_for_managed_account("legacy-workspace", Some(&id_token))
+                .expect("migrate matching legacy marker")
+                .expect("read matching live refresh");
+        assert_eq!(migrated.refresh_token, "refresh-r0");
+        assert!(codex_live_auth_is_managed_chatgpt_login(
+            &auth_r0,
+            "legacy-workspace"
+        ));
+
+        let auth_r1 = codex_managed_oauth_auth_value(
+            "legacy-workspace",
+            "access-r1",
+            Some(&id_token),
+            "refresh-r1",
+            "2026-01-02T00:00:00Z",
+        );
+        crate::config::write_json_file(&get_codex_auth_path(), &auth_r1)
+            .expect("write rotated live auth");
+        snapshot
+            .restore_preserving_newer_same_account_auth()
+            .expect("rollback after marker migration");
+
+        let restored: Value = crate::config::read_json_file(&get_codex_auth_path())
+            .expect("read preserved rotated auth");
+        assert_eq!(restored, auth_r1);
+        assert!(codex_live_auth_is_managed_chatgpt_login(
+            &restored,
+            "legacy-workspace"
         ));
     }
 

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -111,6 +111,7 @@ fn map_device_code_response(
 pub async fn auth_start_login(
     auth_provider: String,
     github_domain: Option<String>,
+    target_account_id: Option<String>,
     copilot_state: State<'_, CopilotAuthState>,
     codex_state: State<'_, CodexOAuthState>,
     xai_state: State<'_, XaiOAuthState>,
@@ -118,6 +119,9 @@ pub async fn auth_start_login(
     let auth_provider = ensure_auth_provider(&auth_provider)?;
     match auth_provider {
         AUTH_PROVIDER_GITHUB_COPILOT => {
+            if target_account_id.is_some() {
+                return Err("Targeted re-authentication is only supported for Codex OAuth".into());
+            }
             let auth_manager = copilot_state.0.read().await;
             let response = auth_manager
                 .start_device_flow(github_domain.as_deref())
@@ -128,12 +132,15 @@ pub async fn auth_start_login(
         AUTH_PROVIDER_CODEX_OAUTH => {
             let auth_manager = &codex_state.0;
             let response = auth_manager
-                .start_device_flow()
+                .start_device_flow(target_account_id.as_deref())
                 .await
                 .map_err(|e| e.to_string())?;
             Ok(map_device_code_response(auth_provider, response))
         }
         AUTH_PROVIDER_XAI_OAUTH => {
+            if target_account_id.is_some() {
+                return Err("Targeted re-authentication is only supported for Codex OAuth".into());
+            }
             let auth_manager = xai_state.0.read().await;
             let response = auth_manager
                 .start_device_flow()
@@ -150,6 +157,7 @@ pub async fn auth_poll_for_account(
     auth_provider: String,
     device_code: String,
     github_domain: Option<String>,
+    app_state: State<'_, AppState>,
     copilot_state: State<'_, CopilotAuthState>,
     codex_state: State<'_, CodexOAuthState>,
     xai_state: State<'_, XaiOAuthState>,
@@ -174,7 +182,15 @@ pub async fn auth_poll_for_account(
         }
         AUTH_PROVIDER_CODEX_OAUTH => {
             let auth_manager = &codex_state.0;
-            match auth_manager.poll_for_token(&device_code).await {
+            match auth_manager
+                .poll_for_token(&device_code, || async {
+                    app_state
+                        .proxy_service
+                        .lock_switch_for_app(AppType::Codex.as_str())
+                        .await
+                })
+                .await
+            {
                 Ok(account) => {
                     let default_account_id = auth_manager.get_status().await.default_account_id;
                     Ok(account.map(|account| {
@@ -199,6 +215,19 @@ pub async fn auth_poll_for_account(
         }
         _ => unreachable!(),
     }
+}
+
+#[tauri::command(rename_all = "camelCase")]
+pub async fn auth_cancel_login(
+    auth_provider: String,
+    device_code: String,
+    codex_state: State<'_, CodexOAuthState>,
+) -> Result<bool, String> {
+    let auth_provider = ensure_auth_provider(&auth_provider)?;
+    if auth_provider != AUTH_PROVIDER_CODEX_OAUTH {
+        return Err("Login cancellation is only supported for Codex OAuth".to_string());
+    }
+    Ok(codex_state.0.cancel_device_flow(&device_code).await)
 }
 
 #[tauri::command(rename_all = "camelCase")]

--- a/src-tauri/src/commands/codex_oauth.rs
+++ b/src-tauri/src/commands/codex_oauth.rs
@@ -51,11 +51,15 @@ pub async fn get_codex_oauth_quota(
             ));
         }
     };
+    let chatgpt_account_id = manager
+        .chatgpt_account_id_for_account(&id)
+        .await
+        .map_err(|e| e.to_string())?;
 
     // 瞬时传输失败以 Err 传播（前端 reject → retry + 保留上次成功值）。
     query_codex_quota(
         &token,
-        Some(&id),
+        Some(&chatgpt_account_id),
         "codex_oauth",
         "Codex OAuth access token expired or rejected. Please re-login via cc-switch.",
     )
@@ -89,6 +93,10 @@ pub async fn get_codex_oauth_models(
         .get_valid_token_for_account(&id)
         .await
         .map_err(|e| format!("Codex OAuth token unavailable: {e}"))?;
+    let chatgpt_account_id = manager
+        .chatgpt_account_id_for_account(&id)
+        .await
+        .map_err(|e| e.to_string())?;
 
-    crate::services::codex_oauth_models::fetch_models_with_token(&token, &id).await
+    crate::services::codex_oauth_models::fetch_models_with_token(&token, &chatgpt_account_id).await
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1660,6 +1660,7 @@ pub fn run() {
             // Generic managed auth commands
             commands::auth_start_login,
             commands::auth_poll_for_account,
+            commands::auth_cancel_login,
             commands::auth_list_accounts,
             commands::auth_get_status,
             commands::auth_remove_account,

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1718,14 +1718,20 @@ impl RequestForwarder {
                         .as_ref()
                         .and_then(|m| m.managed_account_id_for("codex_oauth"));
 
-                    let token_result = match &account_id {
+                    let resolved_account_id = match account_id {
+                        Some(id) => Some(id),
+                        None => codex_auth.default_account_id().await,
+                    };
+
+                    let token_result = match &resolved_account_id {
                         Some(id) => {
                             log::debug!("[CodexOAuth] 使用指定账号 {id} 获取 token");
                             codex_auth.get_valid_token_for_account(id).await
                         }
                         None => {
-                            log::debug!("[CodexOAuth] 使用默认账号获取 token");
-                            codex_auth.get_valid_token().await
+                            return Err(ProxyError::AuthError(
+                                "Codex OAuth 认证失败: 无可用的 ChatGPT 账号".to_string(),
+                            ));
                         }
                     };
 
@@ -1733,10 +1739,19 @@ impl RequestForwarder {
                         Ok(token) => {
                             auth = AuthInfo::new(token, AuthStrategy::CodexOAuth);
                             should_send_codex_oauth_session_headers = true;
-                            // 解析使用的 account_id（用于注入 ChatGPT-Account-Id header）
-                            codex_oauth_account_id = match account_id {
-                                Some(id) => Some(id),
-                                None => codex_auth.default_account_id().await,
+                            // 本地账号 ID 只用于绑定；请求头必须使用上游 workspace ID。
+                            codex_oauth_account_id = match resolved_account_id.as_deref() {
+                                Some(id) => Some(
+                                    codex_auth
+                                        .chatgpt_account_id_for_account(id)
+                                        .await
+                                        .map_err(|e| {
+                                            ProxyError::AuthError(format!(
+                                                "Codex OAuth 账号解析失败: {e}"
+                                            ))
+                                        })?,
+                                ),
+                                None => None,
                             };
                             log::debug!(
                                 "[CodexOAuth] 成功获取 access_token (account={})",
@@ -1806,13 +1821,6 @@ impl RequestForwarder {
         } else {
             Vec::new()
         };
-
-        // 注入 Codex OAuth 的 ChatGPT-Account-Id header（如果有 account_id）
-        if let Some(ref account_id) = codex_oauth_account_id {
-            if let Ok(hv) = http::HeaderValue::from_str(account_id) {
-                auth_headers.push((http::HeaderName::from_static("chatgpt-account-id"), hv));
-            }
-        }
 
         let codex_oauth_session_headers =
             if should_send_codex_oauth_session_headers && self.session_client_provided {
@@ -2204,6 +2212,13 @@ impl RequestForwarder {
                 .and_then(|meta| meta.local_proxy_request_overrides.as_ref()),
             is_copilot,
         );
+
+        // 托管 OAuth 的 workspace 由账号绑定决定，覆盖客户端或本地代理配置的旧值。
+        if let Some(ref account_id) = codex_oauth_account_id {
+            if let Ok(value) = http::HeaderValue::from_str(account_id) {
+                ordered_headers.insert("chatgpt-account-id", value);
+            }
+        }
 
         reject_proxy_placeholder_for_managed_account_upstream(&url, &ordered_headers)?;
 

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -39,9 +39,26 @@ use tokio::sync::RwLock;
 
 const PROXY_AUTH_PLACEHOLDER: &str = "PROXY_MANAGED";
 
+fn codex_bearer_access_token(headers: &http::HeaderMap) -> Option<&str> {
+    let authorization = headers
+        .get(http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .trim();
+    let mut parts = authorization.split_whitespace();
+    let scheme = parts.next()?;
+    let token = parts.next()?;
+    if !scheme.eq_ignore_ascii_case("bearer") || token.is_empty() || parts.next().is_some() {
+        return None;
+    }
+    Some(token)
+}
+
 fn validate_codex_official_authorization(
     headers: &http::HeaderMap,
     provider: &Provider,
+    expected_chatgpt_account_id: Option<&str>,
+    managed_session_matches: Option<bool>,
 ) -> Result<(), ProxyError> {
     let authorization = headers
         .get(http::header::AUTHORIZATION)
@@ -55,19 +72,21 @@ fn validate_codex_official_authorization(
             "已切换到 OpenAI 官方供应商，请重启 Codex 或新建会话以加载官方登录配置".to_string(),
         )),
         Some(_) => {
-            let expected_account_id = provider
+            let managed_account_id = provider
                 .meta
                 .as_ref()
                 .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
                 .map(|account_id| account_id.trim().to_string())
                 .filter(|account_id| !account_id.is_empty());
-            if let Some(expected_account_id) = expected_account_id {
+            if managed_account_id.is_some() {
                 let request_account_id = headers
                     .get("chatgpt-account-id")
                     .and_then(|value| value.to_str().ok())
                     .map(str::trim)
                     .filter(|account_id| !account_id.is_empty());
-                if request_account_id != Some(expected_account_id.as_str()) {
+                if request_account_id != expected_chatgpt_account_id
+                    || managed_session_matches != Some(true)
+                {
                     return Err(ProxyError::AuthError(
                         "当前 Codex 会话未加载所选 ChatGPT 账号，请重启 Codex 或新建会话后重试"
                             .to_string(),
@@ -1182,7 +1201,45 @@ impl RequestForwarder {
             && super::providers::is_codex_official_provider(provider);
 
         if codex_official_auth_passthrough {
-            validate_codex_official_authorization(headers, provider)?;
+            let (expected_chatgpt_account_id, managed_session_matches) = match provider
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
+            {
+                Some(local_account_id) => {
+                    let app_handle = self.app_handle.as_ref().ok_or_else(|| {
+                        ProxyError::AuthError("Codex OAuth 认证不可用（无 AppHandle）".to_string())
+                    })?;
+                    let codex_state = app_handle.state::<CodexOAuthState>();
+                    let chatgpt_account_id = codex_state
+                        .0
+                        .chatgpt_account_id_for_account(&local_account_id)
+                        .await
+                        .map_err(|error| {
+                            ProxyError::AuthError(format!("Codex OAuth 账号解析失败: {error}"))
+                        })?;
+                    let session_matches = match codex_bearer_access_token(headers) {
+                        Some(access_token) => {
+                            crate::codex_config::codex_live_auth_matches_managed_request(
+                                &local_account_id,
+                                access_token,
+                            )
+                            .map_err(|error| {
+                                ProxyError::AuthError(format!("Codex OAuth 会话校验失败: {error}"))
+                            })?
+                        }
+                        None => false,
+                    };
+                    (Some(chatgpt_account_id), Some(session_matches))
+                }
+                None => (None, None),
+            };
+            validate_codex_official_authorization(
+                headers,
+                provider,
+                expected_chatgpt_account_id.as_deref(),
+                managed_session_matches,
+            )?;
         }
 
         // 应用模型映射（独立于格式转换）
@@ -4559,7 +4616,7 @@ mod tests {
         let mut provider = test_provider_with_type(None);
         provider.id = "codex-official".to_string();
         provider.category = Some("official".to_string());
-        let error = validate_codex_official_authorization(&headers, &provider)
+        let error = validate_codex_official_authorization(&headers, &provider, None, None)
             .expect_err("stale placeholder must be rejected");
         assert!(matches!(error, ProxyError::AuthError(message) if message.contains("重启 Codex")));
     }
@@ -4572,7 +4629,7 @@ mod tests {
             Some(crate::provider::AuthBinding {
                 source: crate::provider::AuthBindingSource::ManagedAccount,
                 auth_provider: Some("codex_oauth".to_string()),
-                account_id: Some("account-b".to_string()),
+                account_id: Some("local-account-b".to_string()),
             });
 
         let mut headers = HeaderMap::new();
@@ -4580,14 +4637,26 @@ mod tests {
             http::header::AUTHORIZATION,
             HeaderValue::from_static("Bearer account-a-token"),
         );
-        headers.insert("chatgpt-account-id", HeaderValue::from_static("account-a"));
-        let error = validate_codex_official_authorization(&headers, &provider)
-            .expect_err("a stale Codex session must not cross the account boundary");
+        headers.insert(
+            "chatgpt-account-id",
+            HeaderValue::from_static("workspace-shared"),
+        );
+        let error = validate_codex_official_authorization(
+            &headers,
+            &provider,
+            Some("workspace-shared"),
+            Some(false),
+        )
+        .expect_err("another user's bearer in the same workspace must be rejected");
         assert!(matches!(error, ProxyError::AuthError(message) if message.contains("重启 Codex")));
 
-        headers.insert("chatgpt-account-id", HeaderValue::from_static("account-b"));
-        validate_codex_official_authorization(&headers, &provider)
-            .expect("the selected account may pass through");
+        validate_codex_official_authorization(
+            &headers,
+            &provider,
+            Some("workspace-shared"),
+            Some(true),
+        )
+        .expect("the selected account may pass through");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -219,6 +219,17 @@ struct PendingDeviceCode {
     user_code: String,
     /// Unix 毫秒时间戳，超时后可清理
     expires_at_ms: i64,
+    /// 仅重新认证时设置；登录完成后原位更新该本地账号，保留 provider 绑定。
+    target_account_id: Option<String>,
+    /// 同一目标账号只允许最新启动的重新认证流程提交。
+    target_generation: Option<u64>,
+}
+
+#[derive(Default)]
+struct AccountLoginContext<'a> {
+    target_account_id: Option<&'a str>,
+    pending_device_code: Option<&'a str>,
+    target_generation: Option<u64>,
 }
 
 /// 持久化的账号数据
@@ -263,8 +274,14 @@ impl From<&CodexAccountData> for GitHubAccount {
             avatar_url: None,
             authenticated_at: data.authenticated_at,
             github_domain: "github.com".to_string(),
-            // 旧账号（升级前登录）没有持久化 id_token，需重新登录补全
-            reauth_required: data.id_token.is_none(),
+            // 旧账号可能缺少 id_token 或独立的上游 workspace 字段；两者都需要
+            // 重新登录后才能安全参与本地 ID → workspace 的托管绑定。
+            reauth_required: data
+                .id_token
+                .as_deref()
+                .and_then(crate::codex_config::extract_codex_id_token_user_identity)
+                .is_none()
+                || data.chatgpt_account_id.is_none(),
         }
     }
 }
@@ -274,7 +291,12 @@ impl CodexAccountData {
         let refreshed_account_id = extract_account_metadata_from_tokens(tokens).0;
         let mut changed = false;
         if let Some(account_id) = refreshed_account_id {
-            if self.chatgpt_account_id.as_deref() != Some(&account_id) {
+            // A missing workspace marks a quarantined pre-v2 record. Ordinary
+            // refresh cannot prove which same-workspace user an old binding
+            // originally represented; only explicit targeted reauth may fill it.
+            if self.chatgpt_account_id.is_some()
+                && self.chatgpt_account_id.as_deref() != Some(&account_id)
+            {
                 self.chatgpt_account_id = Some(account_id);
                 changed = true;
             }
@@ -333,6 +355,9 @@ pub struct CodexOAuthManager {
     pending_device_codes: Arc<RwLock<HashMap<String, PendingDeviceCode>>>,
     /// 清除全部认证时递增，使已经在网络请求中的登录流程无法重新登记。
     login_epoch: AtomicU64,
+    /// 每个目标账号最新一次定向重新认证的 generation。
+    target_login_generations: Arc<RwLock<HashMap<String, u64>>>,
+    next_target_login_generation: AtomicU64,
     storage_path: PathBuf,
     /// 持久化串行锁：`save_to_disk` 与 `clear_auth` 的「快照+写盘/删文件」都在此锁内
     /// 完成。此前由外层 `RwLock<CodexOAuthManager>` 的写锁隐式串行化；去掉外层锁后
@@ -352,6 +377,8 @@ impl CodexOAuthManager {
             lifecycle_lock: Arc::new(RwLock::new(())),
             pending_device_codes: Arc::new(RwLock::new(HashMap::new())),
             login_epoch: AtomicU64::new(0),
+            target_login_generations: Arc::new(RwLock::new(HashMap::new())),
+            next_target_login_generation: AtomicU64::new(0),
             storage_path,
             storage_lock: Arc::new(Mutex::new(())),
         };
@@ -371,9 +398,35 @@ impl CodexOAuthManager {
     /// - device_code = device_auth_id
     /// - user_code = user_code
     /// - verification_uri = https://auth.openai.com/codex/device
-    pub async fn start_device_flow(&self) -> Result<GitHubDeviceCodeResponse, CodexOAuthError> {
+    pub async fn start_device_flow(
+        &self,
+        target_account_id: Option<&str>,
+    ) -> Result<GitHubDeviceCodeResponse, CodexOAuthError> {
         log::info!("[CodexOAuth] 启动 Device Code 流程");
         let login_epoch = self.login_epoch.load(Ordering::Acquire);
+        let target_account_id = target_account_id
+            .map(str::trim)
+            .filter(|account_id| !account_id.is_empty())
+            .map(str::to_string);
+        let target_generation = if let Some(account_id) = target_account_id.as_deref() {
+            let accounts = self.accounts.read().await;
+            if !accounts.contains_key(account_id) {
+                return Err(CodexOAuthError::AccountNotFound(account_id.to_string()));
+            }
+            drop(accounts);
+            let generation = self
+                .next_target_login_generation
+                .fetch_add(1, Ordering::AcqRel)
+                .wrapping_add(1);
+            let mut generations = self.target_login_generations.write().await;
+            generations
+                .entry(account_id.to_string())
+                .and_modify(|current| *current = (*current).max(generation))
+                .or_insert(generation);
+            Some(generation)
+        } else {
+            None
+        };
 
         let response = crate::proxy::http_client::get()
             .post(DEVICE_AUTH_USERCODE_URL)
@@ -406,6 +459,8 @@ impl CodexOAuthManager {
             device.user_code.clone(),
             expires_at_ms,
             login_epoch,
+            target_account_id,
+            target_generation,
         )
         .await?;
 
@@ -429,6 +484,8 @@ impl CodexOAuthManager {
         user_code: String,
         expires_at_ms: i64,
         login_epoch: u64,
+        target_account_id: Option<String>,
+        target_generation: Option<u64>,
     ) -> Result<(), CodexOAuthError> {
         let mut pending = self.pending_device_codes.write().await;
         if self.login_epoch.load(Ordering::Acquire) != login_epoch {
@@ -442,18 +499,33 @@ impl CodexOAuthManager {
             PendingDeviceCode {
                 user_code,
                 expires_at_ms,
+                target_account_id,
+                target_generation,
             },
         );
         Ok(())
     }
 
+    pub async fn cancel_device_flow(&self, device_code: &str) -> bool {
+        self.pending_device_codes
+            .write()
+            .await
+            .remove(device_code)
+            .is_some()
+    }
+
     /// 轮询 Device Code 状态
     ///
     /// 接收 device_code（即 device_auth_id），返回 Some(account) 表示授权成功
-    pub async fn poll_for_token(
+    pub async fn poll_for_token<BeforeCommit, CommitFuture, CommitGuard>(
         &self,
         device_code: &str,
-    ) -> Result<Option<GitHubAccount>, CodexOAuthError> {
+        before_commit: BeforeCommit,
+    ) -> Result<Option<GitHubAccount>, CodexOAuthError>
+    where
+        BeforeCommit: FnOnce() -> CommitFuture,
+        CommitFuture: std::future::Future<Output = CommitGuard>,
+    {
         let entry = {
             let pending = self.pending_device_codes.read().await;
             pending.get(device_code).cloned()
@@ -471,7 +543,7 @@ impl CodexOAuthManager {
             return Err(CodexOAuthError::ExpiredToken);
         }
 
-        let user_code = entry.user_code;
+        let user_code = entry.user_code.clone();
 
         log::debug!("[CodexOAuth] 轮询 Device Code");
 
@@ -526,7 +598,26 @@ impl CodexOAuthManager {
             CodexOAuthError::ParseError("无法从 token 中提取 chatgpt_account_id".to_string())
         })?;
 
+        let id_token = tokens
+            .id_token
+            .clone()
+            .filter(|token| !token.trim().is_empty())
+            .ok_or_else(|| {
+                CodexOAuthError::TokenFetchFailed(
+                    "登录响应缺少 id_token，账号未保存，请重新登录".to_string(),
+                )
+            })?;
+        if crate::codex_config::extract_codex_id_token_subject(&id_token).is_none() {
+            return Err(CodexOAuthError::TokenFetchFailed(
+                "登录响应无法确认稳定用户身份，账号未保存，请重新登录".to_string(),
+            ));
+        }
+
         let obtained_at_ms = chrono::Utc::now().timestamp_millis();
+        // Provider switching and managed live-auth writes use the same guard.
+        // Acquire it only after the network exchange succeeds so ordinary
+        // authorization-pending polls never block provider operations.
+        let _commit_guard = before_commit().await;
         // 登录提交与该账号的 refresh/adopt 共用一把 generation 锁；账号和
         // access cache 一次写入，旧刷新响应因此不能覆盖新登录链。
         let account = self
@@ -534,14 +625,17 @@ impl CodexOAuthManager {
                 chatgpt_account_id,
                 refresh_token,
                 email,
-                // 空字符串视为缺失，避免写出空的 id_token
-                tokens.id_token.clone().filter(|t| !t.trim().is_empty()),
+                Some(id_token),
                 Some(CachedAccessToken {
                     token: tokens.access_token.clone(),
                     expires_at_ms: compute_expires_at_ms(tokens.expires_in),
                     obtained_at_ms,
                 }),
-                Some(device_code),
+                AccountLoginContext {
+                    target_account_id: entry.target_account_id.as_deref(),
+                    pending_device_code: Some(device_code),
+                    target_generation: entry.target_generation,
+                },
             )
             .await?;
 
@@ -638,20 +732,44 @@ impl CodexOAuthManager {
         account_id: &str,
     ) -> Result<String, CodexOAuthError> {
         let _lifecycle = self.lifecycle_lock.read().await;
+        self.ensure_account_ready_for_use(account_id).await?;
         Ok(self.resolve_valid_cached_token(account_id).await?.token)
+    }
+
+    async fn ensure_account_ready_for_use(&self, account_id: &str) -> Result<(), CodexOAuthError> {
+        let accounts = self.accounts.read().await;
+        let account = accounts
+            .get(account_id)
+            .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
+        if account
+            .id_token
+            .as_deref()
+            .and_then(crate::codex_config::extract_codex_id_token_user_identity)
+            .is_none()
+            || account.chatgpt_account_id.is_none()
+        {
+            return Err(CodexOAuthError::ParseError(format!(
+                "账号 {account_id} 缺少 id_token 中可证明的用户身份或 workspace，请重新认证"
+            )));
+        }
+        Ok(())
     }
 
     async fn read_managed_live_auth_refresh_for_account(
         &self,
         account_id: &str,
     ) -> Result<Option<(String, Option<String>, Option<i64>)>, CodexOAuthError> {
-        let managed_id_token = {
+        let (managed_id_token, managed_workspace) = {
             let accounts = self.accounts.read().await;
-            accounts
+            let account = accounts
                 .get(account_id)
-                .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?
-                .id_token
-                .clone()
+                .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
+            let workspace = account.chatgpt_account_id.clone().ok_or_else(|| {
+                CodexOAuthError::ParseError(format!(
+                    "账号 {account_id} 缺少 workspace 身份，请重新认证"
+                ))
+            })?;
+            (account.id_token.clone(), workspace)
         };
         let Some(live_refresh) =
             crate::codex_config::read_codex_live_auth_refresh_for_managed_account(
@@ -663,27 +781,10 @@ impl CodexOAuthManager {
             return Ok(None);
         };
 
-        let mut needs_save = false;
-        {
-            let mut accounts = self.accounts.write().await;
-            let account = accounts
-                .get_mut(account_id)
-                .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
-            match account.chatgpt_account_id.as_deref() {
-                None => {
-                    account.chatgpt_account_id = Some(live_refresh.chatgpt_account_id.clone());
-                    needs_save = true;
-                }
-                Some(stored) if stored != live_refresh.chatgpt_account_id => {
-                    return Err(CodexOAuthError::TokenFetchFailed(format!(
-                        "Codex OAuth 账号 {account_id} 的 workspace 与磁盘凭据不一致，本次操作已取消"
-                    )));
-                }
-                Some(_) => {}
-            }
-        }
-        if needs_save {
-            self.save_to_disk().await?;
+        if managed_workspace != live_refresh.chatgpt_account_id {
+            return Err(CodexOAuthError::TokenFetchFailed(format!(
+                "Codex OAuth 账号 {account_id} 的 workspace 与磁盘凭据不一致，本次操作已取消"
+            )));
         }
         Ok(Some((
             live_refresh.refresh_token,
@@ -919,6 +1020,7 @@ impl CodexOAuthManager {
         account_id: &str,
     ) -> Result<ManagedTokenBundle, CodexOAuthError> {
         let _lifecycle = self.lifecycle_lock.read().await;
+        self.ensure_account_ready_for_use(account_id).await?;
         let refresh_lock = self.get_refresh_lock(account_id).await;
         let _refresh_guard = refresh_lock.lock().await;
 
@@ -1253,17 +1355,24 @@ impl CodexOAuthManager {
         // have been removed as one lifecycle transition.
         let _lifecycle = self.lifecycle_lock.write().await;
 
-        {
+        let managed_id_token = {
             let accounts = self.accounts.read().await;
-            if !accounts.contains_key(account_id) {
-                return Err(CodexOAuthError::AccountNotFound(account_id.to_string()));
-            }
-        }
+            accounts
+                .get(account_id)
+                .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?
+                .id_token
+                .clone()
+        };
 
         // Explicit Auth Center removal means credentials for this managed
         // account must leave the machine. Content matching intentionally also
         // claims a native `codex login` of the same account; that is the same
         // account-scoped credential the user just chose to remove.
+        crate::codex_config::prepare_codex_live_auth_for_managed_account_removal(
+            account_id,
+            managed_id_token.as_deref(),
+        )
+        .map_err(|error| CodexOAuthError::TokenFetchFailed(error.to_string()))?;
         crate::codex_config::clear_codex_live_auth_for_managed_account(account_id)
             .map_err(|error| CodexOAuthError::IoError(error.to_string()))?;
 
@@ -1278,6 +1387,10 @@ impl CodexOAuthManager {
             let mut locks = self.refresh_locks.write().await;
             locks.remove(account_id);
         }
+        self.target_login_generations
+            .write()
+            .await
+            .remove(account_id);
 
         {
             let accounts = self.accounts.read().await;
@@ -1318,14 +1431,21 @@ impl CodexOAuthManager {
         // the clear has committed.
         let _lifecycle = self.lifecycle_lock.write().await;
 
-        let account_ids = self
+        let accounts_to_clear = self
             .accounts
             .read()
             .await
-            .keys()
-            .cloned()
+            .iter()
+            .map(|(account_id, account)| (account_id.clone(), account.id_token.clone()))
             .collect::<Vec<_>>();
-        for account_id in &account_ids {
+        for (account_id, id_token) in &accounts_to_clear {
+            crate::codex_config::prepare_codex_live_auth_for_managed_account_removal(
+                account_id,
+                id_token.as_deref(),
+            )
+            .map_err(|error| CodexOAuthError::TokenFetchFailed(error.to_string()))?;
+        }
+        for (account_id, _) in &accounts_to_clear {
             crate::codex_config::clear_codex_live_auth_for_managed_account(account_id)
                 .map_err(|error| CodexOAuthError::IoError(error.to_string()))?;
         }
@@ -1349,6 +1469,7 @@ impl CodexOAuthManager {
             let mut locks = self.refresh_locks.write().await;
             locks.clear();
         }
+        self.target_login_generations.write().await.clear();
         {
             let mut pending = self.pending_device_codes.write().await;
             self.login_epoch.fetch_add(1, Ordering::AcqRel);
@@ -1476,28 +1597,75 @@ impl CodexOAuthManager {
         email: Option<String>,
         id_token: Option<String>,
         initial_access_token: Option<CachedAccessToken>,
-        pending_device_code: Option<&str>,
+        context: AccountLoginContext<'_>,
     ) -> Result<GitHubAccount, CodexOAuthError> {
         let _lifecycle = self.lifecycle_lock.read().await;
-        if let Some(device_code) = pending_device_code {
-            // `clear_auth` owns lifecycle(write) while clearing pending flows.
-            // Re-check under lifecycle(read) at commit time so a poll that was
-            // already on the network cannot recreate an account after clear.
-            if self
-                .pending_device_codes
-                .write()
-                .await
-                .remove(device_code)
-                .is_none()
-            {
-                return Err(CodexOAuthError::ExpiredToken);
-            }
-        }
-        let account_id = Uuid::new_v4().to_string();
+        let target_account_id = context
+            .target_account_id
+            .map(str::trim)
+            .filter(|account_id| !account_id.is_empty())
+            .map(str::to_string);
+        let replacing_existing = target_account_id.is_some();
+        let account_id = target_account_id.unwrap_or_else(|| Uuid::new_v4().to_string());
         let refresh_lock = self.get_refresh_lock(&account_id).await;
         let _refresh_guard = refresh_lock.lock().await;
         let now = chrono::Utc::now().timestamp();
         let now_ms = chrono::Utc::now().timestamp_millis();
+
+        if replacing_existing {
+            let accounts = self.accounts.read().await;
+            let existing = accounts
+                .get(&account_id)
+                .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.clone()))?;
+            let expected_workspace = existing
+                .chatgpt_account_id
+                .as_deref()
+                .unwrap_or(existing.account_id.as_str());
+            if expected_workspace != chatgpt_account_id {
+                return Err(CodexOAuthError::TokenFetchFailed(format!(
+                    "重新登录的 ChatGPT workspace 与账号 {account_id} 不一致"
+                )));
+            }
+
+            let new_id_token = id_token.as_deref().ok_or_else(|| {
+                CodexOAuthError::TokenFetchFailed(
+                    "重新登录未返回 id_token，原账号保持不变".to_string(),
+                )
+            })?;
+            let existing_subject = existing
+                .id_token
+                .as_deref()
+                .and_then(crate::codex_config::extract_codex_id_token_subject);
+            let new_subject = crate::codex_config::extract_codex_id_token_subject(new_id_token);
+            let user_identity_matches = match existing_subject.as_deref() {
+                Some(existing) if new_subject.as_deref() == Some(existing) => true,
+                Some(_) => {
+                    return Err(CodexOAuthError::TokenFetchFailed(format!(
+                        "重新登录的 ChatGPT 用户与账号 {account_id} 不一致"
+                    )));
+                }
+                None => {
+                    let existing_email = existing
+                        .email
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty());
+                    let new_email = email
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty());
+                    matches!(
+                        (existing_email, new_email),
+                        (Some(existing), Some(new)) if existing.eq_ignore_ascii_case(new)
+                    )
+                }
+            };
+            if !user_identity_matches {
+                return Err(CodexOAuthError::TokenFetchFailed(format!(
+                    "无法确认重新登录的 ChatGPT 用户属于账号 {account_id}，原账号保持不变"
+                )));
+            }
+        }
 
         let data = CodexAccountData {
             account_id: account_id.clone(),
@@ -1511,6 +1679,59 @@ impl CodexOAuthManager {
 
         let account = GitHubAccount::from(&data);
 
+        // Linearize cancel/newer-flow against the actual commit, after waiting
+        // for the account lock. Holding both guards through persistence means
+        // cancellation cannot report success after this point, while a cancel
+        // or newer generation that won the race makes this flow fail closed.
+        let _pending_commit_guard = if let Some(device_code) = context.pending_device_code {
+            let generations = self.target_login_generations.read().await;
+            let mut pending_codes = self.pending_device_codes.write().await;
+            let pending = pending_codes
+                .get(device_code)
+                .ok_or(CodexOAuthError::ExpiredToken)?;
+            let generation_matches = match (
+                pending.target_account_id.as_deref(),
+                pending.target_generation,
+            ) {
+                (Some(account_id), Some(generation)) => {
+                    context.target_account_id == Some(account_id)
+                        && context.target_generation == Some(generation)
+                        && generations.get(account_id) == Some(&generation)
+                }
+                (None, None) => {
+                    context.target_account_id.is_none() && context.target_generation.is_none()
+                }
+                _ => false,
+            };
+            if pending.expires_at_ms <= chrono::Utc::now().timestamp_millis() || !generation_matches
+            {
+                return Err(CodexOAuthError::ExpiredToken);
+            }
+            pending_codes.remove(device_code);
+            Some((generations, pending_codes))
+        } else {
+            None
+        };
+
+        // Persist a prospective snapshot before publishing new credentials to
+        // readers. A failed atomic write therefore leaves the target account
+        // and its access-token cache untouched.
+        let _persist = self.storage_lock.lock().await;
+        let mut persisted_accounts = self.accounts.read().await.clone();
+        persisted_accounts.insert(account_id.clone(), data.clone());
+        let persisted_default = self
+            .resolve_default_account_id()
+            .await
+            .or_else(|| Some(account_id.clone()));
+        let store = CodexOAuthStore {
+            version: 2,
+            accounts: persisted_accounts,
+            default_account_id: persisted_default,
+        };
+        let content = serde_json::to_string_pretty(&store)
+            .map_err(|error| CodexOAuthError::ParseError(error.to_string()))?;
+        self.write_store_atomic(&content)?;
+
         {
             let mut accounts = self.accounts.write().await;
             accounts.insert(account_id.clone(), data);
@@ -1521,15 +1742,10 @@ impl CodexOAuthManager {
                 access_tokens.remove(&account_id);
             }
         }
-
-        {
-            let mut default = self.default_account_id.write().await;
-            if default.is_none() {
-                *default = Some(account_id);
-            }
+        let mut default = self.default_account_id.write().await;
+        if default.is_none() {
+            *default = Some(account_id);
         }
-
-        self.save_to_disk().await?;
         Ok(account)
     }
 
@@ -1907,7 +2123,7 @@ mod tests {
                     Some("user@example.com".to_string()),
                     None,
                     None,
-                    None,
+                    AccountLoginContext::default(),
                 )
                 .await
                 .unwrap();
@@ -1941,7 +2157,7 @@ mod tests {
                 Some("first@example.com".to_string()),
                 None,
                 None,
-                None,
+                AccountLoginContext::default(),
             )
             .await
             .unwrap();
@@ -1952,7 +2168,7 @@ mod tests {
                 Some("second@example.com".to_string()),
                 None,
                 None,
-                None,
+                AccountLoginContext::default(),
             )
             .await
             .unwrap();
@@ -1988,7 +2204,196 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_v1_store_preserves_existing_account_id() {
+    async fn targeted_reauth_updates_account_in_place_and_preserves_binding_id() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        let user_a_id_token = crate::codex_config::test_codex_id_token("user-a");
+        let existing = manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "rt-old".to_string(),
+                Some("user@example.com".to_string()),
+                None,
+                None,
+                AccountLoginContext::default(),
+            )
+            .await
+            .unwrap();
+
+        let refreshed = manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "rt-new".to_string(),
+                Some("user@example.com".to_string()),
+                Some(user_a_id_token.clone()),
+                Some(CachedAccessToken {
+                    token: "access-new".to_string(),
+                    expires_at_ms: i64::MAX,
+                    obtained_at_ms: 42,
+                }),
+                AccountLoginContext {
+                    target_account_id: Some(&existing.id),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(refreshed.id, existing.id);
+        assert_eq!(manager.list_accounts().await.len(), 1);
+        let accounts = manager.accounts.read().await;
+        let account = accounts.get(&existing.id).unwrap();
+        assert_eq!(account.refresh_token, "rt-new");
+        assert_eq!(account.id_token.as_deref(), Some(user_a_id_token.as_str()));
+        drop(accounts);
+        assert_eq!(
+            manager
+                .access_tokens
+                .read()
+                .await
+                .get(&existing.id)
+                .map(|token| token.token.as_str()),
+            Some("access-new")
+        );
+
+        let mismatch = manager
+            .add_account_internal(
+                "different-workspace".to_string(),
+                "rt-wrong".to_string(),
+                None,
+                Some("id-wrong".to_string()),
+                None,
+                AccountLoginContext {
+                    target_account_id: Some(&existing.id),
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(matches!(
+            mismatch,
+            Err(CodexOAuthError::TokenFetchFailed(_))
+        ));
+        assert_eq!(
+            manager
+                .accounts
+                .read()
+                .await
+                .get(&existing.id)
+                .unwrap()
+                .refresh_token,
+            "rt-new"
+        );
+
+        let other_user = manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "rt-other-user".to_string(),
+                Some("user@example.com".to_string()),
+                Some(crate::codex_config::test_codex_id_token("user-b")),
+                None,
+                AccountLoginContext {
+                    target_account_id: Some(&existing.id),
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(matches!(
+            other_user,
+            Err(CodexOAuthError::TokenFetchFailed(_))
+        ));
+        assert_eq!(
+            manager
+                .accounts
+                .read()
+                .await
+                .get(&existing.id)
+                .unwrap()
+                .refresh_token,
+            "rt-new"
+        );
+
+        // Make the configured store path unwritable as a file. Reauth must not
+        // publish the new generation in memory when the atomic write fails.
+        manager.storage_path = temp.path().to_path_buf();
+        let write_failure = manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "rt-uncommitted".to_string(),
+                Some("user@example.com".to_string()),
+                Some(user_a_id_token),
+                Some(CachedAccessToken {
+                    token: "access-uncommitted".to_string(),
+                    expires_at_ms: i64::MAX,
+                    obtained_at_ms: 43,
+                }),
+                AccountLoginContext {
+                    target_account_id: Some(&existing.id),
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(matches!(write_failure, Err(CodexOAuthError::IoError(_))));
+        assert_eq!(
+            manager
+                .accounts
+                .read()
+                .await
+                .get(&existing.id)
+                .unwrap()
+                .refresh_token,
+            "rt-new"
+        );
+        assert_eq!(
+            manager
+                .access_tokens
+                .read()
+                .await
+                .get(&existing.id)
+                .map(|token| token.token.as_str()),
+            Some("access-new")
+        );
+    }
+
+    #[tokio::test]
+    async fn targeted_reauth_accepts_email_change_for_same_subject() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        let id_token = crate::codex_config::test_codex_id_token("stable-user");
+        let existing = manager
+            .add_account_internal(
+                "workspace".to_string(),
+                "refresh-old".to_string(),
+                Some("old@example.com".to_string()),
+                Some(id_token.clone()),
+                None,
+                AccountLoginContext::default(),
+            )
+            .await
+            .unwrap();
+
+        manager
+            .add_account_internal(
+                "workspace".to_string(),
+                "refresh-new".to_string(),
+                Some("new@example.com".to_string()),
+                Some(id_token),
+                None,
+                AccountLoginContext {
+                    target_account_id: Some(&existing.id),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        let accounts = manager.accounts.read().await;
+        let account = accounts.get(&existing.id).unwrap();
+        assert_eq!(account.email.as_deref(), Some("new@example.com"));
+        assert_eq!(account.refresh_token, "refresh-new");
+    }
+
+    #[tokio::test]
+    async fn test_v1_store_stays_quarantined_until_targeted_reauth() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().to_path_buf();
         let manager = CodexOAuthManager::new(path.clone());
@@ -1999,6 +2404,7 @@ mod tests {
                     "account_id": "legacy-workspace",
                     "email": "legacy@example.com",
                     "refresh_token": "rt-legacy",
+                    "id_token": "legacy-id-token",
                     "authenticated_at": 1
                 }
             },
@@ -2013,9 +2419,16 @@ mod tests {
         let accounts = manager.list_accounts().await;
         assert_eq!(accounts.len(), 1);
         assert_eq!(accounts[0].id, "legacy-workspace");
+        assert!(accounts[0].reauth_required);
         assert!(matches!(
             manager
                 .chatgpt_account_id_for_account("legacy-workspace")
+                .await,
+            Err(CodexOAuthError::ParseError(_))
+        ));
+        assert!(matches!(
+            manager
+                .get_valid_token_for_account("legacy-workspace")
                 .await,
             Err(CodexOAuthError::ParseError(_))
         ));
@@ -2066,7 +2479,7 @@ mod tests {
         };
         {
             let mut stored = manager.accounts.write().await;
-            assert!(stored
+            assert!(!stored
                 .get_mut("legacy-workspace")
                 .unwrap()
                 .apply_refreshed_tokens(&refreshed_tokens));
@@ -2079,13 +2492,11 @@ mod tests {
             manager.default_account_id().await.as_deref(),
             Some("legacy-workspace")
         );
-        assert_eq!(
-            manager
-                .chatgpt_account_id_for_account("legacy-workspace")
-                .await
-                .unwrap(),
-            "actual-workspace"
-        );
+        assert!(manager
+            .chatgpt_account_id_for_account("legacy-workspace")
+            .await
+            .is_err());
+        assert!(manager.list_accounts().await[0].reauth_required);
         assert_eq!(
             manager
                 .accounts
@@ -2096,6 +2507,29 @@ mod tests {
                 .refresh_token,
             "rt-rotated"
         );
+
+        manager
+            .add_account_internal(
+                "legacy-workspace".to_string(),
+                "rt-reauthenticated".to_string(),
+                Some("legacy@example.com".to_string()),
+                Some(crate::codex_config::test_codex_id_token("legacy-user")),
+                None,
+                AccountLoginContext {
+                    target_account_id: Some("legacy-workspace"),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            manager
+                .chatgpt_account_id_for_account("legacy-workspace")
+                .await
+                .unwrap(),
+            "legacy-workspace"
+        );
+        assert!(!manager.list_accounts().await[0].reauth_required);
     }
 
     #[tokio::test]
@@ -2110,7 +2544,7 @@ mod tests {
                 Some("a@example.com".to_string()),
                 None,
                 None,
-                None,
+                AccountLoginContext::default(),
             )
             .await
             .unwrap();
@@ -2121,7 +2555,7 @@ mod tests {
                 Some("b@example.com".to_string()),
                 None,
                 None,
-                None,
+                AccountLoginContext::default(),
             )
             .await
             .unwrap();
@@ -2424,6 +2858,8 @@ mod tests {
             PendingDeviceCode {
                 user_code: "ABCD-EFGH".to_string(),
                 expires_at_ms: chrono::Utc::now().timestamp_millis() + 60_000,
+                target_account_id: None,
+                target_generation: None,
             },
         );
 
@@ -2435,7 +2871,10 @@ mod tests {
                 None,
                 None,
                 None,
-                Some("device-auth-id"),
+                AccountLoginContext {
+                    pending_device_code: Some("device-auth-id"),
+                    ..Default::default()
+                },
             )
             .await;
 
@@ -2457,11 +2896,226 @@ mod tests {
                 "ABCD-EFGH".to_string(),
                 chrono::Utc::now().timestamp_millis() + 60_000,
                 login_epoch,
+                None,
+                None,
             )
             .await;
 
         assert!(matches!(result, Err(CodexOAuthError::ExpiredToken)));
         assert!(manager.pending_device_codes.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancel_device_flow_invalidates_a_pending_commit() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        manager
+            .register_pending_device_code(
+                "cancelled-device-auth-id".to_string(),
+                "ABCD-EFGH".to_string(),
+                chrono::Utc::now().timestamp_millis() + 60_000,
+                manager.login_epoch.load(Ordering::Acquire),
+                Some("target-account".to_string()),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(manager.cancel_device_flow("cancelled-device-auth-id").await);
+
+        assert!(manager.pending_device_codes.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancel_device_flow_invalidates_commit_waiting_for_account_lock() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = Arc::new(CodexOAuthManager::new(temp.path().to_path_buf()));
+        let existing = manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "refresh-original".to_string(),
+                Some("user@example.com".to_string()),
+                Some(crate::codex_config::test_codex_id_token("user-a")),
+                None,
+                AccountLoginContext::default(),
+            )
+            .await
+            .unwrap();
+        manager
+            .target_login_generations
+            .write()
+            .await
+            .insert(existing.id.clone(), 1);
+        manager
+            .register_pending_device_code(
+                "cancelled-waiting-flow".to_string(),
+                "ABCD-EFGH".to_string(),
+                chrono::Utc::now().timestamp_millis() + 60_000,
+                manager.login_epoch.load(Ordering::Acquire),
+                Some(existing.id.clone()),
+                Some(1),
+            )
+            .await
+            .unwrap();
+
+        let refresh_lock = manager.get_refresh_lock(&existing.id).await;
+        let refresh_guard = refresh_lock.lock().await;
+        let commit_manager = Arc::clone(&manager);
+        let account_id = existing.id.clone();
+        let commit = tokio::spawn(async move {
+            commit_manager
+                .add_account_internal(
+                    "shared-workspace".to_string(),
+                    "refresh-cancelled".to_string(),
+                    Some("user@example.com".to_string()),
+                    Some(crate::codex_config::test_codex_id_token("user-a")),
+                    None,
+                    AccountLoginContext {
+                        target_account_id: Some(&account_id),
+                        pending_device_code: Some("cancelled-waiting-flow"),
+                        target_generation: Some(1),
+                    },
+                )
+                .await
+        });
+
+        for _ in 0..100 {
+            if Arc::strong_count(&refresh_lock) >= 3 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            Arc::strong_count(&refresh_lock) >= 3,
+            "commit did not reach the account lock"
+        );
+
+        assert!(manager.cancel_device_flow("cancelled-waiting-flow").await);
+        drop(refresh_guard);
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), commit)
+            .await
+            .expect("commit should finish")
+            .expect("commit task should not panic");
+        assert!(matches!(result, Err(CodexOAuthError::ExpiredToken)));
+        assert_eq!(
+            manager
+                .accounts
+                .read()
+                .await
+                .get(&existing.id)
+                .unwrap()
+                .refresh_token,
+            "refresh-original"
+        );
+    }
+
+    #[tokio::test]
+    async fn only_latest_targeted_device_flow_can_commit() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        let existing = manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "refresh-original".to_string(),
+                Some("user@example.com".to_string()),
+                Some(crate::codex_config::test_codex_id_token("user-a")),
+                None,
+                AccountLoginContext::default(),
+            )
+            .await
+            .unwrap();
+
+        manager
+            .target_login_generations
+            .write()
+            .await
+            .insert(existing.id.clone(), 2);
+        for (device_code, generation) in [("stale-flow", 1), ("latest-flow", 2)] {
+            manager.pending_device_codes.write().await.insert(
+                device_code.to_string(),
+                PendingDeviceCode {
+                    user_code: "ABCD-EFGH".to_string(),
+                    expires_at_ms: chrono::Utc::now().timestamp_millis() + 60_000,
+                    target_account_id: Some(existing.id.clone()),
+                    target_generation: Some(generation),
+                },
+            );
+        }
+
+        let stale = manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "refresh-stale".to_string(),
+                Some("user@example.com".to_string()),
+                Some(crate::codex_config::test_codex_id_token("user-a")),
+                None,
+                AccountLoginContext {
+                    target_account_id: Some(&existing.id),
+                    pending_device_code: Some("stale-flow"),
+                    target_generation: Some(1),
+                },
+            )
+            .await;
+        assert!(matches!(stale, Err(CodexOAuthError::ExpiredToken)));
+
+        manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "refresh-latest".to_string(),
+                Some("user@example.com".to_string()),
+                Some(crate::codex_config::test_codex_id_token("user-a")),
+                None,
+                AccountLoginContext {
+                    target_account_id: Some(&existing.id),
+                    pending_device_code: Some("latest-flow"),
+                    target_generation: Some(2),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            manager
+                .accounts
+                .read()
+                .await
+                .get(&existing.id)
+                .unwrap()
+                .refresh_token,
+            "refresh-latest"
+        );
+    }
+
+    #[tokio::test]
+    async fn device_flow_cannot_commit_after_expiry() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        manager.pending_device_codes.write().await.insert(
+            "expired-flow".to_string(),
+            PendingDeviceCode {
+                user_code: "ABCD-EFGH".to_string(),
+                expires_at_ms: chrono::Utc::now().timestamp_millis() - 1,
+                target_account_id: None,
+                target_generation: None,
+            },
+        );
+
+        let result = manager
+            .add_account_internal(
+                "workspace".to_string(),
+                "refresh".to_string(),
+                None,
+                Some(crate::codex_config::test_codex_id_token("user")),
+                None,
+                AccountLoginContext {
+                    pending_device_code: Some("expired-flow"),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(CodexOAuthError::ExpiredToken)));
+        assert!(manager.list_accounts().await.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -13,7 +13,7 @@
 //! ## 多账号支持
 //! - 每个 ChatGPT 账号独立存储 refresh_token
 //! - Provider 通过 meta.authBinding 关联账号（auth_provider = "codex_oauth"）
-//! - 通过 JWT id_token 提取 chatgpt_account_id 作为账号唯一标识
+//! - 本地账号 ID 用于绑定和缓存；chatgpt_account_id 仅表示上游 workspace
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 
@@ -28,6 +28,7 @@ use std::sync::{
 };
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock};
+use uuid::Uuid;
 
 use super::copilot_auth::{GitHubAccount, GitHubDeviceCodeResponse};
 
@@ -144,16 +145,8 @@ struct IdTokenClaims {
     chatgpt_account_id: Option<String>,
     #[serde(default)]
     email: Option<String>,
-    #[serde(default)]
-    organizations: Vec<OrgClaim>,
     #[serde(default, rename = "https://api.openai.com/auth")]
     openai_auth: Option<OpenAiAuthClaim>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-struct OrgClaim {
-    #[serde(default)]
-    id: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -231,8 +224,11 @@ struct PendingDeviceCode {
 /// 持久化的账号数据
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct CodexAccountData {
-    /// chatgpt_account_id（同时作为 HashMap 的 key）
+    /// 本地稳定账号 ID（同时作为 HashMap 的 key）
     pub account_id: String,
+    /// 上游 ChatGPT workspace ID（用于 chatgpt-account-id 请求头）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chatgpt_account_id: Option<String>,
     /// 账号邮箱（如果可获取）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
@@ -255,11 +251,15 @@ impl From<&CodexAccountData> for GitHubAccount {
     fn from(data: &CodexAccountData) -> Self {
         GitHubAccount {
             id: data.account_id.clone(),
-            // 用 email 作为显示名（若无则用 account_id）
-            login: data
-                .email
-                .clone()
-                .unwrap_or_else(|| format!("ChatGPT ({})", &data.account_id)),
+            // 用 email 作为显示名（若无则用上游 workspace ID）
+            login: data.email.clone().unwrap_or_else(|| {
+                format!(
+                    "ChatGPT ({})",
+                    data.chatgpt_account_id
+                        .as_deref()
+                        .unwrap_or(&data.account_id)
+                )
+            }),
             avatar_url: None,
             authenticated_at: data.authenticated_at,
             github_domain: "github.com".to_string(),
@@ -269,7 +269,32 @@ impl From<&CodexAccountData> for GitHubAccount {
     }
 }
 
-/// 持久化存储结构（v1）
+impl CodexAccountData {
+    fn apply_refreshed_tokens(&mut self, tokens: &OAuthTokenResponse) -> bool {
+        let refreshed_account_id = extract_account_metadata_from_tokens(tokens).0;
+        let mut changed = false;
+        if let Some(account_id) = refreshed_account_id {
+            if self.chatgpt_account_id.as_deref() != Some(&account_id) {
+                self.chatgpt_account_id = Some(account_id);
+                changed = true;
+            }
+        }
+        if let Some(refresh_token) = tokens
+            .refresh_token
+            .as_ref()
+            .filter(|token| !token.trim().is_empty())
+        {
+            if self.refresh_token != *refresh_token {
+                self.refresh_token = refresh_token.clone();
+                changed = true;
+            }
+        }
+
+        changed
+    }
+}
+
+/// 持久化存储结构（v2）
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct CodexOAuthStore {
     #[serde(default)]
@@ -283,6 +308,7 @@ struct CodexOAuthStore {
 /// 写入托管 Codex `auth.json` 所需的完整可刷新 token 束。
 #[derive(Debug, Clone)]
 pub(crate) struct ManagedTokenBundle {
+    pub chatgpt_account_id: String,
     pub access_token: String,
     pub id_token: Option<String>,
     pub refresh_token: String,
@@ -495,9 +521,9 @@ impl CodexOAuthManager {
             CodexOAuthError::TokenFetchFailed("响应缺少 refresh_token".to_string())
         })?;
 
-        let (account_id, email) = extract_identity_from_tokens(&tokens);
-        let account_id = account_id.ok_or_else(|| {
-            CodexOAuthError::ParseError("无法从 token 中提取 account_id".to_string())
+        let (chatgpt_account_id, email) = extract_account_metadata_from_tokens(&tokens);
+        let chatgpt_account_id = chatgpt_account_id.ok_or_else(|| {
+            CodexOAuthError::ParseError("无法从 token 中提取 chatgpt_account_id".to_string())
         })?;
 
         let obtained_at_ms = chrono::Utc::now().timestamp_millis();
@@ -505,7 +531,7 @@ impl CodexOAuthManager {
         // access cache 一次写入，旧刷新响应因此不能覆盖新登录链。
         let account = self
             .add_account_internal(
-                account_id.clone(),
+                chatgpt_account_id,
                 refresh_token,
                 email,
                 // 空字符串视为缺失，避免写出空的 id_token
@@ -615,6 +641,57 @@ impl CodexOAuthManager {
         Ok(self.resolve_valid_cached_token(account_id).await?.token)
     }
 
+    async fn read_managed_live_auth_refresh_for_account(
+        &self,
+        account_id: &str,
+    ) -> Result<Option<(String, Option<String>, Option<i64>)>, CodexOAuthError> {
+        let managed_id_token = {
+            let accounts = self.accounts.read().await;
+            accounts
+                .get(account_id)
+                .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?
+                .id_token
+                .clone()
+        };
+        let Some(live_refresh) =
+            crate::codex_config::read_codex_live_auth_refresh_for_managed_account(
+                account_id,
+                managed_id_token.as_deref(),
+            )
+            .map_err(|error| CodexOAuthError::TokenFetchFailed(error.to_string()))?
+        else {
+            return Ok(None);
+        };
+
+        let mut needs_save = false;
+        {
+            let mut accounts = self.accounts.write().await;
+            let account = accounts
+                .get_mut(account_id)
+                .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
+            match account.chatgpt_account_id.as_deref() {
+                None => {
+                    account.chatgpt_account_id = Some(live_refresh.chatgpt_account_id.clone());
+                    needs_save = true;
+                }
+                Some(stored) if stored != live_refresh.chatgpt_account_id => {
+                    return Err(CodexOAuthError::TokenFetchFailed(format!(
+                        "Codex OAuth 账号 {account_id} 的 workspace 与磁盘凭据不一致，本次操作已取消"
+                    )));
+                }
+                Some(_) => {}
+            }
+        }
+        if needs_save {
+            self.save_to_disk().await?;
+        }
+        Ok(Some((
+            live_refresh.refresh_token,
+            live_refresh.id_token,
+            live_refresh.last_refresh_ms,
+        )))
+    }
+
     /// 解析账号的有效缓存 token（含真实获取时间），必要时刷新。
     ///
     /// 返回完整 `CachedAccessToken`，使 token 与其 `obtained_at_ms` 天然配套（写托管
@@ -659,8 +736,9 @@ impl CodexOAuthManager {
         // Codex CLI may have advanced the shared refresh-token generation since
         // this manager last used the account. Reload it under the same per-account
         // lock before deciding whether a network refresh is necessary.
-        if let Some((live_refresh, live_id_token, live_last_refresh_ms)) =
-            crate::codex_config::read_codex_live_auth_refresh_for_account(account_id)
+        if let Some((live_refresh, live_id_token, live_last_refresh_ms)) = self
+            .read_managed_live_auth_refresh_for_account(account_id)
+            .await?
         {
             self.adopt_account_refresh_token_under_lock(
                 account_id,
@@ -699,9 +777,10 @@ impl CodexOAuthManager {
                 // If Codex CLI refreshed between our pre-read and request, reload
                 // its newer generation and retry exactly once. Error-code handling
                 // includes OpenAI's `refresh_token_reused` response.
-                let Some((live_refresh, live_id_token, live_last_refresh_ms)) =
-                    crate::codex_config::read_codex_live_auth_refresh_for_account(account_id)
-                        .filter(|(token, _, _)| token.trim() != refresh_token.as_str())
+                let Some((live_refresh, live_id_token, live_last_refresh_ms)) = self
+                    .read_managed_live_auth_refresh_for_account(account_id)
+                    .await?
+                    .filter(|(token, _, _)| token.trim() != refresh_token.as_str())
                 else {
                     return Err(CodexOAuthError::RefreshTokenInvalid);
                 };
@@ -727,7 +806,7 @@ impl CodexOAuthManager {
 
         // 如果服务端返回了新的 refresh_token 或 id_token，更新存储
         let mut needs_save = false;
-        let (stored_refresh_token, stored_id_token) = {
+        let (stored_refresh_token, stored_id_token, chatgpt_account_id) = {
             let mut accounts = self.accounts.write().await;
             let account = accounts
                 .get_mut(account_id)
@@ -740,15 +819,8 @@ impl CodexOAuthManager {
                     "账号凭据已更新，已丢弃旧刷新响应".to_string(),
                 ));
             }
-            if let Some(new_refresh) = new_tokens
-                .refresh_token
-                .clone()
-                .filter(|token| !token.trim().is_empty())
-            {
-                if new_refresh != account.refresh_token {
-                    account.refresh_token = new_refresh;
-                    needs_save = true;
-                }
+            if account.apply_refreshed_tokens(&new_tokens) {
+                needs_save = true;
             }
             // 刷新使用 openid scope，正常会返回新 id_token；为空则视为缺失，
             // 保留旧值而非覆盖（旧值的 claims 仍可用于账号/套餐显示）。
@@ -766,11 +838,20 @@ impl CodexOAuthManager {
                 account.token_updated_at_ms = obtained_at_ms;
                 needs_save = true;
             }
-            (account.refresh_token.clone(), account.id_token.clone())
+            (
+                account.refresh_token.clone(),
+                account.id_token.clone(),
+                account.chatgpt_account_id.clone(),
+            )
         };
         if needs_save {
             self.save_to_disk().await?;
         }
+        let chatgpt_account_id = chatgpt_account_id.ok_or_else(|| {
+            CodexOAuthError::ParseError(
+                "无法从刷新后的 token 中提取 chatgpt_account_id".to_string(),
+            )
+        })?;
 
         let cached = CachedAccessToken {
             token: new_tokens.access_token.clone(),
@@ -782,7 +863,7 @@ impl CodexOAuthManager {
             .unwrap_or_else(chrono::Utc::now)
             .to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
         let refreshed_auth = crate::codex_config::codex_managed_oauth_auth_value(
-            account_id,
+            &chatgpt_account_id,
             &cached.token,
             stored_id_token.as_deref(),
             &stored_refresh_token,
@@ -854,8 +935,9 @@ impl CodexOAuthManager {
         // access token. Keeping this check after resolution also preserves the
         // RefreshTokenInvalid recovery path: the server may disprove manager R0,
         // force-adopt disk R1, and only then produce a safe bundle.
-        if let Some((live_refresh, live_id_token, live_last_refresh_ms)) =
-            crate::codex_config::read_codex_live_auth_refresh_for_account(account_id)
+        if let Some((live_refresh, live_id_token, live_last_refresh_ms)) = self
+            .read_managed_live_auth_refresh_for_account(account_id)
+            .await?
         {
             let outcome = self
                 .adopt_account_refresh_token_under_lock(
@@ -886,14 +968,23 @@ impl CodexOAuthManager {
             chrono::DateTime::<chrono::Utc>::from_timestamp_millis(cached.obtained_at_ms)
                 .unwrap_or_else(chrono::Utc::now)
                 .to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
-        let (id_token, refresh_token) = {
+        let (chatgpt_account_id, id_token, refresh_token) = {
             let accounts = self.accounts.read().await;
             let account = accounts
                 .get(account_id)
                 .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
-            (account.id_token.clone(), account.refresh_token.clone())
+            (
+                account.chatgpt_account_id.clone().ok_or_else(|| {
+                    CodexOAuthError::ParseError(
+                        "账号缺少 chatgpt_account_id，请重新认证".to_string(),
+                    )
+                })?,
+                account.id_token.clone(),
+                account.refresh_token.clone(),
+            )
         };
         Ok(ManagedTokenBundle {
+            chatgpt_account_id,
             access_token: cached.token,
             id_token,
             refresh_token,
@@ -952,12 +1043,6 @@ impl CodexOAuthManager {
         &self,
         account_id: &str,
     ) -> Result<Option<String>, CodexOAuthError> {
-        let Some((live_refresh, live_id_token, live_last_refresh_ms)) =
-            crate::codex_config::read_codex_live_auth_refresh_for_account(account_id)
-        else {
-            return Ok(None);
-        };
-
         let _lifecycle = self.lifecycle_lock.read().await;
         let refresh_lock = self.get_refresh_lock(account_id).await;
         let _guard = refresh_lock.lock().await;
@@ -967,6 +1052,12 @@ impl CodexOAuthManager {
                 .get(account_id)
                 .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
         }
+        let Some((live_refresh, live_id_token, live_last_refresh_ms)) = self
+            .read_managed_live_auth_refresh_for_account(account_id)
+            .await?
+        else {
+            return Ok(None);
+        };
 
         let outcome = self
             .adopt_account_refresh_token_under_lock(
@@ -1133,6 +1224,20 @@ impl CodexOAuthManager {
         self.resolve_default_account_id().await
     }
 
+    /// 将本地账号 ID 解析为上游 ChatGPT workspace ID。
+    pub async fn chatgpt_account_id_for_account(
+        &self,
+        account_id: &str,
+    ) -> Result<String, CodexOAuthError> {
+        let accounts = self.accounts.read().await;
+        let account = accounts
+            .get(account_id)
+            .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
+        account.chatgpt_account_id.clone().ok_or_else(|| {
+            CodexOAuthError::ParseError("账号缺少 chatgpt_account_id，请重新认证".to_string())
+        })
+    }
+
     // ==================== 多账号管理 ====================
 
     pub async fn list_accounts(&self) -> Vec<GitHubAccount> {
@@ -1289,20 +1394,52 @@ impl CodexOAuthManager {
         access_token: &str,
         id_token: Option<&str>,
     ) -> Result<(), CodexOAuthError> {
-        let obtained_at_ms = chrono::Utc::now().timestamp_millis();
-        self.add_account_internal(
-            account_id.to_string(),
-            "test-refresh-token".to_string(),
-            Some(format!("{account_id}@example.test")),
-            id_token.map(|token| token.to_string()),
-            Some(CachedAccessToken {
-                token: access_token.to_string(),
-                expires_at_ms: obtained_at_ms + 3_600_000,
-                obtained_at_ms,
-            }),
-            None,
+        self.add_test_account_with_workspace_and_access_token(
+            account_id,
+            account_id,
+            access_token,
+            id_token,
         )
-        .await?;
+        .await
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn add_test_account_with_workspace_and_access_token(
+        &self,
+        account_id: &str,
+        chatgpt_account_id: &str,
+        access_token: &str,
+        id_token: Option<&str>,
+    ) -> Result<(), CodexOAuthError> {
+        let obtained_at_ms = chrono::Utc::now().timestamp_millis();
+        let data = CodexAccountData {
+            account_id: account_id.to_string(),
+            chatgpt_account_id: Some(chatgpt_account_id.to_string()),
+            email: Some(format!("{account_id}@example.test")),
+            refresh_token: "test-refresh-token".to_string(),
+            authenticated_at: chrono::Utc::now().timestamp(),
+            id_token: id_token.map(|token| token.to_string()),
+            token_updated_at_ms: obtained_at_ms,
+        };
+        {
+            let mut accounts = self.accounts.write().await;
+            accounts.insert(account_id.to_string(), data);
+            self.access_tokens.write().await.insert(
+                account_id.to_string(),
+                CachedAccessToken {
+                    token: access_token.to_string(),
+                    expires_at_ms: obtained_at_ms + 3_600_000,
+                    obtained_at_ms,
+                },
+            );
+        }
+        {
+            let mut default = self.default_account_id.write().await;
+            if default.is_none() {
+                *default = Some(account_id.to_string());
+            }
+        }
+        self.save_to_disk().await?;
 
         Ok(())
     }
@@ -1334,7 +1471,7 @@ impl CodexOAuthManager {
 
     async fn add_account_internal(
         &self,
-        account_id: String,
+        chatgpt_account_id: String,
         refresh_token: String,
         email: Option<String>,
         id_token: Option<String>,
@@ -1356,6 +1493,7 @@ impl CodexOAuthManager {
                 return Err(CodexOAuthError::ExpiredToken);
             }
         }
+        let account_id = Uuid::new_v4().to_string();
         let refresh_lock = self.get_refresh_lock(&account_id).await;
         let _refresh_guard = refresh_lock.lock().await;
         let now = chrono::Utc::now().timestamp();
@@ -1363,6 +1501,7 @@ impl CodexOAuthManager {
 
         let data = CodexAccountData {
             account_id: account_id.clone(),
+            chatgpt_account_id: Some(chatgpt_account_id),
             email,
             refresh_token,
             authenticated_at: now,
@@ -1538,7 +1677,7 @@ impl CodexOAuthManager {
         let default = self.resolve_default_account_id().await;
 
         let store = CodexOAuthStore {
-            version: 1,
+            version: 2,
             accounts,
             default_account_id: default,
         };
@@ -1610,39 +1749,33 @@ fn parse_jwt_claims(token: &str) -> Option<IdTokenClaims> {
     serde_json::from_slice(&decoded).ok()
 }
 
-/// 从 token 响应中提取 (account_id, email)
-fn extract_identity_from_tokens(tokens: &OAuthTokenResponse) -> (Option<String>, Option<String>) {
+/// 从 token 响应中提取 (chatgpt_account_id, email)
+fn extract_account_metadata_from_tokens(
+    tokens: &OAuthTokenResponse,
+) -> (Option<String>, Option<String>) {
     let mut account_id: Option<String> = None;
     let mut email: Option<String> = None;
 
     if let Some(id_token) = tokens.id_token.as_deref() {
         if let Some(claims) = parse_jwt_claims(id_token) {
-            account_id = claims
-                .chatgpt_account_id
-                .clone()
-                .or_else(|| {
-                    claims
-                        .openai_auth
-                        .as_ref()
-                        .and_then(|a| a.chatgpt_account_id.clone())
-                })
-                .or_else(|| claims.organizations.first().and_then(|o| o.id.clone()));
+            account_id = claims.chatgpt_account_id.clone().or_else(|| {
+                claims
+                    .openai_auth
+                    .as_ref()
+                    .and_then(|a| a.chatgpt_account_id.clone())
+            });
             email = claims.email.clone();
         }
     }
 
     if account_id.is_none() {
         if let Some(claims) = parse_jwt_claims(&tokens.access_token) {
-            account_id = claims
-                .chatgpt_account_id
-                .clone()
-                .or_else(|| {
-                    claims
-                        .openai_auth
-                        .as_ref()
-                        .and_then(|a| a.chatgpt_account_id.clone())
-                })
-                .or_else(|| claims.organizations.first().and_then(|o| o.id.clone()));
+            account_id = claims.chatgpt_account_id.clone().or_else(|| {
+                claims
+                    .openai_auth
+                    .as_ref()
+                    .and_then(|a| a.chatgpt_account_id.clone())
+            });
             if email.is_none() {
                 email = claims.email.clone();
             }
@@ -1737,19 +1870,18 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_jwt_claims_organizations_fallback() {
+    fn test_extract_account_metadata_does_not_use_organization_id() {
         let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
         let payload = URL_SAFE_NO_PAD.encode(b"{\"organizations\":[{\"id\":\"org-456\"}]}");
         let jwt = format!("{header}.{payload}.");
-        let claims = parse_jwt_claims(&jwt).unwrap();
-        assert_eq!(
-            claims
-                .organizations
-                .first()
-                .and_then(|o| o.id.clone())
-                .as_deref(),
-            Some("org-456")
-        );
+        let tokens = OAuthTokenResponse {
+            access_token: jwt,
+            refresh_token: None,
+            id_token: None,
+            expires_in: None,
+        };
+
+        assert_eq!(extract_account_metadata_from_tokens(&tokens), (None, None));
     }
 
     #[tokio::test]
@@ -1766,11 +1898,11 @@ mod tests {
         let path = temp.path().to_path_buf();
 
         // Manually inject an account through internal methods
-        {
+        let account_id = {
             let manager = CodexOAuthManager::new(path.clone());
-            manager
+            let account = manager
                 .add_account_internal(
-                    "acc-123".to_string(),
+                    "workspace-123".to_string(),
                     "rt-secret".to_string(),
                     Some("user@example.com".to_string()),
                     None,
@@ -1779,13 +1911,191 @@ mod tests {
                 )
                 .await
                 .unwrap();
-        }
+            account.id
+        };
 
         // New manager should load from disk
         let manager2 = CodexOAuthManager::new(path);
         let accounts = manager2.list_accounts().await;
         assert_eq!(accounts.len(), 1);
-        assert_eq!(accounts[0].id, "acc-123");
+        assert_eq!(accounts[0].id, account_id);
+        assert_eq!(
+            manager2
+                .chatgpt_account_id_for_account(&account_id)
+                .await
+                .unwrap(),
+            "workspace-123"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_same_workspace_accounts_are_stored_separately() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().to_path_buf();
+        let manager = CodexOAuthManager::new(path.clone());
+
+        let first = manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "rt-first".to_string(),
+                Some("first@example.com".to_string()),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let second = manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "rt-second".to_string(),
+                Some("second@example.com".to_string()),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_ne!(first.id, second.id);
+        assert_eq!(manager.list_accounts().await.len(), 2);
+        assert_eq!(
+            manager
+                .chatgpt_account_id_for_account(&first.id)
+                .await
+                .unwrap(),
+            "shared-workspace"
+        );
+        assert_eq!(
+            manager
+                .chatgpt_account_id_for_account(&second.id)
+                .await
+                .unwrap(),
+            "shared-workspace"
+        );
+
+        let accounts = manager.accounts.read().await;
+        assert_eq!(accounts.get(&first.id).unwrap().refresh_token, "rt-first");
+        assert_eq!(accounts.get(&second.id).unwrap().refresh_token, "rt-second");
+        drop(accounts);
+        drop(manager);
+
+        let manager = CodexOAuthManager::new(path);
+        assert_eq!(manager.list_accounts().await.len(), 2);
+        let accounts = manager.accounts.read().await;
+        assert_eq!(accounts.get(&first.id).unwrap().refresh_token, "rt-first");
+        assert_eq!(accounts.get(&second.id).unwrap().refresh_token, "rt-second");
+    }
+
+    #[tokio::test]
+    async fn test_v1_store_preserves_existing_account_id() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().to_path_buf();
+        let manager = CodexOAuthManager::new(path.clone());
+        let legacy = serde_json::json!({
+            "version": 1,
+            "accounts": {
+                "legacy-workspace": {
+                    "account_id": "legacy-workspace",
+                    "email": "legacy@example.com",
+                    "refresh_token": "rt-legacy",
+                    "authenticated_at": 1
+                }
+            },
+            "default_account_id": "legacy-workspace"
+        });
+        manager
+            .write_store_atomic(&serde_json::to_string(&legacy).unwrap())
+            .unwrap();
+        drop(manager);
+
+        let manager = CodexOAuthManager::new(path.clone());
+        let accounts = manager.list_accounts().await;
+        assert_eq!(accounts.len(), 1);
+        assert_eq!(accounts[0].id, "legacy-workspace");
+        assert!(matches!(
+            manager
+                .chatgpt_account_id_for_account("legacy-workspace")
+                .await,
+            Err(CodexOAuthError::ParseError(_))
+        ));
+
+        let header = URL_SAFE_NO_PAD.encode(b"{\"alg\":\"none\"}");
+        let unresolved_payload =
+            URL_SAFE_NO_PAD.encode(b"{\"organizations\":[{\"id\":\"org-456\"}]}");
+        let unresolved_tokens = OAuthTokenResponse {
+            access_token: format!("{header}.{unresolved_payload}."),
+            refresh_token: Some("rt-rotated".to_string()),
+            id_token: None,
+            expires_in: Some(3600),
+        };
+        {
+            let mut stored = manager.accounts.write().await;
+            assert!(stored
+                .get_mut("legacy-workspace")
+                .unwrap()
+                .apply_refreshed_tokens(&unresolved_tokens));
+        }
+        manager.save_to_disk().await.unwrap();
+        drop(manager);
+
+        let manager = CodexOAuthManager::new(path.clone());
+        assert!(manager
+            .chatgpt_account_id_for_account("legacy-workspace")
+            .await
+            .is_err());
+        assert_eq!(
+            manager
+                .accounts
+                .read()
+                .await
+                .get("legacy-workspace")
+                .unwrap()
+                .refresh_token,
+            "rt-rotated"
+        );
+
+        let payload = URL_SAFE_NO_PAD.encode(
+            b"{\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"actual-workspace\"}}",
+        );
+        let refreshed_tokens = OAuthTokenResponse {
+            access_token: format!("{header}.{payload}."),
+            refresh_token: None,
+            id_token: None,
+            expires_in: Some(3600),
+        };
+        {
+            let mut stored = manager.accounts.write().await;
+            assert!(stored
+                .get_mut("legacy-workspace")
+                .unwrap()
+                .apply_refreshed_tokens(&refreshed_tokens));
+        }
+        manager.save_to_disk().await.unwrap();
+        drop(manager);
+
+        let manager = CodexOAuthManager::new(path);
+        assert_eq!(
+            manager.default_account_id().await.as_deref(),
+            Some("legacy-workspace")
+        );
+        assert_eq!(
+            manager
+                .chatgpt_account_id_for_account("legacy-workspace")
+                .await
+                .unwrap(),
+            "actual-workspace"
+        );
+        assert_eq!(
+            manager
+                .accounts
+                .read()
+                .await
+                .get("legacy-workspace")
+                .unwrap()
+                .refresh_token,
+            "rt-rotated"
+        );
     }
 
     #[tokio::test]
@@ -1793,7 +2103,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let manager = CodexOAuthManager::new(temp.path().to_path_buf());
 
-        manager
+        let first = manager
             .add_account_internal(
                 "acc-123".to_string(),
                 "rt".to_string(),
@@ -1804,7 +2114,7 @@ mod tests {
             )
             .await
             .unwrap();
-        manager
+        let second = manager
             .add_account_internal(
                 "acc-456".to_string(),
                 "rt2".to_string(),
@@ -1816,10 +2126,10 @@ mod tests {
             .await
             .unwrap();
 
-        manager.remove_account("acc-123").await.unwrap();
+        manager.remove_account(&first.id).await.unwrap();
         let accounts = manager.list_accounts().await;
         assert_eq!(accounts.len(), 1);
-        assert_eq!(accounts[0].id, "acc-456");
+        assert_eq!(accounts[0].id, second.id);
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -816,24 +816,6 @@ fn get_codex_managed_oauth_live_auth_value(
 ) -> Result<Value, AppError> {
     std::thread::spawn(move || {
         tauri::async_runtime::block_on(async move {
-            if let Some((refresh_token, id_token, last_refresh_ms)) =
-                crate::codex_config::read_codex_live_auth_refresh_for_account(&account_id)
-            {
-                if let Err(err) = manager
-                    .adopt_account_refresh_token(
-                        &account_id,
-                        refresh_token,
-                        id_token,
-                        last_refresh_ms,
-                    )
-                    .await
-                {
-                    log::warn!(
-                        "读回 Codex CLI 轮换后的 refresh_token 失败（account={account_id}）: {err}"
-                    );
-                }
-            }
-
             let bundle = manager
                 .get_valid_token_bundle_for_account(&account_id)
                 .await
@@ -853,7 +835,7 @@ fn get_codex_managed_oauth_live_auth_value(
                 })?;
 
             Ok::<Value, String>(codex_managed_oauth_live_auth(
-                &account_id,
+                &bundle.chatgpt_account_id,
                 &bundle.access_token,
                 Some(id_token),
                 &bundle.refresh_token,
@@ -887,7 +869,7 @@ pub(crate) fn prepare_codex_managed_oauth_live_auth_switch_away(
 }
 
 pub(crate) fn codex_managed_oauth_live_auth(
-    account_id: &str,
+    chatgpt_account_id: &str,
     access_token: &str,
     id_token: Option<&str>,
     refresh_token: &str,
@@ -897,7 +879,7 @@ pub(crate) fn codex_managed_oauth_live_auth(
     // refresh_token、account_id，并带顶层 last_refresh。**必须**包含 refresh_token，
     // 否则 Codex CLI 在 access_token 过期后无法自刷新（“裸跑 codex” 会静默失效）。
     crate::codex_config::codex_managed_oauth_auth_value(
-        account_id,
+        chatgpt_account_id,
         access_token,
         id_token,
         refresh_token,
@@ -1276,13 +1258,12 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
                 config_str,
                 profile,
             )?;
-            if provider
+            if let Some(account_id) = provider
                 .meta
                 .as_ref()
                 .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
-                .is_some()
             {
-                crate::codex_config::record_codex_managed_oauth_live_auth(auth)?;
+                crate::codex_config::record_codex_managed_oauth_live_auth(auth, &account_id)?;
             }
         }
         AppType::Gemini => {
@@ -2715,8 +2696,9 @@ base_url = "https://a.example/v1"
         let manager = Arc::new(CodexOAuthManager::new(temp.path().to_path_buf()));
         tauri::async_runtime::block_on(async {
             manager
-                .add_test_account_with_access_token(
-                    "acct-managed",
+                .add_test_account_with_workspace_and_access_token(
+                    "local-managed",
+                    "workspace-shared",
                     "managed-token",
                     Some("managed-id-token"),
                 )
@@ -2739,7 +2721,7 @@ base_url = "https://a.example/v1"
             auth_binding: Some(AuthBinding {
                 source: AuthBindingSource::ManagedAccount,
                 auth_provider: Some("codex_oauth".to_string()),
-                account_id: Some("acct-managed".to_string()),
+                account_id: Some("local-managed".to_string()),
             }),
             ..Default::default()
         });
@@ -2762,7 +2744,7 @@ base_url = "https://a.example/v1"
             .expect("tokens object");
         assert_eq!(
             tokens.get("account_id").and_then(|v| v.as_str()),
-            Some("acct-managed")
+            Some("workspace-shared")
         );
         assert_eq!(
             tokens.get("access_token").and_then(|v| v.as_str()),

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3109,8 +3109,8 @@ impl ProxyService {
                     profile,
                 )
                 .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
-                if target_managed_codex_account_id.is_some() {
-                    crate::codex_config::record_codex_managed_oauth_live_auth(auth)
+                if let Some(account_id) = target_managed_codex_account_id.as_deref() {
+                    crate::codex_config::record_codex_managed_oauth_live_auth(auth, account_id)
                         .map_err(|error| format!("记录 Codex 托管认证标记失败: {error}"))?;
                 }
             }
@@ -3271,10 +3271,9 @@ impl ProxyService {
             return Err("Codex 备份必须是 JSON 对象".to_string());
         };
 
-        // Access tokens and refresh tokens rotate independently while Codex is
-        // running, so backup stripping must be account-scoped and content-based
-        // rather than tied to a stale marker fingerprint. A native login of the
-        // same managed account is treated equivalently and remains live-only.
+        // Access and refresh tokens rotate independently while Codex is running,
+        // so backup stripping uses the stable local-account marker plus workspace
+        // ID rather than a token fingerprint.
         if crate::codex_config::codex_live_auth_is_managed_chatgpt_login(existing_auth, account_id)
         {
             // Do not copy the outgoing managed bundle over the target. Keep the
@@ -3608,11 +3607,11 @@ impl ProxyService {
     ) -> Result<(), String> {
         let official_passthrough =
             provider.is_some_and(crate::proxy::providers::is_codex_official_provider);
-        let managed_official = official_passthrough
-            && provider
-                .and_then(|provider| provider.meta.as_ref())
-                .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
-                .is_some_and(|account_id| !account_id.trim().is_empty());
+        let managed_account_id = provider
+            .and_then(|provider| provider.meta.as_ref())
+            .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
+            .filter(|account_id| !account_id.trim().is_empty());
+        let managed_official = official_passthrough && managed_account_id.is_some();
         let placeholder_auth = config
             .get("auth")
             .is_some_and(Self::codex_auth_has_proxy_placeholder);
@@ -3644,8 +3643,13 @@ impl ProxyService {
                     Some(&prepared_config),
                 )
                 .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
-                crate::codex_config::record_codex_managed_oauth_live_auth(auth)
-                    .map_err(|e| format!("记录 Codex 托管认证标记失败: {e}"))?;
+                crate::codex_config::record_codex_managed_oauth_live_auth(
+                    auth,
+                    managed_account_id
+                        .as_deref()
+                        .expect("managed official account checked"),
+                )
+                .map_err(|e| format!("记录 Codex 托管认证标记失败: {e}"))?;
                 return Ok(());
             }
             let live_config = if official_passthrough {
@@ -7602,15 +7606,16 @@ wire_api = "responses"
 
     #[test]
     #[serial]
-    fn codex_snapshot_rollback_preserves_newer_same_account_generation() {
+    fn codex_snapshot_rollback_preserves_newer_native_login_without_marker() {
         let _home = TempHome::new();
         crate::settings::reload_settings().expect("reload settings");
+        let id_token = crate::codex_config::test_codex_id_token("native-user");
 
         let auth_r0 = json!({
             "auth_mode": "chatgpt",
             "OPENAI_API_KEY": null,
             "tokens": {
-                "id_token": "id-r0",
+                "id_token": id_token,
                 "access_token": "access-r0",
                 "refresh_token": "refresh-r0",
                 "account_id": "acct-a"
@@ -7619,8 +7624,6 @@ wire_api = "responses"
         });
         crate::codex_config::write_codex_live_atomic(&auth_r0, Some("model = \"before\"\n"))
             .expect("seed R0 live");
-        crate::codex_config::record_codex_managed_oauth_live_auth(&auth_r0)
-            .expect("record R0 marker");
         let snapshot = crate::codex_config::CodexLiveStateSnapshot::capture()
             .expect("capture transaction snapshot");
 
@@ -7628,7 +7631,7 @@ wire_api = "responses"
             "auth_mode": "chatgpt",
             "OPENAI_API_KEY": null,
             "tokens": {
-                "id_token": "id-r1",
+                "id_token": crate::codex_config::test_codex_id_token("native-user"),
                 "access_token": "access-r1",
                 "refresh_token": "refresh-r1",
                 "account_id": "acct-a"
@@ -7637,8 +7640,6 @@ wire_api = "responses"
         });
         crate::codex_config::write_codex_live_atomic(&auth_r1, Some("model = \"after\"\n"))
             .expect("write concurrent R1 live");
-        crate::codex_config::record_codex_managed_oauth_live_auth(&auth_r1)
-            .expect("record R1 marker");
 
         snapshot
             .restore_preserving_newer_same_account_auth()
@@ -7648,10 +7649,7 @@ wire_api = "responses"
             crate::config::read_json_file(&crate::codex_config::get_codex_auth_path())
                 .expect("read restored auth");
         assert_eq!(restored, auth_r1, "newer same-account auth must survive");
-        assert!(
-            crate::codex_config::codex_auth_matches_recorded_managed_oauth(&restored, "acct-a")
-                .expect("check R1 marker")
-        );
+        assert!(!crate::codex_config::codex_managed_oauth_live_auth_marker_exists());
         assert_eq!(
             std::fs::read_to_string(crate::codex_config::get_codex_config_path())
                 .expect("read rolled-back config"),
@@ -7661,24 +7659,25 @@ wire_api = "responses"
 
     #[test]
     #[serial]
-    fn codex_snapshot_rollback_restores_previous_cross_account_generation() {
+    fn codex_snapshot_rollback_restores_previous_local_account_in_same_workspace() {
         let _home = TempHome::new();
         crate::settings::reload_settings().expect("reload settings");
+        let id_token_a = crate::codex_config::test_codex_id_token("user-a");
 
         let auth_a = json!({
             "auth_mode": "chatgpt",
             "OPENAI_API_KEY": null,
             "tokens": {
-                "id_token": "id-a",
+                "id_token": id_token_a,
                 "access_token": "access-a",
                 "refresh_token": "refresh-a",
-                "account_id": "acct-a"
+                "account_id": "workspace-shared"
             },
             "last_refresh": "2026-01-01T00:00:00Z"
         });
         crate::codex_config::write_codex_live_atomic(&auth_a, Some("model = \"before\"\n"))
             .expect("seed account A live");
-        crate::codex_config::record_codex_managed_oauth_live_auth(&auth_a)
+        crate::codex_config::record_codex_managed_oauth_live_auth(&auth_a, "local-a")
             .expect("record A marker");
         let snapshot = crate::codex_config::CodexLiveStateSnapshot::capture()
             .expect("capture account A snapshot");
@@ -7687,16 +7686,16 @@ wire_api = "responses"
             "auth_mode": "chatgpt",
             "OPENAI_API_KEY": null,
             "tokens": {
-                "id_token": "id-b",
+                "id_token": crate::codex_config::test_codex_id_token("user-b"),
                 "access_token": "access-b",
                 "refresh_token": "refresh-b",
-                "account_id": "acct-b"
+                "account_id": "workspace-shared"
             },
             "last_refresh": "2026-01-02T00:00:00Z"
         });
         crate::codex_config::write_codex_live_atomic(&auth_b, Some("model = \"after\"\n"))
             .expect("write account B live");
-        crate::codex_config::record_codex_managed_oauth_live_auth(&auth_b)
+        crate::codex_config::record_codex_managed_oauth_live_auth(&auth_b, "local-b")
             .expect("record B marker");
 
         snapshot
@@ -7708,7 +7707,7 @@ wire_api = "responses"
                 .expect("read restored auth");
         assert_eq!(restored, auth_a, "failed A to B change must restore A");
         assert!(
-            crate::codex_config::codex_auth_matches_recorded_managed_oauth(&restored, "acct-a")
+            crate::codex_config::codex_auth_matches_recorded_managed_oauth(&restored, "local-a")
                 .expect("check restored A marker")
         );
         assert_eq!(

--- a/src/components/providers/forms/CodexOAuthSection.tsx
+++ b/src/components/providers/forms/CodexOAuthSection.tsx
@@ -108,6 +108,8 @@ export const CodexOAuthSection: React.FC<CodexOAuthSectionProps> = ({
     isRemovingAccount,
     isSettingDefaultAccount,
     addAccount,
+    reauthAccount,
+    retryAuth,
     removeAccount,
     setDefaultAccount,
     cancelAuth,
@@ -498,19 +500,21 @@ export const CodexOAuthSection: React.FC<CodexOAuthSectionProps> = ({
                     )}
                   </div>
                   <div className="flex shrink-0 items-center gap-1">
-                    {account.reauth_required && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="h-7 gap-1 border-amber-400/70 px-2 text-xs text-amber-700 hover:bg-amber-100 dark:border-amber-500/50 dark:text-amber-300 dark:hover:bg-amber-900/40"
-                        onClick={addAccount}
-                        disabled={isAddingAccount}
-                      >
-                        <RefreshCw className="h-3.5 w-3.5" />
-                        {t("codexOauth.reauthLogin", "重新登录")}
-                      </Button>
-                    )}
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className={`h-7 gap-1 px-2 text-xs ${
+                        account.reauth_required
+                          ? "border-amber-400/70 text-amber-700 hover:bg-amber-100 dark:border-amber-500/50 dark:text-amber-300 dark:hover:bg-amber-900/40"
+                          : "text-muted-foreground"
+                      }`}
+                      onClick={() => reauthAccount(account.id)}
+                      disabled={isAddingAccount}
+                    >
+                      <RefreshCw className="h-3.5 w-3.5" />
+                      {t("codexOauth.reauthLogin", "重新登录")}
+                    </Button>
                     {defaultAccountId !== account.id && (
                       <Button
                         type="button"
@@ -642,7 +646,7 @@ export const CodexOAuthSection: React.FC<CodexOAuthSectionProps> = ({
           <div className="flex gap-2">
             <Button
               type="button"
-              onClick={addAccount}
+              onClick={retryAuth}
               variant="outline"
               size="sm"
             >

--- a/src/components/providers/forms/hooks/useManagedAuth.ts
+++ b/src/components/providers/forms/hooks/useManagedAuth.ts
@@ -11,6 +11,10 @@ import type {
 } from "@/lib/api";
 
 type PollingState = "idle" | "polling" | "success" | "error";
+type LoginRequest = {
+  targetAccountId?: string;
+  generation: number;
+};
 
 export function useManagedAuth(
   authProvider: ManagedAuthProvider,
@@ -29,6 +33,10 @@ export function useManagedAuth(
     null,
   );
   const pollingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flowGenerationRef = useRef(0);
+  const activeDeviceCodeRef = useRef<string | null>(null);
+  const retryTargetAccountIdRef = useRef<string | undefined>(undefined);
+  const flowTransitionRef = useRef<Promise<void>>(Promise.resolve());
 
   const {
     data: authStatus,
@@ -57,15 +65,60 @@ export function useManagedAuth(
     }
   }, []);
 
+  const cancelBackendFlow = useCallback(
+    async (deviceCode: string | null): Promise<boolean> => {
+      if (authProvider !== "codex_oauth" || !deviceCode) return true;
+      try {
+        const cancelled = await authApi.authCancelLogin(
+          authProvider,
+          deviceCode,
+        );
+        if (!cancelled) {
+          await queryClient.invalidateQueries({
+            queryKey: ["managed-auth-status", authProvider],
+          });
+        }
+        return cancelled;
+      } catch (e) {
+        console.debug("[ManagedAuth] Failed to cancel device flow:", e);
+        await queryClient.invalidateQueries({
+          queryKey: ["managed-auth-status", authProvider],
+        });
+        return false;
+      }
+    },
+    [authProvider, queryClient],
+  );
+
+  const queueBackendCancellation = useCallback(
+    (deviceCode: string | null) => {
+      const transition = flowTransitionRef.current.then(async () => {
+        await cancelBackendFlow(deviceCode);
+      });
+      flowTransitionRef.current = transition;
+      return transition;
+    },
+    [cancelBackendFlow],
+  );
+
   useEffect(() => {
     return () => {
+      flowGenerationRef.current += 1;
+      void cancelBackendFlow(activeDeviceCodeRef.current);
+      activeDeviceCodeRef.current = null;
       stopPolling();
     };
-  }, [stopPolling]);
+  }, [cancelBackendFlow, stopPolling]);
 
   const startLoginMutation = useMutation({
-    mutationFn: () => authApi.authStartLogin(authProvider, githubDomain),
-    onSuccess: async (response) => {
+    mutationFn: ({ targetAccountId }: LoginRequest) =>
+      authApi.authStartLogin(authProvider, githubDomain, targetAccountId),
+    onSuccess: async (response, request) => {
+      if (request.generation !== flowGenerationRef.current) {
+        void cancelBackendFlow(response.device_code);
+        return;
+      }
+      activeDeviceCodeRef.current = response.device_code;
       setDeviceCode(response);
       setPollingState("polling");
       setError(null);
@@ -75,12 +128,14 @@ export function useManagedAuth(
       } catch (e) {
         console.debug("[ManagedAuth] Failed to copy user code:", e);
       }
+      if (request.generation !== flowGenerationRef.current) return;
 
       try {
         await settingsApi.openExternal(response.verification_uri);
       } catch (e) {
         console.debug("[ManagedAuth] Failed to open browser:", e);
       }
+      if (request.generation !== flowGenerationRef.current) return;
 
       // Add a small buffer on top of GitHub's suggested interval to avoid
       // hitting slow_down responses too aggressively during device polling.
@@ -88,8 +143,12 @@ export function useManagedAuth(
       const expiresAt = Date.now() + response.expires_in * 1000;
 
       const pollOnce = async () => {
+        if (request.generation !== flowGenerationRef.current) return;
         if (Date.now() > expiresAt) {
           stopPolling();
+          activeDeviceCodeRef.current = null;
+          void cancelBackendFlow(response.device_code);
+          flowGenerationRef.current += 1;
           setPollingState("error");
           setError("Device code expired. Please try again.");
           return;
@@ -101,36 +160,50 @@ export function useManagedAuth(
             response.device_code,
             githubDomain,
           );
+          if (request.generation !== flowGenerationRef.current) return;
           if (newAccount) {
             stopPolling();
+            activeDeviceCodeRef.current = null;
+            flowGenerationRef.current += 1;
+            const completionGeneration = flowGenerationRef.current;
             setPollingState("success");
             await refetchStatus();
             await queryClient.invalidateQueries({ queryKey });
+            if (completionGeneration !== flowGenerationRef.current) return;
             setPollingState("idle");
             setDeviceCode(null);
           }
         } catch (e) {
+          if (request.generation !== flowGenerationRef.current) return;
           const errorMessage = e instanceof Error ? e.message : String(e);
           if (
             !errorMessage.includes("pending") &&
             !errorMessage.includes("slow_down")
           ) {
             stopPolling();
+            activeDeviceCodeRef.current = null;
+            void cancelBackendFlow(response.device_code);
+            flowGenerationRef.current += 1;
             setPollingState("error");
             setError(errorMessage);
           }
         }
       };
 
-      void pollOnce();
       pollingIntervalRef.current = setInterval(pollOnce, interval);
       pollingTimeoutRef.current = setTimeout(() => {
+        if (request.generation !== flowGenerationRef.current) return;
         stopPolling();
+        activeDeviceCodeRef.current = null;
+        void cancelBackendFlow(response.device_code);
+        flowGenerationRef.current += 1;
         setPollingState("error");
         setError("Device code expired. Please try again.");
       }, response.expires_in * 1000);
+      void pollOnce();
     },
-    onError: (e) => {
+    onError: (e, request) => {
+      if (request.generation !== flowGenerationRef.current) return;
       setPollingState("error");
       setError(e instanceof Error ? e.message : String(e));
     },
@@ -191,20 +264,50 @@ export function useManagedAuth(
     },
   });
 
-  const startAuth = useCallback(() => {
-    setPollingState("idle");
-    setDeviceCode(null);
-    setError(null);
-    stopPolling();
-    startLoginMutation.mutate();
-  }, [startLoginMutation, stopPolling]);
+  const beginLogin = useCallback(
+    (targetAccountId?: string) => {
+      const previousDeviceCode = activeDeviceCodeRef.current;
+      activeDeviceCodeRef.current = null;
+      const generation = flowGenerationRef.current + 1;
+      flowGenerationRef.current = generation;
+      retryTargetAccountIdRef.current = targetAccountId;
+      setPollingState("idle");
+      setDeviceCode(null);
+      setError(null);
+      stopPolling();
+      void queueBackendCancellation(previousDeviceCode).then(() => {
+        if (generation !== flowGenerationRef.current) return;
+        startLoginMutation.mutate({ targetAccountId, generation });
+      });
+    },
+    [queueBackendCancellation, startLoginMutation, stopPolling],
+  );
+
+  const startAuth = useCallback(() => beginLogin(), [beginLogin]);
+
+  const reauthAccount = useCallback(
+    (accountId: string) => {
+      beginLogin(accountId);
+    },
+    [beginLogin],
+  );
+
+  const retryAuth = useCallback(
+    () => beginLogin(retryTargetAccountIdRef.current),
+    [beginLogin],
+  );
 
   const cancelAuth = useCallback(() => {
+    flowGenerationRef.current += 1;
+    const previousDeviceCode = activeDeviceCodeRef.current;
+    activeDeviceCodeRef.current = null;
+    retryTargetAccountIdRef.current = undefined;
     stopPolling();
     setPollingState("idle");
     setDeviceCode(null);
     setError(null);
-  }, [stopPolling]);
+    void queueBackendCancellation(previousDeviceCode);
+  }, [queueBackendCancellation, stopPolling]);
 
   const logout = useCallback(() => {
     logoutMutation.mutate();
@@ -247,6 +350,8 @@ export function useManagedAuth(
     isSettingDefaultAccount: setDefaultAccountMutation.isPending,
     startAuth,
     addAccount: startAuth,
+    reauthAccount,
+    retryAuth,
     cancelAuth,
     logout,
     removeAccount,

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -13,7 +13,7 @@ export interface ManagedAuthAccount {
   authenticated_at: number;
   is_default: boolean;
   github_domain: string;
-  /** Codex-only: the account predates persisted id_token support. */
+  /** Codex-only: the account lacks identity or workspace metadata required for binding. */
   reauth_required?: boolean;
   /** xAI-only: the refresh credential is invalid and the account is unusable. */
   requires_reauth: boolean;
@@ -39,10 +39,12 @@ export interface ManagedAuthDeviceCodeResponse {
 export async function authStartLogin(
   authProvider: ManagedAuthProvider,
   githubDomain?: string,
+  targetAccountId?: string,
 ): Promise<ManagedAuthDeviceCodeResponse> {
   return invoke<ManagedAuthDeviceCodeResponse>("auth_start_login", {
     authProvider,
     githubDomain: githubDomain || null,
+    targetAccountId: targetAccountId || null,
   });
 }
 
@@ -55,6 +57,16 @@ export async function authPollForAccount(
     authProvider,
     deviceCode,
     githubDomain: githubDomain || null,
+  });
+}
+
+export async function authCancelLogin(
+  authProvider: ManagedAuthProvider,
+  deviceCode: string,
+): Promise<boolean> {
+  return invoke<boolean>("auth_cancel_login", {
+    authProvider,
+    deviceCode,
   });
 }
 
@@ -105,6 +117,7 @@ export async function authLogout(
 export const authApi = {
   authStartLogin,
   authPollForAccount,
+  authCancelLogin,
   authListAccounts,
   authGetStatus,
   authRemoveAccount,

--- a/tests/components/CodexOAuthSection.test.tsx
+++ b/tests/components/CodexOAuthSection.test.tsx
@@ -78,6 +78,8 @@ describe("CodexOAuthSection", () => {
       isRemovingAccount: false,
       isSettingDefaultAccount: false,
       addAccount: vi.fn(),
+      reauthAccount: vi.fn(),
+      retryAuth: vi.fn(),
       removeAccount: vi.fn(),
       setDefaultAccount: vi.fn(),
       cancelAuth: vi.fn(),
@@ -113,6 +115,44 @@ describe("CodexOAuthSection", () => {
     expect(
       screen.getAllByTestId("account-quota").map((quota) => quota.textContent),
     ).toEqual(["account-1", "account-2"]);
+  });
+
+  it("reauthenticates the selected legacy account in place", async () => {
+    const user = userEvent.setup();
+    const authResult = mocks.useCodexOauth();
+    const reauthAccount = vi.fn();
+    mocks.useCodexOauth.mockReturnValue({
+      ...authResult,
+      reauthAccount,
+      accounts: [
+        {
+          ...authResult.accounts[0],
+          reauth_required: true,
+        },
+      ],
+    });
+
+    render(<CodexOAuthSection />);
+    await user.click(screen.getByRole("button", { name: "重新登录" }));
+
+    expect(reauthAccount).toHaveBeenCalledWith("account-1");
+    expect(authResult.addAccount).not.toHaveBeenCalled();
+  });
+
+  it("allows an existing account to reauthenticate in place", async () => {
+    const user = userEvent.setup();
+    const authResult = mocks.useCodexOauth();
+    const reauthAccount = vi.fn();
+    mocks.useCodexOauth.mockReturnValue({
+      ...authResult,
+      reauthAccount,
+      accounts: [authResult.accounts[0]],
+    });
+
+    render(<CodexOAuthSection />);
+    await user.click(screen.getByRole("button", { name: "重新登录" }));
+
+    expect(reauthAccount).toHaveBeenCalledWith("account-1");
   });
 
   it("selects a specific account when multiple accounts are managed", async () => {

--- a/tests/hooks/useManagedAuth.test.tsx
+++ b/tests/hooks/useManagedAuth.test.tsx
@@ -6,6 +6,9 @@ import { useManagedAuth } from "@/components/providers/forms/hooks/useManagedAut
 
 const apiMocks = vi.hoisted(() => ({
   authGetStatus: vi.fn(),
+  authStartLogin: vi.fn(),
+  authPollForAccount: vi.fn(),
+  authCancelLogin: vi.fn(),
   authRemoveAccount: vi.fn(),
 }));
 const toastMocks = vi.hoisted(() => ({
@@ -15,10 +18,20 @@ const toastMocks = vi.hoisted(() => ({
 vi.mock("@/lib/api", () => ({
   authApi: {
     authGetStatus: (...args: unknown[]) => apiMocks.authGetStatus(...args),
+    authStartLogin: (...args: unknown[]) => apiMocks.authStartLogin(...args),
+    authPollForAccount: (...args: unknown[]) =>
+      apiMocks.authPollForAccount(...args),
+    authCancelLogin: (...args: unknown[]) => apiMocks.authCancelLogin(...args),
     authRemoveAccount: (...args: unknown[]) =>
       apiMocks.authRemoveAccount(...args),
   },
-  settingsApi: {},
+  settingsApi: {
+    openExternal: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/clipboard", () => ({
+  copyText: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("sonner", () => ({
@@ -62,7 +75,163 @@ describe("useManagedAuth", () => {
         },
       ],
     });
+    apiMocks.authStartLogin
+      .mockReset()
+      .mockImplementation(() => new Promise(() => {}));
+    apiMocks.authPollForAccount.mockReset().mockResolvedValue(null);
+    apiMocks.authCancelLogin.mockReset().mockResolvedValue(true);
     apiMocks.authRemoveAccount.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("starts reauthentication for the selected account", async () => {
+    const { result } = renderHook(() => useManagedAuth("codex_oauth"), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isStatusSuccess).toBe(true));
+
+    act(() => result.current.reauthAccount("acct-1"));
+
+    await waitFor(() =>
+      expect(apiMocks.authStartLogin).toHaveBeenCalledWith(
+        "codex_oauth",
+        undefined,
+        "acct-1",
+      ),
+    );
+  });
+
+  it("retries reauthentication for the same target account", async () => {
+    apiMocks.authStartLogin.mockRejectedValue(new Error("start failed"));
+    const { result } = renderHook(() => useManagedAuth("codex_oauth"), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isStatusSuccess).toBe(true));
+
+    act(() => result.current.reauthAccount("acct-1"));
+    await waitFor(() => expect(result.current.pollingState).toBe("error"));
+    act(() => result.current.retryAuth());
+
+    await waitFor(() =>
+      expect(apiMocks.authStartLogin).toHaveBeenCalledTimes(2),
+    );
+    expect(apiMocks.authStartLogin).toHaveBeenNthCalledWith(
+      2,
+      "codex_oauth",
+      undefined,
+      "acct-1",
+    );
+  });
+
+  it("cancels the active Codex device flow in the backend", async () => {
+    apiMocks.authStartLogin.mockResolvedValue({
+      provider: "codex_oauth",
+      device_code: "device-1",
+      user_code: "ABCD-EFGH",
+      verification_uri: "https://example.com/device",
+      expires_in: 600,
+      interval: 5,
+    });
+    apiMocks.authPollForAccount.mockImplementation(() => new Promise(() => {}));
+    const { result } = renderHook(() => useManagedAuth("codex_oauth"), {
+      wrapper: createWrapper(),
+    });
+    act(() => result.current.reauthAccount("acct-1"));
+    await waitFor(() => expect(result.current.deviceCode).not.toBeNull());
+
+    act(() => result.current.cancelAuth());
+
+    await waitFor(() =>
+      expect(apiMocks.authCancelLogin).toHaveBeenCalledWith(
+        "codex_oauth",
+        "device-1",
+      ),
+    );
+    expect(result.current.pollingState).toBe("idle");
+  });
+
+  it("refreshes status when login committed before cancellation", async () => {
+    let resolvePoll!: (account: object) => void;
+    let resolveCancel!: (cancelled: boolean) => void;
+    apiMocks.authStartLogin.mockResolvedValue({
+      provider: "codex_oauth",
+      device_code: "device-1",
+      user_code: "ABCD-EFGH",
+      verification_uri: "https://example.com/device",
+      expires_in: 600,
+      interval: 5,
+    });
+    apiMocks.authPollForAccount.mockImplementation(
+      () => new Promise((resolve) => (resolvePoll = resolve)),
+    );
+    apiMocks.authCancelLogin.mockImplementation(
+      () => new Promise((resolve) => (resolveCancel = resolve)),
+    );
+    const { result } = renderHook(() => useManagedAuth("codex_oauth"), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isStatusSuccess).toBe(true));
+
+    act(() => result.current.reauthAccount("acct-1"));
+    await waitFor(() => expect(apiMocks.authPollForAccount).toHaveBeenCalled());
+    apiMocks.authGetStatus.mockResolvedValue({
+      provider: "codex_oauth",
+      authenticated: true,
+      default_account_id: "acct-1",
+      accounts: [
+        ...result.current.accounts,
+        {
+          id: "acct-2",
+          provider: "codex_oauth",
+          login: "other@example.com",
+          avatar_url: null,
+          authenticated_at: 2,
+          is_default: false,
+          github_domain: "",
+          reauth_required: false,
+          requires_reauth: false,
+        },
+      ],
+    });
+
+    act(() => result.current.cancelAuth());
+    await waitFor(() => expect(apiMocks.authCancelLogin).toHaveBeenCalled());
+    act(() => {
+      resolvePoll({ id: "acct-2" });
+      resolveCancel(false);
+    });
+
+    await waitFor(() => expect(result.current.accounts).toHaveLength(2));
+  });
+
+  it("waits for active-flow cancellation before starting another login", async () => {
+    let resolveCancel!: (cancelled: boolean) => void;
+    apiMocks.authStartLogin.mockResolvedValue({
+      provider: "codex_oauth",
+      device_code: "device-1",
+      user_code: "ABCD-EFGH",
+      verification_uri: "https://example.com/device",
+      expires_in: 600,
+      interval: 5,
+    });
+    apiMocks.authPollForAccount.mockImplementation(() => new Promise(() => {}));
+    apiMocks.authCancelLogin.mockImplementation(
+      () => new Promise((resolve) => (resolveCancel = resolve)),
+    );
+    const { result } = renderHook(() => useManagedAuth("codex_oauth"), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => result.current.reauthAccount("acct-1"));
+    await waitFor(() => expect(result.current.deviceCode).not.toBeNull());
+    act(() => result.current.reauthAccount("acct-1"));
+    await waitFor(() => expect(apiMocks.authCancelLogin).toHaveBeenCalled());
+    expect(apiMocks.authStartLogin).toHaveBeenCalledTimes(1);
+
+    act(() => resolveCancel(true));
+
+    await waitFor(() =>
+      expect(apiMocks.authStartLogin).toHaveBeenCalledTimes(2),
+    );
   });
 
   it("shows a success toast after removing an account", async () => {


### PR DESCRIPTION
## Summary

- assign each managed Codex OAuth login a stable local account ID so different users in one ChatGPT workspace can coexist
- keep local identity separate from the upstream workspace ID, and validate official passthrough against the resolved workspace plus the exact live bearer
- reauthenticate an existing account in place after verifying workspace and stable OIDC subject, preserving provider bindings and quarantining ambiguous legacy records
- linearize refresh, persistence, cancellation, expiry, and concurrent reauthentication so stale flows cannot publish credentials
- migrate legacy live-auth ownership only when stored identity proves the account before removal

## Scope

This is limited to Codex OAuth identity, persistence, request validation and selection, targeted reauthentication, native Codex auth compatibility paths, and the corresponding UI and regression tests. It does not change other auth providers, auth.json structure, OAuth revocation, imports, sessions, provider-binding removal semantics, or the pre-existing cross-file remove/logout transaction design.

## Tests

- cargo test --manifest-path src-tauri/Cargo.toml --lib
- cargo clippy --manifest-path src-tauri/Cargo.toml --lib --all-features -- -D warnings
- cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
- pnpm test:unit
- pnpm typecheck
- pnpm format:check
- git diff --check

Fixes #2245