### PR TITLE
fix(claude): require routing takeover when 1M context marker is declared

### DIFF
--- a/src/utils/providerCapabilities.test.ts
+++ b/src/utils/providerCapabilities.test.ts
@@ -343,8 +343,7 @@ describe("providerNeedsRouting", () => {
             meta: { apiFormat: "anthropic" },
             settingsConfig: {
               env: {
-                ANTHROPIC_SMALL_FAST_MODEL:
-                  "claude-3-5-haiku-20241022[1M]",
+                ANTHROPIC_SMALL_FAST_MODEL: "claude-3-5-haiku-20241022[1M]",
               },
             },
           }),

--- a/src/utils/providerCapabilities.test.ts
+++ b/src/utils/providerCapabilities.test.ts
@@ -334,6 +334,22 @@ describe("providerNeedsRouting", () => {
           }),
         ),
       ).toBe(true);
+
+      expect(
+        providerNeedsRouting(
+          "claude",
+          mkProvider({
+            category: "third_party",
+            meta: { apiFormat: "anthropic" },
+            settingsConfig: {
+              env: {
+                ANTHROPIC_SMALL_FAST_MODEL:
+                  "claude-3-5-haiku-20241022[1M]",
+              },
+            },
+          }),
+        ),
+      ).toBe(true);
     });
   });
 

--- a/src/utils/providerCapabilities.test.ts
+++ b/src/utils/providerCapabilities.test.ts
@@ -302,6 +302,39 @@ describe("providerNeedsRouting", () => {
         ),
       ).toBe(true);
     });
