### PR TITLE
fix(codex): proxy xAI deferred tool_search over native Responses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,10 +210,14 @@ jobs:
       - name: Run Windows-to-WSL2 filesystem contract
         shell: pwsh
         run: |
-          $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
-          $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $testName = "config::tests::atomic_write_replaces_existing_wsl_unc_file"
-          $testList = cargo test --lib --manifest-path src-tauri/Cargo.toml -- --ignored --list
+          $testExe = Get-ChildItem -Path "src-tauri\target\debug\deps" -Filter "cc_switch_lib-*.exe" |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+          if (-not $testExe) {
+            throw "Expected compiled test executable was not found"
+          }
+          $testList = & $testExe --ignored --list
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -221,7 +225,9 @@ jobs:
           if ($testList -notcontains $expected) {
             throw "Expected ignored test was not discovered: $testName"
           }
-          cargo test --lib --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
+          $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
+          $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
+          & $testExe $testName --ignored --exact --nocapture
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -311,6 +311,11 @@ impl CodexLiveStateSnapshot {
 pub enum CodexCatalogToolProfile {
     ProxyChat,
     NativeResponses,
+    /// Codex talks through cc-switch's takeover proxy to a strict native
+    /// Responses gateway whose private `tool_search` protocol is translated by
+    /// the proxy. This profile keeps the clean native tool surface while
+    /// advertising deferred search support to Codex.
+    ProxiedNativeResponses,
     /// Codex talks (through cc-switch's proxy) to a native Anthropic Messages
     /// gateway. Like `NativeResponses` it must suppress Codex's freeform custom
     /// tools — the Responses→Anthropic transform keeps only `function` tools.
@@ -1252,6 +1257,12 @@ fn codex_catalog_model_entry(
         }
     }
 
+    if profile == CodexCatalogToolProfile::ProxiedNativeResponses {
+        // This capability is valid only while cc-switch takeover owns the live
+        // endpoint and translates Codex's private tool-search protocol.
+        entry_obj.insert("supports_search_tool".to_string(), json!(true));
+    }
+
     // Per-model reasoning levels override the template's conservative
     // none/high default (e.g. a LiteLLM gateway serving a model that accepts
     // low/medium/high/xhigh/max). Applies to every profile.
@@ -1912,9 +1923,9 @@ fn codex_model_catalog_from_settings(
     // no cache dependency); proxy-chat providers keep cloning Codex's gpt-5.5
     // entry so the proxy can rewrite custom<->function tools as before.
     let template = match profile {
-        CodexCatalogToolProfile::NativeResponses | CodexCatalogToolProfile::Anthropic => {
-            load_codex_native_responses_template()
-        }
+        CodexCatalogToolProfile::NativeResponses
+        | CodexCatalogToolProfile::ProxiedNativeResponses
+        | CodexCatalogToolProfile::Anthropic => load_codex_native_responses_template(),
         CodexCatalogToolProfile::ProxyChat => load_codex_model_catalog_template()?,
     };
     Ok(Some(codex_model_catalog_from_specs(
@@ -2020,7 +2031,8 @@ pub fn prepare_codex_config_text_with_model_catalog(
             // The Responses→Anthropic transform silently drops the Codex web_search
             // hosted tool, so always disable it here rather than present a dead tool.
             CodexCatalogToolProfile::Anthropic => true,
-            CodexCatalogToolProfile::NativeResponses => {
+            CodexCatalogToolProfile::NativeResponses
+            | CodexCatalogToolProfile::ProxiedNativeResponses => {
                 codex_native_gateway_rejects_web_search(&config_text)
             }
             CodexCatalogToolProfile::ProxyChat => false,
@@ -4045,6 +4057,32 @@ base_url = "https://production.api/v1"
         assert!(template.get("supports_search_tool").is_none());
         assert!(template.get("supports_image_detail_original").is_none());
         assert!(template.get("web_search_tool_type").is_none());
+    }
+
+    #[test]
+    fn proxied_native_catalog_alone_enables_deferred_search() {
+        let settings = json!({
+            "modelCatalog": {"models": [{"model": "grok-4.6"}]}
+        });
+        let direct = codex_model_catalog_from_settings(
+            &settings,
+            "",
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .unwrap()
+        .unwrap();
+        let proxied = codex_model_catalog_from_settings(
+            &settings,
+            "",
+            CodexCatalogToolProfile::ProxiedNativeResponses,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(direct["models"][0]["supports_search_tool"], json!(false));
+        assert_eq!(proxied["models"][0]["supports_search_tool"], json!(true));
+        assert!(proxied["models"][0].get("tools").is_none());
+        assert_eq!(proxied["models"][0]["shell_type"], "shell_command");
     }
 
     #[test]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1564,23 +1564,51 @@ impl RequestForwarder {
             mapped_body
         };
 
-        // Native Responses passthrough to a strict third-party gateway (xAI):
-        // flatten Codex's private `namespace`/plugin tool declarations into
-        // top-level function tools so the upstream's strict serde parser does
-        // not 422 on `unknown variant "namespace"`. The Chat/Anthropic paths
-        // above already unwrap namespaces, so this only fires on the native
-        // passthrough. The response handler restores the flat names using a map
-        // re-derived from the same request tools.
-        if matches!(app_type, AppType::Codex | AppType::GrokBuild)
+        let is_xai_native_responses = matches!(app_type, AppType::Codex | AppType::GrokBuild)
             && !codex_responses_to_chat
             && !codex_responses_to_anthropic
-            && super::providers::provider_needs_responses_namespace_flatten(provider)
+            && super::providers::provider_needs_responses_namespace_flatten(provider);
+
+        // Codex's private deferred-search items are not part of xAI's strict
+        // Responses schema. Proxy them as an ordinary function before namespace
+        // flattening; discovered namespaces are promoted here so only selected
+        // tools become model-visible.
+        if is_xai_native_responses
+            && super::providers::transform_codex_responses_xai_tool_search::prepare_xai_tool_search_request(
+                &mut request_body,
+            )?
+        {
+            log::debug!(
+                "[Codex] Proxied deferred tool search for xAI native Responses (provider={})",
+                provider.id
+            );
+        }
+
+        // Flatten non-deferred namespace children into top-level function tools
+        // so xAI does not reject the private namespace carrier. Deferred children
+        // stay hidden until Codex returns them in a tool_search_output.
+        if is_xai_native_responses
             && super::providers::transform_codex_responses_namespace::flatten_request_namespaces(
                 &mut request_body,
             )?
         {
             log::debug!(
                 "[Codex] Flattened namespace tools for native Responses upstream (provider={})",
+                provider.id
+            );
+        }
+
+        // A tool discovered in an earlier turn can be replayed directly as a
+        // top-level function, bypassing the carriers normalized above. Run one
+        // final function-only pass after namespace flattening so xAI never sees
+        // a root `object | null` (or another non-object union branch).
+        if is_xai_native_responses
+            && super::providers::transform_codex_responses_xai_tool_search::normalize_xai_top_level_function_schemas(
+                &mut request_body,
+            )
+        {
+            log::debug!(
+                "[Codex] Normalized top-level xAI function schemas (provider={})",
                 provider.id
             );
         }
@@ -1592,10 +1620,7 @@ impl RequestForwarder {
         // xAI OAuth path, so the prompt-cache prefix stays stable and no other
         // provider is affected. Runs after the flatten above so lifted
         // `namespace` tools survive the tool-type whitelist.
-        if matches!(app_type, AppType::Codex | AppType::GrokBuild)
-            && !codex_responses_to_chat
-            && !codex_responses_to_anthropic
-            && super::providers::provider_needs_responses_namespace_flatten(provider)
+        if is_xai_native_responses
             && super::providers::transform_codex_responses_xai_sanitize::sanitize_xai_responses_request(
                 &mut request_body,
             )

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1178,6 +1178,8 @@ impl RequestForwarder {
             && super::providers::should_convert_codex_responses_to_chat(provider, endpoint);
         let codex_responses_to_anthropic = matches!(app_type, AppType::Codex | AppType::GrokBuild)
             && super::providers::should_convert_codex_responses_to_anthropic(provider, endpoint);
+        let client_uses_codex_private_tools =
+            super::providers::client_uses_codex_private_tools(app_type);
         let codex_official_auth_passthrough = matches!(app_type, AppType::Codex)
             && super::providers::is_codex_official_provider(provider);
 
@@ -1476,10 +1478,13 @@ impl RequestForwarder {
             super::providers::apply_codex_chat_upstream_model(provider, &mut mapped_body);
             let reasoning_config =
                 super::providers::resolve_codex_chat_reasoning_config(provider, &mapped_body);
-            let mut chat_body = super::providers::transform_codex_chat::responses_to_chat_completions_with_reasoning(
-                mapped_body,
-                reasoning_config.as_ref(),
-            )?;
+            let tool_context =
+                super::providers::responses_tool_context_for_client(app_type, &mapped_body)?;
+            let mut chat_body = super::providers::transform_codex_chat::responses_to_chat_completions_with_reasoning_and_tool_context(
+                    mapped_body,
+                    reasoning_config.as_ref(),
+                    &tool_context,
+                )?;
             super::providers::inject_codex_chat_prompt_cache_key(
                 provider,
                 &mut chat_body,
@@ -1514,10 +1519,13 @@ impl RequestForwarder {
             // accepted by every current Claude model and virtually all gateways. The
             // transform clamps any thinking budget below this value.
             const DEFAULT_CODEX_ANTHROPIC_MAX_TOKENS: u64 = 8192;
+            let tool_context =
+                super::providers::responses_tool_context_for_client(app_type, &mapped_body)?;
             let mut anthropic_body =
-                super::providers::transform_codex_anthropic::responses_request_to_anthropic(
+                super::providers::transform_codex_anthropic::responses_request_to_anthropic_with_tool_context(
                     mapped_body,
                     DEFAULT_CODEX_ANTHROPIC_MAX_TOKENS,
+                    &tool_context,
                 )?;
             // Handle the 1M-context marker [1m]: strip the model-name suffix (the
             // gateway doesn't recognize it) and set the flag so the beta header is
@@ -1568,12 +1576,14 @@ impl RequestForwarder {
             && !codex_responses_to_chat
             && !codex_responses_to_anthropic
             && super::providers::provider_needs_responses_namespace_flatten(provider);
+        let is_codex_private_xai_responses =
+            is_xai_native_responses && client_uses_codex_private_tools;
 
         // Codex's private deferred-search items are not part of xAI's strict
         // Responses schema. Proxy them as an ordinary function before namespace
         // flattening; discovered namespaces are promoted here so only selected
         // tools become model-visible.
-        if is_xai_native_responses
+        if is_codex_private_xai_responses
             && super::providers::transform_codex_responses_xai_tool_search::prepare_xai_tool_search_request(
                 &mut request_body,
             )?
@@ -1587,7 +1597,7 @@ impl RequestForwarder {
         // Flatten non-deferred namespace children into top-level function tools
         // so xAI does not reject the private namespace carrier. Deferred children
         // stay hidden until Codex returns them in a tool_search_output.
-        if is_xai_native_responses
+        if is_codex_private_xai_responses
             && super::providers::transform_codex_responses_namespace::flatten_request_namespaces(
                 &mut request_body,
             )?
@@ -1620,14 +1630,25 @@ impl RequestForwarder {
         // xAI OAuth path, so the prompt-cache prefix stays stable and no other
         // provider is affected. Runs after the flatten above so lifted
         // `namespace` tools survive the tool-type whitelist.
-        if is_xai_native_responses
-            && super::providers::transform_codex_responses_xai_sanitize::sanitize_xai_responses_request(
-                &mut request_body,
-            )
-        {
+        let sanitized_xai_responses = is_xai_native_responses
+            && if client_uses_codex_private_tools {
+                super::providers::transform_codex_responses_xai_sanitize::sanitize_xai_responses_request(
+                    &mut request_body,
+                )
+            } else {
+                super::providers::transform_codex_responses_xai_sanitize::sanitize_standard_xai_responses_request(
+                    &mut request_body,
+                )
+            };
+        if sanitized_xai_responses {
             log::debug!(
-                "[Codex] Sanitized xAI-unsupported Responses fields (provider={})",
-                provider.id
+                "[{}] Sanitized xAI-unsupported Responses fields (provider={})",
+                if client_uses_codex_private_tools {
+                    "Codex"
+                } else {
+                    "Grok Build"
+                },
+                provider.id,
             );
         }
 

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -32,7 +32,8 @@ use super::{
             create_anthropic_sse_stream_from_responses_with_web_search_options,
         },
         transform, transform_codex_anthropic, transform_codex_chat,
-        transform_codex_responses_namespace, transform_gemini, transform_responses,
+        transform_codex_responses_namespace, transform_codex_responses_xai_tool_search,
+        transform_gemini, transform_responses,
     },
     response_processor::{
         create_logged_passthrough_stream, create_usage_collector, process_response,
@@ -879,6 +880,8 @@ async fn handle_responses_for_app(
     // {namespace, name} map used to restore the native Responses upstream's
     // function-call names (see the namespace-restore dispatch below).
     let namespace_restore_map = transform_codex_responses_namespace::namespace_restore_map(&body);
+    let restore_tool_search =
+        transform_codex_responses_xai_tool_search::request_offers_tool_search(&body);
 
     let forwarder = ctx.create_forwarder(&state);
     let mut result = match forwarder
@@ -938,7 +941,7 @@ async fn handle_responses_for_app(
     // them to `{name, namespace}` so the Codex client matches them against its
     // namespaced tool registry.
     if super::providers::provider_needs_responses_namespace_flatten(&ctx.provider)
-        && !namespace_restore_map.is_empty()
+        && (!namespace_restore_map.is_empty() || restore_tool_search)
     {
         return handle_codex_responses_namespace_restore(
             response,
@@ -946,6 +949,7 @@ async fn handle_responses_for_app(
             &state,
             connection_guard,
             namespace_restore_map,
+            restore_tool_search,
         )
         .await;
     }
@@ -1078,6 +1082,8 @@ async fn handle_responses_compact_for_app(
         .unwrap_or(false);
     let codex_tool_context = transform_codex_chat::build_codex_tool_context_from_request(&body);
     let namespace_restore_map = transform_codex_responses_namespace::namespace_restore_map(&body);
+    let restore_tool_search =
+        transform_codex_responses_xai_tool_search::request_offers_tool_search(&body);
 
     let forwarder = ctx.create_forwarder(&state);
     let mut result = match forwarder
@@ -1132,7 +1138,7 @@ async fn handle_responses_compact_for_app(
     }
 
     if super::providers::provider_needs_responses_namespace_flatten(&ctx.provider)
-        && !namespace_restore_map.is_empty()
+        && (!namespace_restore_map.is_empty() || restore_tool_search)
     {
         return handle_codex_responses_namespace_restore(
             response,
@@ -1140,6 +1146,7 @@ async fn handle_responses_compact_for_app(
             &state,
             connection_guard,
             namespace_restore_map,
+            restore_tool_search,
         )
         .await;
     }
@@ -1168,6 +1175,7 @@ async fn handle_codex_responses_namespace_restore(
         String,
         transform_codex_responses_namespace::NamespacedName,
     >,
+    restore_tool_search: bool,
 ) -> Result<axum::response::Response, ProxyError> {
     let status = response.status();
 
@@ -1189,9 +1197,10 @@ async fn handle_codex_responses_namespace_restore(
         }
 
         let restore_stream =
-            transform_codex_responses_namespace::create_namespace_restore_sse_stream(
+            transform_codex_responses_namespace::create_tool_call_restore_sse_stream(
                 response.bytes_stream(),
                 restore_map,
+                restore_tool_search,
             );
         let usage_collector =
             create_usage_collector(ctx, state, status.as_u16(), &CODEX_PARSER_CONFIG);
@@ -1228,9 +1237,10 @@ async fn handle_codex_responses_namespace_restore(
     // this only guards against a malformed upstream).
     let restored_bytes = match serde_json::from_slice::<Value>(&body_bytes) {
         Ok(mut value) => {
-            transform_codex_responses_namespace::restore_response_namespaces(
+            transform_codex_responses_namespace::restore_response_tool_calls(
                 &mut value,
                 &restore_map,
+                restore_tool_search,
             );
             if let Some(usage) =
                 TokenUsage::from_codex_response_auto(&value).filter(TokenUsage::has_billable_tokens)

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -19,7 +19,7 @@ use super::{
     providers::{
         codex_chat_common::extract_reasoning_field_text,
         codex_chat_history::record_responses_sse_stream,
-        get_adapter, get_claude_api_format,
+        codex_tool_bridge, get_adapter, get_claude_api_format,
         streaming::create_anthropic_sse_stream,
         streaming_codex_anthropic::{
             create_responses_sse_stream_from_anthropic_with_context,
@@ -875,13 +875,21 @@ async fn handle_responses_for_app(
         .get("stream")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    let codex_tool_context = transform_codex_chat::build_codex_tool_context_from_request(&body);
+    let client_uses_codex_private_tools =
+        super::providers::client_uses_codex_private_tools(&app_type);
+    // Build eagerly from the original request, but surface bridge-only
+    // collisions only when this provider actually needs a flat-tool adapter.
+    let codex_tool_context = super::providers::responses_tool_context_for_client(&app_type, &body);
     // Captured before `body` is moved into the forwarder: the flat-name →
     // {namespace, name} map used to restore the native Responses upstream's
     // function-call names (see the namespace-restore dispatch below).
-    let namespace_restore_map = transform_codex_responses_namespace::namespace_restore_map(&body);
-    let restore_tool_search =
-        transform_codex_responses_xai_tool_search::request_offers_tool_search(&body);
+    let namespace_restore_map = if client_uses_codex_private_tools {
+        transform_codex_responses_namespace::namespace_restore_map(&body)
+    } else {
+        Default::default()
+    };
+    let restore_tool_search = client_uses_codex_private_tools
+        && transform_codex_responses_xai_tool_search::request_offers_tool_search(&body);
 
     let forwarder = ctx.create_forwarder(&state);
     let mut result = match forwarder
@@ -918,7 +926,7 @@ async fn handle_responses_for_app(
             &state,
             is_stream,
             connection_guard,
-            codex_tool_context,
+            codex_tool_context?,
         )
         .await;
     }
@@ -930,7 +938,7 @@ async fn handle_responses_for_app(
             &state,
             is_stream,
             connection_guard,
-            codex_tool_context,
+            codex_tool_context?,
         )
         .await;
     }
@@ -1080,10 +1088,16 @@ async fn handle_responses_compact_for_app(
         .get("stream")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    let codex_tool_context = transform_codex_chat::build_codex_tool_context_from_request(&body);
-    let namespace_restore_map = transform_codex_responses_namespace::namespace_restore_map(&body);
-    let restore_tool_search =
-        transform_codex_responses_xai_tool_search::request_offers_tool_search(&body);
+    let client_uses_codex_private_tools =
+        super::providers::client_uses_codex_private_tools(&app_type);
+    let codex_tool_context = super::providers::responses_tool_context_for_client(&app_type, &body);
+    let namespace_restore_map = if client_uses_codex_private_tools {
+        transform_codex_responses_namespace::namespace_restore_map(&body)
+    } else {
+        Default::default()
+    };
+    let restore_tool_search = client_uses_codex_private_tools
+        && transform_codex_responses_xai_tool_search::request_offers_tool_search(&body);
 
     let forwarder = ctx.create_forwarder(&state);
     let mut result = match forwarder
@@ -1120,7 +1134,7 @@ async fn handle_responses_compact_for_app(
             &state,
             is_stream,
             connection_guard,
-            codex_tool_context,
+            codex_tool_context?,
         )
         .await;
     }
@@ -1132,7 +1146,7 @@ async fn handle_responses_compact_for_app(
             &state,
             is_stream,
             connection_guard,
-            codex_tool_context,
+            codex_tool_context?,
         )
         .await;
     }
@@ -1318,7 +1332,7 @@ async fn handle_codex_chat_to_responses_transform(
     state: &ProxyState,
     is_stream: bool,
     connection_guard: Option<ActiveConnectionGuard>,
-    tool_context: transform_codex_chat::CodexToolContext,
+    tool_context: codex_tool_bridge::CodexToolContext,
 ) -> Result<axum::response::Response, ProxyError> {
     let status = response.status();
 
@@ -1557,7 +1571,7 @@ async fn handle_codex_anthropic_to_responses_transform(
     state: &ProxyState,
     is_stream: bool,
     connection_guard: Option<ActiveConnectionGuard>,
-    codex_tool_context: transform_codex_chat::CodexToolContext,
+    codex_tool_context: codex_tool_bridge::CodexToolContext,
 ) -> Result<axum::response::Response, ProxyError> {
     let status = response.status();
 

--- a/src-tauri/src/proxy/providers/codex_tool_bridge.rs
+++ b/src-tauri/src/proxy/providers/codex_tool_bridge.rs
@@ -1,0 +1,1004 @@
+//! Shared Codex tool-catalog bridge for upstream protocols that only expose
+//! flat function tools.
+//!
+//! The Codex Responses protocol has richer tool identities (`namespace`,
+//! `custom`, and the private deferred `tool_search` flow). Chat Completions,
+//! Anthropic Messages, and several OAuth-backed gateways expose a flat function
+//! namespace instead. This module owns the lossy boundary in one place:
+//!
+//! - assign stable upstream names and preserve their original Codex identity;
+//! - reserve one private name for the deferred-search shim;
+//! - omit unloaded deferred catalog entries while search is available;
+//! - promote tools returned by `tool_search_output` and `additional_tools`;
+//! - reject ambiguous cross-identity name collisions instead of silently
+//!   selecting whichever declaration happened to appear first.
+
+use std::collections::HashMap;
+
+use serde_json::{json, Value};
+
+use super::codex_chat_common::{
+    attach_optional_reasoning_content_field, response_function_call_item,
+    response_function_call_item_with_namespace,
+};
+use crate::proxy::{
+    error::ProxyError,
+    json_canonical::{canonical_json_string, short_sha256_hex},
+};
+
+pub(crate) const TOOL_SEARCH_NATIVE_TYPE: &str = "tool_search";
+pub(crate) const TOOL_SEARCH_PROXY_NAME: &str = "ccswitch_tool_search";
+pub(crate) const CUSTOM_TOOL_INPUT_FIELD: &str = "input";
+
+const CHAT_TOOL_NAME_MAX_LEN: usize = 64;
+const CUSTOM_TOOL_INPUT_DESCRIPTION: &str = "Raw string input for the original custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description.";
+const CUSTOM_TOOL_PRESERVED_METADATA_HEADING: &str = "Original tool definition:";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CodexToolKind {
+    Function,
+    Namespace,
+    Custom,
+    ToolSearch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CodexToolSpec {
+    pub(crate) kind: CodexToolKind,
+    pub(crate) name: String,
+    pub(crate) namespace: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct CodexToolContext {
+    enable_codex_private_tools: bool,
+    function_tools: Vec<Value>,
+    upstream_name_to_spec: HashMap<String, CodexToolSpec>,
+    upstream_name_to_index: HashMap<String, usize>,
+    namespace_name_to_upstream_name: HashMap<(String, String), String>,
+}
+
+impl CodexToolContext {
+    pub(crate) fn uses_codex_private_tools(&self) -> bool {
+        self.enable_codex_private_tools
+    }
+
+    /// Function-shaped tools ready for Chat Completions or another flat-tool
+    /// adapter. Anthropic renders these into its native tool schema.
+    pub(crate) fn function_tools(&self) -> &[Value] {
+        &self.function_tools
+    }
+
+    pub(crate) fn lookup_upstream_name(&self, upstream_name: &str) -> Option<&CodexToolSpec> {
+        self.upstream_name_to_spec.get(upstream_name)
+    }
+
+    pub(crate) fn is_custom_tool_upstream_name(&self, upstream_name: &str) -> bool {
+        self.lookup_upstream_name(upstream_name)
+            .is_some_and(|spec| matches!(&spec.kind, CodexToolKind::Custom))
+    }
+
+    pub(crate) fn upstream_name_for_response_function(
+        &self,
+        name: &str,
+        namespace: Option<&str>,
+    ) -> String {
+        if let Some(namespace) = namespace
+            .filter(|_| self.enable_codex_private_tools)
+            .filter(|value| !value.is_empty())
+        {
+            if let Some(upstream_name) = self
+                .namespace_name_to_upstream_name
+                .get(&(namespace.to_string(), name.to_string()))
+            {
+                return upstream_name.clone();
+            }
+            return flatten_namespace_tool_name(namespace, name);
+        }
+
+        name.to_string()
+    }
+
+    /// Resolve a forced function choice only when that exact function was
+    /// published to the flat-tool upstream. Historical calls use the looser
+    /// resolver above because they may legitimately reference an older catalog;
+    /// a current tool choice must never point at an omitted deferred tool.
+    pub(crate) fn require_published_response_function(
+        &self,
+        name: &str,
+        namespace: Option<&str>,
+    ) -> Result<String, ProxyError> {
+        let namespace = namespace.filter(|value| !value.is_empty());
+        let upstream_name = self.upstream_name_for_response_function(name, namespace);
+        let matches_identity = self
+            .lookup_upstream_name(&upstream_name)
+            .is_some_and(|spec| {
+                spec.name == name
+                    && spec.namespace.as_deref() == namespace
+                    && matches!(
+                        (&spec.kind, namespace),
+                        (CodexToolKind::Function, None) | (CodexToolKind::Namespace, Some(_))
+                    )
+            });
+        if matches_identity {
+            return Ok(upstream_name);
+        }
+
+        let display_name = namespace
+            .map(|namespace| format!("{namespace}/{name}"))
+            .unwrap_or_else(|| name.to_string());
+        Err(ProxyError::InvalidRequest(format!(
+            "tool_choice selects unavailable function tool {display_name:?}; the tool may still be deferred"
+        )))
+    }
+
+    pub(crate) fn require_published_custom_tool(&self, name: &str) -> Result<String, ProxyError> {
+        if self.lookup_upstream_name(name).is_some_and(|spec| {
+            spec.kind == CodexToolKind::Custom && spec.name == name && spec.namespace.is_none()
+        }) {
+            return Ok(name.to_string());
+        }
+        Err(ProxyError::InvalidRequest(format!(
+            "tool_choice selects unavailable custom tool {name:?}; the tool may still be deferred"
+        )))
+    }
+
+    pub(crate) fn require_published_tool_search(&self) -> Result<String, ProxyError> {
+        if self
+            .lookup_upstream_name(TOOL_SEARCH_PROXY_NAME)
+            .is_some_and(|spec| spec.kind == CodexToolKind::ToolSearch)
+        {
+            return Ok(TOOL_SEARCH_PROXY_NAME.to_string());
+        }
+        Err(ProxyError::InvalidRequest(
+            "tool_choice selects tool_search, but the request does not publish tool_search"
+                .to_string(),
+        ))
+    }
+
+    fn add_function_proxy(
+        &mut self,
+        upstream_name: String,
+        spec: CodexToolSpec,
+        function_tool: Value,
+    ) -> Result<(), ProxyError> {
+        if upstream_name.trim().is_empty() {
+            return Ok(());
+        }
+
+        if let Some(existing) = self.upstream_name_to_spec.get(&upstream_name) {
+            if existing != &spec {
+                return Err(ProxyError::TransformError(format!(
+                    "Codex tools {:?} and {:?} both map to upstream function name {upstream_name:?}",
+                    existing, spec
+                )));
+            }
+
+            // A tool discovered later in the request is authoritative over an
+            // earlier catalog copy with the same identity. This refreshes stale
+            // schemas without changing the stable upstream name or response map.
+            if let Some(index) = self.upstream_name_to_index.get(&upstream_name).copied() {
+                self.function_tools[index] = function_tool;
+            }
+            return Ok(());
+        }
+
+        let index = self.function_tools.len();
+        if let Some(namespace) = spec.namespace.as_ref() {
+            self.namespace_name_to_upstream_name.insert(
+                (namespace.clone(), spec.name.clone()),
+                upstream_name.clone(),
+            );
+        }
+        self.upstream_name_to_index
+            .insert(upstream_name.clone(), index);
+        self.upstream_name_to_spec.insert(upstream_name, spec);
+        self.function_tools.push(function_tool);
+        Ok(())
+    }
+
+    fn add_function_tool(
+        &mut self,
+        tool: &Value,
+        namespace: Option<&str>,
+        loaded: bool,
+        reserve_private_proxy_name: bool,
+    ) -> Result<(), ProxyError> {
+        if !loaded && is_deferred_tool(tool) {
+            return Ok(());
+        }
+        let Some(original_name) = responses_tool_name(tool) else {
+            return Ok(());
+        };
+        if reserve_private_proxy_name
+            && namespace.is_none()
+            && original_name == TOOL_SEARCH_PROXY_NAME
+        {
+            return Err(reserved_proxy_name_error());
+        }
+        let upstream_name = namespace
+            .map(|namespace| flatten_namespace_tool_name(namespace, &original_name))
+            .unwrap_or_else(|| original_name.clone());
+
+        let Some(function_tool) = responses_function_tool_to_chat_tool(tool, &upstream_name) else {
+            return Ok(());
+        };
+        let spec = CodexToolSpec {
+            kind: if namespace.is_some() {
+                CodexToolKind::Namespace
+            } else {
+                CodexToolKind::Function
+            },
+            name: original_name,
+            namespace: namespace.map(ToString::to_string),
+        };
+        self.add_function_proxy(upstream_name, spec, function_tool)
+    }
+
+    fn add_custom_tool(
+        &mut self,
+        tool: &Value,
+        loaded: bool,
+        reserve_private_proxy_name: bool,
+    ) -> Result<(), ProxyError> {
+        if !loaded && is_deferred_tool(tool) {
+            return Ok(());
+        }
+        let Some(name) = responses_tool_name(tool) else {
+            return Ok(());
+        };
+        if reserve_private_proxy_name && name == TOOL_SEARCH_PROXY_NAME {
+            return Err(reserved_proxy_name_error());
+        }
+        let description = json!(responses_custom_tool_description(tool));
+        let function_tool = json!({
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        CUSTOM_TOOL_INPUT_FIELD: {
+                            "type": "string",
+                            "description": CUSTOM_TOOL_INPUT_DESCRIPTION
+                        }
+                    },
+                    "required": [CUSTOM_TOOL_INPUT_FIELD]
+                }
+            }
+        });
+        let spec = CodexToolSpec {
+            kind: CodexToolKind::Custom,
+            name: name.clone(),
+            namespace: None,
+        };
+        self.add_function_proxy(name, spec, function_tool)
+    }
+
+    fn add_tool_search_tool(&mut self) -> Result<(), ProxyError> {
+        let function_tool = json!({
+            "type": "function",
+            "function": {
+                "name": TOOL_SEARCH_PROXY_NAME,
+                "description": "Search and load Codex tools, plugins, connectors, and MCP namespaces for the current task.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Search query for tools or connectors to load."
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum number of tool groups to return."
+                        }
+                    },
+                    "required": ["query"]
+                }
+            }
+        });
+        let spec = CodexToolSpec {
+            kind: CodexToolKind::ToolSearch,
+            name: TOOL_SEARCH_PROXY_NAME.to_string(),
+            namespace: None,
+        };
+        self.add_function_proxy(TOOL_SEARCH_PROXY_NAME.to_string(), spec, function_tool)
+    }
+
+    fn add_namespace_tool(&mut self, tool: &Value, loaded: bool) -> Result<(), ProxyError> {
+        if !loaded && is_deferred_tool(tool) {
+            return Ok(());
+        }
+        let Some(namespace) = tool
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(());
+        };
+        let Some(children) = tool
+            .get("tools")
+            .or_else(|| tool.get("children"))
+            .and_then(Value::as_array)
+        else {
+            return Ok(());
+        };
+
+        for child in children {
+            if child.get("type").and_then(Value::as_str) == Some("function") {
+                self.add_function_tool(child, Some(namespace), loaded, true)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn add_response_tool(
+        &mut self,
+        tool: &Value,
+        loaded: bool,
+        enable_codex_private_tools: bool,
+    ) -> Result<(), ProxyError> {
+        match tool {
+            Value::String(name) => self.add_custom_tool(
+                &json!({
+                    "type": "custom",
+                    "name": name
+                }),
+                loaded,
+                enable_codex_private_tools,
+            ),
+            Value::Object(_) => match tool.get("type").and_then(Value::as_str) {
+                Some("function") => {
+                    self.add_function_tool(tool, None, loaded, enable_codex_private_tools)
+                }
+                Some("custom") => self.add_custom_tool(tool, loaded, enable_codex_private_tools),
+                Some(TOOL_SEARCH_NATIVE_TYPE) if enable_codex_private_tools => {
+                    self.add_tool_search_tool()
+                }
+                Some("namespace") if enable_codex_private_tools => {
+                    self.add_namespace_tool(tool, loaded)
+                }
+                _ => Ok(()),
+            },
+            _ => Ok(()),
+        }
+    }
+}
+
+pub(crate) fn build_codex_tool_context_from_request(
+    body: &Value,
+) -> Result<CodexToolContext, ProxyError> {
+    build_tool_context_from_request(body, true)
+}
+
+/// Build a flat tool catalog for a standard Responses client without enabling
+/// Codex's private `tool_search`, `namespace`, deferred-loading, or
+/// `additional_tools` semantics.
+pub(crate) fn build_standard_responses_tool_context_from_request(
+    body: &Value,
+) -> Result<CodexToolContext, ProxyError> {
+    build_tool_context_from_request(body, false)
+}
+
+fn build_tool_context_from_request(
+    body: &Value,
+    enable_codex_private_tools: bool,
+) -> Result<CodexToolContext, ProxyError> {
+    let offers_tool_search = enable_codex_private_tools && request_offers_tool_search(body);
+    let mut context = CodexToolContext {
+        enable_codex_private_tools,
+        ..Default::default()
+    };
+
+    if let Some(tools) = body.get("tools").and_then(Value::as_array) {
+        for tool in tools {
+            // Without the private search shim there is no loading phase, so
+            // preserve legacy behavior and expose the complete catalog.
+            context.add_response_tool(tool, !offers_tool_search, enable_codex_private_tools)?;
+        }
+    }
+
+    if enable_codex_private_tools {
+        match body.get("input") {
+            Some(Value::Array(items)) => {
+                for item in items {
+                    add_direct_tool_carrier(item, &mut context)?;
+                }
+            }
+            Some(Value::Object(_)) => {
+                add_direct_tool_carrier(&body["input"], &mut context)?;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(context)
+}
+
+fn add_direct_tool_carrier(item: &Value, context: &mut CodexToolContext) -> Result<(), ProxyError> {
+    if !matches!(
+        item.get("type").and_then(Value::as_str),
+        Some("tool_search_output" | "additional_tools")
+    ) {
+        return Ok(());
+    }
+    if let Some(tools) = item.get("tools").and_then(Value::as_array) {
+        for tool in tools {
+            context.add_response_tool(tool, true, true)?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn request_offers_tool_search(body: &Value) -> bool {
+    body.get("tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| {
+            tools.iter().any(|tool| {
+                tool.get("type").and_then(Value::as_str) == Some(TOOL_SEARCH_NATIVE_TYPE)
+            })
+        })
+}
+
+pub(crate) fn flatten_namespace_tool_name(namespace: &str, name: &str) -> String {
+    let full_name = format!("{namespace}__{name}");
+    if full_name.len() <= CHAT_TOOL_NAME_MAX_LEN {
+        return full_name;
+    }
+
+    let hash = short_sha256_hex(full_name.as_bytes());
+    let suffix = format!("__{hash}");
+    let prefix_len = CHAT_TOOL_NAME_MAX_LEN.saturating_sub(suffix.len());
+    let mut prefix = String::new();
+    for ch in full_name.chars() {
+        if prefix.len() + ch.len_utf8() > prefix_len {
+            break;
+        }
+        prefix.push(ch);
+    }
+    format!("{prefix}{suffix}")
+}
+
+fn reserved_proxy_name_error() -> ProxyError {
+    ProxyError::TransformError(format!(
+        "function name {TOOL_SEARCH_PROXY_NAME} is reserved for the Codex tool_search proxy shim"
+    ))
+}
+
+fn is_deferred_tool(tool: &Value) -> bool {
+    tool.get("defer_loading")
+        .or_else(|| tool.get("deferLoading"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn responses_tool_name(tool: &Value) -> Option<String> {
+    tool.get("function")
+        .and_then(|function| function.get("name"))
+        .or_else(|| tool.get("name"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn responses_custom_tool_description(tool: &Value) -> String {
+    let mut description = String::new();
+    description.push_str(CUSTOM_TOOL_PRESERVED_METADATA_HEADING);
+    description.push_str("\n```json\n");
+    description.push_str(&canonical_json_string(tool));
+    description.push_str("\n```");
+    description
+}
+
+fn normalize_function_parameters(params: Option<&Value>) -> Value {
+    let mut params = match params {
+        Some(Value::Object(obj)) => Value::Object(obj.clone()),
+        _ => json!({"type": "object", "properties": {}}),
+    };
+    if let Some(obj) = params.as_object_mut() {
+        if obj.get("type").and_then(Value::as_str) != Some("object") {
+            obj.insert("type".to_string(), json!("object"));
+        }
+    }
+    params
+}
+
+fn responses_function_tool_to_chat_tool(tool: &Value, upstream_name: &str) -> Option<Value> {
+    if tool.get("type").and_then(Value::as_str) != Some("function") {
+        return None;
+    }
+
+    if let Some(function) = tool.get("function") {
+        let mut function_tool = json!({
+            "type": "function",
+            "function": function.clone()
+        });
+        if let Some(obj) = function_tool
+            .get_mut("function")
+            .and_then(Value::as_object_mut)
+        {
+            let parameters = normalize_function_parameters(obj.get("parameters"));
+            obj.insert("parameters".to_string(), parameters);
+            obj.insert("name".to_string(), json!(upstream_name));
+            if let Some(strict) = tool.get("strict").cloned() {
+                obj.entry("strict".to_string()).or_insert(strict);
+            }
+        }
+        return Some(function_tool);
+    }
+
+    let mut function = json!({
+        "name": upstream_name,
+        "description": tool.get("description").cloned().unwrap_or(Value::Null),
+        "parameters": normalize_function_parameters(tool.get("parameters"))
+    });
+    if let Some(strict) = tool.get("strict") {
+        function["strict"] = strict.clone();
+    }
+
+    Some(json!({
+        "type": "function",
+        "function": function
+    }))
+}
+
+pub(crate) fn response_tool_call_item_id_from_upstream_name(
+    call_id: &str,
+    upstream_name: &str,
+    context: &CodexToolContext,
+) -> String {
+    if context.is_custom_tool_upstream_name(upstream_name) {
+        format!("ctc_{call_id}")
+    } else {
+        format!("fc_{call_id}")
+    }
+}
+
+pub(crate) fn response_tool_call_item_from_upstream_name(
+    item_id: &str,
+    status: &str,
+    call_id: &str,
+    upstream_name: &str,
+    arguments: &str,
+    reasoning: Option<&str>,
+    context: &CodexToolContext,
+) -> Value {
+    match context.lookup_upstream_name(upstream_name) {
+        Some(spec) if spec.kind == CodexToolKind::ToolSearch => {
+            response_tool_search_call_item(call_id, status, arguments, reasoning)
+        }
+        Some(spec) if spec.kind == CodexToolKind::Custom => response_custom_tool_call_item(
+            item_id, status, call_id, &spec.name, arguments, reasoning,
+        ),
+        Some(spec) => response_function_call_item_with_namespace(
+            item_id,
+            status,
+            call_id,
+            &spec.name,
+            spec.namespace.as_deref(),
+            arguments,
+            reasoning,
+        ),
+        None => response_function_call_item(
+            item_id,
+            status,
+            call_id,
+            upstream_name,
+            arguments,
+            reasoning,
+        ),
+    }
+}
+
+fn response_tool_search_call_item(
+    call_id: &str,
+    status: &str,
+    arguments: &str,
+    reasoning: Option<&str>,
+) -> Value {
+    let parsed_arguments = parse_tool_arguments_object(arguments);
+    let mut item = json!({
+        "type": "tool_search_call",
+        "call_id": call_id,
+        "status": status,
+        "execution": "client",
+        "arguments": parsed_arguments
+    });
+    attach_optional_reasoning_content_field(&mut item, reasoning);
+    item
+}
+
+fn response_custom_tool_call_item(
+    item_id: &str,
+    status: &str,
+    call_id: &str,
+    name: &str,
+    arguments: &str,
+    reasoning: Option<&str>,
+) -> Value {
+    let input = custom_tool_input_from_upstream_arguments(arguments);
+    let mut item = json!({
+        "id": item_id,
+        "type": "custom_tool_call",
+        "status": status,
+        "call_id": call_id,
+        "name": name,
+        "input": input
+    });
+    attach_optional_reasoning_content_field(&mut item, reasoning);
+    item
+}
+
+fn parse_tool_arguments_object(arguments: &str) -> Value {
+    if arguments.trim().is_empty() {
+        return json!({});
+    }
+    serde_json::from_str::<Value>(arguments)
+        .ok()
+        .filter(Value::is_object)
+        .unwrap_or_else(|| json!({ "query": arguments }))
+}
+
+pub(crate) fn custom_tool_input_from_upstream_arguments(arguments: &str) -> String {
+    if arguments.trim().is_empty() {
+        return String::new();
+    }
+    match serde_json::from_str::<Value>(arguments) {
+        Ok(Value::Object(obj)) => obj
+            .get(CUSTOM_TOOL_INPUT_FIELD)
+            .and_then(Value::as_str)
+            .unwrap_or(arguments)
+            .to_string(),
+        _ => arguments.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn upstream_names(context: &CodexToolContext) -> Vec<&str> {
+        context
+            .function_tools()
+            .iter()
+            .filter_map(|tool| tool["function"]["name"].as_str())
+            .collect()
+    }
+
+    #[test]
+    fn ordinary_tool_search_coexists_with_private_search_shim() {
+        let body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {"type": "function", "name": "tool_search", "parameters": {}}
+            ]
+        });
+
+        let context = build_codex_tool_context_from_request(&body).unwrap();
+        assert_eq!(
+            upstream_names(&context),
+            vec![TOOL_SEARCH_PROXY_NAME, TOOL_SEARCH_NATIVE_TYPE]
+        );
+        assert_eq!(
+            context
+                .lookup_upstream_name(TOOL_SEARCH_PROXY_NAME)
+                .unwrap()
+                .kind,
+            CodexToolKind::ToolSearch
+        );
+        assert_eq!(
+            context
+                .lookup_upstream_name(TOOL_SEARCH_NATIVE_TYPE)
+                .unwrap()
+                .kind,
+            CodexToolKind::Function
+        );
+    }
+
+    #[test]
+    fn proxy_name_is_reserved_for_top_level_functions() {
+        let body = json!({
+            "tools": [{"type": "function", "name": TOOL_SEARCH_PROXY_NAME, "parameters": {}}]
+        });
+        assert!(build_codex_tool_context_from_request(&body).is_err());
+    }
+
+    #[test]
+    fn forced_choice_requires_the_exact_tool_to_be_published() {
+        let context = build_codex_tool_context_from_request(&json!({
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "function",
+                    "name": "deferred_function",
+                    "defer_loading": true,
+                    "parameters": {}
+                },
+                {"type": "custom", "name": "deferred_custom", "defer_loading": true},
+                {"type": "custom", "name": "ready_custom"}
+            ]
+        }))
+        .unwrap();
+
+        assert!(context
+            .require_published_response_function("deferred_function", None)
+            .is_err());
+        assert!(context
+            .require_published_custom_tool("deferred_custom")
+            .is_err());
+        assert_eq!(
+            context
+                .require_published_custom_tool("ready_custom")
+                .unwrap(),
+            "ready_custom"
+        );
+        assert_eq!(
+            context.require_published_tool_search().unwrap(),
+            TOOL_SEARCH_PROXY_NAME
+        );
+    }
+
+    #[test]
+    fn function_and_custom_name_collision_is_rejected_in_both_orders() {
+        for tools in [
+            json!([
+                {"type": "function", "name": "same", "parameters": {}},
+                {"type": "custom", "name": "same"}
+            ]),
+            json!([
+                {"type": "custom", "name": "same"},
+                {"type": "function", "name": "same", "parameters": {}}
+            ]),
+        ] {
+            assert!(build_codex_tool_context_from_request(&json!({"tools": tools})).is_err());
+        }
+    }
+
+    #[test]
+    fn namespace_and_top_level_flat_name_collision_is_rejected() {
+        let body = json!({
+            "tools": [
+                {"type": "function", "name": "mcp__mail____search", "parameters": {}},
+                {
+                    "type": "namespace",
+                    "name": "mcp__mail__",
+                    "tools": [{"type": "function", "name": "search", "parameters": {}}]
+                }
+            ]
+        });
+        assert!(build_codex_tool_context_from_request(&body).is_err());
+    }
+
+    #[test]
+    fn deferred_catalog_is_omitted_until_loaded() {
+        let body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "namespace",
+                    "name": "mcp__mail__",
+                    "defer_loading": true,
+                    "tools": [{
+                        "type": "function",
+                        "name": "search",
+                        "defer_loading": true,
+                        "parameters": {"type": "object", "properties": {"stale": {"type": "string"}}}
+                    }]
+                }
+            ],
+            "input": [{
+                "type": "tool_search_output",
+                "tools": [{
+                    "type": "namespace",
+                    "name": "mcp__mail__",
+                    "defer_loading": true,
+                    "tools": [{
+                        "type": "function",
+                        "name": "search",
+                        "defer_loading": true,
+                        "parameters": {"type": "object", "properties": {"query": {"type": "string"}}}
+                    }]
+                }]
+            }]
+        });
+
+        let context = build_codex_tool_context_from_request(&body).unwrap();
+        assert_eq!(
+            upstream_names(&context),
+            vec![TOOL_SEARCH_PROXY_NAME, "mcp__mail____search"]
+        );
+        assert_eq!(
+            context.function_tools()[1]["function"]["parameters"]["properties"]["query"]["type"],
+            "string"
+        );
+        assert!(
+            context.function_tools()[1]["function"]["parameters"]["properties"]
+                .get("stale")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn additional_tools_are_loaded() {
+        let body = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": [{
+                "type": "additional_tools",
+                "tools": [{"type": "function", "name": "loaded", "parameters": {}}]
+            }]
+        });
+        let context = build_codex_tool_context_from_request(&body).unwrap();
+        assert_eq!(
+            upstream_names(&context),
+            vec![TOOL_SEARCH_PROXY_NAME, "loaded"]
+        );
+    }
+
+    #[test]
+    fn single_input_tool_carrier_is_loaded() {
+        let body = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": {
+                "type": "tool_search_output",
+                "tools": [{"type": "function", "name": "loaded", "parameters": {}}]
+            }
+        });
+        let context = build_codex_tool_context_from_request(&body).unwrap();
+        assert_eq!(
+            upstream_names(&context),
+            vec![TOOL_SEARCH_PROXY_NAME, "loaded"]
+        );
+    }
+
+    #[test]
+    fn discovered_copy_replaces_stale_catalog_schema() {
+        let body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "function",
+                    "name": "lookup",
+                    "parameters": {"type": "object", "properties": {"stale": {"type": "string"}}}
+                }
+            ],
+            "input": [{
+                "type": "additional_tools",
+                "tools": [{
+                    "type": "function",
+                    "name": "lookup",
+                    "parameters": {"type": "object", "properties": {"query": {"type": "string"}}}
+                }]
+            }]
+        });
+        let context = build_codex_tool_context_from_request(&body).unwrap();
+        let lookup = &context.function_tools()[1]["function"]["parameters"]["properties"];
+        assert_eq!(lookup["query"]["type"], "string");
+        assert!(lookup.get("stale").is_none());
+    }
+
+    #[test]
+    fn nested_business_json_is_not_scanned_for_tool_carriers() {
+        let body = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": [{
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "metadata": {
+                        "type": "additional_tools",
+                        "tools": [{"type": "function", "name": "not_a_real_tool"}]
+                    }
+                }]
+            }]
+        });
+        let context = build_codex_tool_context_from_request(&body).unwrap();
+        assert_eq!(upstream_names(&context), vec![TOOL_SEARCH_PROXY_NAME]);
+    }
+
+    #[test]
+    fn response_identity_restores_only_the_proxy_search_name() {
+        let body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {"type": "function", "name": "tool_search", "parameters": {}}
+            ]
+        });
+        let context = build_codex_tool_context_from_request(&body).unwrap();
+
+        let proxy = response_tool_call_item_from_upstream_name(
+            "fc_proxy",
+            "completed",
+            "call_proxy",
+            TOOL_SEARCH_PROXY_NAME,
+            "{\"query\":\"mail\"}",
+            None,
+            &context,
+        );
+        assert_eq!(proxy["type"], "tool_search_call");
+        assert_eq!(proxy["arguments"]["query"], "mail");
+
+        let native = response_tool_call_item_from_upstream_name(
+            "fc_native",
+            "completed",
+            "call_native",
+            TOOL_SEARCH_NATIVE_TYPE,
+            "{}",
+            None,
+            &context,
+        );
+        assert_eq!(native["type"], "function_call");
+        assert_eq!(native["name"], TOOL_SEARCH_NATIVE_TYPE);
+    }
+
+    #[test]
+    fn namespaced_child_may_use_proxy_bare_name() {
+        let body = json!({
+            "tools": [{
+                "type": "namespace",
+                "name": "mcp__tools__",
+                "tools": [{
+                    "type": "function",
+                    "name": TOOL_SEARCH_PROXY_NAME,
+                    "parameters": {}
+                }]
+            }]
+        });
+        let context = build_codex_tool_context_from_request(&body).unwrap();
+        assert_eq!(
+            upstream_names(&context),
+            vec!["mcp__tools____ccswitch_tool_search"]
+        );
+    }
+
+    #[test]
+    fn standard_responses_context_does_not_enable_codex_private_tools() {
+        let body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "namespace",
+                    "name": "mcp__private__",
+                    "tools": [{"type": "function", "name": "hidden", "parameters": {}}]
+                },
+                {
+                    "type": "function",
+                    "name": "deferred_but_standard",
+                    "defer_loading": true,
+                    "parameters": {}
+                },
+                {
+                    "type": "function",
+                    "name": TOOL_SEARCH_PROXY_NAME,
+                    "parameters": {}
+                }
+            ],
+            "input": [{
+                "type": "additional_tools",
+                "tools": [{"type": "function", "name": "private_loaded", "parameters": {}}]
+            }]
+        });
+
+        let context = build_standard_responses_tool_context_from_request(&body).unwrap();
+        assert!(!context.uses_codex_private_tools());
+        assert_eq!(
+            upstream_names(&context),
+            vec!["deferred_but_standard", TOOL_SEARCH_PROXY_NAME]
+        );
+
+        let restored = response_tool_call_item_from_upstream_name(
+            "fc_standard",
+            "completed",
+            "call_standard",
+            TOOL_SEARCH_PROXY_NAME,
+            "{}",
+            None,
+            &context,
+        );
+        assert_eq!(restored["type"], "function_call");
+        assert_eq!(restored["name"], TOOL_SEARCH_PROXY_NAME);
+    }
+}

--- a/src-tauri/src/proxy/providers/codex_tool_bridge.rs
+++ b/src-tauri/src/proxy/providers/codex_tool_bridge.rs
@@ -339,6 +339,7 @@ impl CodexToolContext {
         tool: &Value,
         loaded: bool,
         enable_codex_private_tools: bool,
+        reserve_private_proxy_name: bool,
     ) -> Result<(), ProxyError> {
         match tool {
             Value::String(name) => self.add_custom_tool(
@@ -347,13 +348,13 @@ impl CodexToolContext {
                     "name": name
                 }),
                 loaded,
-                enable_codex_private_tools,
+                reserve_private_proxy_name,
             ),
             Value::Object(_) => match tool.get("type").and_then(Value::as_str) {
                 Some("function") => {
-                    self.add_function_tool(tool, None, loaded, enable_codex_private_tools)
+                    self.add_function_tool(tool, None, loaded, reserve_private_proxy_name)
                 }
-                Some("custom") => self.add_custom_tool(tool, loaded, enable_codex_private_tools),
+                Some("custom") => self.add_custom_tool(tool, loaded, reserve_private_proxy_name),
                 Some(TOOL_SEARCH_NATIVE_TYPE) if enable_codex_private_tools => {
                     self.add_tool_search_tool()
                 }
@@ -396,7 +397,12 @@ fn build_tool_context_from_request(
         for tool in tools {
             // Without the private search shim there is no loading phase, so
             // preserve legacy behavior and expose the complete catalog.
-            context.add_response_tool(tool, !offers_tool_search, enable_codex_private_tools)?;
+            context.add_response_tool(
+                tool,
+                !offers_tool_search,
+                enable_codex_private_tools,
+                offers_tool_search,
+            )?;
         }
     }
 
@@ -404,11 +410,11 @@ fn build_tool_context_from_request(
         match body.get("input") {
             Some(Value::Array(items)) => {
                 for item in items {
-                    add_direct_tool_carrier(item, &mut context)?;
+                    add_direct_tool_carrier(item, &mut context, offers_tool_search)?;
                 }
             }
             Some(Value::Object(_)) => {
-                add_direct_tool_carrier(&body["input"], &mut context)?;
+                add_direct_tool_carrier(&body["input"], &mut context, offers_tool_search)?;
             }
             _ => {}
         }
@@ -417,7 +423,11 @@ fn build_tool_context_from_request(
     Ok(context)
 }
 
-fn add_direct_tool_carrier(item: &Value, context: &mut CodexToolContext) -> Result<(), ProxyError> {
+fn add_direct_tool_carrier(
+    item: &Value,
+    context: &mut CodexToolContext,
+    reserve_private_proxy_name: bool,
+) -> Result<(), ProxyError> {
     if !matches!(
         item.get("type").and_then(Value::as_str),
         Some("tool_search_output" | "additional_tools")
@@ -426,7 +436,7 @@ fn add_direct_tool_carrier(item: &Value, context: &mut CodexToolContext) -> Resu
     }
     if let Some(tools) = item.get("tools").and_then(Value::as_array) {
         for tool in tools {
-            context.add_response_tool(tool, true, true)?;
+            context.add_response_tool(tool, true, true, reserve_private_proxy_name)?;
         }
     }
     Ok(())
@@ -699,11 +709,30 @@ mod tests {
     }
 
     #[test]
-    fn proxy_name_is_reserved_for_top_level_functions() {
+    fn proxy_name_is_reserved_when_private_search_shim_is_published() {
+        let body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {"type": "function", "name": TOOL_SEARCH_PROXY_NAME, "parameters": {}}
+            ]
+        });
+        assert!(build_codex_tool_context_from_request(&body).is_err());
+    }
+
+    #[test]
+    fn proxy_name_is_available_without_private_search_shim() {
         let body = json!({
             "tools": [{"type": "function", "name": TOOL_SEARCH_PROXY_NAME, "parameters": {}}]
         });
-        assert!(build_codex_tool_context_from_request(&body).is_err());
+        let context = build_codex_tool_context_from_request(&body).unwrap();
+        assert_eq!(upstream_names(&context), vec![TOOL_SEARCH_PROXY_NAME]);
+        assert_eq!(
+            context
+                .lookup_upstream_name(TOOL_SEARCH_PROXY_NAME)
+                .unwrap()
+                .kind,
+            CodexToolKind::Function
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -36,6 +36,7 @@ pub mod transform_codex_anthropic;
 pub mod transform_codex_chat;
 pub mod transform_codex_responses_namespace;
 pub mod transform_codex_responses_xai_sanitize;
+pub mod transform_codex_responses_xai_tool_search;
 pub mod transform_gemini;
 pub mod transform_responses;
 pub mod xai_oauth_auth;

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod codex_chat_common;
 pub mod codex_chat_history;
 pub mod codex_oauth_auth;
 pub(crate) mod codex_responses_sse;
+pub(crate) mod codex_tool_bridge;
 pub mod copilot_auth;
 pub mod copilot_model_map;
 mod gemini;
@@ -47,6 +48,24 @@ use serde::{Deserialize, Serialize};
 
 pub const CHATGPT_CODEX_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 pub const XAI_API_BASE_URL: &str = "https://api.x.ai/v1";
+
+/// Only the Codex client speaks the private deferred-tool dialect. Grok Build
+/// also uses the Responses wire format, but its requests are standard Responses
+/// requests and must not inherit Codex-only `tool_search`/`namespace` handling.
+pub(crate) fn client_uses_codex_private_tools(app_type: &AppType) -> bool {
+    matches!(app_type, AppType::Codex)
+}
+
+pub(crate) fn responses_tool_context_for_client(
+    app_type: &AppType,
+    body: &serde_json::Value,
+) -> Result<codex_tool_bridge::CodexToolContext, crate::proxy::error::ProxyError> {
+    if client_uses_codex_private_tools(app_type) {
+        codex_tool_bridge::build_codex_tool_context_from_request(body)
+    } else {
+        codex_tool_bridge::build_standard_responses_tool_context_from_request(body)
+    }
+}
 
 // 公开导出
 pub use adapter::ProviderAdapter;
@@ -315,6 +334,20 @@ mod tests {
         assert!(!ProviderType::GeminiCli.needs_transform());
         assert!(!ProviderType::OpenRouter.needs_transform());
         assert!(ProviderType::GitHubCopilot.needs_transform());
+    }
+
+    #[test]
+    fn codex_private_tools_are_not_enabled_for_other_responses_clients() {
+        assert!(client_uses_codex_private_tools(&AppType::Codex));
+        assert!(!client_uses_codex_private_tools(&AppType::GrokBuild));
+        assert!(!client_uses_codex_private_tools(&AppType::OpenCode));
+
+        let request = json!({"tools": [{"type": "tool_search"}]});
+        let codex_context = responses_tool_context_for_client(&AppType::Codex, &request).unwrap();
+        let grok_context =
+            responses_tool_context_for_client(&AppType::GrokBuild, &request).unwrap();
+        assert_eq!(codex_context.function_tools().len(), 1);
+        assert!(grok_context.function_tools().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/streaming_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_anthropic.rs
@@ -7,6 +7,10 @@
 //! this set of events.
 
 use super::codex_responses_sse as sse;
+use super::codex_tool_bridge::{
+    response_tool_call_item_from_upstream_name, response_tool_call_item_id_from_upstream_name,
+    CodexToolContext,
+};
 use super::transform_codex_anthropic::{
     build_responses_usage_from_anthropic, map_anthropic_stop_reason_to_status,
     responses_reasoning_item_from_anthropic_block,
@@ -14,10 +18,6 @@ use super::transform_codex_anthropic::{
 #[cfg(test)]
 use super::transform_codex_anthropic::{
     decode_anthropic_thinking_block, ANTHROPIC_THINKING_ENCRYPTED_PREFIX,
-};
-use super::transform_codex_chat::{
-    response_tool_call_item_from_chat_name, response_tool_call_item_id_from_chat_name,
-    CodexToolContext,
 };
 use super::transform_responses::sanitize_anthropic_tool_use_input_json;
 use crate::proxy::json_canonical::canonicalize_tool_arguments_str;
@@ -210,9 +210,12 @@ impl AnthropicToResponsesState {
                     .filter(|v| v.as_object().map(|o| !o.is_empty()).unwrap_or(false))
                     .map(|v| v.to_string())
                     .unwrap_or_default();
-                let item_id =
-                    response_tool_call_item_id_from_chat_name(call_id, name, &self.tool_context);
-                let item = response_tool_call_item_from_chat_name(
+                let item_id = response_tool_call_item_id_from_upstream_name(
+                    call_id,
+                    name,
+                    &self.tool_context,
+                );
+                let item = response_tool_call_item_from_upstream_name(
                     &item_id,
                     "in_progress",
                     call_id,
@@ -298,7 +301,9 @@ impl AnthropicToResponsesState {
                     .unwrap_or("");
                 block.accum.push_str(partial);
                 // The Read tool needs to be sanitized at close time, to avoid emitting pages:"" deltas mid-stream
-                if block.name == "Read" || self.tool_context.is_custom_tool_chat_name(&block.name) {
+                if block.name == "Read"
+                    || self.tool_context.is_custom_tool_upstream_name(&block.name)
+                {
                     return Vec::new();
                 }
                 vec![sse::function_call_arguments_delta(
@@ -373,8 +378,8 @@ impl AnthropicToResponsesState {
                 } else {
                     canonicalize_tool_arguments_str(&raw_input)
                 };
-                let is_custom_tool = self.tool_context.is_custom_tool_chat_name(&name);
-                let item = response_tool_call_item_from_chat_name(
+                let is_custom_tool = self.tool_context.is_custom_tool_upstream_name(&name);
+                let item = response_tool_call_item_from_upstream_name(
                     &item_id,
                     if self.stream_truncated {
                         "incomplete"
@@ -1149,7 +1154,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_namespace_tool_stream_restores_namespace() {
-        let context = super::super::transform_codex_chat::build_codex_tool_context_from_request(
+        let context = super::super::codex_tool_bridge::build_codex_tool_context_from_request(
             &json!({
                 "tools": [{
                     "type": "namespace",
@@ -1157,7 +1162,8 @@ mod tests {
                     "tools": [{"type": "function", "name": "read", "parameters": {"type": "object"}}]
                 }]
             }),
-        );
+        )
+        .unwrap();
         let input = concat!(
             "event: message_start\n",
             "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_ns\",\"model\":\"claude\"}}\n\n",

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -5,11 +5,12 @@ use super::{
     codex_chat_common::{
         extract_reasoning_field_text, split_leading_think_block, strip_leading_think_open_tag,
     },
+    codex_tool_bridge::{
+        custom_tool_input_from_upstream_arguments, response_tool_call_item_from_upstream_name,
+        response_tool_call_item_id_from_upstream_name, CodexToolContext,
+    },
     transform_codex_chat::{
-        chat_usage_to_responses_usage, custom_tool_input_from_chat_arguments,
-        response_id_from_chat_id, response_status_from_finish_reason,
-        response_tool_call_item_from_chat_name, response_tool_call_item_id_from_chat_name,
-        CodexToolContext,
+        chat_usage_to_responses_usage, response_id_from_chat_id, response_status_from_finish_reason,
     },
 };
 use crate::proxy::json_canonical::canonicalize_tool_arguments_str;
@@ -420,7 +421,9 @@ impl ChatToResponsesState {
             current_name = state.name.clone();
         }
 
-        let is_custom_tool = self.tool_context.is_custom_tool_chat_name(&current_name);
+        let is_custom_tool = self
+            .tool_context
+            .is_custom_tool_upstream_name(&current_name);
         let mut events = Vec::new();
 
         if !args_delta.is_empty() && !is_custom_tool {
@@ -460,13 +463,13 @@ impl ChatToResponsesState {
             };
             state.added = true;
             state.output_index = Some(assigned);
-            state.item_id = response_tool_call_item_id_from_chat_name(
+            state.item_id = response_tool_call_item_id_from_upstream_name(
                 &state.call_id,
                 &state.name,
                 &self.tool_context,
             );
 
-            let item = response_tool_call_item_from_chat_name(
+            let item = response_tool_call_item_from_upstream_name(
                 &state.item_id,
                 "in_progress",
                 &state.call_id,
@@ -479,7 +482,7 @@ impl ChatToResponsesState {
             events.push(sse::output_item_added(assigned, &item));
 
             if !state.arguments.is_empty()
-                && !self.tool_context.is_custom_tool_chat_name(&state.name)
+                && !self.tool_context.is_custom_tool_upstream_name(&state.name)
             {
                 events.push(sse::function_call_arguments_delta(
                     assigned,
@@ -661,12 +664,12 @@ impl ChatToResponsesState {
                     state.call_id = format!("call_{key}");
                 }
                 state.output_index = Some(assigned);
-                state.item_id = response_tool_call_item_id_from_chat_name(
+                state.item_id = response_tool_call_item_id_from_upstream_name(
                     &state.call_id,
                     &state.name,
                     &self.tool_context,
                 );
-                let item = response_tool_call_item_from_chat_name(
+                let item = response_tool_call_item_from_upstream_name(
                     &state.item_id,
                     "in_progress",
                     &state.call_id,
@@ -687,8 +690,8 @@ impl ChatToResponsesState {
             };
             let output_index = state.output_index.unwrap_or(0);
             let arguments = canonicalize_tool_arguments_str(&state.arguments);
-            let is_custom_tool = self.tool_context.is_custom_tool_chat_name(&state.name);
-            let item = response_tool_call_item_from_chat_name(
+            let is_custom_tool = self.tool_context.is_custom_tool_upstream_name(&state.name);
+            let item = response_tool_call_item_from_upstream_name(
                 &state.item_id,
                 "completed",
                 &state.call_id,
@@ -701,7 +704,7 @@ impl ChatToResponsesState {
             self.output_items.push((output_index, item.clone()));
 
             if is_custom_tool {
-                let input = custom_tool_input_from_chat_arguments(&arguments);
+                let input = custom_tool_input_from_upstream_arguments(&arguments);
                 if !input.is_empty() {
                     events.push(sse::custom_tool_call_input_delta(
                         output_index,
@@ -1297,7 +1300,8 @@ mod tests {
             "tools": [{ "type": "custom", "name": "exec" }]
         });
         let context =
-            super::super::transform_codex_chat::build_codex_tool_context_from_request(&request);
+            super::super::codex_tool_bridge::build_codex_tool_context_from_request(&request)
+                .unwrap();
         let output = collect_with_context(
             vec![
                 "data: {\"id\":\"chatcmpl_custom\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_custom\",\"type\":\"function\",\"function\":{\"name\":\"exec\"}}]}}]}\n\n",
@@ -1383,7 +1387,8 @@ mod tests {
             }]
         });
         let context =
-            super::super::transform_codex_chat::build_codex_tool_context_from_request(&request);
+            super::super::codex_tool_bridge::build_codex_tool_context_from_request(&request)
+                .unwrap();
         let output = collect_with_context(
             vec![
                 "data: {\"id\":\"chatcmpl_gmail\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_gmail\",\"type\":\"function\",\"function\":{\"name\":\"mcp__codex_apps__gmail___search_emails\"}}]}}]}\n\n",
@@ -1408,10 +1413,11 @@ mod tests {
             "input": "Search for Gmail tools."
         });
         let context =
-            super::super::transform_codex_chat::build_codex_tool_context_from_request(&request);
+            super::super::codex_tool_bridge::build_codex_tool_context_from_request(&request)
+                .unwrap();
         let output = collect_with_context(
             vec![
-                "data: {\"id\":\"chatcmpl_tool_search\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_tool_search_1\",\"type\":\"function\",\"function\":{\"name\":\"tool_search\"}}]}}]}\n\n",
+                "data: {\"id\":\"chatcmpl_tool_search\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_tool_search_1\",\"type\":\"function\",\"function\":{\"name\":\"ccswitch_tool_search\"}}]}}]}\n\n",
                 "data: {\"id\":\"chatcmpl_tool_search\",\"model\":\"gpt-5.4\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"query\\\":\\\"Gmail search emails\\\",\\\"limit\\\":10}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
                 "data: [DONE]\n\n",
             ],

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -10,9 +10,9 @@
 //! - `transform_responses.rs`: Anthropic request → Responses request, Responses response → Anthropic response
 //! - this module:               Responses request → Anthropic request, Anthropic response → Responses response
 
-use super::transform_codex_chat::{
-    build_codex_tool_context_from_request, response_tool_call_item_from_chat_name,
-    response_tool_call_item_id_from_chat_name, CodexToolContext,
+use super::codex_tool_bridge::{
+    build_codex_tool_context_from_request, response_tool_call_item_from_upstream_name,
+    response_tool_call_item_id_from_upstream_name, CodexToolContext, TOOL_SEARCH_PROXY_NAME,
 };
 use super::transform_responses::{sanitize_anthropic_tool_use_input, TOOL_RESULT_ERROR_MARKER};
 use crate::proxy::error::ProxyError;
@@ -26,7 +26,6 @@ use serde_json::{json, Value};
 use std::collections::{BTreeMap, HashSet};
 
 pub(crate) const ANTHROPIC_THINKING_ENCRYPTED_PREFIX: &str = "ccswitch-anthropic-thinking-v1:";
-const TOOL_SEARCH_PROXY_NAME: &str = "tool_search";
 
 /// Maps Codex's reasoning.effort to the token budget for Anthropic thinking.
 ///
@@ -225,12 +224,21 @@ fn responses_system_text(item: &Value) -> Vec<String> {
     }
 }
 
+#[allow(dead_code)]
 pub fn responses_request_to_anthropic(
     body: Value,
     default_max_tokens: u64,
 ) -> Result<Value, ProxyError> {
+    let tool_context = build_codex_tool_context_from_request(&body)?;
+    responses_request_to_anthropic_with_tool_context(body, default_max_tokens, &tool_context)
+}
+
+pub(crate) fn responses_request_to_anthropic_with_tool_context(
+    body: Value,
+    default_max_tokens: u64,
+    tool_context: &CodexToolContext,
+) -> Result<Value, ProxyError> {
     let mut result = json!({});
-    let tool_context = build_codex_tool_context_from_request(&body);
     let model = body
         .get("model")
         .and_then(|value| value.as_str())
@@ -266,7 +274,7 @@ pub fn responses_request_to_anthropic(
 
     // input → messages
     let mut messages = match body.get("input") {
-        Some(Value::Array(items)) => convert_input_to_messages(items, &tool_context)?,
+        Some(Value::Array(items)) => convert_input_to_messages(items, tool_context)?,
         Some(Value::String(text)) if is_meaningful_text(text) => vec![json!({
             "role": "user",
             "content": [{ "type": "text", "text": text }]
@@ -382,7 +390,7 @@ pub fn responses_request_to_anthropic(
     // Reuse the Codex tool context so function, namespace, custom, tool_search, and
     // dynamically loaded tools all receive stable flat names upstream.
     let anth_tools: Vec<Value> = tool_context
-        .chat_tools()
+        .function_tools()
         .iter()
         .filter_map(chat_tool_to_anthropic_tool)
         .collect();
@@ -397,7 +405,7 @@ pub fn responses_request_to_anthropic(
     // unsupported hosted tools (for example web_search) must drop tool_choice too.
     if has_tools {
         if let Some(tc) = body.get("tool_choice") {
-            let mapped = map_tool_choice_to_anthropic(tc, &tool_context);
+            let mapped = map_tool_choice_to_anthropic(tc, tool_context)?;
             let forced = matches!(
                 mapped.get("type").and_then(|value| value.as_str()),
                 Some("any" | "tool")
@@ -466,8 +474,11 @@ fn chat_tool_to_anthropic_tool(chat_tool: &Value) -> Option<Value> {
 }
 
 /// tool_choice: Responses → Anthropic (the reverse of `map_tool_choice_to_responses`)
-fn map_tool_choice_to_anthropic(tool_choice: &Value, tool_context: &CodexToolContext) -> Value {
-    match tool_choice {
+fn map_tool_choice_to_anthropic(
+    tool_choice: &Value,
+    tool_context: &CodexToolContext,
+) -> Result<Value, ProxyError> {
+    let mapped = match tool_choice {
         Value::String(s) => match s.as_str() {
             "required" => json!({ "type": "any" }),
             "auto" => json!({ "type": "auto" }),
@@ -478,15 +489,25 @@ fn map_tool_choice_to_anthropic(tool_choice: &Value, tool_context: &CodexToolCon
             Some("function") => {
                 let name = obj.get("name").and_then(|n| n.as_str()).unwrap_or("");
                 let namespace = obj.get("namespace").and_then(|value| value.as_str());
-                let upstream_name = tool_context.chat_name_for_response_function(name, namespace);
+                let upstream_name =
+                    tool_context.require_published_response_function(name, namespace)?;
                 json!({ "type": "tool", "name": upstream_name })
             }
-            Some("custom") => json!({
-                "type": "tool",
-                "name": obj.get("name").and_then(|value| value.as_str()).unwrap_or("")
-            }),
+            Some("custom") => {
+                let name = obj
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("");
+                let upstream_name = tool_context.require_published_custom_tool(name)?;
+                json!({ "type": "tool", "name": upstream_name })
+            }
             Some("tool_search") => {
-                json!({ "type": "tool", "name": TOOL_SEARCH_PROXY_NAME })
+                if tool_context.uses_codex_private_tools() {
+                    let upstream_name = tool_context.require_published_tool_search()?;
+                    json!({ "type": "tool", "name": upstream_name })
+                } else {
+                    json!({ "type": "auto" })
+                }
             }
             // Other object shapes (allowed_tools / hosted-tool selectors, etc.) are
             // not recognized by Anthropic; downgrade to auto to avoid passing OpenAI's
@@ -494,7 +515,8 @@ fn map_tool_choice_to_anthropic(tool_choice: &Value, tool_context: &CodexToolCon
             _ => json!({ "type": "auto" }),
         },
         _ => json!({ "type": "auto" }),
-    }
+    };
+    Ok(mapped)
 }
 
 /// Re-nests the flat Responses input[] back into Anthropic messages.
@@ -512,11 +534,9 @@ fn convert_input_to_messages(
 
     for item in items {
         let item_type = item.get("type").and_then(|t| t.as_str());
-        if matches!(
-            item_type,
-            Some("function_call" | "custom_tool_call" | "tool_search_call")
-        ) && item.get("status").and_then(Value::as_str) == Some("incomplete")
-        {
+        let is_tool_call = matches!(item_type, Some("function_call" | "custom_tool_call"))
+            || (tool_context.uses_codex_private_tools() && item_type == Some("tool_search_call"));
+        if is_tool_call && item.get("status").and_then(Value::as_str) == Some("incomplete") {
             log::warn!(
                 "[Codex/Anthropic] Dropping incomplete historical tool call: type={}, call_id={}",
                 item_type.unwrap_or("unknown"),
@@ -537,7 +557,8 @@ fn convert_input_to_messages(
                     .unwrap_or("");
                 let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
                 let namespace = item.get("namespace").and_then(|value| value.as_str());
-                let upstream_name = tool_context.chat_name_for_response_function(name, namespace);
+                let upstream_name =
+                    tool_context.upstream_name_for_response_function(name, namespace);
                 let args_str = item.get("arguments").and_then(|v| v.as_str()).unwrap_or("");
                 let input: Value = if args_str.trim().is_empty() {
                     json!({})
@@ -587,7 +608,7 @@ fn convert_input_to_messages(
                     }),
                 );
             }
-            Some("tool_search_call") => {
+            Some("tool_search_call") if tool_context.uses_codex_private_tools() => {
                 let call_id = item
                     .get("call_id")
                     .and_then(|value| value.as_str())
@@ -609,7 +630,11 @@ fn convert_input_to_messages(
                     }),
                 );
             }
-            Some("function_call_output" | "custom_tool_call_output" | "tool_search_output") => {
+            Some("function_call_output" | "custom_tool_call_output")
+            | Some("tool_search_output")
+                if item_type != Some("tool_search_output")
+                    || tool_context.uses_codex_private_tools() =>
+            {
                 let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
                 let output = tool_result_content_from_responses_item(item);
                 let mut block = json!({
@@ -1326,8 +1351,8 @@ pub(crate) fn anthropic_response_to_responses_with_context(
                     let input = block.get("input").cloned().unwrap_or(json!({}));
                     let input = sanitize_anthropic_tool_use_input(name, input);
                     let item_id =
-                        response_tool_call_item_id_from_chat_name(call_id, name, tool_context);
-                    output.push(response_tool_call_item_from_chat_name(
+                        response_tool_call_item_id_from_upstream_name(call_id, name, tool_context);
+                    output.push(response_tool_call_item_from_upstream_name(
                         &item_id,
                         "completed",
                         call_id,
@@ -1695,6 +1720,100 @@ mod tests {
     }
 
     #[test]
+    fn test_request_keeps_native_tool_search_distinct_from_proxy() {
+        let input = json!({
+            "model": "claude",
+            "max_output_tokens": 100,
+            "input": [{"role": "user", "content": "find tools"}],
+            "tools": [
+                {"type": "tool_search"},
+                {"type": "function", "name": "tool_search", "parameters": {}}
+            ],
+            "tool_choice": {"type": "tool_search"}
+        });
+
+        let result = responses_request_to_anthropic(input, 4096).unwrap();
+        let names = result["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec![TOOL_SEARCH_PROXY_NAME, "tool_search"]);
+        assert_eq!(result["tool_choice"]["name"], TOOL_SEARCH_PROXY_NAME);
+    }
+
+    #[test]
+    fn standard_responses_history_does_not_proxy_codex_tool_search_items() {
+        let input = json!({
+            "model": "claude",
+            "max_output_tokens": 100,
+            "tools": [{"type": "tool_search"}],
+            "input": [
+                {"role": "user", "content": "hello"},
+                {
+                    "type": "tool_search_call",
+                    "call_id": "call_private",
+                    "arguments": {"query": "mail"}
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "call_private",
+                    "tools": [{"type": "function", "name": "private_loaded"}]
+                }
+            ]
+        });
+        let context =
+            super::super::codex_tool_bridge::build_standard_responses_tool_context_from_request(
+                &input,
+            )
+            .unwrap();
+
+        let result =
+            responses_request_to_anthropic_with_tool_context(input, 4096, &context).unwrap();
+        assert_eq!(result["messages"].as_array().unwrap().len(), 1);
+        assert!(result.get("tools").is_none());
+    }
+
+    #[test]
+    fn standard_tool_search_choice_downgrades_to_auto() {
+        let input = json!({
+            "model": "claude",
+            "max_output_tokens": 100,
+            "tools": [
+                {"type": "tool_search"},
+                {"type": "function", "name": "plain", "parameters": {}}
+            ],
+            "tool_choice": {"type": "tool_search"},
+            "input": "hello"
+        });
+        let context =
+            super::super::codex_tool_bridge::build_standard_responses_tool_context_from_request(
+                &input,
+            )
+            .unwrap();
+
+        let result =
+            responses_request_to_anthropic_with_tool_context(input, 4096, &context).unwrap();
+        assert_eq!(result["tool_choice"], json!({"type": "auto"}));
+        assert_eq!(result["tools"][0]["name"], "plain");
+    }
+
+    #[test]
+    fn test_request_rejects_cross_kind_name_collision() {
+        let input = json!({
+            "model": "claude",
+            "max_output_tokens": 100,
+            "input": [{"role": "user", "content": "use a tool"}],
+            "tools": [
+                {"type": "function", "name": "same", "parameters": {}},
+                {"type": "custom", "name": "same"}
+            ]
+        });
+        assert!(responses_request_to_anthropic(input, 4096).is_err());
+    }
+
+    #[test]
     fn test_request_tools_and_filtering() {
         let input = json!({
             "model": "claude",
@@ -1777,6 +1896,29 @@ mod tests {
                 .unwrap()["tool_choice"],
             json!({"type": "tool", "name": "x"})
         );
+    }
+
+    #[test]
+    fn test_request_rejects_choice_for_unloaded_deferred_tool() {
+        let input = json!({
+            "model": "claude",
+            "max_output_tokens": 100,
+            "input": [{"role": "user", "content": "search docs"}],
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "function",
+                    "name": "search_docs",
+                    "defer_loading": true,
+                    "parameters": {"type": "object"}
+                }
+            ],
+            "tool_choice": {"type": "function", "name": "search_docs"}
+        });
+
+        let error = responses_request_to_anthropic(input, 4096).unwrap_err();
+        assert!(matches!(error, ProxyError::InvalidRequest(_)));
+        assert!(error.to_string().contains("search_docs"));
     }
 
     #[test]
@@ -2646,7 +2788,8 @@ mod tests {
                 "name": "mcp_files",
                 "tools": [{"type": "function", "name": "read", "parameters": {"type": "object"}}]
             }]
-        }));
+        }))
+        .unwrap();
         let response = anthropic_response_to_responses_with_context(
             json!({
                 "id": "msg_ns",

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -6,15 +6,18 @@
 
 use super::codex_chat_common::{
     append_reasoning_content, extract_reasoning_field_text, extract_reasoning_summary_text,
-    response_function_call_item, response_function_call_item_with_namespace,
     split_leading_think_block,
+};
+use super::codex_tool_bridge::{
+    build_codex_tool_context_from_request, response_tool_call_item_from_upstream_name,
+    response_tool_call_item_id_from_upstream_name, CodexToolContext, CUSTOM_TOOL_INPUT_FIELD,
+    TOOL_SEARCH_PROXY_NAME,
 };
 use crate::provider::CodexChatReasoningConfig;
 use crate::proxy::{
     error::ProxyError,
     json_canonical::{
         canonical_json_string, canonicalize_json_string_if_parseable, canonicalize_tool_arguments,
-        short_sha256_hex,
     },
     tool_media::{
         chat_file_from_input_file, flush_pending_chat_tool_media, plan_chat_tool_output_media,
@@ -23,7 +26,6 @@ use crate::proxy::{
     },
 };
 use serde_json::{json, Value};
-use std::collections::{HashMap, HashSet};
 
 const EXTRA_CHAT_PASSTHROUGH_FIELDS: &[&str] = &[
     "frequency_penalty",
@@ -42,217 +44,6 @@ const EXTRA_CHAT_PASSTHROUGH_FIELDS: &[&str] = &[
     "user",
 ];
 
-const TOOL_SEARCH_PROXY_NAME: &str = "tool_search";
-const CUSTOM_TOOL_INPUT_FIELD: &str = "input";
-const CHAT_TOOL_NAME_MAX_LEN: usize = 64;
-const CUSTOM_TOOL_INPUT_DESCRIPTION: &str = "Raw string input for the original custom tool. Preserve formatting exactly and follow the original tool definition embedded in the description.";
-const CUSTOM_TOOL_PRESERVED_METADATA_HEADING: &str = "Original tool definition:";
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum CodexToolKind {
-    Function,
-    Namespace,
-    Custom,
-    ToolSearch,
-}
-
-#[derive(Debug, Clone)]
-pub(crate) struct CodexToolSpec {
-    pub(crate) kind: CodexToolKind,
-    pub(crate) name: String,
-    pub(crate) namespace: Option<String>,
-}
-
-#[derive(Debug, Clone, Default)]
-pub(crate) struct CodexToolContext {
-    chat_tools: Vec<Value>,
-    seen_chat_names: HashSet<String>,
-    chat_name_to_spec: HashMap<String, CodexToolSpec>,
-    namespace_name_to_chat_name: HashMap<(String, String), String>,
-}
-
-impl CodexToolContext {
-    pub(crate) fn chat_tools(&self) -> &[Value] {
-        &self.chat_tools
-    }
-
-    pub(crate) fn lookup_chat_name(&self, chat_name: &str) -> Option<&CodexToolSpec> {
-        self.chat_name_to_spec.get(chat_name)
-    }
-
-    pub(crate) fn is_custom_tool_chat_name(&self, chat_name: &str) -> bool {
-        self.lookup_chat_name(chat_name)
-            .is_some_and(|spec| matches!(&spec.kind, CodexToolKind::Custom))
-    }
-
-    pub(crate) fn chat_name_for_response_function(
-        &self,
-        name: &str,
-        namespace: Option<&str>,
-    ) -> String {
-        if let Some(namespace) = namespace.filter(|value| !value.is_empty()) {
-            if let Some(chat_name) = self
-                .namespace_name_to_chat_name
-                .get(&(namespace.to_string(), name.to_string()))
-            {
-                return chat_name.clone();
-            }
-            return flatten_namespace_tool_name(namespace, name);
-        }
-
-        name.to_string()
-    }
-
-    fn add_chat_tool(&mut self, chat_name: String, spec: CodexToolSpec, chat_tool: Value) {
-        if chat_name.trim().is_empty() || self.seen_chat_names.contains(&chat_name) {
-            return;
-        }
-        self.seen_chat_names.insert(chat_name.clone());
-        if let Some(namespace) = spec.namespace.as_ref() {
-            self.namespace_name_to_chat_name
-                .insert((namespace.clone(), spec.name.clone()), chat_name.clone());
-        }
-        self.chat_name_to_spec.insert(chat_name, spec);
-        self.chat_tools.push(chat_tool);
-    }
-
-    fn add_function_tool(&mut self, tool: &Value, namespace: Option<&str>) {
-        let Some(original_name) = responses_tool_name(tool) else {
-            return;
-        };
-        let chat_name = namespace
-            .map(|namespace| flatten_namespace_tool_name(namespace, &original_name))
-            .unwrap_or_else(|| original_name.clone());
-
-        let Some(chat_tool) = responses_function_tool_to_chat_tool(tool, &chat_name) else {
-            return;
-        };
-        let spec = CodexToolSpec {
-            kind: if namespace.is_some() {
-                CodexToolKind::Namespace
-            } else {
-                CodexToolKind::Function
-            },
-            name: original_name,
-            namespace: namespace.map(ToString::to_string),
-        };
-        self.add_chat_tool(chat_name, spec, chat_tool);
-    }
-
-    fn add_custom_tool(&mut self, tool: &Value) {
-        let Some(name) = responses_tool_name(tool) else {
-            return;
-        };
-        let description = json!(responses_custom_tool_description(tool));
-        let chat_tool = json!({
-            "type": "function",
-            "function": {
-                "name": name,
-                "description": description,
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        CUSTOM_TOOL_INPUT_FIELD: {
-                            "type": "string",
-                            "description": CUSTOM_TOOL_INPUT_DESCRIPTION
-                        }
-                    },
-                    "required": [CUSTOM_TOOL_INPUT_FIELD]
-                }
-            }
-        });
-        let spec = CodexToolSpec {
-            kind: CodexToolKind::Custom,
-            name: name.clone(),
-            namespace: None,
-        };
-        self.add_chat_tool(name, spec, chat_tool);
-    }
-
-    fn add_tool_search_tool(&mut self) {
-        let chat_tool = json!({
-            "type": "function",
-            "function": {
-                "name": TOOL_SEARCH_PROXY_NAME,
-                "description": "Search and load Codex tools, plugins, connectors, and MCP namespaces for the current task.",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "query": {
-                            "type": "string",
-                            "description": "Search query for tools or connectors to load."
-                        },
-                        "limit": {
-                            "type": "integer",
-                            "description": "Maximum number of tool groups to return."
-                        }
-                    },
-                    "required": ["query"]
-                }
-            }
-        });
-        let spec = CodexToolSpec {
-            kind: CodexToolKind::ToolSearch,
-            name: TOOL_SEARCH_PROXY_NAME.to_string(),
-            namespace: None,
-        };
-        self.add_chat_tool(TOOL_SEARCH_PROXY_NAME.to_string(), spec, chat_tool);
-    }
-
-    fn add_namespace_tool(&mut self, namespace_tool: &Value) {
-        let Some(namespace) = namespace_tool.get("name").and_then(|v| v.as_str()) else {
-            return;
-        };
-        let Some(children) = namespace_tool
-            .get("tools")
-            .or_else(|| namespace_tool.get("children"))
-            .and_then(|v| v.as_array())
-        else {
-            return;
-        };
-
-        for child in children {
-            if child.get("type").and_then(|v| v.as_str()) == Some("function") {
-                self.add_function_tool(child, Some(namespace));
-            }
-        }
-    }
-
-    fn add_response_tool(&mut self, tool: &Value) {
-        match tool {
-            Value::String(name) => {
-                self.add_custom_tool(&json!({
-                    "type": "custom",
-                    "name": name
-                }));
-            }
-            Value::Object(_) => match tool.get("type").and_then(|v| v.as_str()) {
-                Some("function") => self.add_function_tool(tool, None),
-                Some("custom") => self.add_custom_tool(tool),
-                Some("tool_search") => self.add_tool_search_tool(),
-                Some("namespace") => self.add_namespace_tool(tool),
-                _ => {}
-            },
-            _ => {}
-        }
-    }
-}
-
-pub(crate) fn build_codex_tool_context_from_request(body: &Value) -> CodexToolContext {
-    let mut context = CodexToolContext::default();
-
-    if let Some(tools) = body.get("tools").and_then(|v| v.as_array()) {
-        for tool in tools {
-            context.add_response_tool(tool);
-        }
-    }
-
-    if let Some(input) = body.get("input") {
-        collect_tool_search_output_tools(input, &mut context);
-    }
-
-    context
-}
-
 /// Convert an OpenAI Responses request into an OpenAI Chat Completions request.
 #[allow(dead_code)]
 pub fn responses_to_chat_completions(body: Value) -> Result<Value, ProxyError> {
@@ -265,8 +56,20 @@ pub fn responses_to_chat_completions_with_reasoning(
     body: Value,
     reasoning_config: Option<&CodexChatReasoningConfig>,
 ) -> Result<Value, ProxyError> {
+    let tool_context = build_codex_tool_context_from_request(&body)?;
+    responses_to_chat_completions_with_reasoning_and_tool_context(
+        body,
+        reasoning_config,
+        &tool_context,
+    )
+}
+
+pub(crate) fn responses_to_chat_completions_with_reasoning_and_tool_context(
+    body: Value,
+    reasoning_config: Option<&CodexChatReasoningConfig>,
+    tool_context: &CodexToolContext,
+) -> Result<Value, ProxyError> {
     let mut result = json!({});
-    let tool_context = build_codex_tool_context_from_request(&body);
 
     if let Some(model) = body.get("model") {
         result["model"] = model.clone();
@@ -284,7 +87,7 @@ pub fn responses_to_chat_completions_with_reasoning(
     }
 
     if let Some(input) = body.get("input") {
-        append_responses_input_as_chat_messages(input, &mut messages, &tool_context)?;
+        append_responses_input_as_chat_messages(input, &mut messages, tool_context)?;
     }
     let messages = collapse_system_messages_to_head(messages);
     result["messages"] = json!(messages);
@@ -312,13 +115,13 @@ pub fn responses_to_chat_completions_with_reasoning(
 
     apply_reasoning_options(&mut result, &body, model, reasoning_config);
 
-    let tools = tool_context.chat_tools();
+    let tools = tool_context.function_tools();
     if !tools.is_empty() {
         result["tools"] = json!(tools);
     }
 
     if let Some(tool_choice) = body.get("tool_choice") {
-        result["tool_choice"] = responses_tool_choice_to_chat(tool_choice, &tool_context);
+        result["tool_choice"] = responses_tool_choice_to_chat(tool_choice, tool_context)?;
     }
 
     for key in EXTRA_CHAT_PASSTHROUGH_FIELDS {
@@ -686,7 +489,7 @@ fn append_responses_item_as_chat_message(
             append_unique_pending_reasoning(pending_reasoning, responses_item_reasoning_text(item));
             pending_tool_calls.push(responses_custom_tool_call_to_chat_tool_call(item));
         }
-        Some("tool_search_call") => {
+        Some("tool_search_call") if tool_context.uses_codex_private_tools() => {
             append_unique_pending_reasoning(pending_reasoning, responses_item_reasoning_text(item));
             pending_tool_calls.push(responses_tool_search_call_to_chat_tool_call(item));
         }
@@ -721,7 +524,10 @@ fn append_responses_item_as_chat_message(
                 "content": output
             }));
         }
-        Some("custom_tool_call_output") | Some("tool_search_output") => {
+        Some("custom_tool_call_output") | Some("tool_search_output")
+            if item_type == Some("custom_tool_call_output")
+                || tool_context.uses_codex_private_tools() =>
+        {
             flush_pending_tool_calls(
                 messages,
                 pending_tool_calls,
@@ -1197,135 +1003,6 @@ fn responses_input_file_to_chat_file(part: &Value) -> Option<Value> {
     chat_file_from_input_file(part)
 }
 
-fn collect_tool_search_output_tools(value: &Value, context: &mut CodexToolContext) {
-    match value {
-        Value::Array(items) => {
-            for item in items {
-                collect_tool_search_output_tools(item, context);
-            }
-        }
-        Value::Object(obj) => {
-            if obj.get("type").and_then(|v| v.as_str()) == Some("tool_search_output") {
-                if let Some(tools) = obj.get("tools").and_then(|v| v.as_array()) {
-                    for tool in tools {
-                        context.add_response_tool(tool);
-                    }
-                }
-            }
-            for value in obj.values() {
-                collect_tool_search_output_tools(value, context);
-            }
-        }
-        _ => {}
-    }
-}
-
-pub(crate) fn flatten_namespace_tool_name(namespace: &str, name: &str) -> String {
-    let full_name = format!("{namespace}__{name}");
-    if full_name.len() <= CHAT_TOOL_NAME_MAX_LEN {
-        return full_name;
-    }
-
-    let hash = short_sha256_hex(full_name.as_bytes());
-    let suffix = format!("__{hash}");
-    let prefix_len = CHAT_TOOL_NAME_MAX_LEN.saturating_sub(suffix.len());
-    let mut prefix = String::new();
-    for ch in full_name.chars() {
-        if prefix.len() + ch.len_utf8() > prefix_len {
-            break;
-        }
-        prefix.push(ch);
-    }
-    format!("{prefix}{suffix}")
-}
-
-fn responses_tool_name(tool: &Value) -> Option<String> {
-    tool.get("function")
-        .and_then(|function| function.get("name"))
-        .or_else(|| tool.get("name"))
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string)
-}
-
-fn responses_custom_tool_description(tool: &Value) -> String {
-    let mut description = String::new();
-    description.push_str(CUSTOM_TOOL_PRESERVED_METADATA_HEADING);
-    description.push_str("\n```json\n");
-    description.push_str(&serialize_tool_definition_for_description(tool));
-    description.push_str("\n```");
-    description
-}
-
-fn serialize_tool_definition_for_description(tool: &Value) -> String {
-    // Keep the embedded definition compact to reduce tool-description token
-    // overhead for chat-only upstreams, while remaining stable across map
-    // storage order.
-    canonical_json_string(tool)
-}
-
-/// Normalize a function's `parameters` JSON Schema so `type` is always `"object"`.
-///
-/// Some Responses tools carry `parameters: null` or `parameters: {"type": null}`,
-/// but OpenAI Chat Completions strictly requires `{"type": "object", "properties": {...}}`.
-fn normalize_function_parameters(params: Option<&Value>) -> Value {
-    let mut params = match params {
-        Some(Value::Object(obj)) => Value::Object(obj.clone()),
-        _ => json!({"type": "object", "properties": {}}),
-    };
-    if let Some(obj) = params.as_object_mut() {
-        match obj.get("type").and_then(|v| v.as_str()) {
-            Some("object") => {}
-            _ => {
-                obj.insert("type".to_string(), json!("object"));
-            }
-        }
-    }
-    params
-}
-
-fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option<Value> {
-    if tool.get("type").and_then(|v| v.as_str()) != Some("function") {
-        return None;
-    }
-
-    if let Some(function) = tool.get("function") {
-        let mut chat_tool = json!({
-            "type": "function",
-            "function": function.clone()
-        });
-        if let Some(obj) = chat_tool
-            .get_mut("function")
-            .and_then(|value| value.as_object_mut())
-        {
-            // Ensure parameters.type is "object" for strict OpenAI-compatible providers
-            let parameters = normalize_function_parameters(obj.get("parameters"));
-            obj.insert("parameters".to_string(), parameters);
-
-            obj.insert("name".to_string(), json!(chat_name));
-            if let Some(strict) = tool.get("strict").cloned() {
-                obj.entry("strict".to_string()).or_insert(strict);
-            }
-        }
-        return Some(chat_tool);
-    }
-
-    let mut function = json!({
-        "name": chat_name,
-        "description": tool.get("description").cloned().unwrap_or(Value::Null),
-        "parameters": normalize_function_parameters(tool.get("parameters"))
-    });
-    if let Some(strict) = tool.get("strict") {
-        function["strict"] = strict.clone();
-    }
-
-    Some(json!({
-        "type": "function",
-        "function": function
-    }))
-}
-
 fn responses_function_call_to_chat_tool_call(
     item: &Value,
     tool_context: &CodexToolContext,
@@ -1337,7 +1014,7 @@ fn responses_function_call_to_chat_tool_call(
         .unwrap_or("");
     let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("");
     let namespace = item.get("namespace").and_then(|v| v.as_str());
-    let chat_name = tool_context.chat_name_for_response_function(name, namespace);
+    let chat_name = tool_context.upstream_name_for_response_function(name, namespace);
     let arguments = canonicalize_tool_arguments(item.get("arguments"));
 
     json!({
@@ -1390,12 +1067,15 @@ fn responses_tool_search_call_to_chat_tool_call(item: &Value) -> Value {
     })
 }
 
-fn responses_tool_choice_to_chat(tool_choice: &Value, tool_context: &CodexToolContext) -> Value {
-    match tool_choice {
+fn responses_tool_choice_to_chat(
+    tool_choice: &Value,
+    tool_context: &CodexToolContext,
+) -> Result<Value, ProxyError> {
+    let mapped = match tool_choice {
         Value::Object(obj) if obj.get("type").and_then(|v| v.as_str()) == Some("function") => {
             let name = obj.get("name").and_then(|v| v.as_str()).unwrap_or("");
             let namespace = obj.get("namespace").and_then(|v| v.as_str());
-            let chat_name = tool_context.chat_name_for_response_function(name, namespace);
+            let chat_name = tool_context.require_published_response_function(name, namespace)?;
             json!({
                 "type": "function",
                 "function": {
@@ -1404,24 +1084,31 @@ fn responses_tool_choice_to_chat(tool_choice: &Value, tool_context: &CodexToolCo
             })
         }
         Value::Object(obj) if obj.get("type").and_then(|v| v.as_str()) == Some("tool_search") => {
-            json!({
-                "type": "function",
-                "function": {
-                    "name": TOOL_SEARCH_PROXY_NAME
-                }
-            })
+            if tool_context.uses_codex_private_tools() {
+                let upstream_name = tool_context.require_published_tool_search()?;
+                json!({
+                    "type": "function",
+                    "function": {
+                        "name": upstream_name
+                    }
+                })
+            } else {
+                json!("auto")
+            }
         }
         Value::Object(obj) if obj.get("type").and_then(|v| v.as_str()) == Some("custom") => {
             let name = obj.get("name").and_then(|v| v.as_str()).unwrap_or("");
+            let upstream_name = tool_context.require_published_custom_tool(name)?;
             json!({
                 "type": "function",
                 "function": {
-                    "name": name
+                    "name": upstream_name
                 }
             })
         }
         _ => tool_choice.clone(),
-    }
+    };
+    Ok(mapped)
 }
 
 /// Convert a non-streaming Chat Completions response into a Responses response.
@@ -1680,8 +1367,8 @@ fn chat_tool_call_to_response_item(
     let name = function.get("name").and_then(|v| v.as_str()).unwrap_or("");
     let arguments = canonicalize_tool_arguments(function.get("arguments"));
 
-    let item_id = response_tool_call_item_id_from_chat_name(&call_id, name, tool_context);
-    response_tool_call_item_from_chat_name(
+    let item_id = response_tool_call_item_id_from_upstream_name(&call_id, name, tool_context);
+    response_tool_call_item_from_upstream_name(
         &item_id,
         "completed",
         &call_id,
@@ -1725,8 +1412,8 @@ fn chat_legacy_function_call_to_response_item(
 
     let arguments = canonicalize_tool_arguments(function_call.get("arguments"));
 
-    let item_id = response_tool_call_item_id_from_chat_name(call_id, name, tool_context);
-    Some(response_tool_call_item_from_chat_name(
+    let item_id = response_tool_call_item_id_from_upstream_name(call_id, name, tool_context);
+    Some(response_tool_call_item_from_upstream_name(
         &item_id,
         "completed",
         call_id,
@@ -1735,112 +1422,6 @@ fn chat_legacy_function_call_to_response_item(
         reasoning,
         tool_context,
     ))
-}
-
-pub(crate) fn response_tool_call_item_id_from_chat_name(
-    call_id: &str,
-    chat_name: &str,
-    tool_context: &CodexToolContext,
-) -> String {
-    if tool_context.is_custom_tool_chat_name(chat_name) {
-        format!("ctc_{call_id}")
-    } else {
-        format!("fc_{call_id}")
-    }
-}
-
-pub(crate) fn response_tool_call_item_from_chat_name(
-    item_id: &str,
-    status: &str,
-    call_id: &str,
-    chat_name: &str,
-    arguments: &str,
-    reasoning: Option<&str>,
-    tool_context: &CodexToolContext,
-) -> Value {
-    match tool_context.lookup_chat_name(chat_name) {
-        Some(spec) if spec.kind == CodexToolKind::ToolSearch => {
-            response_tool_search_call_item(call_id, status, arguments, reasoning)
-        }
-        Some(spec) if spec.kind == CodexToolKind::Custom => response_custom_tool_call_item(
-            item_id, status, call_id, &spec.name, arguments, reasoning,
-        ),
-        Some(spec) => response_function_call_item_with_namespace(
-            item_id,
-            status,
-            call_id,
-            &spec.name,
-            spec.namespace.as_deref(),
-            arguments,
-            reasoning,
-        ),
-        None => {
-            response_function_call_item(item_id, status, call_id, chat_name, arguments, reasoning)
-        }
-    }
-}
-
-fn response_tool_search_call_item(
-    call_id: &str,
-    status: &str,
-    arguments: &str,
-    reasoning: Option<&str>,
-) -> Value {
-    let parsed_arguments = parse_tool_arguments_object(arguments);
-    let mut item = json!({
-        "type": "tool_search_call",
-        "call_id": call_id,
-        "status": status,
-        "execution": "client",
-        "arguments": parsed_arguments
-    });
-    super::codex_chat_common::attach_optional_reasoning_content_field(&mut item, reasoning);
-    item
-}
-
-fn response_custom_tool_call_item(
-    item_id: &str,
-    status: &str,
-    call_id: &str,
-    name: &str,
-    arguments: &str,
-    reasoning: Option<&str>,
-) -> Value {
-    let input = custom_tool_input_from_chat_arguments(arguments);
-    let mut item = json!({
-        "id": item_id,
-        "type": "custom_tool_call",
-        "status": status,
-        "call_id": call_id,
-        "name": name,
-        "input": input
-    });
-    super::codex_chat_common::attach_optional_reasoning_content_field(&mut item, reasoning);
-    item
-}
-
-fn parse_tool_arguments_object(arguments: &str) -> Value {
-    if arguments.trim().is_empty() {
-        return json!({});
-    }
-    serde_json::from_str::<Value>(arguments)
-        .ok()
-        .filter(|value| value.is_object())
-        .unwrap_or_else(|| json!({ "query": arguments }))
-}
-
-pub(crate) fn custom_tool_input_from_chat_arguments(arguments: &str) -> String {
-    if arguments.trim().is_empty() {
-        return String::new();
-    }
-    match serde_json::from_str::<Value>(arguments) {
-        Ok(Value::Object(obj)) => obj
-            .get(CUSTOM_TOOL_INPUT_FIELD)
-            .and_then(|value| value.as_str())
-            .unwrap_or(arguments)
-            .to_string(),
-        _ => arguments.to_string(),
-    }
 }
 
 pub(crate) fn chat_usage_to_responses_usage(usage: Option<&Value>) -> Value {
@@ -2445,6 +2026,45 @@ mod tests {
     }
 
     #[test]
+    fn responses_request_to_chat_keeps_native_tool_search_distinct_from_proxy() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [
+                {"type": "tool_search"},
+                {"type": "function", "name": "tool_search", "parameters": {}}
+            ],
+            "tool_choice": {"type": "tool_search"},
+            "input": "Find tools."
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let names = result["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool.pointer("/function/name").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec![TOOL_SEARCH_PROXY_NAME, "tool_search"]);
+        assert_eq!(
+            result["tool_choice"]["function"]["name"],
+            TOOL_SEARCH_PROXY_NAME
+        );
+    }
+
+    #[test]
+    fn responses_request_to_chat_rejects_cross_kind_name_collision() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [
+                {"type": "function", "name": "same", "parameters": {}},
+                {"type": "custom", "name": "same"}
+            ],
+            "input": "Use a tool."
+        });
+        assert!(responses_to_chat_completions(input).is_err());
+    }
+
+    #[test]
     fn responses_request_to_chat_exposes_tool_search_and_loaded_namespace_tools() {
         let input = json!({
             "model": "gpt-5.4",
@@ -2497,11 +2117,11 @@ mod tests {
             .filter_map(|tool| tool.pointer("/function/name").and_then(|v| v.as_str()))
             .collect::<Vec<_>>();
 
-        assert!(tool_names.contains(&"tool_search"));
+        assert!(tool_names.contains(&TOOL_SEARCH_PROXY_NAME));
         assert!(tool_names.contains(&"mcp__codex_apps__gmail___search_emails"));
         assert_eq!(
             result["messages"][0]["tool_calls"][0]["function"]["name"],
-            "tool_search"
+            TOOL_SEARCH_PROXY_NAME
         );
         assert_eq!(result["messages"][1]["role"], "tool");
         assert_eq!(result["messages"][1]["tool_call_id"], "call_tool_search_1");
@@ -2509,6 +2129,62 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("mcp__codex_apps__gmail"));
+    }
+
+    #[test]
+    fn standard_responses_history_does_not_proxy_codex_tool_search_items() {
+        let input = json!({
+            "model": "grok-4.5",
+            "tools": [{"type": "tool_search"}],
+            "input": [
+                {"role": "user", "content": "hello"},
+                {
+                    "type": "tool_search_call",
+                    "call_id": "call_private",
+                    "arguments": {"query": "mail"}
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "call_private",
+                    "tools": [{"type": "function", "name": "private_loaded"}]
+                }
+            ]
+        });
+        let context =
+            super::super::codex_tool_bridge::build_standard_responses_tool_context_from_request(
+                &input,
+            )
+            .unwrap();
+
+        let result =
+            responses_to_chat_completions_with_reasoning_and_tool_context(input, None, &context)
+                .unwrap();
+        assert_eq!(result["messages"].as_array().unwrap().len(), 1);
+        assert!(result.get("tools").is_none());
+    }
+
+    #[test]
+    fn standard_tool_search_choice_downgrades_to_auto() {
+        let input = json!({
+            "model": "grok-4.5",
+            "tools": [
+                {"type": "tool_search"},
+                {"type": "function", "name": "plain", "parameters": {}}
+            ],
+            "tool_choice": {"type": "tool_search"},
+            "input": "hello"
+        });
+        let context =
+            super::super::codex_tool_bridge::build_standard_responses_tool_context_from_request(
+                &input,
+            )
+            .unwrap();
+
+        let result =
+            responses_to_chat_completions_with_reasoning_and_tool_context(input, None, &context)
+                .unwrap();
+        assert_eq!(result["tool_choice"], "auto");
+        assert_eq!(result["tools"][0]["function"]["name"], "plain");
     }
 
     #[test]
@@ -4197,7 +3873,7 @@ mod tests {
                 }]
             }]
         });
-        let context = build_codex_tool_context_from_request(&request);
+        let context = build_codex_tool_context_from_request(&request).unwrap();
         let chat = json!({
             "id": "chatcmpl_gmail",
             "object": "chat.completion",
@@ -4238,7 +3914,7 @@ mod tests {
             "tools": [{"type": "tool_search"}],
             "input": "Find tools."
         });
-        let context = build_codex_tool_context_from_request(&request);
+        let context = build_codex_tool_context_from_request(&request).unwrap();
         let chat = json!({
             "id": "chatcmpl_tool_search",
             "object": "chat.completion",
@@ -4251,7 +3927,7 @@ mod tests {
                         "id": "call_tool_search_1",
                         "type": "function",
                         "function": {
-                            "name": "tool_search",
+                            "name": TOOL_SEARCH_PROXY_NAME,
                             "arguments": "{\"query\":\"Gmail search emails\",\"limit\":10}"
                         }
                     }]
@@ -4279,7 +3955,7 @@ mod tests {
             "tools": [{"type": "custom", "name": "apply_patch"}],
             "input": "Patch it."
         });
-        let context = build_codex_tool_context_from_request(&request);
+        let context = build_codex_tool_context_from_request(&request).unwrap();
         let chat = json!({
             "id": "chatcmpl_custom",
             "object": "chat.completion",
@@ -4783,6 +4459,28 @@ mod tests {
         );
         assert_eq!(result["tool_choice"]["type"], "function");
         assert_eq!(result["tool_choice"]["function"]["name"], "get_weather");
+    }
+
+    #[test]
+    fn responses_request_to_chat_rejects_choice_for_unloaded_deferred_tool() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "function",
+                    "name": "search_docs",
+                    "defer_loading": true,
+                    "parameters": {"type": "object"}
+                }
+            ],
+            "tool_choice": {"type": "function", "name": "search_docs"},
+            "input": "hi"
+        });
+
+        let error = responses_to_chat_completions(input).unwrap_err();
+        assert!(matches!(error, ProxyError::InvalidRequest(_)));
+        assert!(error.to_string().contains("search_docs"));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_responses_namespace.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_namespace.rs
@@ -49,11 +49,36 @@ pub(crate) struct NamespacedName {
 /// flatten; derives names exactly as [`flatten_request_namespaces`] does.
 pub(crate) fn namespace_restore_map(request_body: &Value) -> HashMap<String, NamespacedName> {
     let mut map = HashMap::new();
-    let Some(tools) = request_body.get("tools").and_then(Value::as_array) else {
-        return map;
-    };
+    if let Some(tools) = request_body.get("tools").and_then(Value::as_array) {
+        add_namespace_tools_to_restore_map(tools, &mut map, false);
+    }
+    // A discovered namespace is carried in the direct protocol item's `tools`
+    // field rather than the next request's top-level declaration. Include it so
+    // calls to newly loaded tools are restored to Codex's namespaced registry.
+    if let Some(input) = request_body.get("input").and_then(Value::as_array) {
+        for item in input {
+            if matches!(
+                item.get("type").and_then(Value::as_str),
+                Some("tool_search_output" | "additional_tools")
+            ) {
+                if let Some(tools) = item.get("tools").and_then(Value::as_array) {
+                    add_namespace_tools_to_restore_map(tools, &mut map, true);
+                }
+            }
+        }
+    }
+    map
+}
+
+fn add_namespace_tools_to_restore_map(
+    tools: &[Value],
+    map: &mut HashMap<String, NamespacedName>,
+    include_deferred: bool,
+) {
     for tool in tools {
-        if tool.get("type").and_then(Value::as_str) != Some("namespace") {
+        if tool.get("type").and_then(Value::as_str) != Some("namespace")
+            || (!include_deferred && is_deferred_tool(tool))
+        {
             continue;
         }
         let Some(namespace) = tool.get("name").and_then(Value::as_str) else {
@@ -64,7 +89,9 @@ pub(crate) fn namespace_restore_map(request_body: &Value) -> HashMap<String, Nam
             continue;
         }
         for child in namespace_children(tool) {
-            if child.get("type").and_then(Value::as_str) != Some("function") {
+            if child.get("type").and_then(Value::as_str) != Some("function")
+                || (!include_deferred && is_deferred_tool(&child))
+            {
                 continue;
             }
             let Some(name) = child.get("name").and_then(Value::as_str) else {
@@ -81,7 +108,6 @@ pub(crate) fn namespace_restore_map(request_body: &Value) -> HashMap<String, Nam
             });
         }
     }
-    map
 }
 
 /// Flatten Codex `namespace` tool declarations in a native Responses request
@@ -130,8 +156,12 @@ pub(crate) fn flatten_request_namespaces(body: &mut Value) -> Result<bool, Proxy
         if namespace.is_empty() {
             continue;
         }
+        let namespace_deferred = is_deferred_tool(tool);
         for child in namespace_children(tool) {
-            if child.get("type").and_then(Value::as_str) != Some("function") {
+            if child.get("type").and_then(Value::as_str) != Some("function")
+                || namespace_deferred
+                || is_deferred_tool(&child)
+            {
                 continue;
             }
             let Some(name) = child.get("name").and_then(Value::as_str).map(str::trim) else {
@@ -181,8 +211,12 @@ pub(crate) fn flatten_request_namespaces(body: &mut Value) -> Result<bool, Proxy
         let Some(namespace) = tool.get("name").and_then(Value::as_str).map(str::trim) else {
             continue;
         };
+        let namespace_deferred = is_deferred_tool(&tool);
         for child in namespace_children(&tool) {
-            if child.get("type").and_then(Value::as_str) != Some("function") {
+            if child.get("type").and_then(Value::as_str) != Some("function")
+                || namespace_deferred
+                || is_deferred_tool(&child)
+            {
                 continue;
             }
             let Some(name) = child.get("name").and_then(Value::as_str).map(str::trim) else {
@@ -198,6 +232,8 @@ pub(crate) fn flatten_request_namespaces(body: &mut Value) -> Result<bool, Proxy
             let mut lifted = child.clone();
             if let Some(obj) = lifted.as_object_mut() {
                 obj.insert("name".to_string(), json!(flat));
+                obj.remove("defer_loading");
+                obj.remove("deferLoading");
             }
             flattened.push(lifted);
         }
@@ -246,12 +282,47 @@ pub(crate) fn restore_sse_event_namespaces(
     restore_value(event, map)
 }
 
+/// Restore both flattened namespace calls and the request-scoped xAI function
+/// shim used for Codex's private `tool_search` protocol.
+pub(crate) fn restore_response_tool_calls(
+    value: &mut Value,
+    map: &HashMap<String, NamespacedName>,
+    restore_tool_search: bool,
+) -> bool {
+    let mut changed = restore_response_namespaces(value, map);
+    if restore_tool_search {
+        changed |=
+            super::transform_codex_responses_xai_tool_search::restore_tool_search_calls(value);
+    }
+    changed
+}
+
+fn restore_sse_event_tool_calls(
+    event: &mut Value,
+    map: &HashMap<String, NamespacedName>,
+    restore_tool_search: bool,
+) -> bool {
+    let mut changed = restore_sse_event_namespaces(event, map);
+    if restore_tool_search {
+        changed |=
+            super::transform_codex_responses_xai_tool_search::restore_tool_search_calls(event);
+    }
+    changed
+}
+
 fn namespace_children(tool: &Value) -> Vec<Value> {
     tool.get("tools")
         .or_else(|| tool.get("children"))
         .and_then(Value::as_array)
         .cloned()
         .unwrap_or_default()
+}
+
+fn is_deferred_tool(tool: &Value) -> bool {
+    tool.get("defer_loading")
+        .or_else(|| tool.get("deferLoading"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn rewrite_namespace_qualified_calls(value: &mut Value, owners: &HashMap<String, NamespacedName>) {
@@ -338,9 +409,10 @@ fn restore_value(value: &mut Value, map: &HashMap<String, NamespacedName>) -> bo
 /// names in each event back to their namespace identity. Events that carry no
 /// affected function call pass through with their inner content preserved
 /// verbatim (only the block delimiter is normalized to `\n\n`).
-pub(crate) fn create_namespace_restore_sse_stream<E>(
+pub(crate) fn create_tool_call_restore_sse_stream<E>(
     stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
     map: HashMap<String, NamespacedName>,
+    restore_tool_search: bool,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send
 where
     E: std::error::Error + Send + 'static,
@@ -359,7 +431,7 @@ where
                         if block.trim().is_empty() {
                             continue;
                         }
-                        yield Ok(restore_sse_block(&block, &map));
+                        yield Ok(restore_sse_block(&block, &map, restore_tool_search));
                     }
                 }
                 Err(e) => {
@@ -376,7 +448,7 @@ where
         }
         let tail = std::mem::take(&mut buffer);
         if !tail.trim().is_empty() {
-            yield Ok(restore_sse_block(&tail, &map));
+            yield Ok(restore_sse_block(&tail, &map, restore_tool_search));
         }
     }
 }
@@ -384,7 +456,11 @@ where
 /// Restore one SSE block. When the block's `data:` JSON carries an affected
 /// function call, re-serialize just that line; otherwise the original block text
 /// is preserved and only the `\n\n` delimiter re-appended.
-fn restore_sse_block(block: &str, map: &HashMap<String, NamespacedName>) -> Bytes {
+fn restore_sse_block(
+    block: &str,
+    map: &HashMap<String, NamespacedName>,
+    restore_tool_search: bool,
+) -> Bytes {
     let mut event_name: Option<&str> = None;
     let mut data_parts: Vec<&str> = Vec::new();
     for line in block.lines() {
@@ -411,7 +487,7 @@ fn restore_sse_block(block: &str, map: &HashMap<String, NamespacedName>) -> Byte
         Err(_) => return Bytes::from(format!("{block}\n\n")),
     };
 
-    if !restore_sse_event_namespaces(&mut event, map) {
+    if !restore_sse_event_tool_calls(&mut event, map, restore_tool_search) {
         return Bytes::from(format!("{block}\n\n"));
     }
 
@@ -493,6 +569,93 @@ mod tests {
         assert_eq!(call["call_id"], "c1");
         // A namespace-typed tool_choice degrades to "auto".
         assert_eq!(body["tool_choice"], json!("auto"));
+    }
+
+    #[test]
+    fn flatten_omits_deferred_children_until_loaded() {
+        let mut body = json!({
+            "tools": [{
+                "type": "namespace",
+                "name": "mcp__large__",
+                "tools": [
+                    {"type": "function", "name": "hot", "defer_loading": false, "parameters": {}},
+                    {"type": "function", "name": "cold_a", "defer_loading": true, "parameters": {}},
+                    {"type": "function", "name": "cold_b", "deferLoading": true, "parameters": {}}
+                ]
+            }]
+        });
+
+        assert!(flatten_request_namespaces(&mut body).unwrap());
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["name"], "mcp__large____hot");
+        assert!(tools[0].get("defer_loading").is_none());
+    }
+
+    #[test]
+    fn restore_map_includes_discovered_namespaces() {
+        let body = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "tools": [{
+                    "type": "namespace",
+                    "name": "mcp__mail__",
+                    "tools": [{"type": "function", "name": "search", "parameters": {}}]
+                }]
+            }]
+        });
+        let map = namespace_restore_map(&body);
+        assert_eq!(
+            map.get("mcp__mail____search"),
+            Some(&NamespacedName {
+                namespace: "mcp__mail__".to_string(),
+                name: "search".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn restore_map_excludes_omitted_deferred_catalog_children() {
+        let body = json!({
+            "tools": [
+                {"type": "function", "name": "mcp__mail____search", "parameters": {}},
+                {
+                    "type": "namespace",
+                    "name": "mcp__mail__",
+                    "tools": [{
+                        "type": "function",
+                        "name": "search",
+                        "defer_loading": true,
+                        "parameters": {}
+                    }]
+                }
+            ]
+        });
+        assert!(namespace_restore_map(&body).is_empty());
+    }
+
+    #[test]
+    fn restore_map_includes_additional_tool_namespaces() {
+        let body = json!({
+            "input": [{
+                "type": "additional_tools",
+                "tools": [{
+                    "type": "namespace",
+                    "name": "mcp__calendar__",
+                    "defer_loading": true,
+                    "tools": [{
+                        "type": "function",
+                        "name": "list_events",
+                        "defer_loading": true,
+                        "parameters": {}
+                    }]
+                }]
+            }]
+        });
+        let map = namespace_restore_map(&body);
+        assert!(map.contains_key("mcp__calendar____list_events"));
     }
 
     #[test]
@@ -604,7 +767,7 @@ mod tests {
             Ok(Bytes::from(done)),
         ];
         let input = stream::iter(chunks);
-        let out = create_namespace_restore_sse_stream(input, map);
+        let out = create_tool_call_restore_sse_stream(input, map, false);
         futures::pin_mut!(out);
 
         let mut collected = String::new();
@@ -619,5 +782,24 @@ mod tests {
         // Unrelated events preserved verbatim.
         assert!(collected.contains("\"delta\":\"hi\""));
         assert!(collected.contains("[DONE]"));
+    }
+
+    #[tokio::test]
+    async fn sse_stream_restores_xai_tool_search_function() {
+        let added = "event: response.output_item.added\n\
+                     data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"name\":\"tool_search\",\"call_id\":\"search_1\",\"arguments\":\"{\\\"query\\\":\\\"mail\\\"}\"}}\n\n";
+        let input = stream::iter(vec![Ok::<Bytes, std::io::Error>(Bytes::from(added))]);
+        let out = create_tool_call_restore_sse_stream(input, HashMap::new(), true);
+        futures::pin_mut!(out);
+
+        let mut collected = String::new();
+        while let Some(chunk) = out.next().await {
+            collected.push_str(std::str::from_utf8(&chunk.unwrap()).unwrap());
+        }
+
+        assert!(collected.contains("\"type\":\"tool_search_call\""));
+        assert!(collected.contains("\"execution\":\"client\""));
+        assert!(collected.contains("\"query\":\"mail\""));
+        assert!(!collected.contains("\"name\":\"tool_search\""));
     }
 }

--- a/src-tauri/src/proxy/providers/transform_codex_responses_namespace.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_namespace.rs
@@ -30,7 +30,7 @@ use std::collections::HashMap;
 
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 use super::transform_codex_chat::flatten_namespace_tool_name;
 use crate::proxy::error::ProxyError;
@@ -729,6 +729,37 @@ mod tests {
     }
 
     #[test]
+    fn restore_tool_calls_keeps_namespaced_child_named_tool_search() {
+        let request = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "tools": [{
+                    "type": "namespace",
+                    "name": "mcp__tools__",
+                    "tools": [{"type": "function", "name": "tool_search", "parameters": {}}]
+                }]
+            }]
+        });
+        let map = namespace_restore_map(&request);
+        let mut response = json!({
+            "output": [{
+                "type": "function_call",
+                "name": "mcp__tools____tool_search",
+                "call_id": "c1",
+                "arguments": "{}"
+            }]
+        });
+
+        assert!(restore_response_tool_calls(&mut response, &map, true));
+        let call = &response["output"][0];
+        assert_eq!(call["type"], "function_call");
+        assert_eq!(call["name"], "tool_search");
+        assert_eq!(call["namespace"], "mcp__tools__");
+    }
+
+    #[test]
     fn long_flat_names_stay_consistent_between_flatten_and_restore() {
         let long_child = "a".repeat(80);
         let body = json!({
@@ -787,7 +818,7 @@ mod tests {
     #[tokio::test]
     async fn sse_stream_restores_xai_tool_search_function() {
         let added = "event: response.output_item.added\n\
-                     data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"name\":\"tool_search\",\"call_id\":\"search_1\",\"arguments\":\"{\\\"query\\\":\\\"mail\\\"}\"}}\n\n";
+                     data: {\"type\":\"response.output_item.added\",\"item\":{\"type\":\"function_call\",\"name\":\"ccswitch_tool_search\",\"call_id\":\"search_1\",\"arguments\":\"{\\\"query\\\":\\\"mail\\\"}\"}}\n\n";
         let input = stream::iter(vec![Ok::<Bytes, std::io::Error>(Bytes::from(added))]);
         let out = create_tool_call_restore_sse_stream(input, HashMap::new(), true);
         futures::pin_mut!(out);
@@ -800,6 +831,6 @@ mod tests {
         assert!(collected.contains("\"type\":\"tool_search_call\""));
         assert!(collected.contains("\"execution\":\"client\""));
         assert!(collected.contains("\"query\":\"mail\""));
-        assert!(!collected.contains("\"name\":\"tool_search\""));
+        assert!(!collected.contains("\"name\":\"ccswitch_tool_search\""));
     }
 }

--- a/src-tauri/src/proxy/providers/transform_codex_responses_namespace.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_namespace.rs
@@ -30,9 +30,9 @@ use std::collections::HashMap;
 
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
-use super::transform_codex_chat::flatten_namespace_tool_name;
+use super::codex_tool_bridge::flatten_namespace_tool_name;
 use crate::proxy::error::ProxyError;
 use crate::proxy::sse::{append_utf8_safe, strip_sse_field, take_sse_block};
 
@@ -329,17 +329,11 @@ fn rewrite_namespace_qualified_calls(value: &mut Value, owners: &HashMap<String,
     match value {
         Value::Array(items) => {
             for item in items {
-                rewrite_namespace_qualified_calls(item, owners);
+                rewrite_namespace_qualified_call(item, owners);
             }
         }
-        Value::Object(obj) => {
-            if obj.get("type").and_then(Value::as_str) == Some("function_call") {
-                rewrite_namespace_qualified_call(value, owners);
-                return;
-            }
-            for child in obj.values_mut() {
-                rewrite_namespace_qualified_calls(child, owners);
-            }
+        Value::Object(_) => {
+            rewrite_namespace_qualified_call(value, owners);
         }
         _ => {}
     }
@@ -379,30 +373,44 @@ fn rewrite_namespace_qualified_call(
 }
 
 fn restore_value(value: &mut Value, map: &HashMap<String, NamespacedName>) -> bool {
+    if restore_direct_function_call(value, map) {
+        return true;
+    }
+    let Some(obj) = value.as_object_mut() else {
+        return false;
+    };
+
     let mut changed = false;
-    match value {
-        Value::Array(items) => {
-            for item in items {
-                changed |= restore_value(item, map);
-            }
+    if let Some(item) = obj.get_mut("item") {
+        changed |= restore_direct_function_call(item, map);
+    }
+    if let Some(output) = obj.get_mut("output").and_then(Value::as_array_mut) {
+        for item in output {
+            changed |= restore_direct_function_call(item, map);
         }
-        Value::Object(obj) => {
-            if obj.get("type").and_then(Value::as_str) == Some("function_call") {
-                if let Some(flat) = obj.get("name").and_then(Value::as_str) {
-                    if let Some(entry) = map.get(flat) {
-                        obj.insert("name".to_string(), json!(entry.name));
-                        obj.insert("namespace".to_string(), json!(entry.namespace));
-                        changed = true;
-                    }
-                }
-            }
-            for child in obj.values_mut() {
-                changed |= restore_value(child, map);
-            }
-        }
-        _ => {}
+    }
+    if let Some(response) = obj.get_mut("response") {
+        changed |= restore_value(response, map);
     }
     changed
+}
+
+fn restore_direct_function_call(value: &mut Value, map: &HashMap<String, NamespacedName>) -> bool {
+    let Some(obj) = value.as_object_mut() else {
+        return false;
+    };
+    if obj.get("type").and_then(Value::as_str) != Some("function_call") {
+        return false;
+    }
+    let Some(flat) = obj.get("name").and_then(Value::as_str) else {
+        return false;
+    };
+    let Some(entry) = map.get(flat) else {
+        return false;
+    };
+    obj.insert("name".to_string(), json!(entry.name));
+    obj.insert("namespace".to_string(), json!(entry.namespace));
+    true
 }
 
 /// Wrap a native Responses SSE byte stream, restoring flattened `function_call`
@@ -757,6 +765,61 @@ mod tests {
         assert_eq!(call["type"], "function_call");
         assert_eq!(call["name"], "tool_search");
         assert_eq!(call["namespace"], "mcp__tools__");
+    }
+
+    #[test]
+    fn restore_tool_calls_keeps_namespaced_child_named_proxy_shim() {
+        let request = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "tools": [{
+                    "type": "namespace",
+                    "name": "mcp__tools__",
+                    "tools": [{
+                        "type": "function",
+                        "name": "ccswitch_tool_search",
+                        "parameters": {}
+                    }]
+                }]
+            }]
+        });
+        let map = namespace_restore_map(&request);
+        let mut response = json!({
+            "output": [{
+                "type": "function_call",
+                "name": "mcp__tools____ccswitch_tool_search",
+                "call_id": "c1",
+                "arguments": "{}"
+            }]
+        });
+
+        assert!(restore_response_tool_calls(&mut response, &map, true));
+        let call = &response["output"][0];
+        assert_eq!(call["type"], "function_call");
+        assert_eq!(call["name"], "ccswitch_tool_search");
+        assert_eq!(call["namespace"], "mcp__tools__");
+    }
+
+    #[test]
+    fn restore_does_not_rewrite_nested_business_json() {
+        let map = namespace_restore_map(&namespace_request());
+        let nested = json!({
+            "type": "function_call",
+            "name": "mcp__files____read",
+            "call_id": "business-data"
+        });
+        let mut response = json!({
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "metadata": nested.clone()}]
+            }]
+        });
+
+        assert!(!restore_response_namespaces(&mut response, &map));
+        assert_eq!(response["output"][0]["content"][0]["metadata"], nested);
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
@@ -40,6 +40,11 @@ const GROK_45_UNSUPPORTED_FIELDS: &[&str] = &[
     "stop",
 ];
 
+/// Codex consumes Responses `reasoning` items as hidden thinking. Asking xAI to
+/// stream reasoning summaries can therefore hide the useful answer from the
+/// user if Grok puts answer-like text in that channel.
+const REASONING_SUMMARY_FIELDS: &[&str] = &["summary", "generate_summary"];
+
 /// Tool `type` values xAI's Responses schema accepts. Sourced from xAI's own
 /// serde error enumeration (which is more complete than sub2api's hand-copied
 /// list — it includes `image_generation`). Any other `type` is a Codex/OpenAI
@@ -95,7 +100,11 @@ pub(crate) fn sanitize_xai_responses_request(body: &mut Value) -> bool {
     //    deserializer refuses a present-but-null content field.
     changed |= strip_null_reasoning_content(body);
 
-    // 6. Whitelist the tool types and clean a now-dangling `tool_choice`.
+    // 6. Keep reasoning effort, but do not ask xAI for reasoning summaries: Codex
+    //    treats that output item as hidden thinking, not final assistant text.
+    changed |= strip_reasoning_summary_request(body);
+
+    // 7. Whitelist the tool types and clean a now-dangling `tool_choice`.
     changed |= filter_unsupported_tools(body);
 
     changed
@@ -236,6 +245,28 @@ fn strip_null_reasoning_content(body: &mut Value) -> bool {
             }
         }
     }
+    changed
+}
+
+fn strip_reasoning_summary_request(body: &mut Value) -> bool {
+    let Some(reasoning) = body.get_mut("reasoning") else {
+        return false;
+    };
+    let Some(obj) = reasoning.as_object_mut() else {
+        return false;
+    };
+
+    let mut changed = false;
+    for field in REASONING_SUMMARY_FIELDS {
+        changed |= obj.remove(*field).is_some();
+    }
+
+    if changed && obj.is_empty() {
+        if let Some(body_obj) = body.as_object_mut() {
+            body_obj.remove("reasoning");
+        }
+    }
+
     changed
 }
 
@@ -451,6 +482,26 @@ mod tests {
         let input = body.get("input").unwrap().as_array().unwrap();
         assert!(input[0].get("content").is_none());
         assert!(input[1].get("content").is_some());
+    }
+
+    #[test]
+    fn strips_reasoning_summary_but_keeps_effort() {
+        let mut body = json!({
+            "model": "grok-4.6",
+            "reasoning": {"effort": "high", "summary": "detailed"}
+        });
+        assert!(sanitize_xai_responses_request(&mut body));
+        assert_eq!(body["reasoning"], json!({"effort": "high"}));
+    }
+
+    #[test]
+    fn removes_empty_reasoning_after_summary_strip() {
+        let mut body = json!({
+            "model": "grok-4.6",
+            "reasoning": {"summary": "auto", "generate_summary": "detailed"}
+        });
+        assert!(sanitize_xai_responses_request(&mut body));
+        assert!(body.get("reasoning").is_none());
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
@@ -68,6 +68,20 @@ const XAI_SUPPORTED_TOOL_TYPES: &[&str] = &[
 /// idempotent: running it twice on the same body changes nothing the second
 /// time.
 pub(crate) fn sanitize_xai_responses_request(body: &mut Value) -> bool {
+    sanitize_xai_responses_request_with_private_tools(body, true)
+}
+
+/// Apply only xAI wire-format compatibility fixes that are valid for a
+/// standard Responses client. In particular, do not promote, drop, or rewrite
+/// Codex-private tool carriers on behalf of Grok Build.
+pub(crate) fn sanitize_standard_xai_responses_request(body: &mut Value) -> bool {
+    sanitize_xai_responses_request_with_private_tools(body, false)
+}
+
+fn sanitize_xai_responses_request_with_private_tools(
+    body: &mut Value,
+    enable_codex_private_tools: bool,
+) -> bool {
     if !body.is_object() {
         return false;
     }
@@ -86,26 +100,37 @@ pub(crate) fn sanitize_xai_responses_request(body: &mut Value) -> bool {
         }
     }
 
-    // 3. Codex plugin-private flags buried at any depth (e.g. inside tools or
-    //    tool parameter schemas).
-    for field in RECURSIVE_UNSUPPORTED_FIELDS {
-        changed |= remove_field_recursive(body, field);
-    }
+    if enable_codex_private_tools {
+        // 3. Codex plugin-private flags buried at any depth (e.g. inside tools
+        //    or tool parameter schemas).
+        for field in RECURSIVE_UNSUPPORTED_FIELDS {
+            changed |= remove_field_recursive(body, field);
+        }
 
-    // 4. Lift the `additional_tools` input carrier (Responses Lite private
-    //    shape) up to top-level `tools` so the supported ones survive.
-    changed |= promote_additional_tools(body);
+        // 4. Lift the `additional_tools` input carrier (Responses Lite private
+        //    shape) up to top-level `tools` so the supported ones survive.
+        changed |= promote_additional_tools(body);
+    }
 
     // 5. Drop `content: null` on reasoning input items — xAI's untagged enum
     //    deserializer refuses a present-but-null content field.
     changed |= strip_null_reasoning_content(body);
 
-    // 6. Keep reasoning effort, but do not ask xAI for reasoning summaries: Codex
-    //    treats that output item as hidden thinking, not final assistant text.
-    changed |= strip_reasoning_summary_request(body);
+    // 6. Keep reasoning effort, but do not ask xAI for reasoning summaries on
+    //    Codex requests: Codex treats that output item as hidden thinking, not
+    //    final assistant text. Other Responses clients retain their own
+    //    reasoning semantics.
+    if enable_codex_private_tools {
+        changed |= strip_reasoning_summary_request(body);
+    }
 
-    // 7. Whitelist the tool types and clean a now-dangling `tool_choice`.
-    changed |= filter_unsupported_tools(body);
+    // 7. Codex-only carriers have already been proxied or promoted, so remove
+    //    any remaining types that xAI cannot parse. Standard clients retain
+    //    their tool declarations unchanged and receive the upstream's own
+    //    validation response instead of silent semantic rewriting.
+    if enable_codex_private_tools {
+        changed |= filter_unsupported_tools(body);
+    }
 
     changed
 }
@@ -525,6 +550,32 @@ mod tests {
             .map(|t| t.get("type").and_then(Value::as_str).unwrap())
             .collect();
         assert_eq!(types, vec!["function", "mcp"]);
+    }
+
+    #[test]
+    fn standard_responses_client_tools_are_not_intercepted() {
+        let mut body = json!({
+            "model": "grok-4.5",
+            "reasoning": {"effort": "high", "summary": "auto"},
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "namespace",
+                    "name": "private",
+                    "external_web_access": true,
+                    "tools": []
+                },
+                {"type": "custom", "name": "custom_tool"}
+            ],
+            "input": [{
+                "type": "additional_tools",
+                "tools": [{"type": "function", "name": "loaded"}]
+            }]
+        });
+        let original = body.clone();
+
+        assert!(!sanitize_standard_xai_responses_request(&mut body));
+        assert_eq!(body, original);
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
@@ -58,8 +58,9 @@ pub(crate) fn prepare_xai_tool_search_request(body: &mut Value) -> Result<bool, 
         changed |= append_loaded_tools(body, loaded_tools)?;
     }
     if offers_tool_search {
-        changed |= omit_unloaded_top_level_functions(body);
+        changed |= omit_unloaded_top_level_tools(body);
     }
+    validate_xai_visible_tool_limit(body)?;
     Ok(changed)
 }
 
@@ -85,22 +86,14 @@ pub(crate) fn normalize_xai_top_level_function_schemas(body: &mut Value) -> bool
     changed
 }
 
-fn omit_unloaded_top_level_functions(body: &mut Value) -> bool {
+fn omit_unloaded_top_level_tools(body: &mut Value) -> bool {
     let Some(tools) = body.get_mut("tools").and_then(Value::as_array_mut) else {
         return false;
     };
     let original_len = tools.len();
     let mut changed = false;
     tools.retain_mut(|tool| {
-        if tool.get("type").and_then(Value::as_str) != Some("function") {
-            return true;
-        }
-        let deferred = tool
-            .get("defer_loading")
-            .or_else(|| tool.get("deferLoading"))
-            .and_then(Value::as_bool)
-            .unwrap_or(false);
-        if deferred {
+        if is_tool_deferred(tool) {
             return false;
         }
         if let Some(obj) = tool.as_object_mut() {
@@ -138,10 +131,14 @@ fn validate_no_search_tool_catalog(body: &Value) -> Result<(), ProxyError> {
         ));
     }
 
+    validate_xai_visible_tool_limit(body)
+}
+
+fn validate_xai_visible_tool_limit(body: &Value) -> Result<(), ProxyError> {
     let visible_tools = count_xai_visible_tools(body);
     if visible_tools > XAI_MAX_TOOL_COUNT {
         return Err(ProxyError::TransformError(format!(
-            "xAI native Responses received {visible_tools} tools without tool_search support; limit is {XAI_MAX_TOOL_COUNT}"
+            "xAI native Responses received {visible_tools} visible tools; limit is {XAI_MAX_TOOL_COUNT}"
         )));
     }
     Ok(())
@@ -172,15 +169,19 @@ fn tools_contain_deferred(tools: &[Value]) -> bool {
 }
 
 fn tool_contains_deferred(tool: &Value) -> bool {
-    tool.get("defer_loading")
-        .or_else(|| tool.get("deferLoading"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
+    is_tool_deferred(tool)
         || tool
             .get("tools")
             .or_else(|| tool.get("children"))
             .and_then(Value::as_array)
             .is_some_and(|tools| tools_contain_deferred(tools))
+}
+
+fn is_tool_deferred(tool: &Value) -> bool {
+    tool.get("defer_loading")
+        .or_else(|| tool.get("deferLoading"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 fn count_xai_visible_tools(body: &Value) -> usize {
@@ -217,6 +218,13 @@ fn collect_xai_visible_tool_keys(
     namespace_key: Option<&str>,
     seen: &mut HashSet<String>,
 ) {
+    // Initial deferred catalog entries are omitted later by the request
+    // transforms. Loaded copies have their marker removed before reaching this
+    // count, so only tools that will actually be sent upstream consume xAI's
+    // catalog limit.
+    if is_tool_deferred(tool) {
+        return;
+    }
     match tool.get("type").and_then(Value::as_str) {
         Some("namespace") => {
             let name = tool
@@ -1314,6 +1322,86 @@ mod tests {
         assert_eq!(body["tools"][0]["name"], TOOL_SEARCH_PROXY_NAME);
         assert_eq!(body["tools"][1]["name"], "hot");
         assert!(body["tools"][1].get("deferLoading").is_none());
+    }
+
+    #[test]
+    fn initial_top_level_deferred_non_function_tools_are_omitted() {
+        let mut body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "mcp",
+                    "server_label": "cold",
+                    "defer_loading": true
+                },
+                {
+                    "type": "mcp",
+                    "server_label": "hot",
+                    "deferLoading": false
+                }
+            ]
+        });
+
+        prepare_xai_tool_search_request(&mut body).unwrap();
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0]["name"], TOOL_SEARCH_PROXY_NAME);
+        assert_eq!(tools[1]["server_label"], "hot");
+        assert!(tools[1].get("deferLoading").is_none());
+    }
+
+    #[test]
+    fn rejects_oversized_catalog_after_search_result_promotion() {
+        let children = (0..XAI_MAX_TOOL_COUNT)
+            .map(|index| {
+                json!({
+                    "type": "function",
+                    "name": format!("loaded_{index}"),
+                    "defer_loading": true,
+                    "parameters": {"type": "object"}
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut body = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "tools": [{
+                    "type": "namespace",
+                    "name": "mcp__loaded__",
+                    "defer_loading": true,
+                    "tools": children
+                }]
+            }]
+        });
+
+        let error = prepare_xai_tool_search_request(&mut body).unwrap_err();
+        assert!(error.to_string().contains("351 visible tools"));
+        assert!(error.to_string().contains("limit is 350"));
+    }
+
+    #[test]
+    fn accepts_search_shim_plus_loaded_catalog_at_limit() {
+        let loaded = (0..XAI_MAX_TOOL_COUNT - 1)
+            .map(|index| {
+                json!({
+                    "type": "function",
+                    "name": format!("loaded_{index}"),
+                    "parameters": {"type": "object"}
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut body = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": [{
+                "type": "additional_tools",
+                "tools": loaded
+            }]
+        });
+
+        prepare_xai_tool_search_request(&mut body).unwrap();
+        assert_eq!(body["tools"].as_array().unwrap().len(), XAI_MAX_TOOL_COUNT);
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
@@ -40,7 +40,7 @@ pub(crate) fn request_offers_tool_search(body: &Value) -> bool {
 ///   exposes exactly the tools Codex selected.
 pub(crate) fn prepare_xai_tool_search_request(body: &mut Value) -> Result<bool, ProxyError> {
     let offers_tool_search = request_offers_tool_search(body);
-    if has_tool_search_proxy_function(body) {
+    if offers_tool_search && has_tool_search_proxy_function(body) {
         return Err(ProxyError::TransformError(
             "function name ccswitch_tool_search is reserved for the xAI tool_search proxy shim"
                 .to_string(),
@@ -55,7 +55,7 @@ pub(crate) fn prepare_xai_tool_search_request(body: &mut Value) -> Result<bool, 
     let mut loaded_tools = take_additional_tools(body, &mut changed);
     loaded_tools.extend(rewrite_tool_search_history(body, &mut changed));
     if !loaded_tools.is_empty() {
-        changed |= append_loaded_tools(body, loaded_tools)?;
+        changed |= append_loaded_tools(body, loaded_tools, offers_tool_search)?;
     }
     if offers_tool_search {
         changed |= omit_unloaded_top_level_tools(body);
@@ -450,7 +450,11 @@ fn canonical_arguments(arguments: Option<&Value>) -> String {
     }
 }
 
-fn append_loaded_tools(body: &mut Value, loaded_tools: Vec<Value>) -> Result<bool, ProxyError> {
+fn append_loaded_tools(
+    body: &mut Value,
+    loaded_tools: Vec<Value>,
+    reserve_tool_search_proxy_name: bool,
+) -> Result<bool, ProxyError> {
     let Some(obj) = body.as_object_mut() else {
         return Ok(false);
     };
@@ -463,7 +467,8 @@ fn append_loaded_tools(body: &mut Value, loaded_tools: Vec<Value>) -> Result<boo
 
     let mut changed = false;
     for tool in loaded_tools {
-        if tool.get("type").and_then(Value::as_str) == Some("function")
+        if reserve_tool_search_proxy_name
+            && tool.get("type").and_then(Value::as_str) == Some("function")
             && tool
                 .get("name")
                 .and_then(Value::as_str)
@@ -1258,7 +1263,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_proxy_function_name_even_without_search_shim() {
+    fn accepts_proxy_function_name_without_search_shim() {
         let mut body = json!({
             "tools": [{
                 "type": "function",
@@ -1266,6 +1271,42 @@ mod tests {
                 "parameters": {}
             }]
         });
+        assert!(!prepare_xai_tool_search_request(&mut body).unwrap());
+        assert_eq!(body["tools"][0]["name"], TOOL_SEARCH_PROXY_NAME);
+    }
+
+    #[test]
+    fn accepts_loaded_proxy_function_name_without_search_shim() {
+        let mut body = json!({
+            "input": [{
+                "type": "additional_tools",
+                "tools": [{
+                    "type": "function",
+                    "name": TOOL_SEARCH_PROXY_NAME,
+                    "parameters": {}
+                }]
+            }]
+        });
+
+        prepare_xai_tool_search_request(&mut body).unwrap();
+        assert_eq!(body["tools"][0]["name"], TOOL_SEARCH_PROXY_NAME);
+    }
+
+    #[test]
+    fn rejects_loaded_proxy_function_name_with_search_shim() {
+        let mut body = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "tools": [{
+                    "type": "function",
+                    "name": TOOL_SEARCH_PROXY_NAME,
+                    "parameters": {}
+                }]
+            }]
+        });
+
         assert!(prepare_xai_tool_search_request(&mut body).is_err());
     }
 

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
@@ -1,0 +1,1045 @@
+//! Codex `tool_search` compatibility for xAI's native Responses endpoint.
+//!
+//! Codex uses private Responses items (`tool_search`, `tool_search_call`, and
+//! `tool_search_output`) to defer large dynamic-tool catalogs. xAI's strict
+//! Responses parser does not accept those item types, but it does accept normal
+//! function tools and function-call history. This module translates only that
+//! protocol surface; Codex remains responsible for searching and executing MCP
+//! tools locally.
+
+use std::collections::HashSet;
+
+use serde_json::{json, Map, Value};
+
+use crate::proxy::error::ProxyError;
+
+const TOOL_SEARCH_PROXY_NAME: &str = "tool_search";
+
+/// Whether the original Codex request offered the private `tool_search` tool.
+///
+/// Response restoration uses this request-scoped bit instead of matching every
+/// function named `tool_search`, so an unrelated user function is never
+/// reclassified accidentally.
+pub(crate) fn request_offers_tool_search(body: &Value) -> bool {
+    body.get("tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| {
+            tools
+                .iter()
+                .any(|tool| tool.get("type").and_then(Value::as_str) == Some("tool_search"))
+        })
+}
+
+/// Translate Codex's private deferred-tool protocol into xAI-compatible native
+/// Responses shapes.
+///
+/// This runs before namespace flattening and the existing xAI sanitizer:
+///
+/// - `type: tool_search` becomes a normal function declaration.
+/// - prior `tool_search_call` items become normal `function_call` history.
+/// - `tool_search_output` tools are promoted to top-level tools, while the
+///   output item becomes a normal `function_call_output`.
+/// - loaded tools have their deferred marker removed so namespace flattening
+///   exposes exactly the tools Codex selected.
+pub(crate) fn prepare_xai_tool_search_request(body: &mut Value) -> Result<bool, ProxyError> {
+    let offers_tool_search = request_offers_tool_search(body);
+    if offers_tool_search && has_tool_search_function(body) {
+        return Err(ProxyError::TransformError(
+            "native tool_search collides with a top-level function named tool_search".to_string(),
+        ));
+    }
+
+    let mut changed = replace_tool_search_declaration(body);
+    changed |= replace_tool_search_choice(body);
+    let mut loaded_tools = take_additional_tools(body, &mut changed);
+    loaded_tools.extend(rewrite_tool_search_history(body, &mut changed));
+    if !loaded_tools.is_empty() {
+        changed |= append_loaded_tools(body, loaded_tools)?;
+    }
+    if offers_tool_search {
+        changed |= omit_unloaded_top_level_functions(body);
+    }
+    Ok(changed)
+}
+
+/// Normalize every top-level function after namespace flattening.
+///
+/// Codex may replay a tool discovered in an earlier turn directly in the next
+/// request's top-level catalog, without another `tool_search_output` carrier.
+/// Those replayed tools must receive the same xAI schema normalization as newly
+/// discovered tools, especially when their root schema is `object | null`.
+pub(crate) fn normalize_xai_top_level_function_schemas(body: &mut Value) -> bool {
+    let Some(tools) = body.get_mut("tools").and_then(Value::as_array_mut) else {
+        return false;
+    };
+    let mut changed = false;
+    for tool in tools {
+        if tool.get("type").and_then(Value::as_str) != Some("function") {
+            continue;
+        }
+        let before = tool.clone();
+        normalize_loaded_tool(tool);
+        changed |= *tool != before;
+    }
+    changed
+}
+
+fn omit_unloaded_top_level_functions(body: &mut Value) -> bool {
+    let Some(tools) = body.get_mut("tools").and_then(Value::as_array_mut) else {
+        return false;
+    };
+    let original_len = tools.len();
+    let mut changed = false;
+    tools.retain_mut(|tool| {
+        if tool.get("type").and_then(Value::as_str) != Some("function") {
+            return true;
+        }
+        let deferred = tool
+            .get("defer_loading")
+            .or_else(|| tool.get("deferLoading"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        if deferred {
+            return false;
+        }
+        if let Some(obj) = tool.as_object_mut() {
+            changed |= obj.remove("defer_loading").is_some();
+            changed |= obj.remove("deferLoading").is_some();
+        }
+        true
+    });
+    changed || tools.len() != original_len
+}
+
+fn has_tool_search_function(body: &Value) -> bool {
+    body.get("tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| {
+            tools.iter().any(|tool| {
+                tool.get("type").and_then(Value::as_str) == Some("function")
+                    && tool.get("name").and_then(Value::as_str) == Some(TOOL_SEARCH_PROXY_NAME)
+            })
+        })
+}
+
+/// Convert xAI's proxy function call back into a client-executed Codex
+/// `tool_search_call`. Recurses through both full Responses payloads and parsed
+/// SSE events.
+pub(crate) fn restore_tool_search_calls(value: &mut Value) -> bool {
+    if restore_direct_output_item(value) {
+        return true;
+    }
+    let Some(obj) = value.as_object_mut() else {
+        return false;
+    };
+
+    let mut changed = false;
+    let is_output_item_event = matches!(
+        obj.get("type").and_then(Value::as_str),
+        Some("response.output_item.added" | "response.output_item.done")
+    );
+    if is_output_item_event {
+        if let Some(item) = obj.get_mut("item") {
+            changed |= restore_direct_output_item(item);
+        }
+    }
+    if let Some(output) = obj.get_mut("output").and_then(Value::as_array_mut) {
+        for item in output {
+            changed |= restore_direct_output_item(item);
+        }
+    }
+    if let Some(response) = obj.get_mut("response") {
+        changed |= restore_tool_search_calls(response);
+    }
+    changed
+}
+
+fn restore_direct_output_item(value: &mut Value) -> bool {
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+    if !is_tool_search_function_call(obj) {
+        return false;
+    }
+    *value = tool_search_call_item(obj);
+    true
+}
+
+fn replace_tool_search_declaration(body: &mut Value) -> bool {
+    let Some(tools) = body.get_mut("tools").and_then(Value::as_array_mut) else {
+        return false;
+    };
+    let mut changed = false;
+    for tool in tools {
+        if tool.get("type").and_then(Value::as_str) == Some("tool_search") {
+            *tool = tool_search_function();
+            changed = true;
+        }
+    }
+    changed
+}
+
+fn replace_tool_search_choice(body: &mut Value) -> bool {
+    let Some(choice) = body.get_mut("tool_choice") else {
+        return false;
+    };
+    if choice.get("type").and_then(Value::as_str) != Some("tool_search") {
+        return false;
+    }
+    *choice = json!({"type": "function", "name": TOOL_SEARCH_PROXY_NAME});
+    true
+}
+
+fn tool_search_function() -> Value {
+    json!({
+        "type": "function",
+        "name": TOOL_SEARCH_PROXY_NAME,
+        "description": "Search and load Codex tools, plugins, connectors, and MCP namespaces for the current task.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Search query for tools or connectors to load."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of tool groups to return."
+                }
+            },
+            "required": ["query"]
+        }
+    })
+}
+
+fn take_additional_tools(body: &mut Value, changed: &mut bool) -> Vec<Value> {
+    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
+        return Vec::new();
+    };
+    if !input
+        .iter()
+        .any(|item| item.get("type").and_then(Value::as_str) == Some("additional_tools"))
+    {
+        return Vec::new();
+    }
+
+    let mut loaded_tools = Vec::new();
+    let mut retained = Vec::with_capacity(input.len());
+    for item in std::mem::take(input) {
+        if item.get("type").and_then(Value::as_str) == Some("additional_tools") {
+            if let Some(tools) = item.get("tools").and_then(Value::as_array) {
+                for tool in tools {
+                    let mut loaded = tool.clone();
+                    normalize_loaded_tool(&mut loaded);
+                    loaded_tools.push(loaded);
+                }
+            }
+            *changed = true;
+        } else {
+            retained.push(item);
+        }
+    }
+    *input = retained;
+    loaded_tools
+}
+
+fn rewrite_tool_search_history(body: &mut Value, changed: &mut bool) -> Vec<Value> {
+    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
+        return Vec::new();
+    };
+
+    let mut loaded_tools = Vec::new();
+    for item in input {
+        match item.get("type").and_then(Value::as_str) {
+            Some("tool_search_call") => {
+                *item = tool_search_call_as_function_call(item);
+                *changed = true;
+            }
+            Some("tool_search_output") => {
+                if let Some(tools) = item.get("tools").and_then(Value::as_array) {
+                    for tool in tools {
+                        let mut loaded = tool.clone();
+                        normalize_loaded_tool(&mut loaded);
+                        loaded_tools.push(loaded);
+                    }
+                }
+                *item = tool_search_output_as_function_output(item);
+                *changed = true;
+            }
+            _ => {}
+        }
+    }
+    loaded_tools
+}
+
+fn tool_search_call_as_function_call(item: &Value) -> Value {
+    let call_id = item
+        .get("call_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let arguments = canonical_arguments(item.get("arguments"));
+    let mut output = json!({
+        "type": "function_call",
+        "name": TOOL_SEARCH_PROXY_NAME,
+        "call_id": call_id,
+        "arguments": arguments
+    });
+    if let Some(status) = item.get("status").cloned() {
+        output["status"] = status;
+    }
+    output
+}
+
+fn tool_search_output_as_function_output(item: &Value) -> Value {
+    let call_id = item
+        .get("call_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let output = serde_json::to_string(item).unwrap_or_else(|_| "{}".to_string());
+    json!({
+        "type": "function_call_output",
+        "call_id": call_id,
+        "output": output
+    })
+}
+
+fn canonical_arguments(arguments: Option<&Value>) -> String {
+    match arguments {
+        Some(Value::String(value)) => value.clone(),
+        Some(value) => serde_json::to_string(value).unwrap_or_else(|_| "{}".to_string()),
+        None => "{}".to_string(),
+    }
+}
+
+fn append_loaded_tools(body: &mut Value, loaded_tools: Vec<Value>) -> Result<bool, ProxyError> {
+    let Some(obj) = body.as_object_mut() else {
+        return Ok(false);
+    };
+    let tools = obj
+        .entry("tools".to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let Some(tools) = tools.as_array_mut() else {
+        return Ok(false);
+    };
+
+    let mut changed = false;
+    for tool in loaded_tools {
+        if tool.get("type").and_then(Value::as_str) == Some("function")
+            && tool.get("name").and_then(Value::as_str) == Some(TOOL_SEARCH_PROXY_NAME)
+        {
+            return Err(ProxyError::TransformError(
+                "discovered function named tool_search collides with the xAI proxy shim"
+                    .to_string(),
+            ));
+        }
+
+        let key = tool_dedup_key(&tool);
+        if tool.get("type").and_then(Value::as_str) == Some("namespace") {
+            if let Some(existing) = tools.iter_mut().find(|candidate| {
+                candidate.get("type").and_then(Value::as_str) == Some("namespace")
+                    && candidate.get("name") == tool.get("name")
+            }) {
+                changed |= merge_namespace_children(existing, &tool);
+                continue;
+            }
+        }
+        if let Some(index) = tools
+            .iter()
+            .position(|existing| tool_dedup_key(existing) == key)
+        {
+            if tools[index] != tool {
+                // A discovered top-level function supersedes its stale deferred
+                // declaration and schema aliases.
+                tools[index] = tool;
+                changed = true;
+            }
+        } else {
+            tools.push(tool);
+            changed = true;
+        }
+    }
+    Ok(changed)
+}
+
+fn merge_namespace_children(existing: &mut Value, loaded: &Value) -> bool {
+    let Some(loaded_children) = loaded
+        .get("tools")
+        .or_else(|| loaded.get("children"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    let Some(existing_obj) = existing.as_object_mut() else {
+        return false;
+    };
+    let mut changed = existing_obj.remove("defer_loading").is_some();
+    changed |= existing_obj.remove("deferLoading").is_some();
+    if !existing_obj.contains_key("tools") {
+        if let Some(children) = existing_obj.remove("children") {
+            existing_obj.insert("tools".to_string(), children);
+            changed = true;
+        }
+    }
+    let existing_children = existing_obj
+        .entry("tools".to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let Some(existing_children) = existing_children.as_array_mut() else {
+        return changed;
+    };
+
+    for loaded_child in loaded_children {
+        let key = tool_dedup_key(loaded_child);
+        if let Some(index) = existing_children
+            .iter()
+            .position(|child| tool_dedup_key(child) == key)
+        {
+            if existing_children[index] != *loaded_child {
+                // Prefer the discovered copy: its deferred marker and schema
+                // aliases have already been normalized.
+                existing_children[index] = loaded_child.clone();
+                changed = true;
+            }
+        } else {
+            existing_children.push(loaded_child.clone());
+            changed = true;
+        }
+    }
+    changed
+}
+
+fn tool_dedup_key(tool: &Value) -> String {
+    let tool_type = tool.get("type").and_then(Value::as_str).unwrap_or_default();
+    let name = tool.get("name").and_then(Value::as_str).unwrap_or_default();
+    if !tool_type.is_empty() || !name.is_empty() {
+        return format!("{tool_type}\0{name}");
+    }
+    tool.to_string()
+}
+
+fn normalize_loaded_tool(tool: &mut Value) {
+    let Some(obj) = tool.as_object_mut() else {
+        return;
+    };
+    obj.remove("defer_loading");
+    obj.remove("deferLoading");
+
+    match obj.get("type").and_then(Value::as_str) {
+        Some("function") => {
+            let mut parameters = ["parameters", "inputSchema", "input_schema"]
+                .iter()
+                .filter_map(|key| obj.get(*key).cloned())
+                .find(|value| value.as_object().is_some_and(|schema| !schema.is_empty()))
+                .unwrap_or_else(|| json!({"type": "object", "properties": {}}));
+            obj.remove("inputSchema");
+            obj.remove("input_schema");
+
+            if let Some(schema) = parameters.as_object_mut() {
+                normalize_root_object_schema(schema);
+            }
+            obj.insert("parameters".to_string(), parameters);
+        }
+        Some("namespace") => {
+            let child_key = if obj.contains_key("tools") {
+                "tools"
+            } else {
+                "children"
+            };
+            if let Some(children) = obj.get_mut(child_key).and_then(Value::as_array_mut) {
+                for child in children {
+                    normalize_loaded_tool(child);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn normalize_root_object_schema(schema: &mut Map<String, Value>) {
+    // xAI does not treat a ref-only branch as an object branch, even when the
+    // referenced `$defs` entry ultimately resolves to an object. Codex
+    // Desktop's automation tool uses several layers of ref-only unions at the
+    // parameter root, so recursively expand only that root candidate graph
+    // into direct object branches. Nested `properties`/`items` schemas are not
+    // traversed, preserving legitimate nullable fields.
+    let defs = schema
+        .get("$defs")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let original_union_key = ["oneOf", "anyOf"]
+        .into_iter()
+        .find(|key| schema.get(*key).is_some())
+        .unwrap_or("oneOf");
+    let mut root_candidate = schema.clone();
+    root_candidate.remove("$defs");
+    let variants = expand_root_object_variants(&root_candidate, &defs, &mut HashSet::new());
+
+    schema.remove("$ref");
+    schema.remove("anyOf");
+    schema.remove("oneOf");
+    if !variants.is_empty() {
+        schema.insert(
+            original_union_key.to_string(),
+            Value::Array(variants.into_iter().map(Value::Object).collect()),
+        );
+    }
+    schema.insert("type".to_string(), json!("object"));
+    schema
+        .entry("properties".to_string())
+        .or_insert_with(|| json!({}));
+}
+
+fn expand_root_object_variants(
+    schema: &Map<String, Value>,
+    defs: &Map<String, Value>,
+    visiting: &mut HashSet<String>,
+) -> Vec<Map<String, Value>> {
+    if !schema_type_can_be_object(schema.get("type")) {
+        return Vec::new();
+    }
+
+    let mut base = schema.clone();
+    base.remove("$ref");
+    base.remove("anyOf");
+    base.remove("oneOf");
+    base.remove("$defs");
+    base.insert("type".to_string(), json!("object"));
+
+    if let Some(reference) = schema.get("$ref").and_then(Value::as_str) {
+        let Some(name) = local_def_name(reference) else {
+            return Vec::new();
+        };
+        if !visiting.insert(name.clone()) {
+            return Vec::new();
+        }
+        let mut variants = defs
+            .get(&name)
+            .and_then(Value::as_object)
+            .map(|target| expand_root_object_variants(target, defs, visiting))
+            .unwrap_or_default();
+        visiting.remove(&name);
+        merge_root_candidate_base(&base, &mut variants);
+        return variants;
+    }
+
+    if let Some(branches) = ["oneOf", "anyOf"]
+        .into_iter()
+        .find_map(|key| schema.get(key).and_then(Value::as_array))
+    {
+        let mut variants = Vec::new();
+        for branch in branches {
+            if let Some(branch) = branch.as_object() {
+                variants.extend(expand_root_object_variants(branch, defs, visiting));
+            }
+        }
+        merge_root_candidate_base(&base, &mut variants);
+        return variants;
+    }
+
+    vec![base]
+}
+
+fn merge_root_candidate_base(base: &Map<String, Value>, variants: &mut [Map<String, Value>]) {
+    for variant in variants {
+        for (key, value) in base {
+            variant.entry(key.clone()).or_insert_with(|| value.clone());
+        }
+        variant.insert("type".to_string(), json!("object"));
+    }
+}
+
+fn local_def_name(reference: &str) -> Option<String> {
+    reference
+        .strip_prefix("#/$defs/")
+        .filter(|name| !name.is_empty() && !name.contains('/'))
+        .map(|name| name.replace("~1", "/").replace("~0", "~"))
+}
+
+fn schema_type_can_be_object(schema_type: Option<&Value>) -> bool {
+    match schema_type {
+        None => true,
+        Some(Value::String(kind)) => kind == "object",
+        Some(Value::Array(kinds)) => kinds.iter().any(|kind| kind.as_str() == Some("object")),
+        Some(_) => false,
+    }
+}
+
+fn is_tool_search_function_call(obj: &Map<String, Value>) -> bool {
+    obj.get("type").and_then(Value::as_str) == Some("function_call")
+        && obj.get("name").and_then(Value::as_str) == Some(TOOL_SEARCH_PROXY_NAME)
+}
+
+fn tool_search_call_item(item: &Map<String, Value>) -> Value {
+    let call_id = item
+        .get("call_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let status = item
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("completed");
+    let mut arguments = item
+        .get("arguments")
+        .and_then(|value| match value {
+            Value::Object(_) => Some(value.clone()),
+            Value::String(raw) => serde_json::from_str::<Value>(raw).ok(),
+            _ => None,
+        })
+        .filter(Value::is_object)
+        .unwrap_or_else(|| json!({}));
+    if let Some(limit) = arguments
+        .get("limit")
+        .and_then(Value::as_str)
+        .and_then(|value| value.parse::<u64>().ok())
+    {
+        arguments["limit"] = json!(limit);
+    }
+
+    let mut output = json!({
+        "type": "tool_search_call",
+        "call_id": call_id,
+        "status": status,
+        "execution": "client",
+        "arguments": arguments
+    });
+    if let Some(reasoning) = item.get("reasoning_content").cloned() {
+        output["reasoning_content"] = reasoning;
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxies_tool_search_and_loaded_namespace_tools() {
+        let mut body = json!({
+            "model": "grok-4.6",
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "namespace",
+                    "name": "mcp__mail__",
+                    "tools": [{
+                        "type": "function",
+                        "name": "search",
+                        "defer_loading": true,
+                        "parameters": {"type": "object"}
+                    }]
+                }
+            ],
+            "tool_choice": {"type": "tool_search"},
+            "input": [
+                {
+                    "type": "tool_search_call",
+                    "call_id": "search_1",
+                    "status": "completed",
+                    "execution": "client",
+                    "arguments": {"query": "search mail", "limit": 5}
+                },
+                {
+                    "type": "tool_search_output",
+                    "call_id": "search_1",
+                    "tools": [{
+                        "type": "namespace",
+                        "name": "mcp__mail__",
+                        "tools": [{
+                            "type": "function",
+                            "name": "search",
+                            "defer_loading": true,
+                            "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}}
+                        }]
+                    }]
+                }
+            ]
+        });
+
+        assert!(request_offers_tool_search(&body));
+        assert!(prepare_xai_tool_search_request(&mut body).unwrap());
+
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["tools"][0]["name"], "tool_search");
+        assert_eq!(
+            body["tool_choice"],
+            json!({"type": "function", "name": "tool_search"})
+        );
+        assert_eq!(body["tools"][1]["type"], "namespace");
+        assert!(body["tools"][1]["tools"][0].get("defer_loading").is_none());
+        assert!(body["tools"][1]["tools"][0].get("inputSchema").is_none());
+        assert_eq!(body["tools"][1]["tools"][0]["parameters"]["type"], "object");
+        assert_eq!(body["input"][0]["type"], "function_call");
+        assert_eq!(body["input"][0]["name"], "tool_search");
+        assert_eq!(body["input"][1]["type"], "function_call_output");
+
+        super::super::transform_codex_responses_namespace::flatten_request_namespaces(&mut body)
+            .unwrap();
+        let names = body["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["tool_search", "mcp__mail____search"]);
+    }
+
+    #[test]
+    fn discovered_namespace_clears_outer_deferred_marker() {
+        let mut body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "namespace",
+                    "name": "mcp__mail__",
+                    "defer_loading": true,
+                    "tools": [{
+                        "type": "function",
+                        "name": "search",
+                        "defer_loading": true,
+                        "parameters": {"type": "object"}
+                    }]
+                }
+            ],
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "tools": [{
+                    "type": "namespace",
+                    "name": "mcp__mail__",
+                    "deferLoading": true,
+                    "tools": [{
+                        "type": "function",
+                        "name": "search",
+                        "deferLoading": true,
+                        "parameters": {"type": "object"}
+                    }]
+                }]
+            }]
+        });
+
+        prepare_xai_tool_search_request(&mut body).unwrap();
+        assert!(body["tools"][1].get("defer_loading").is_none());
+        super::super::transform_codex_responses_namespace::flatten_request_namespaces(&mut body)
+            .unwrap();
+        assert_eq!(body["tools"][1]["name"], "mcp__mail____search");
+    }
+
+    #[test]
+    fn discovered_function_replaces_stale_top_level_copy_without_corrupting_schema() {
+        let mut body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "function",
+                    "name": "lookup",
+                    "defer_loading": true,
+                    "parameters": {"type": "object"}
+                }
+            ],
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "tools": [{
+                    "type": "function",
+                    "name": "lookup",
+                    "deferLoading": true,
+                    "parameters": {"oneOf": [{"required": ["id"]}]},
+                    "inputSchema": {"type": "string"}
+                }]
+            }]
+        });
+        body["input"][0]["tools"][0]["parameters"]["properties"] = json!({
+            "defer_loading": {"type": "boolean"}
+        });
+
+        prepare_xai_tool_search_request(&mut body).unwrap();
+        let lookup = &body["tools"][1];
+        assert!(lookup.get("defer_loading").is_none());
+        assert!(lookup.get("deferLoading").is_none());
+        assert!(lookup.get("inputSchema").is_none());
+        assert_eq!(lookup["parameters"]["type"], "object");
+        assert_eq!(
+            lookup["parameters"]["properties"]["defer_loading"]["type"],
+            "boolean"
+        );
+    }
+
+    #[test]
+    fn invalid_parameters_fall_back_to_valid_schema_alias() {
+        let mut tool = json!({
+            "type": "function",
+            "name": "lookup",
+            "parameters": null,
+            "inputSchema": {
+                "type": "object",
+                "properties": {"id": {"type": "string"}}
+            }
+        });
+        normalize_loaded_tool(&mut tool);
+        assert_eq!(tool["parameters"]["properties"]["id"]["type"], "string");
+        assert!(tool.get("inputSchema").is_none());
+    }
+
+    #[test]
+    fn loaded_root_union_drops_non_object_branches_for_xai() {
+        let mut tool = json!({
+            "type": "function",
+            "name": "automation_update",
+            "parameters": {
+                "anyOf": [
+                    {
+                        "type": "object",
+                        "properties": {"id": {"type": "string"}}
+                    },
+                    {"type": "null"}
+                ]
+            }
+        });
+
+        normalize_loaded_tool(&mut tool);
+        assert_eq!(tool["parameters"]["type"], "object");
+        let branches = tool["parameters"]["anyOf"].as_array().unwrap();
+        assert_eq!(branches.len(), 1);
+        assert_eq!(branches[0]["type"], "object");
+        assert_eq!(branches[0]["properties"]["id"]["type"], "string");
+    }
+
+    #[test]
+    fn replayed_top_level_function_union_is_normalized_after_flatten() {
+        let mut body = json!({
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "codex_app__automation_update",
+                    "parameters": {
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "value": {"anyOf": [{"type": "string"}, {"type": "null"}]}
+                                }
+                            },
+                            {"type": "null"}
+                        ]
+                    }
+                },
+                {"type": "web_search"}
+            ]
+        });
+
+        assert!(normalize_xai_top_level_function_schemas(&mut body));
+        let parameters = &body["tools"][0]["parameters"];
+        assert_eq!(parameters["type"], "object");
+        assert_eq!(parameters["oneOf"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            parameters["oneOf"][0]["properties"]["value"]["anyOf"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(body["tools"][1]["type"], "web_search");
+        assert!(!normalize_xai_top_level_function_schemas(&mut body));
+    }
+
+    #[test]
+    fn automation_root_ref_union_graph_is_normalized_for_xai() {
+        let mut tool = json!({
+            "type": "function",
+            "name": "automation_update",
+            "parameters": {
+                "oneOf": [
+                    {"$ref": "#/$defs/view"},
+                    {"$ref": "#/$defs/create"},
+                    {"$ref": "#/$defs/update"}
+                ],
+                "$defs": {
+                    "view": {
+                        "type": "object",
+                        "properties": {"mode": {"type": "string"}}
+                    },
+                    "create": {
+                        "oneOf": [
+                            {"$ref": "#/$defs/create_cron"},
+                            {"$ref": "#/$defs/create_heartbeat"}
+                        ]
+                    },
+                    "create_cron": {
+                        "type": "object",
+                        "properties": {
+                            "notificationPolicy": {
+                                "anyOf": [
+                                    {"type": "string"},
+                                    {"type": "null"}
+                                ]
+                            }
+                        }
+                    },
+                    "create_heartbeat": {"type": "object", "properties": {}},
+                    "update": {
+                        "oneOf": [
+                            {"type": "object", "properties": {"id": {"type": "string"}}},
+                            {"type": "object", "properties": {"name": {"type": "string"}}}
+                        ]
+                    }
+                }
+            }
+        });
+
+        normalize_loaded_tool(&mut tool);
+        let parameters = &tool["parameters"];
+        assert_eq!(parameters["type"], "object");
+        let branches = parameters["oneOf"].as_array().unwrap();
+        assert_eq!(branches.len(), 5);
+        assert!(branches.iter().all(|branch| branch["type"] == "object"));
+        assert!(branches.iter().all(|branch| branch.get("$ref").is_none()));
+        assert!(branches
+            .iter()
+            .all(|branch| branch.get("oneOf").is_none() && branch.get("anyOf").is_none()));
+        assert_eq!(
+            branches[1]["properties"]["notificationPolicy"]["anyOf"][1]["type"],
+            "null"
+        );
+    }
+
+    #[test]
+    fn additional_tools_are_promoted_before_namespace_flatten() {
+        let mut body = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": [{
+                "type": "additional_tools",
+                "tools": [{
+                    "type": "namespace",
+                    "name": "mcp__calendar__",
+                    "defer_loading": true,
+                    "tools": [{
+                        "type": "function",
+                        "name": "list_events",
+                        "defer_loading": true,
+                        "input_schema": {}
+                    }]
+                }]
+            }]
+        });
+
+        prepare_xai_tool_search_request(&mut body).unwrap();
+        assert!(body["input"].as_array().unwrap().is_empty());
+        super::super::transform_codex_responses_namespace::flatten_request_namespaces(&mut body)
+            .unwrap();
+        assert_eq!(body["tools"][1]["name"], "mcp__calendar____list_events");
+        assert_eq!(body["tools"][1]["parameters"]["type"], "object");
+    }
+
+    #[test]
+    fn rejects_native_tool_search_function_name_collision() {
+        let mut body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {"type": "function", "name": "tool_search", "parameters": {}}
+            ]
+        });
+        assert!(prepare_xai_tool_search_request(&mut body).is_err());
+        assert_eq!(body["tools"][0]["type"], "tool_search");
+    }
+
+    #[test]
+    fn initial_top_level_deferred_functions_are_omitted() {
+        let deferred = (0..400)
+            .map(|index| {
+                json!({
+                    "type": "function",
+                    "name": format!("deferred_{index}"),
+                    "defer_loading": true,
+                    "parameters": {"type": "object"}
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut tools = vec![json!({"type": "tool_search"})];
+        tools.extend(deferred);
+        tools.push(json!({
+            "type": "function",
+            "name": "hot",
+            "deferLoading": false,
+            "parameters": {"type": "object"}
+        }));
+        let mut body = json!({"tools": tools});
+
+        prepare_xai_tool_search_request(&mut body).unwrap();
+        assert_eq!(body["tools"].as_array().unwrap().len(), 2);
+        assert_eq!(body["tools"][0]["name"], "tool_search");
+        assert_eq!(body["tools"][1]["name"], "hot");
+        assert!(body["tools"][1].get("deferLoading").is_none());
+    }
+
+    #[test]
+    fn full_xai_pipeline_keeps_large_deferred_catalog_under_limit() {
+        let children = (0..400)
+            .map(|index| {
+                json!({
+                    "type": "function",
+                    "name": format!("tool_{index}"),
+                    "defer_loading": true,
+                    "parameters": {"type": "object"}
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut body = json!({
+            "model": "grok-4.6",
+            "tools": [
+                {"type": "tool_search"},
+                {"type": "namespace", "name": "mcp__large__", "tools": children}
+            ],
+            "input": "Find the right tool."
+        });
+
+        assert!(prepare_xai_tool_search_request(&mut body).unwrap());
+        assert!(
+            super::super::transform_codex_responses_namespace::flatten_request_namespaces(
+                &mut body
+            )
+            .unwrap()
+        );
+        super::super::transform_codex_responses_xai_sanitize::sanitize_xai_responses_request(
+            &mut body,
+        );
+
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["name"], "tool_search");
+    }
+
+    #[test]
+    fn restores_only_proxy_tool_search_calls_when_enabled_by_caller() {
+        let mut response = json!({
+            "type": "response.completed",
+            "response": {
+                "output": [{
+                    "type": "function_call",
+                    "name": "tool_search",
+                    "call_id": "search_1",
+                    "status": "completed",
+                    "arguments": "{\"query\":\"mail\",\"limit\":\"3\"}"
+                }]
+            }
+        });
+
+        assert!(restore_tool_search_calls(&mut response));
+        let call = &response["response"]["output"][0];
+        assert_eq!(call["type"], "tool_search_call");
+        assert_eq!(call["execution"], "client");
+        assert_eq!(call["arguments"]["query"], "mail");
+        assert!(call.get("name").is_none());
+    }
+
+    #[test]
+    fn malformed_tool_search_arguments_fail_closed_to_empty_object() {
+        let mut call = json!({
+            "type": "function_call",
+            "name": "tool_search",
+            "call_id": "search_1",
+            "arguments": "not json"
+        });
+        assert!(restore_tool_search_calls(&mut call));
+        assert_eq!(call["arguments"], json!({}));
+    }
+}

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
@@ -11,10 +11,12 @@ use std::collections::HashSet;
 
 use serde_json::{json, Map, Value};
 
+use super::codex_tool_bridge::{
+    request_offers_tool_search as shared_request_offers_tool_search, TOOL_SEARCH_NATIVE_TYPE,
+    TOOL_SEARCH_PROXY_NAME,
+};
 use crate::proxy::error::ProxyError;
 
-const TOOL_SEARCH_NATIVE_NAME: &str = "tool_search";
-const TOOL_SEARCH_PROXY_NAME: &str = "ccswitch_tool_search";
 const XAI_MAX_TOOL_COUNT: usize = 350;
 
 /// Whether the original Codex request offered the private `tool_search` tool.
@@ -22,13 +24,7 @@ const XAI_MAX_TOOL_COUNT: usize = 350;
 /// Response restoration uses this request-scoped bit so an unrelated user
 /// function is never reclassified accidentally.
 pub(crate) fn request_offers_tool_search(body: &Value) -> bool {
-    body.get("tools")
-        .and_then(Value::as_array)
-        .is_some_and(|tools| {
-            tools.iter().any(|tool| {
-                tool.get("type").and_then(Value::as_str) == Some(TOOL_SEARCH_NATIVE_NAME)
-            })
-        })
+    shared_request_offers_tool_search(body)
 }
 
 /// Translate Codex's private deferred-tool protocol into xAI-compatible native
@@ -44,9 +40,10 @@ pub(crate) fn request_offers_tool_search(body: &Value) -> bool {
 ///   exposes exactly the tools Codex selected.
 pub(crate) fn prepare_xai_tool_search_request(body: &mut Value) -> Result<bool, ProxyError> {
     let offers_tool_search = request_offers_tool_search(body);
-    if has_reserved_tool_search_function(body) {
+    if has_tool_search_proxy_function(body) {
         return Err(ProxyError::TransformError(
-            "native tool_search collides with a reserved xAI function name".to_string(),
+            "function name ccswitch_tool_search is reserved for the xAI tool_search proxy shim"
+                .to_string(),
         ));
     }
     if !offers_tool_search {
@@ -115,7 +112,7 @@ fn omit_unloaded_top_level_functions(body: &mut Value) -> bool {
     changed || tools.len() != original_len
 }
 
-fn has_reserved_tool_search_function(body: &Value) -> bool {
+fn has_tool_search_proxy_function(body: &Value) -> bool {
     body.get("tools")
         .and_then(Value::as_array)
         .is_some_and(|tools| {
@@ -124,13 +121,13 @@ fn has_reserved_tool_search_function(body: &Value) -> bool {
                     && tool
                         .get("name")
                         .and_then(Value::as_str)
-                        .is_some_and(is_reserved_tool_search_function_name)
+                        .is_some_and(is_tool_search_proxy_name)
             })
         })
 }
 
-fn is_reserved_tool_search_function_name(name: &str) -> bool {
-    name == TOOL_SEARCH_NATIVE_NAME || name == TOOL_SEARCH_PROXY_NAME
+fn is_tool_search_proxy_name(name: &str) -> bool {
+    name == TOOL_SEARCH_PROXY_NAME
 }
 
 fn validate_no_search_tool_catalog(body: &Value) -> Result<(), ProxyError> {
@@ -305,7 +302,7 @@ fn replace_tool_search_declaration(body: &mut Value) -> bool {
     };
     let mut changed = false;
     for tool in tools {
-        if tool.get("type").and_then(Value::as_str) == Some(TOOL_SEARCH_NATIVE_NAME) {
+        if tool.get("type").and_then(Value::as_str) == Some(TOOL_SEARCH_NATIVE_TYPE) {
             *tool = tool_search_function();
             changed = true;
         }
@@ -317,7 +314,7 @@ fn replace_tool_search_choice(body: &mut Value) -> bool {
     let Some(choice) = body.get_mut("tool_choice") else {
         return false;
     };
-    if choice.get("type").and_then(Value::as_str) != Some(TOOL_SEARCH_NATIVE_NAME) {
+    if choice.get("type").and_then(Value::as_str) != Some(TOOL_SEARCH_NATIVE_TYPE) {
         return false;
     }
     *choice = json!({"type": "function", "name": TOOL_SEARCH_PROXY_NAME});
@@ -462,7 +459,7 @@ fn append_loaded_tools(body: &mut Value, loaded_tools: Vec<Value>) -> Result<boo
             && tool
                 .get("name")
                 .and_then(Value::as_str)
-                .is_some_and(is_reserved_tool_search_function_name)
+                .is_some_and(is_tool_search_proxy_name)
         {
             return Err(ProxyError::TransformError(
                 "discovered function collides with the xAI tool_search proxy shim".to_string(),
@@ -1147,23 +1144,25 @@ mod tests {
     }
 
     #[test]
-    fn rejects_native_tool_search_function_name_collision() {
+    fn accepts_native_tool_search_function_alongside_search_shim() {
         let mut body = json!({
             "tools": [
                 {"type": "tool_search"},
                 {"type": "function", "name": "tool_search", "parameters": {}}
             ]
         });
-        assert!(prepare_xai_tool_search_request(&mut body).is_err());
-        assert_eq!(body["tools"][0]["type"], "tool_search");
+        assert!(prepare_xai_tool_search_request(&mut body).unwrap());
+        assert_eq!(body["tools"][0]["name"], TOOL_SEARCH_PROXY_NAME);
+        assert_eq!(body["tools"][1]["name"], TOOL_SEARCH_NATIVE_TYPE);
     }
 
     #[test]
-    fn rejects_reserved_tool_search_function_even_without_search_shim() {
+    fn accepts_native_tool_search_function_without_search_shim() {
         let mut body = json!({
             "tools": [{"type": "function", "name": "tool_search", "parameters": {}}]
         });
-        assert!(prepare_xai_tool_search_request(&mut body).is_err());
+        assert!(!prepare_xai_tool_search_request(&mut body).unwrap());
+        assert_eq!(body["tools"][0]["name"], TOOL_SEARCH_NATIVE_TYPE);
     }
 
     #[test]
@@ -1176,6 +1175,38 @@ mod tests {
         });
         assert!(prepare_xai_tool_search_request(&mut body).is_err());
         assert_eq!(body["tools"][0]["type"], "tool_search");
+    }
+
+    #[test]
+    fn rejects_proxy_function_name_even_without_search_shim() {
+        let mut body = json!({
+            "tools": [{
+                "type": "function",
+                "name": TOOL_SEARCH_PROXY_NAME,
+                "parameters": {}
+            }]
+        });
+        assert!(prepare_xai_tool_search_request(&mut body).is_err());
+    }
+
+    #[test]
+    fn accepts_discovered_native_tool_search_function() {
+        let mut body = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "tools": [{
+                    "type": "function",
+                    "name": TOOL_SEARCH_NATIVE_TYPE,
+                    "parameters": {"type": "object"}
+                }]
+            }]
+        });
+
+        assert!(prepare_xai_tool_search_request(&mut body).unwrap());
+        assert_eq!(body["tools"][0]["name"], TOOL_SEARCH_PROXY_NAME);
+        assert_eq!(body["tools"][1]["name"], TOOL_SEARCH_NATIVE_TYPE);
     }
 
     #[test]
@@ -1327,13 +1358,22 @@ mod tests {
         let mut response = json!({
             "type": "response.completed",
             "response": {
-                "output": [{
-                    "type": "function_call",
-                    "name": TOOL_SEARCH_PROXY_NAME,
-                    "call_id": "search_1",
-                    "status": "completed",
-                    "arguments": "{\"query\":\"mail\",\"limit\":\"3\"}"
-                }]
+                "output": [
+                    {
+                        "type": "function_call",
+                        "name": TOOL_SEARCH_PROXY_NAME,
+                        "call_id": "search_1",
+                        "status": "completed",
+                        "arguments": "{\"query\":\"mail\",\"limit\":\"3\"}"
+                    },
+                    {
+                        "type": "function_call",
+                        "name": TOOL_SEARCH_NATIVE_TYPE,
+                        "call_id": "native_1",
+                        "status": "completed",
+                        "arguments": "{}"
+                    }
+                ]
             }
         });
 
@@ -1343,6 +1383,9 @@ mod tests {
         assert_eq!(call["execution"], "client");
         assert_eq!(call["arguments"]["query"], "mail");
         assert!(call.get("name").is_none());
+        let native_call = &response["response"]["output"][1];
+        assert_eq!(native_call["type"], "function_call");
+        assert_eq!(native_call["name"], TOOL_SEARCH_NATIVE_TYPE);
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashSet;
 
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 
 use crate::proxy::error::ProxyError;
 
@@ -187,45 +187,72 @@ fn tool_contains_deferred(tool: &Value) -> bool {
 }
 
 fn count_xai_visible_tools(body: &Value) -> usize {
-    let top_level = body
-        .get("tools")
-        .and_then(Value::as_array)
-        .map(|tools| tools.iter().map(count_xai_visible_tool).sum::<usize>())
-        .unwrap_or(0);
-    let promoted = body
-        .get("input")
-        .and_then(Value::as_array)
-        .map(|items| {
-            items
-                .iter()
-                .filter(|item| {
-                    matches!(
-                        item.get("type").and_then(Value::as_str),
-                        Some("additional_tools" | "tool_search_output")
-                    )
-                })
-                .filter_map(|item| item.get("tools").and_then(Value::as_array))
-                .flat_map(|tools| tools.iter())
-                .map(count_xai_visible_tool)
-                .sum::<usize>()
-        })
-        .unwrap_or(0);
-    top_level + promoted
+    // Promotion (`append_loaded_tools`) merges carrier tools into the top-level
+    // catalog by the same dedup keys, so a repeated `additional_tools` copy must
+    // not inflate the no-search 350-tool check.
+    let mut seen = HashSet::new();
+    if let Some(tools) = body.get("tools").and_then(Value::as_array) {
+        for tool in tools {
+            collect_xai_visible_tool_keys(tool, None, &mut seen);
+        }
+    }
+    if let Some(items) = body.get("input").and_then(Value::as_array) {
+        for item in items {
+            if !matches!(
+                item.get("type").and_then(Value::as_str),
+                Some("additional_tools" | "tool_search_output")
+            ) {
+                continue;
+            }
+            let Some(tools) = item.get("tools").and_then(Value::as_array) else {
+                continue;
+            };
+            for tool in tools {
+                collect_xai_visible_tool_keys(tool, None, &mut seen);
+            }
+        }
+    }
+    seen.len()
 }
 
-fn count_xai_visible_tool(tool: &Value) -> usize {
+fn collect_xai_visible_tool_keys(
+    tool: &Value,
+    namespace_key: Option<&str>,
+    seen: &mut HashSet<String>,
+) {
     match tool.get("type").and_then(Value::as_str) {
-        Some("namespace") => tool
-            .get("tools")
-            .or_else(|| tool.get("children"))
-            .and_then(Value::as_array)
-            .map(|children| children.iter().map(count_xai_visible_tool).sum())
-            .unwrap_or(0),
+        Some("namespace") => {
+            let name = tool
+                .get("name")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .unwrap_or("");
+            let nested_key = match namespace_key {
+                Some(parent) => format!("{parent}\0namespace\0{name}"),
+                None => format!("namespace\0{name}"),
+            };
+            if let Some(children) = tool
+                .get("tools")
+                .or_else(|| tool.get("children"))
+                .and_then(Value::as_array)
+            {
+                for child in children {
+                    collect_xai_visible_tool_keys(child, Some(&nested_key), seen);
+                }
+            }
+        }
         Some(
             "function" | "web_search" | "x_search" | "image_generation" | "collections_search"
             | "file_search" | "code_execution" | "code_interpreter" | "mcp" | "shell",
-        ) => 1,
-        _ => 0,
+        ) => {
+            let tool_key = tool_dedup_key(tool);
+            let key = match namespace_key {
+                Some(namespace_key) => format!("{namespace_key}\0{tool_key}"),
+                None => tool_key,
+            };
+            seen.insert(key);
+        }
+        _ => {}
     }
 }
 
@@ -1082,11 +1109,9 @@ mod tests {
         assert_eq!(branches.len(), 5);
         assert!(branches.iter().all(|branch| branch["type"] == "object"));
         assert!(branches.iter().all(|branch| branch.get("$ref").is_none()));
-        assert!(
-            branches
-                .iter()
-                .all(|branch| branch.get("oneOf").is_none() && branch.get("anyOf").is_none())
-        );
+        assert!(branches
+            .iter()
+            .all(|branch| branch.get("oneOf").is_none() && branch.get("anyOf").is_none()));
         assert_eq!(
             branches[1]["properties"]["notificationPolicy"]["anyOf"][1]["type"],
             "null"
@@ -1171,6 +1196,42 @@ mod tests {
             .map(|index| json!({"type": "function", "name": format!("tool_{index}")}))
             .collect::<Vec<_>>();
         let mut body = json!({"tools": tools});
+        assert!(prepare_xai_tool_search_request(&mut body).is_err());
+    }
+
+    #[test]
+    fn accepts_catalog_at_limit_when_additional_tools_repeat_top_level() {
+        let tools = (0..XAI_MAX_TOOL_COUNT)
+            .map(|index| json!({"type": "function", "name": format!("tool_{index}")}))
+            .collect::<Vec<_>>();
+        let mut body = json!({
+            "tools": tools.clone(),
+            "input": [{
+                "type": "additional_tools",
+                "tools": tools
+            }]
+        });
+        assert!(prepare_xai_tool_search_request(&mut body).is_ok());
+        assert_eq!(body["tools"].as_array().unwrap().len(), XAI_MAX_TOOL_COUNT);
+        assert!(body["input"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|item| item.get("type").and_then(Value::as_str) != Some("additional_tools")));
+    }
+
+    #[test]
+    fn rejects_oversized_unique_catalog_with_additional_tools_without_tool_search_shim() {
+        let tools = (0..XAI_MAX_TOOL_COUNT)
+            .map(|index| json!({"type": "function", "name": format!("tool_{index}")}))
+            .collect::<Vec<_>>();
+        let mut body = json!({
+            "tools": tools,
+            "input": [{
+                "type": "additional_tools",
+                "tools": [{"type": "function", "name": "tool_extra"}]
+            }]
+        });
         assert!(prepare_xai_tool_search_request(&mut body).is_err());
     }
 

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
@@ -9,24 +9,25 @@
 
 use std::collections::HashSet;
 
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::proxy::error::ProxyError;
 
-const TOOL_SEARCH_PROXY_NAME: &str = "tool_search";
+const TOOL_SEARCH_NATIVE_NAME: &str = "tool_search";
+const TOOL_SEARCH_PROXY_NAME: &str = "ccswitch_tool_search";
+const XAI_MAX_TOOL_COUNT: usize = 350;
 
 /// Whether the original Codex request offered the private `tool_search` tool.
 ///
-/// Response restoration uses this request-scoped bit instead of matching every
-/// function named `tool_search`, so an unrelated user function is never
-/// reclassified accidentally.
+/// Response restoration uses this request-scoped bit so an unrelated user
+/// function is never reclassified accidentally.
 pub(crate) fn request_offers_tool_search(body: &Value) -> bool {
     body.get("tools")
         .and_then(Value::as_array)
         .is_some_and(|tools| {
-            tools
-                .iter()
-                .any(|tool| tool.get("type").and_then(Value::as_str) == Some("tool_search"))
+            tools.iter().any(|tool| {
+                tool.get("type").and_then(Value::as_str) == Some(TOOL_SEARCH_NATIVE_NAME)
+            })
         })
 }
 
@@ -43,10 +44,13 @@ pub(crate) fn request_offers_tool_search(body: &Value) -> bool {
 ///   exposes exactly the tools Codex selected.
 pub(crate) fn prepare_xai_tool_search_request(body: &mut Value) -> Result<bool, ProxyError> {
     let offers_tool_search = request_offers_tool_search(body);
-    if offers_tool_search && has_tool_search_function(body) {
+    if has_reserved_tool_search_function(body) {
         return Err(ProxyError::TransformError(
-            "native tool_search collides with a top-level function named tool_search".to_string(),
+            "native tool_search collides with a reserved xAI function name".to_string(),
         ));
+    }
+    if !offers_tool_search {
+        validate_no_search_tool_catalog(body)?;
     }
 
     let mut changed = replace_tool_search_declaration(body);
@@ -111,15 +115,118 @@ fn omit_unloaded_top_level_functions(body: &mut Value) -> bool {
     changed || tools.len() != original_len
 }
 
-fn has_tool_search_function(body: &Value) -> bool {
+fn has_reserved_tool_search_function(body: &Value) -> bool {
     body.get("tools")
         .and_then(Value::as_array)
         .is_some_and(|tools| {
             tools.iter().any(|tool| {
                 tool.get("type").and_then(Value::as_str) == Some("function")
-                    && tool.get("name").and_then(Value::as_str) == Some(TOOL_SEARCH_PROXY_NAME)
+                    && tool
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .is_some_and(is_reserved_tool_search_function_name)
             })
         })
+}
+
+fn is_reserved_tool_search_function_name(name: &str) -> bool {
+    name == TOOL_SEARCH_NATIVE_NAME || name == TOOL_SEARCH_PROXY_NAME
+}
+
+fn validate_no_search_tool_catalog(body: &Value) -> Result<(), ProxyError> {
+    if body_contains_deferred_tools(body) {
+        return Err(ProxyError::TransformError(
+            "xAI native Responses received deferred Codex tools without tool_search support"
+                .to_string(),
+        ));
+    }
+
+    let visible_tools = count_xai_visible_tools(body);
+    if visible_tools > XAI_MAX_TOOL_COUNT {
+        return Err(ProxyError::TransformError(format!(
+            "xAI native Responses received {visible_tools} tools without tool_search support; limit is {XAI_MAX_TOOL_COUNT}"
+        )));
+    }
+    Ok(())
+}
+
+fn body_contains_deferred_tools(body: &Value) -> bool {
+    body.get("tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| tools_contain_deferred(tools))
+        || body
+            .get("input")
+            .and_then(Value::as_array)
+            .is_some_and(|items| {
+                items.iter().any(|item| {
+                    matches!(
+                        item.get("type").and_then(Value::as_str),
+                        Some("additional_tools" | "tool_search_output")
+                    ) && item
+                        .get("tools")
+                        .and_then(Value::as_array)
+                        .is_some_and(|tools| tools_contain_deferred(tools))
+                })
+            })
+}
+
+fn tools_contain_deferred(tools: &[Value]) -> bool {
+    tools.iter().any(tool_contains_deferred)
+}
+
+fn tool_contains_deferred(tool: &Value) -> bool {
+    tool.get("defer_loading")
+        .or_else(|| tool.get("deferLoading"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        || tool
+            .get("tools")
+            .or_else(|| tool.get("children"))
+            .and_then(Value::as_array)
+            .is_some_and(|tools| tools_contain_deferred(tools))
+}
+
+fn count_xai_visible_tools(body: &Value) -> usize {
+    let top_level = body
+        .get("tools")
+        .and_then(Value::as_array)
+        .map(|tools| tools.iter().map(count_xai_visible_tool).sum::<usize>())
+        .unwrap_or(0);
+    let promoted = body
+        .get("input")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter(|item| {
+                    matches!(
+                        item.get("type").and_then(Value::as_str),
+                        Some("additional_tools" | "tool_search_output")
+                    )
+                })
+                .filter_map(|item| item.get("tools").and_then(Value::as_array))
+                .flat_map(|tools| tools.iter())
+                .map(count_xai_visible_tool)
+                .sum::<usize>()
+        })
+        .unwrap_or(0);
+    top_level + promoted
+}
+
+fn count_xai_visible_tool(tool: &Value) -> usize {
+    match tool.get("type").and_then(Value::as_str) {
+        Some("namespace") => tool
+            .get("tools")
+            .or_else(|| tool.get("children"))
+            .and_then(Value::as_array)
+            .map(|children| children.iter().map(count_xai_visible_tool).sum())
+            .unwrap_or(0),
+        Some(
+            "function" | "web_search" | "x_search" | "image_generation" | "collections_search"
+            | "file_search" | "code_execution" | "code_interpreter" | "mcp" | "shell",
+        ) => 1,
+        _ => 0,
+    }
 }
 
 /// Convert xAI's proxy function call back into a client-executed Codex
@@ -171,7 +278,7 @@ fn replace_tool_search_declaration(body: &mut Value) -> bool {
     };
     let mut changed = false;
     for tool in tools {
-        if tool.get("type").and_then(Value::as_str) == Some("tool_search") {
+        if tool.get("type").and_then(Value::as_str) == Some(TOOL_SEARCH_NATIVE_NAME) {
             *tool = tool_search_function();
             changed = true;
         }
@@ -183,7 +290,7 @@ fn replace_tool_search_choice(body: &mut Value) -> bool {
     let Some(choice) = body.get_mut("tool_choice") else {
         return false;
     };
-    if choice.get("type").and_then(Value::as_str) != Some("tool_search") {
+    if choice.get("type").and_then(Value::as_str) != Some(TOOL_SEARCH_NATIVE_NAME) {
         return false;
     }
     *choice = json!({"type": "function", "name": TOOL_SEARCH_PROXY_NAME});
@@ -325,11 +432,13 @@ fn append_loaded_tools(body: &mut Value, loaded_tools: Vec<Value>) -> Result<boo
     let mut changed = false;
     for tool in loaded_tools {
         if tool.get("type").and_then(Value::as_str) == Some("function")
-            && tool.get("name").and_then(Value::as_str) == Some(TOOL_SEARCH_PROXY_NAME)
+            && tool
+                .get("name")
+                .and_then(Value::as_str)
+                .is_some_and(is_reserved_tool_search_function_name)
         {
             return Err(ProxyError::TransformError(
-                "discovered function named tool_search collides with the xAI proxy shim"
-                    .to_string(),
+                "discovered function collides with the xAI tool_search proxy shim".to_string(),
             ));
         }
 
@@ -408,10 +517,26 @@ fn merge_namespace_children(existing: &mut Value, loaded: &Value) -> bool {
 }
 
 fn tool_dedup_key(tool: &Value) -> String {
-    let tool_type = tool.get("type").and_then(Value::as_str).unwrap_or_default();
-    let name = tool.get("name").and_then(Value::as_str).unwrap_or_default();
-    if !tool_type.is_empty() || !name.is_empty() {
+    let tool_type = tool
+        .get("type")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default();
+    let name = tool
+        .get("name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default();
+    if !tool_type.is_empty() && !name.is_empty() {
         return format!("{tool_type}\0{name}");
+    }
+    if tool_type == "mcp" {
+        if let Some(label) = tool.get("server_label").and_then(Value::as_str) {
+            let label = label.trim();
+            if !label.is_empty() {
+                return format!("mcp\0{label}");
+            }
+        }
     }
     tool.to_string()
 }
@@ -428,7 +553,11 @@ fn normalize_loaded_tool(tool: &mut Value) {
             let mut parameters = ["parameters", "inputSchema", "input_schema"]
                 .iter()
                 .filter_map(|key| obj.get(*key).cloned())
-                .find(|value| value.as_object().is_some_and(|schema| !schema.is_empty()))
+                .find(|value| {
+                    value
+                        .as_object()
+                        .is_some_and(schema_alias_can_be_root_object)
+                })
                 .unwrap_or_else(|| json!({"type": "object", "properties": {}}));
             obj.remove("inputSchema");
             obj.remove("input_schema");
@@ -468,18 +597,29 @@ fn normalize_root_object_schema(schema: &mut Map<String, Value>) {
         .unwrap_or_default();
     let original_union_key = ["oneOf", "anyOf"]
         .into_iter()
-        .find(|key| schema.get(*key).is_some())
-        .unwrap_or("oneOf");
+        .find(|key| schema.get(*key).is_some());
+    let had_root_ref = schema.get("$ref").is_some();
     let mut root_candidate = schema.clone();
     root_candidate.remove("$defs");
-    let variants = expand_root_object_variants(&root_candidate, &defs, &mut HashSet::new());
+    let mut variants = expand_root_object_variants(&root_candidate, &defs, &mut HashSet::new());
 
     schema.remove("$ref");
     schema.remove("anyOf");
     schema.remove("oneOf");
-    if !variants.is_empty() {
+    if let Some(union_key) = original_union_key {
+        if !variants.is_empty() {
+            schema.insert(
+                union_key.to_string(),
+                Value::Array(variants.into_iter().map(Value::Object).collect()),
+            );
+        }
+    } else if had_root_ref && variants.len() == 1 {
+        for (key, value) in variants.pop().unwrap() {
+            schema.insert(key, value);
+        }
+    } else if had_root_ref && !variants.is_empty() {
         schema.insert(
-            original_union_key.to_string(),
+            "oneOf".to_string(),
             Value::Array(variants.into_iter().map(Value::Object).collect()),
         );
     }
@@ -487,6 +627,10 @@ fn normalize_root_object_schema(schema: &mut Map<String, Value>) {
     schema
         .entry("properties".to_string())
         .or_insert_with(|| json!({}));
+}
+
+fn schema_alias_can_be_root_object(schema: &Map<String, Value>) -> bool {
+    !schema.is_empty() && schema_type_can_be_object(schema.get("type"))
 }
 
 fn expand_root_object_variants(
@@ -567,6 +711,7 @@ fn schema_type_can_be_object(schema_type: Option<&Value>) -> bool {
 fn is_tool_search_function_call(obj: &Map<String, Value>) -> bool {
     obj.get("type").and_then(Value::as_str) == Some("function_call")
         && obj.get("name").and_then(Value::as_str) == Some(TOOL_SEARCH_PROXY_NAME)
+        && !obj.contains_key("namespace")
 }
 
 fn tool_search_call_item(item: &Map<String, Value>) -> Value {
@@ -659,17 +804,17 @@ mod tests {
         assert!(prepare_xai_tool_search_request(&mut body).unwrap());
 
         assert_eq!(body["tools"][0]["type"], "function");
-        assert_eq!(body["tools"][0]["name"], "tool_search");
+        assert_eq!(body["tools"][0]["name"], TOOL_SEARCH_PROXY_NAME);
         assert_eq!(
             body["tool_choice"],
-            json!({"type": "function", "name": "tool_search"})
+            json!({"type": "function", "name": TOOL_SEARCH_PROXY_NAME})
         );
         assert_eq!(body["tools"][1]["type"], "namespace");
         assert!(body["tools"][1]["tools"][0].get("defer_loading").is_none());
         assert!(body["tools"][1]["tools"][0].get("inputSchema").is_none());
         assert_eq!(body["tools"][1]["tools"][0]["parameters"]["type"], "object");
         assert_eq!(body["input"][0]["type"], "function_call");
-        assert_eq!(body["input"][0]["name"], "tool_search");
+        assert_eq!(body["input"][0]["name"], TOOL_SEARCH_PROXY_NAME);
         assert_eq!(body["input"][1]["type"], "function_call_output");
 
         super::super::transform_codex_responses_namespace::flatten_request_namespaces(&mut body)
@@ -680,7 +825,7 @@ mod tests {
             .iter()
             .filter_map(|tool| tool.get("name").and_then(Value::as_str))
             .collect::<Vec<_>>();
-        assert_eq!(names, vec!["tool_search", "mcp__mail____search"]);
+        assert_eq!(names, vec![TOOL_SEARCH_PROXY_NAME, "mcp__mail____search"]);
     }
 
     #[test]
@@ -769,7 +914,7 @@ mod tests {
         let mut tool = json!({
             "type": "function",
             "name": "lookup",
-            "parameters": null,
+            "parameters": {"type": "string"},
             "inputSchema": {
                 "type": "object",
                 "properties": {"id": {"type": "string"}}
@@ -778,6 +923,50 @@ mod tests {
         normalize_loaded_tool(&mut tool);
         assert_eq!(tool["parameters"]["properties"]["id"]["type"], "string");
         assert!(tool.get("inputSchema").is_none());
+    }
+
+    #[test]
+    fn ordinary_object_schema_is_not_wrapped_in_synthetic_union() {
+        let mut tool = json!({
+            "type": "function",
+            "name": "lookup",
+            "parameters": {
+                "type": "object",
+                "properties": {"id": {"type": "string"}}
+            }
+        });
+
+        normalize_loaded_tool(&mut tool);
+        let parameters = &tool["parameters"];
+        assert_eq!(parameters["type"], "object");
+        assert_eq!(parameters["properties"]["id"]["type"], "string");
+        assert!(parameters.get("oneOf").is_none());
+        assert!(parameters.get("anyOf").is_none());
+    }
+
+    #[test]
+    fn sole_root_ref_schema_is_inlined_without_synthetic_union() {
+        let mut tool = json!({
+            "type": "function",
+            "name": "lookup",
+            "parameters": {
+                "$ref": "#/$defs/query",
+                "$defs": {
+                    "query": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}}
+                    }
+                }
+            }
+        });
+
+        normalize_loaded_tool(&mut tool);
+        let parameters = &tool["parameters"];
+        assert_eq!(parameters["type"], "object");
+        assert_eq!(parameters["properties"]["q"]["type"], "string");
+        assert!(parameters.get("oneOf").is_none());
+        assert!(parameters.get("anyOf").is_none());
+        assert!(parameters.get("$ref").is_none());
     }
 
     #[test]
@@ -893,9 +1082,11 @@ mod tests {
         assert_eq!(branches.len(), 5);
         assert!(branches.iter().all(|branch| branch["type"] == "object"));
         assert!(branches.iter().all(|branch| branch.get("$ref").is_none()));
-        assert!(branches
-            .iter()
-            .all(|branch| branch.get("oneOf").is_none() && branch.get("anyOf").is_none()));
+        assert!(
+            branches
+                .iter()
+                .all(|branch| branch.get("oneOf").is_none() && branch.get("anyOf").is_none())
+        );
         assert_eq!(
             branches[1]["properties"]["notificationPolicy"]["anyOf"][1]["type"],
             "null"
@@ -943,6 +1134,68 @@ mod tests {
     }
 
     #[test]
+    fn rejects_reserved_tool_search_function_even_without_search_shim() {
+        let mut body = json!({
+            "tools": [{"type": "function", "name": "tool_search", "parameters": {}}]
+        });
+        assert!(prepare_xai_tool_search_request(&mut body).is_err());
+    }
+
+    #[test]
+    fn rejects_proxy_function_name_collision() {
+        let mut body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {"type": "function", "name": TOOL_SEARCH_PROXY_NAME, "parameters": {}}
+            ]
+        });
+        assert!(prepare_xai_tool_search_request(&mut body).is_err());
+        assert_eq!(body["tools"][0]["type"], "tool_search");
+    }
+
+    #[test]
+    fn rejects_deferred_catalog_without_tool_search_shim() {
+        let mut body = json!({
+            "tools": [{
+                "type": "namespace",
+                "name": "mcp__large__",
+                "tools": [{"type": "function", "name": "cold", "defer_loading": true}]
+            }]
+        });
+        assert!(prepare_xai_tool_search_request(&mut body).is_err());
+    }
+
+    #[test]
+    fn rejects_oversized_catalog_without_tool_search_shim() {
+        let tools = (0..351)
+            .map(|index| json!({"type": "function", "name": format!("tool_{index}")}))
+            .collect::<Vec<_>>();
+        let mut body = json!({"tools": tools});
+        assert!(prepare_xai_tool_search_request(&mut body).is_err());
+    }
+
+    #[test]
+    fn loaded_mcp_tools_dedup_by_server_label() {
+        let mut body = json!({
+            "tools": [{"type": "tool_search"}],
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "tools": [
+                    {"type": "mcp", "server_label": "alpha"},
+                    {"type": "mcp", "server_label": "beta"}
+                ]
+            }]
+        });
+
+        prepare_xai_tool_search_request(&mut body).unwrap();
+        let tools = body["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 3);
+        assert!(tools.iter().any(|tool| tool["server_label"] == "alpha"));
+        assert!(tools.iter().any(|tool| tool["server_label"] == "beta"));
+    }
+
+    #[test]
     fn initial_top_level_deferred_functions_are_omitted() {
         let deferred = (0..400)
             .map(|index| {
@@ -966,7 +1219,7 @@ mod tests {
 
         prepare_xai_tool_search_request(&mut body).unwrap();
         assert_eq!(body["tools"].as_array().unwrap().len(), 2);
-        assert_eq!(body["tools"][0]["name"], "tool_search");
+        assert_eq!(body["tools"][0]["name"], TOOL_SEARCH_PROXY_NAME);
         assert_eq!(body["tools"][1]["name"], "hot");
         assert!(body["tools"][1].get("deferLoading").is_none());
     }
@@ -1005,7 +1258,7 @@ mod tests {
 
         let tools = body["tools"].as_array().unwrap();
         assert_eq!(tools.len(), 1);
-        assert_eq!(tools[0]["name"], "tool_search");
+        assert_eq!(tools[0]["name"], TOOL_SEARCH_PROXY_NAME);
     }
 
     #[test]
@@ -1015,7 +1268,7 @@ mod tests {
             "response": {
                 "output": [{
                     "type": "function_call",
-                    "name": "tool_search",
+                    "name": TOOL_SEARCH_PROXY_NAME,
                     "call_id": "search_1",
                     "status": "completed",
                     "arguments": "{\"query\":\"mail\",\"limit\":\"3\"}"
@@ -1035,7 +1288,7 @@ mod tests {
     fn malformed_tool_search_arguments_fail_closed_to_empty_object() {
         let mut call = json!({
             "type": "function_call",
-            "name": "tool_search",
+            "name": TOOL_SEARCH_PROXY_NAME,
             "call_id": "search_1",
             "arguments": "not json"
         });

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_tool_search.rs
@@ -503,6 +503,18 @@ fn append_loaded_tools(body: &mut Value, loaded_tools: Vec<Value>) -> Result<boo
 }
 
 fn merge_namespace_children(existing: &mut Value, loaded: &Value) -> bool {
+    // An outer deferred marker means none of the original namespace children
+    // were published. A search result is the authoritative selected subset, so
+    // retaining unmatched children from the stale catalog would expose tools
+    // the client never loaded.
+    if is_tool_deferred(existing) {
+        if existing != loaded {
+            *existing = loaded.clone();
+            return true;
+        }
+        return false;
+    }
+
     let Some(loaded_children) = loaded
         .get("tools")
         .or_else(|| loaded.get("children"))
@@ -899,6 +911,66 @@ mod tests {
         super::super::transform_codex_responses_namespace::flatten_request_namespaces(&mut body)
             .unwrap();
         assert_eq!(body["tools"][1]["name"], "mcp__mail____search");
+    }
+
+    #[test]
+    fn discovered_subset_replaces_outer_deferred_namespace_catalog() {
+        let mut body = json!({
+            "tools": [
+                {"type": "tool_search"},
+                {
+                    "type": "namespace",
+                    "name": "mcp__mail__",
+                    "defer_loading": true,
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "search",
+                            "parameters": {"type": "object", "properties": {"stale": {"type": "string"}}}
+                        },
+                        {
+                            "type": "function",
+                            "name": "delete",
+                            "parameters": {"type": "object"}
+                        }
+                    ]
+                }
+            ],
+            "input": [{
+                "type": "tool_search_output",
+                "call_id": "search_1",
+                "tools": [{
+                    "type": "namespace",
+                    "name": "mcp__mail__",
+                    "defer_loading": true,
+                    "tools": [{
+                        "type": "function",
+                        "name": "search",
+                        "defer_loading": true,
+                        "parameters": {"type": "object", "properties": {"query": {"type": "string"}}}
+                    }]
+                }]
+            }]
+        });
+
+        prepare_xai_tool_search_request(&mut body).unwrap();
+        let namespace = &body["tools"][1];
+        assert!(namespace.get("defer_loading").is_none());
+        assert_eq!(namespace["tools"].as_array().unwrap().len(), 1);
+        assert_eq!(namespace["tools"][0]["name"], "search");
+        assert!(namespace["tools"][0]["parameters"]["properties"]
+            .get("stale")
+            .is_none());
+
+        super::super::transform_codex_responses_namespace::flatten_request_namespaces(&mut body)
+            .unwrap();
+        let names = body["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool.get("name").and_then(Value::as_str))
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec![TOOL_SEARCH_PROXY_NAME, "mcp__mail____search"]);
     }
 
     #[test]

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3601,6 +3601,20 @@ impl ProxyService {
         auth.get("OPENAI_API_KEY").and_then(|v| v.as_str()) == Some(PROXY_TOKEN_PLACEHOLDER)
     }
 
+    fn codex_takeover_catalog_tool_profile(
+        provider: Option<&Provider>,
+    ) -> crate::codex_config::CodexCatalogToolProfile {
+        match provider {
+            Some(provider) if provider.is_xai_oauth() => {
+                // Only takeover mode owns the proxy bridge that converts
+                // Codex's private deferred-search protocol for xAI.
+                crate::codex_config::CodexCatalogToolProfile::ProxiedNativeResponses
+            }
+            Some(provider) => crate::proxy::providers::resolve_codex_catalog_tool_profile(provider),
+            None => crate::codex_config::CodexCatalogToolProfile::ProxyChat,
+        }
+    }
+
     fn write_codex_takeover_live_for_provider(
         &self,
         config: &Value,
@@ -3623,9 +3637,7 @@ impl ProxyService {
         // makes Codex supply its native authorization.
         if official_passthrough || placeholder_auth {
             let config_str = config.get("config").and_then(|v| v.as_str()).unwrap_or("");
-            let profile = provider
-                .map(crate::proxy::providers::resolve_codex_catalog_tool_profile)
-                .unwrap_or(crate::codex_config::CodexCatalogToolProfile::ProxyChat);
+            let profile = Self::codex_takeover_catalog_tool_profile(provider);
             let prepared_config =
                 crate::codex_config::prepare_codex_live_config_text_with_optional_catalog(
                     config, config_str, profile,
@@ -4357,6 +4369,30 @@ mod tests {
             .expect("env should exist");
         assert_env_str(env, "ANTHROPIC_API_KEY", None);
         assert_env_str(env, "ANTHROPIC_AUTH_TOKEN", Some(PROXY_TOKEN_PLACEHOLDER));
+    }
+
+    #[test]
+    fn codex_xai_search_profile_is_takeover_only() {
+        let mut provider = Provider::with_id(
+            "xai-codex".to_string(),
+            "xAI Codex".to_string(),
+            json!({}),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            provider_type: Some("xai_oauth".to_string()),
+            api_format: Some("openai_responses".to_string()),
+            ..Default::default()
+        });
+
+        assert_eq!(
+            crate::proxy::providers::resolve_codex_catalog_tool_profile(&provider),
+            crate::codex_config::CodexCatalogToolProfile::NativeResponses
+        );
+        assert_eq!(
+            ProxyService::codex_takeover_catalog_tool_profile(Some(&provider)),
+            crate::codex_config::CodexCatalogToolProfile::ProxiedNativeResponses
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix Codex requests routed through xAI OAuth exceeding xAI's 350-tool limit by translating Codex's private deferred-tool protocol at the proxy boundary.

The proxy now keeps deferred MCP and namespace tools hidden until Codex selects them, while preserving standard Responses behavior for clients such as Grok Build.

## Changes

- Advertise deferred tool search only for the proxied xAI native Responses profile; direct native Responses behavior is unchanged.
- Add a shared Codex tool bridge for Chat Completions and Anthropic adapters, covering function, custom, namespace, and deferred `tool_search` identities.
- Translate Codex's private `tool_search` to the internal upstream name `ccswitch_tool_search`, allowing an ordinary user function named `tool_search` to coexist safely.
- Reserve `ccswitch_tool_search` only while the private search shim is actually published; ordinary no-search requests may use that function name.
- Promote tools returned by `tool_search_output` and `additional_tools`; omit deferred catalog entries of every tool kind until they are loaded.
- Replace an outer-deferred namespace with the authoritative loaded subset so untouched catalog children never become visible during namespace flattening.
- Enforce xAI's 350-tool limit against the final deduplicated visible catalog after deferred results are promoted, including the search shim and loaded namespace children.
- Detect ambiguous function/custom/namespace name collisions and return an explicit transform error instead of silently choosing one declaration.
- Restore proxied function calls to their original Codex `tool_search_call` or namespaced function-call shape in both streaming and non-streaming responses.
- Normalize loaded function schemas, including root `object | null` unions, before forwarding them to xAI.
- Restrict Codex-private namespace, deferred-loading, and tool-search handling to the Codex client. Grok Build keeps standard Responses tool and reasoning semantics.
- Limit namespace restoration to actual Responses output containers so nested business JSON is not rewritten accidentally.

Search and tool execution remain local to Codex; this PR only translates the wire protocol.

## Testing

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 2748 passed, 5 ignored.
- `cargo check --manifest-path src-tauri/Cargo.toml`.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`.
- `git diff --check`.

## Notes

- Fixes #6795.
- No user-facing UI or i18n changes.
