### PR TITLE
fix(proxy): strip Claude total token markers

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -55,43 +55,44 @@ pub(crate) fn strip_leading_anthropic_billing_header(text: &str) -> &str {
     }
 }
 
-/// Strip Claude Code's per-turn context-budget marker from system text.
+/// Recognize Claude Code's standalone per-turn context-budget marker.
 ///
 /// Claude Code sends this marker as a standalone Anthropic `system` message
 /// during multi-turn conversations. OpenAI-compatible endpoints do not use it,
 /// and merging the changing marker into the first system message prevents
-/// stable prompt-prefix caching (#6789). Only callers handling system text
-/// should use this helper; user and assistant content must remain untouched.
+/// stable prompt-prefix caching (#6789).
+///
+/// The payload shape is intentionally strict. A user-authored XML element with
+/// the same tag must remain intact unless it is the known Claude marker form.
+fn is_anthropic_total_tokens_marker(text: &str) -> bool {
+    let text = text.trim();
+    let Some(payload) = text
+        .strip_prefix(ANTHROPIC_TOTAL_TOKENS_OPEN_TAG)
+        .and_then(|text| text.strip_suffix(ANTHROPIC_TOTAL_TOKENS_CLOSE_TAG))
+    else {
+        return false;
+    };
+
+    let mut fields = payload.split_whitespace();
+    let Some(token_count) = fields.next() else {
+        return false;
+    };
+
+    !token_count.is_empty()
+        && token_count.bytes().all(|byte| byte.is_ascii_digit())
+        && fields.next() == Some("tokens")
+        && fields.next() == Some("left")
+        && fields.next().is_none()
+}
+
+/// Remove Claude Code's standalone per-turn context-budget marker.
+///
+/// Only callers handling system text should use this helper; user and
+/// assistant content must remain untouched.
 fn strip_anthropic_total_tokens_marker(text: &mut String) {
-    if !text.contains(ANTHROPIC_TOTAL_TOKENS_OPEN_TAG) {
-        return;
+    if is_anthropic_total_tokens_marker(text) {
+        text.clear();
     }
-
-    let original = text.clone();
-    let mut stripped = String::with_capacity(original.len());
-    let mut remaining = original.as_str();
-
-    loop {
-        let Some(open_offset) = remaining.find(ANTHROPIC_TOTAL_TOKENS_OPEN_TAG) else {
-            stripped.push_str(remaining);
-            break;
-        };
-
-        stripped.push_str(&remaining[..open_offset]);
-        let content_start = open_offset + ANTHROPIC_TOTAL_TOKENS_OPEN_TAG.len();
-        let Some(close_offset) = remaining[content_start..].find(ANTHROPIC_TOTAL_TOKENS_CLOSE_TAG)
-        else {
-            // Preserve an unterminated marker rather than deleting the rest of
-            // the prompt when the input is malformed or user-authored.
-            stripped.push_str(&remaining[open_offset..]);
-            break;
-        };
-
-        remaining =
-            &remaining[content_start + close_offset + ANTHROPIC_TOTAL_TOKENS_CLOSE_TAG.len()..];
-    }
-
-    *text = stripped;
 }
 
 /// Detect OpenAI o-series reasoning models (o1, o3, o4-mini, etc.)
@@ -366,9 +367,9 @@ fn normalize_openai_system_messages(messages: &mut Vec<Value>) {
                         return true;
                     };
 
-                    let had_marker = text.contains(ANTHROPIC_TOTAL_TOKENS_OPEN_TAG);
+                    let is_marker = is_anthropic_total_tokens_marker(text);
                     strip_anthropic_total_tokens_marker(text);
-                    !(had_marker && text.trim().is_empty())
+                    !(is_marker && text.is_empty())
                 });
             }
             _ => {}
@@ -978,8 +979,7 @@ mod tests {
     }
 
     #[test]
