### PR TITLE
docs(deeplink): fix MCP config examples

### DIFF
--- a/docs/user-manual/en/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/en/5-faq/5.3-deeplink.md
@@ -80,7 +80,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `apps` | Yes | App list (comma-separated, e.g., `claude,codex,gemini,opencode`) |
-| `config` | Yes | MCP server configuration (JSON format) |
+| `config` | Yes | Base64-encoded MCP JSON configuration; the decoded value must contain a top-level `mcpServers` object |
 | `enabled` | No | Whether to enable (boolean) |
 
 **Skill parameters** (resource=skill):
@@ -107,7 +107,7 @@ ccswitch://v1/import?resource=provider&app=claude&name=My%20Provider&endpoint=ht
 ### Import MCP Server
 
 ```
-ccswitch://v1/import?resource=mcp&apps=claude,codex&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-server-fetch%22%5D%7D&name=mcp-fetch
+ccswitch://v1/import?resource=mcp&apps=claude%2Ccodex&config=eyJtY3BTZXJ2ZXJzIjp7Im1jcC1mZXRjaCI6eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3Atc2VydmVyLWZldGNoIl19fX0%3D
 ```
 
 ### Import Prompt Preset
@@ -127,8 +127,9 @@ ccswitch://v1/import?resource=skill&name=my-skill&repo=owner/repo&directory=skil
 ### Manual Generation
 
 1. Prepare parameters
-2. Assemble the URL following V1 protocol format
-3. URL-encode special characters
+2. Base64-encode the raw content for parameters that require it (for example, MCP `config` and Prompt `content`)
+3. Assemble the URL following V1 protocol format
+4. URL-encode special characters
 
 **Example**:
 
@@ -231,7 +232,7 @@ ccswitch://v1/import?resource=provider&app=claude&name=Test%20Provider&apiKey=sk
 ### Example: Import MCP Server
 
 ```
-ccswitch://v1/import?resource=mcp&name=mcp-fetch&apps=claude,codex,gemini&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-server-fetch%22%5D%7D
+ccswitch://v1/import?resource=mcp&apps=claude%2Ccodex%2Cgemini&config=eyJtY3BTZXJ2ZXJzIjp7Im1jcC1mZXRjaCI6eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3Atc2VydmVyLWZldGNoIl19fX0%3D
 ```
 
 ## Troubleshooting

--- a/docs/user-manual/ja/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/ja/5-faq/5.3-deeplink.md
@@ -80,7 +80,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | パラメータ | 必須 | 説明 |
 |------|------|------|
 | `apps` | はい | アプリリスト（カンマ区切り、例：`claude,codex,gemini,opencode`） |
-| `config` | はい | MCP サーバー設定（JSON 形式） |
+| `config` | はい | Base64 エンコードした MCP JSON 設定。デコード後の最上位に `mcpServers` オブジェクトが必要 |
 | `enabled` | いいえ | 有効にするかどうか（ブール値） |
 
 **Skill パラメータ**（resource=skill）：
@@ -107,7 +107,7 @@ ccswitch://v1/import?resource=provider&app=claude&name=My%20Provider&endpoint=ht
 ### MCP サーバーのインポート
 
 ```
-ccswitch://v1/import?resource=mcp&apps=claude,codex&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-server-fetch%22%5D%7D&name=mcp-fetch
+ccswitch://v1/import?resource=mcp&apps=claude%2Ccodex&config=eyJtY3BTZXJ2ZXJzIjp7Im1jcC1mZXRjaCI6eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3Atc2VydmVyLWZldGNoIl19fX0%3D
 ```
 
 ### Prompt プリセットのインポート
@@ -127,8 +127,9 @@ ccswitch://v1/import?resource=skill&name=my-skill&repo=owner/repo&directory=skil
 ### 手動生成
 
 1. パラメータを準備
-2. V1 プロトコル形式で URL を組み立て
-3. 特殊文字を URL エンコード
+2. Base64 が必要なパラメータ（例：MCP の `config`、Prompt の `content`）の元の内容をエンコード
+3. V1 プロトコル形式で URL を組み立て
+4. 特殊文字を URL エンコード
 
 **例**：
 