+
+    it("声明 [1M] 能力标记的 Anthropic 格式供应商需要路由接管以剥离后缀", () => {
+      expect(
+        providerNeedsRouting(
+          "claude",
+          mkProvider({
+            category: "third_party",
+            meta: { apiFormat: "anthropic" },
+            settingsConfig: {
+              env: {
+                ANTHROPIC_DEFAULT_SONNET_MODEL:
+                  "claude-3-7-sonnet-20250219[1M]",
+              },
+            },
+          }),
+        ),
+      ).toBe(true);
+
+      expect(
+        providerNeedsRouting(
+          "claude",
+          mkProvider({
+            category: "third_party",
+            meta: { apiFormat: "anthropic" },
+            settingsConfig: {
+              env: {
+                ANTHROPIC_MODEL: "claude-3-7-sonnet-20250219 [1m]",
+              },
+            },
+          }),
+        ),
+      ).toBe(true);
+    });
   });
 
   describe("Codex 非 OAuth 按格式判定（Responses 直连）", () => {

--- a/src/utils/providerCapabilities.ts
+++ b/src/utils/providerCapabilities.ts
@@ -15,9 +15,7 @@ export const CODEX_OFFICIAL_PROVIDER_ID = "codex-official";
 export const GROKBUILD_OFFICIAL_PROVIDER_ID = "grokbuild-official";
 
 export type CodexOfficialIdentity =
-  | "native_login"
-  | "managed_account"
-  | "api_key";
+  "native_login" | "managed_account" | "api_key";
 
 const nonEmptyString = (value: unknown): boolean =>
   typeof value === "string" && value.trim().length > 0;

--- a/src/utils/providerCapabilities.ts
+++ b/src/utils/providerCapabilities.ts
@@ -15,7 +15,9 @@ export const CODEX_OFFICIAL_PROVIDER_ID = "codex-official";
 export const GROKBUILD_OFFICIAL_PROVIDER_ID = "grokbuild-official";
 
 export type CodexOfficialIdentity =
-  "native_login" | "managed_account" | "api_key";
+  | "native_login"
+  | "managed_account"
+  | "api_key";
 
 const nonEmptyString = (value: unknown): boolean =>
   typeof value === "string" && value.trim().length > 0;

--- a/src/utils/providerCapabilities.ts
+++ b/src/utils/providerCapabilities.ts
@@ -100,6 +100,45 @@ export function supportsOfficialProxyTakeover(
   return true;
 }
 
+export function hasAnyClaudeOneMMarker(settingsConfig: unknown): boolean {
+  if (!settingsConfig) return false;
+  let cfg: Record<string, unknown> | null = null;
+  if (typeof settingsConfig === "string") {
+    try {
+      cfg = JSON.parse(settingsConfig);
+    } catch {
+      return false;
+    }
+  } else if (typeof settingsConfig === "object" && settingsConfig !== null) {
+    cfg = settingsConfig as Record<string, unknown>;
+  }
+  if (!cfg) return false;
+
+  const env = (cfg.env ?? cfg) as Record<string, unknown> | undefined;
+  if (!env || typeof env !== "object") return false;
+
+  const modelFields = [
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_FABLE_MODEL",
+    "CLAUDE_CODE_SUBAGENT_MODEL",
+  ];
+
+  for (const field of modelFields) {
+    const val = env[field];
+    if (
+      typeof val === "string" &&
+      val.trimEnd().toLowerCase().endsWith("[1m]")
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * 供应商在指定应用下是否必须开启路由接管才能正常工作（badge 与切换警告共用的权威谓词）。
  *
@@ -140,7 +179,14 @@ export function providerNeedsRouting(
   if (appId === "claude") {
     const fmt = provider.meta?.apiFormat;
     // Claude 原生是 Anthropic 格式，任何非 anthropic 格式都需要代理转换。
-    return provider.meta?.isFullUrl === true || (!!fmt && fmt !== "anthropic");
+    // 若声明了 [1M] 能力标记，直连第三方中转通常因不识别 [1M] 后缀报错 400/404，
+    // 必须通过本地代理在转发时剥离 [1M] 并保留 1M 上下文。
+    const hasOneM = hasAnyClaudeOneMMarker(provider.settingsConfig);
+    return (
+      provider.meta?.isFullUrl === true ||
+      (!!fmt && fmt !== "anthropic") ||
+      hasOneM
+    );
   }
 
   if (appId === "codex" || appId === "grokbuild") {

--- a/src/utils/providerCapabilities.ts
+++ b/src/utils/providerCapabilities.ts
@@ -123,6 +123,7 @@ export function hasAnyClaudeOneMMarker(settingsConfig: unknown): boolean {
     "ANTHROPIC_DEFAULT_SONNET_MODEL",
     "ANTHROPIC_DEFAULT_OPUS_MODEL",
     "ANTHROPIC_DEFAULT_FABLE_MODEL",
+    "ANTHROPIC_SMALL_FAST_MODEL",
     "CLAUDE_CODE_SUBAGENT_MODEL",
   ];
 


### PR DESCRIPTION
## Summary / 概述

Fixes an issue where Claude Code configured with third-party Anthropic relay providers fails with `400 / 404 Model not found` when 1M context is enabled, or silently falls back to 200K when `[1M]` is removed.

### Details / 详情
1. **Context Window Constraint**: Claude Code strictly requires the `[1M]` model suffix (e.g., `claude-3-7-sonnet-20250219[1M]`) to unlock 1,000,000-token context windows and ignores `CLAUDE_CODE_MAX_CONTEXT_TOKENS` for `claude-*` models.
2. **Direct Connection Issue**: When `[1M]` was toggled on an Anthropic-format provider, `providerNeedsRouting("claude", provider)` previously evaluated to `false`, allowing direct connections where Claude Code sent raw `[1M]` model IDs to third-party relay gateways, causing upstream `400 / 404` errors.
3. **Resolution**: Updated `providerNeedsRouting` to check `hasAnyClaudeOneMMarker` across all model fields in `settingsConfig.env`. When `[1M]` is present, `needsRouting` evaluates to `true`, ensuring requests route through the local proxy where `model_mapper.rs` strips `[1M]` before forwarding to upstream gateways while preserving Claude Code's local 1M context.

## Related Issue / 关联 Issue

Closes #3679

## Checklist / 检查清单

- [x] TypeScript unit tests updated and verified in `providerCapabilities.test.ts`
- [x] Clean, minimal, and targeted changes without breaking schema changes