### PR TITLE
fix(proxy): apply media prevention to Codex responses input before up…

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1514,11 +1514,6 @@ impl RequestForwarder {
         // suffix and add the context-1m beta header.
         let mut codex_anthropic_one_m = false;
 
-        // 转换请求体（如果需要）
-        if matches!(app_type, AppType::Codex | AppType::GrokBuild) {
-            self.apply_media_prevention(&mut mapped_body, provider);
-        }
-
         let mut request_body = if codex_responses_to_chat {
             let mut mapped_body = mapped_body;
             let explicit_prompt_cache_key = mapped_body
@@ -1535,6 +1530,7 @@ impl RequestForwarder {
                 );
             }
             super::providers::apply_codex_chat_upstream_model(provider, &mut mapped_body);
+            self.apply_media_prevention(&mut mapped_body, provider);
             let reasoning_config =
                 super::providers::resolve_codex_chat_reasoning_config(provider, &mapped_body);
             let mut chat_body = super::providers::transform_codex_chat::responses_to_chat_completions_with_reasoning(
@@ -1552,6 +1548,7 @@ impl RequestForwarder {
         } else if codex_responses_to_anthropic {
             let mut mapped_body = mapped_body;
             super::providers::apply_codex_upstream_model(provider, &mut mapped_body);
+            self.apply_media_prevention(&mut mapped_body, provider);
             // Per-provider output ceiling override. Codex does not forward its
             // `model_max_output_tokens` in the request body, so honor the value
             // configured on the provider here — it takes precedence over any
@@ -5238,6 +5235,60 @@ mod tests {
             .as_str()
             .unwrap()
             .contains(crate::proxy::media_sanitizer::UNSUPPORTED_IMAGE_MARKER));
+    }
+
+    #[test]
+    fn prevention_resolves_upstream_model_substitution_before_transform() {
+        let fwd = forwarder_with_rectifier(RectifierConfig::default());
+        let mut provider = provider_with_settings(json!({
+            "models": [ { "id": "deepseek-v4-flash", "input": ["text"] } ]
+        }));
+        if let Some(meta) = provider.meta.as_mut() {
+            meta.model = Some("deepseek-v4-flash".to_string());
+        }
+
+        let mut body = json!({
+            "model": "gpt-4o",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "inspect screen"}]
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "tool_call_1",
+                    "name": "view_image",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "tool_call_1",
+                    "output": [
+                        {
+                            "type": "input_image",
+                            "image_url": "data:image/png;base64,YWJj"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        super::super::providers::apply_codex_chat_upstream_model(&provider, &mut body);
+        assert_eq!(body["model"], "deepseek-v4-flash");
+
+        let replaced = fwd.apply_media_prevention(&mut body, &provider);
+        assert_eq!(replaced, 1);
+
+        let chat =
+            super::super::providers::transform_codex_chat::responses_to_chat_completions(body)
+                .unwrap();
+        let messages = chat["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[1]["role"], "assistant");
+        assert_eq!(messages[2]["role"], "tool");
+        assert_eq!(messages[2]["tool_call_id"], "tool_call_1");
     }
 
     #[test]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -5240,12 +5240,11 @@ mod tests {
     #[test]
     fn prevention_resolves_upstream_model_substitution_before_transform() {
         let fwd = forwarder_with_rectifier(RectifierConfig::default());
-        let mut provider = provider_with_settings(json!({
+        let provider = provider_with_settings(json!({
+            "api_format": "chat",
+            "model": "deepseek-v4-flash",
             "models": [ { "id": "deepseek-v4-flash", "input": ["text"] } ]
         }));
-        if let Some(meta) = provider.meta.as_mut() {
-            meta.model = Some("deepseek-v4-flash".to_string());
-        }
 
         let mut body = json!({
             "model": "gpt-4o",

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1515,6 +1515,10 @@ impl RequestForwarder {
         let mut codex_anthropic_one_m = false;
 
         // 转换请求体（如果需要）
+        if matches!(app_type, AppType::Codex | AppType::GrokBuild) {
+            self.apply_media_prevention(&mut mapped_body, provider);
+        }
+
         let mut request_body = if codex_responses_to_chat {
             let mut mapped_body = mapped_body;
             let explicit_prompt_cache_key = mapped_body
@@ -5156,6 +5160,84 @@ mod tests {
             "显式 text-only 即使关闭 heuristic 也应预替换"
         );
         assert_eq!(declared_body["messages"][0]["content"][0]["type"], "text");
+    }
+
+    #[test]
+    fn prevention_replaces_codex_tool_output_images_for_text_only_models() {
+        let fwd = forwarder_with_rectifier(RectifierConfig::default());
+        let provider = provider_with_settings(json!({
+            "models": [ { "id": "deepseek-chat", "input": ["text"] } ]
+        }));
+
+        let mut body = body_with_codex_tool_output_image(false);
+        body["model"] = json!("deepseek-chat");
+
+        let replaced = fwd.apply_media_prevention(&mut body, &provider);
+        assert_eq!(replaced, 1);
+
+        let output = &body["input"][0]["output"];
+        assert_eq!(
+            output["content"][0]["text"],
+            crate::proxy::media_sanitizer::UNSUPPORTED_IMAGE_MARKER
+        );
+    }
+
+    #[test]
+    fn prevention_end_to_end_avoids_synthetic_user_message_for_text_only_codex_tool() {
+        let fwd = forwarder_with_rectifier(RectifierConfig::default());
+        let provider = provider_with_settings(json!({
+            "models": [ { "id": "kimi-k3", "input": ["text"] } ]
+        }));
+
+        let mut body = json!({
+            "model": "kimi-k3",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "inspect screen"}]
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "tool_call_1",
+                    "name": "view_image",
+                    "arguments": "{}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "tool_call_1",
+                    "output": [
+                        {
+                            "type": "input_image",
+                            "image_url": "data:image/png;base64,YWJj"
+                        }
+                    ]
+                }
+            ]
+        });
+
+        // Pre-sanitization before transform
+        let replaced = fwd.apply_media_prevention(&mut body, &provider);
+        assert_eq!(replaced, 1);
+
+        // Convert to Chat Completions
+        let chat =
+            super::super::providers::transform_codex_chat::responses_to_chat_completions(body)
+                .unwrap();
+        let messages = chat["messages"].as_array().unwrap();
+
+        // Exactly 3 messages: user -> assistant (tool_calls) -> tool
+        // NO synthetic trailing user message that breaks strict Chat Completions tool turn sequence!
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[1]["role"], "assistant");
+        assert_eq!(messages[1]["tool_calls"][0]["id"], "tool_call_1");
+        assert_eq!(messages[2]["role"], "tool");
+        assert_eq!(messages[2]["tool_call_id"], "tool_call_1");
+        assert!(messages[2]["content"]
+            .as_str()
+            .unwrap()
+            .contains(crate::proxy::media_sanitizer::UNSUPPORTED_IMAGE_MARKER));
     }
 
     #[test]


### PR DESCRIPTION
### Summary

Fixes #6697.

When using Codex with tools that output images (e.g. `view_image`) against a text-only upstream (such as Kimi For Coding or DeepSeek), `transform_codex_chat` previously moved the image to a synthetic `user` message after the `tool` message. Strict Chat Completions gateways (like Moonshot/Kimi) rejected this broken tool-call sequence with HTTP 400 (`The following tool_call_ids did not have response messages`), permanently breaking the session history.

### Changes
1. Applied `apply_media_prevention` to `mapped_body` before Codex Responses-to-Chat / Responses-to-Anthropic conversion (aligning with how Claude requests are sanitized before conversion).
2. Allowed `media_sanitizer::replace_images_in_responses_input` to sanitize tool output images into text placeholders in-place before Chat message construction, preserving strict 1:1 `tool_calls` ↔ `tool_call_id` message pairing without injecting synthetic user messages.
3. Added unit tests `prevention_replaces_codex_tool_output_images_for_text_only_models` and `prevention_end_to_end_avoids_synthetic_user_message_for_text_only_codex_tool`.