-    fn test_anthropic_to_openai_strips_total_tokens_from_system_content_without_touching_user_text()
-    {
+    fn test_anthropic_to_openai_preserves_embedded_total_tokens_text() {
         let input = json!({
             "model": "deepseek-v4-flash",
             "max_tokens": 1024,
@@ -992,7 +992,10 @@ mod tests {
 
         let result = anthropic_to_openai(input).unwrap();
 
-        assert_eq!(result["messages"][0]["content"], "Stable system ");
+        assert_eq!(
+            result["messages"][0]["content"],
+            "Stable system <total_tokens>15000000 tokens left</total_tokens>"
+        );
         assert_eq!(
             result["messages"][1]["content"],
             "Keep this literal: <total_tokens>15000000 tokens left</total_tokens>"
@@ -1041,6 +1044,29 @@ mod tests {
             result["messages"][0]["content"],
             "Keep this literal: <total_tokens>unfinished"
         );
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_preserves_unknown_total_tokens_payload() {
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "<total_tokens>XML example</total_tokens>"
+                },
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+
+        assert_eq!(
+            result["messages"][0]["content"],
+            "<total_tokens>XML example</total_tokens>"
+        );
+        assert_eq!(result["messages"][1]["content"], "Hello");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -348,50 +348,44 @@ fn map_tool_choice_to_chat(tool_choice: &Value) -> Value {
 }
 
 fn normalize_openai_system_messages(messages: &mut Vec<Value>) {
-    for message in messages.iter_mut() {
+    messages.retain_mut(|message| {
         if message.get("role").and_then(|value| value.as_str()) != Some("system") {
-            continue;
+            return true;
         }
 
         let Some(content) = message.get_mut("content") else {
-            continue;
+            return true;
         };
 
         match content {
             Value::String(text) => {
+                let is_marker = is_anthropic_total_tokens_marker(text);
                 strip_anthropic_total_tokens_marker(text);
+                !is_marker
             }
             Value::Array(content_parts) => {
+                let mut stripped_marker = false;
                 content_parts.retain_mut(|part| {
                     let Some(Value::String(text)) = part.get_mut("text") else {
                         return true;
                     };
 
-                    let is_marker = is_anthropic_total_tokens_marker(text);
-                    strip_anthropic_total_tokens_marker(text);
-                    !(is_marker && text.is_empty())
+                    if is_anthropic_total_tokens_marker(text) {
+                        stripped_marker = true;
+                        return false;
+                    }
+
+                    true
                 });
-            }
-            _ => {}
-        }
-    }
 
-    // Removing a marker can leave only the line breaks that surrounded it.
-    // Drop those system messages before counting them, otherwise their number
-    // would still grow with every turn and change the cached prefix.
-    messages.retain(|message| {
-        if message.get("role").and_then(|value| value.as_str()) != Some("system") {
-            return true;
-        }
-
-        match message.get("content") {
-            Some(Value::String(text)) => !text.trim().is_empty(),
-            Some(Value::Array(content_parts)) => {
-                !content_parts.is_empty()
-                    && !content_parts.iter().all(|part| {
+                // A marker-only content array should disappear with its
+                // message. Preserve any other meaningful content, including
+                // non-text blocks, and preserve unrelated blank system parts.
+                !stripped_marker
+                    || content_parts.iter().any(|part| {
                         part.get("text")
                             .and_then(Value::as_str)
-                            .is_some_and(|text| text.trim().is_empty())
+                            .is_none_or(|text| !text.trim().is_empty())
                     })
             }
             _ => true,
@@ -426,14 +420,14 @@ fn normalize_openai_system_messages(messages: &mut Vec<Value>) {
         }
 
         match message.get("content") {
-            Some(Value::String(text)) if !text.trim().is_empty() => parts.push(text.clone()),
+            Some(Value::String(text)) if !text.is_empty() => parts.push(text.clone()),
             Some(Value::Array(content_parts)) => {
                 let text = content_parts
                     .iter()
                     .filter_map(|part| part.get("text").and_then(|value| value.as_str()))
                     .collect::<Vec<_>>()
                     .join("\n");
-                if !text.trim().is_empty() {
+                if !text.is_empty() {
                     parts.push(text);
                 }
             }
@@ -1066,6 +1060,24 @@ mod tests {
             result["messages"][0]["content"],
             "<total_tokens>XML example</total_tokens>"
         );
+        assert_eq!(result["messages"][1]["content"], "Hello");
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_preserves_unrelated_blank_system_message() {
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "messages": [
+                {"role": "system", "content": "\n"},
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+
+        assert_eq!(result["messages"][0]["role"], "system");
+        assert_eq!(result["messages"][0]["content"], "\n");
         assert_eq!(result["messages"][1]["content"], "Hello");
     }
 

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -14,6 +14,8 @@ use crate::proxy::{
 use serde_json::{json, Value};
 
 const ANTHROPIC_BILLING_HEADER_PREFIX: &str = "x-anthropic-billing-header:";
+const ANTHROPIC_TOTAL_TOKENS_OPEN_TAG: &str = "<total_tokens>";
+const ANTHROPIC_TOTAL_TOKENS_CLOSE_TAG: &str = "</total_tokens>";
 
 /// Strip only a leading Claude Code attribution line from system text.
 ///
@@ -51,6 +53,45 @@ pub(crate) fn strip_leading_anthropic_billing_header(text: &str) -> &str {
     } else {
         rest
     }
+}
+
+/// Strip Claude Code's per-turn context-budget marker from system text.
+///
+/// Claude Code sends this marker as a standalone Anthropic `system` message
+/// during multi-turn conversations. OpenAI-compatible endpoints do not use it,
+/// and merging the changing marker into the first system message prevents
+/// stable prompt-prefix caching (#6789). Only callers handling system text
+/// should use this helper; user and assistant content must remain untouched.
+fn strip_anthropic_total_tokens_marker(text: &mut String) {
+    if !text.contains(ANTHROPIC_TOTAL_TOKENS_OPEN_TAG) {
+        return;
+    }
+
+    let original = text.clone();
+    let mut stripped = String::with_capacity(original.len());
+    let mut remaining = original.as_str();
+
+    loop {
+        let Some(open_offset) = remaining.find(ANTHROPIC_TOTAL_TOKENS_OPEN_TAG) else {
+            stripped.push_str(remaining);
+            break;
+        };
+
+        stripped.push_str(&remaining[..open_offset]);
+        let content_start = open_offset + ANTHROPIC_TOTAL_TOKENS_OPEN_TAG.len();
+        let Some(close_offset) = remaining[content_start..].find(ANTHROPIC_TOTAL_TOKENS_CLOSE_TAG)
+        else {
+            // Preserve an unterminated marker rather than deleting the rest of
+            // the prompt when the input is malformed or user-authored.
+            stripped.push_str(&remaining[open_offset..]);
+            break;
+        };
+
+        remaining =
+            &remaining[content_start + close_offset + ANTHROPIC_TOTAL_TOKENS_CLOSE_TAG.len()..];
+    }
+
+    *text = stripped;
 }
 
 /// Detect OpenAI o-series reasoning models (o1, o3, o4-mini, etc.)
@@ -306,6 +347,56 @@ fn map_tool_choice_to_chat(tool_choice: &Value) -> Value {
 }
 
 fn normalize_openai_system_messages(messages: &mut Vec<Value>) {
+    for message in messages.iter_mut() {
+        if message.get("role").and_then(|value| value.as_str()) != Some("system") {
+            continue;
+        }
+
+        let Some(content) = message.get_mut("content") else {
+            continue;
+        };
+
+        match content {
+            Value::String(text) => {
+                strip_anthropic_total_tokens_marker(text);
+            }
+            Value::Array(content_parts) => {
+                content_parts.retain_mut(|part| {
+                    let Some(Value::String(text)) = part.get_mut("text") else {
+                        return true;
+                    };
+
+                    let had_marker = text.contains(ANTHROPIC_TOTAL_TOKENS_OPEN_TAG);
+                    strip_anthropic_total_tokens_marker(text);
+                    !(had_marker && text.trim().is_empty())
+                });
+            }
+            _ => {}
+        }
+    }
+
+    // Removing a marker can leave only the line breaks that surrounded it.
+    // Drop those system messages before counting them, otherwise their number
+    // would still grow with every turn and change the cached prefix.
+    messages.retain(|message| {
+        if message.get("role").and_then(|value| value.as_str()) != Some("system") {
+            return true;
+        }
+
+        match message.get("content") {
+            Some(Value::String(text)) => !text.trim().is_empty(),
+            Some(Value::Array(content_parts)) => {
+                !content_parts.is_empty()
+                    && !content_parts.iter().all(|part| {
+                        part.get("text")
+                            .and_then(Value::as_str)
+                            .is_some_and(|text| text.trim().is_empty())
+                    })
+            }
+            _ => true,
+        }
+    });
+
     let system_count = messages
         .iter()
         .filter(|message| message.get("role").and_then(|value| value.as_str()) == Some("system"))
@@ -334,14 +425,14 @@ fn normalize_openai_system_messages(messages: &mut Vec<Value>) {
         }
 
         match message.get("content") {
-            Some(Value::String(text)) if !text.is_empty() => parts.push(text.clone()),
+            Some(Value::String(text)) if !text.trim().is_empty() => parts.push(text.clone()),
             Some(Value::Array(content_parts)) => {
                 let text = content_parts
                     .iter()
                     .filter_map(|part| part.get("text").and_then(|value| value.as_str()))
                     .collect::<Vec<_>>()
                     .join("\n");
-                if !text.is_empty() {
+                if !text.trim().is_empty() {
                     parts.push(text);
                 }
             }
@@ -854,6 +945,101 @@ mod tests {
         assert_eq!(
             result["messages"][0]["content"],
             "Keep this literal:\nx-anthropic-billing-header: example"
+        );
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_strips_total_tokens_from_merged_system_messages() {
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "system": [{"type": "text", "text": "Stable system prompt"}],
+            "messages": [
+                {"role": "user", "content": "First question"},
+                {"role": "system", "content": "\n<total_tokens>15000000 tokens left</total_tokens>\n"},
+                {"role": "assistant", "content": "First answer"},
+                {"role": "user", "content": "Second question"},
+                {"role": "system", "content": "\n<total_tokens>15000000 tokens left</total_tokens>\n"}
+            ]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "Stable system prompt");
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(messages[2]["role"], "assistant");
+        assert_eq!(messages[3]["role"], "user");
+        assert!(messages
+            .iter()
+            .all(|message| !message.to_string().contains("<total_tokens>")));
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_strips_total_tokens_from_system_content_without_touching_user_text()
+    {
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "system": "Stable system <total_tokens>15000000 tokens left</total_tokens>",
+            "messages": [{
+                "role": "user",
+                "content": "Keep this literal: <total_tokens>15000000 tokens left</total_tokens>"
+            }]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+
+        assert_eq!(result["messages"][0]["content"], "Stable system ");
+        assert_eq!(
+            result["messages"][1]["content"],
+            "Keep this literal: <total_tokens>15000000 tokens left</total_tokens>"
+        );
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_strips_total_tokens_from_system_content_array() {
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "Stable system prompt"},
+                        {"type": "text", "text": "\n<total_tokens>15000000 tokens left</total_tokens>\n"}
+                    ]
+                },
+                {"role": "user", "content": "Hello"}
+            ]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+
+        assert_eq!(
+            result["messages"][0]["content"],
+            json!([{"type": "text", "text": "Stable system prompt"}])
+        );
+        assert_eq!(result["messages"][1]["role"], "user");
+        assert!(!result.to_string().contains("<total_tokens>"));
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_preserves_unterminated_total_tokens_text() {
+        let input = json!({
+            "model": "deepseek-v4-flash",
+            "max_tokens": 1024,
+            "system": "Keep this literal: <total_tokens>unfinished",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+
+        assert_eq!(
+            result["messages"][0]["content"],
+            "Keep this literal: <total_tokens>unfinished"
         );
     }
 


### PR DESCRIPTION
## Summary / 概述

Fix the Claude-to-OpenAI conversion path so Claude Code's dynamic
`<total_tokens>...</total_tokens>` markers do not accumulate in the
merged OpenAI system prompt.

修复 Claude→OpenAI 转换路径，避免 Claude Code 的动态
`<total_tokens>...</total_tokens>` 标签不断累积到 OpenAI system 字符串中，
导致 OpenAI 兼容端点的 prompt cache 命中率下降。

The fix only affects system messages. User and assistant content remains unchanged.

该修复只处理 system 消息，不会修改 user 和 assistant 内容。

## Related Issue / 关联 Issue

Fixes #6789

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|----------------|
| Not applicable: backend-only change / 不适用：仅后端代理逻辑修改 | Not applicable: no UI changes / 不适用：没有界面变化 |

## Validation / 验证

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml` passed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` passed.
- Anthropic/OpenAI transform tests: 70 passed.
- Rust library tests: 2672 passed, 5 ignored.
- `git diff --check` passed.
- Added regression tests for merged system messages, system content arrays,
  user content preservation, and unterminated markers.

## Checklist / 检查清单

- [ ] `pnpm typecheck` was not run; this is a Rust-only change /
      未运行；本次仅修改 Rust 后端代码
- [ ] `pnpm format:check` was not run; this is a Rust-only change /
      未运行；本次仅修改 Rust 后端代码
- [x] `cargo clippy` passes /
      `cargo clippy` 已通过
- [x] No user-facing text changed; i18n update is not applicable /
      未修改用户可见文本，不需要更新国际化文件