@@ -231,7 +232,7 @@ ccswitch://v1/import?resource=provider&app=claude&name=Test%20Provider&apiKey=sk
 ### 例：MCP サーバーのインポート
 
 ```
-ccswitch://v1/import?resource=mcp&name=mcp-fetch&apps=claude,codex,gemini&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-server-fetch%22%5D%7D
+ccswitch://v1/import?resource=mcp&apps=claude%2Ccodex%2Cgemini&config=eyJtY3BTZXJ2ZXJzIjp7Im1jcC1mZXRjaCI6eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3Atc2VydmVyLWZldGNoIl19fX0%3D
 ```
 
 ## トラブルシューティング

--- a/docs/user-manual/zh/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/zh/5-faq/5.3-deeplink.md
@@ -80,7 +80,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | 参数 | 必填 | 说明 |
 |------|------|------|
 | `apps` | 是 | 应用列表（逗号分隔，如 `claude,codex,gemini,opencode`） |
-| `config` | 是 | MCP 服务器配置（JSON 格式） |
+| `config` | 是 | Base64 编码的 MCP JSON 配置；解码后顶层必须包含 `mcpServers` 对象 |
 | `enabled` | 否 | 是否启用（布尔值） |
 
 **Skill 参数**（resource=skill）：
@@ -107,7 +107,7 @@ ccswitch://v1/import?resource=provider&app=claude&name=My%20Provider&endpoint=ht
 ### 导入 MCP 服务器
 
 ```
-ccswitch://v1/import?resource=mcp&apps=claude,codex&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-server-fetch%22%5D%7D&name=mcp-fetch
+ccswitch://v1/import?resource=mcp&apps=claude%2Ccodex&config=eyJtY3BTZXJ2ZXJzIjp7Im1jcC1mZXRjaCI6eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3Atc2VydmVyLWZldGNoIl19fX0%3D
 ```
 
 ### 导入 Prompt 预设
@@ -127,8 +127,9 @@ ccswitch://v1/import?resource=skill&name=my-skill&repo=owner/repo&directory=skil
 ### 手动生成
 
 1. 准备参数
-2. 按 V1 协议格式拼接 URL
-3. URL 编码特殊字符
+2. 对要求 Base64 编码的参数（例如 MCP 的 `config`、Prompt 的 `content`）先编码原始内容
+3. 按 V1 协议格式拼接 URL
+4. URL 编码特殊字符
 
 **示例**：
 
@@ -231,7 +232,7 @@ ccswitch://v1/import?resource=provider&app=claude&name=Test%20Provider&apiKey=sk
 ### 示例：导入 MCP 服务器
 
 ```
-ccswitch://v1/import?resource=mcp&name=mcp-fetch&apps=claude,codex,gemini&config=%7B%22command%22%3A%22uvx%22%2C%22args%22%3A%5B%22mcp-server-fetch%22%5D%7D
+ccswitch://v1/import?resource=mcp&apps=claude%2Ccodex%2Cgemini&config=eyJtY3BTZXJ2ZXJzIjp7Im1jcC1mZXRjaCI6eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyJtY3Atc2VydmVyLWZldGNoIl19fX0%3D
 ```
 
 ## 故障排除


### PR DESCRIPTION
## Summary / 概述

- Clarify that MCP deep-link `config` is Base64-encoded.
  明确 MCP 深度链接的 `config` 参数需要进行 Base64 编码。

- Document that the decoded JSON must contain a top-level `mcpServers` object.
  说明解码后的 JSON 顶层必须包含 `mcpServers` 对象。

- Fix the MCP examples in the Chinese, English, and Japanese manuals.
  修正中文、英文和日文手册中的 MCP 示例。

- No runtime code was changed.
  未修改运行时代码。

## Related Issue / 关联 Issue

Fixes #6767

## Screenshots / 截图

Not applicable. This is a documentation-only change.
不适用。本 PR 仅修改文档。

## Validation / 验证

- `git diff --check`
- Decoded all six MCP documentation links.
- Verified raw URL-encoded JSON, bare-server Base64, and wrapped MCP Base64 cases.

- 已通过 `git diff --check`
- 已解码并检查文档中的 6 条 MCP 链接。
- 已验证原始 URL 编码 JSON、裸服务器 Base64 和正确包装后的 Base64 三种情况。

## Checklist / 检查清单

- [ ] `pnpm typecheck` was not run; documentation-only change.
- [ ] `pnpm format:check` was not run; documentation-only change.
- [x] No Rust code was changed; `cargo clippy` is not applicable.
- [x] Updated the Chinese, English, and Japanese documentation.