### PR TITLE
fix(prompts): keep unmanaged prompt files intact when a restore enables none

### DIFF
--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -30,11 +30,12 @@ fn project_prompt_set_to_path(
 
     if let Some((_, prompt)) = enabled.first() {
         write_text_file(target_path, &prompt.content)?;
-    } else if target_path.exists() {
-        // Match the existing "disable the last prompt" behavior without
-        // creating an otherwise unused application config directory.
-        write_text_file(target_path, "")?;
     }
+    // With nothing enabled, leave the target file untouched. This projection
+    // only runs after a database restore, and the live file is not part of
+    // the sync payload — clearing it here would wipe local content the
+    // restored snapshot never contained. Disabling the last prompt from the
+    // UI still clears the file via `PromptService::upsert_prompt`.
 
     if enabled.len() <= 1 {
         return Ok(None);
@@ -523,15 +524,21 @@ mod tests {
     }
 
     #[test]
-    fn restored_prompt_projection_clears_a_stale_file_when_none_are_enabled() {
+    fn restored_prompt_projection_preserves_the_live_file_when_none_are_enabled() {
         let temp = tempdir().expect("tempdir");
         let path = temp.path().join("AGENTS.md");
-        std::fs::write(&path, "stale").expect("seed stale prompt");
-        let prompts = IndexMap::new();
+        std::fs::write(&path, "local content").expect("seed live prompt file");
+        let mut prompts = IndexMap::new();
+        prompts.insert("off".to_string(), prompt("off", "managed", false));
 
-        let warning = project_prompt_set_to_path(&prompts, &path).expect("clear prompt");
+        let warning = project_prompt_set_to_path(&prompts, &path).expect("project prompt");
         assert!(warning.is_none());
-        assert_eq!(std::fs::read_to_string(path).expect("read prompt"), "");
+        // The live file is not part of the sync payload, so a restore with no
+        // enabled prompt must not wipe local content it never contained.
+        assert_eq!(
+            std::fs::read_to_string(path).expect("read prompt"),
+            "local content"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Hi 👋 Another one from the open-issue pile — this time the WebDAV AGENTS.md wipe reported in #6778.

Fixes #6778

## Problem

WebDAV/S3 "download" restores `db.sql` and then runs `run_post_import_sync` → `PromptService::sync_all_to_live`, which projects the imported prompt rows back to the live prompt files. When the restored database has **no enabled prompt** for an app, `project_prompt_set_to_path` took the `else` branch and overwrote the local file (e.g. `~/.config/opencode/AGENTS.md`) with an empty string. Those files are never part of the upload payload, so a machine whose cloud DB happens to have no enabled prompt gets its local AGENTS.md wiped by a plain download — exactly the data destruction #6778 describes.

## Fix

Drop the clear-on-nothing-enabled branch from `project_prompt_set_to_path` and leave the target file untouched instead.

- This is safe because that branch was only ever reachable from restore paths: `project_prompt_set_to_path` ← `sync_to_live` ← `sync_all_to_live` ← `run_post_import_sync`, and `sync_to_live` has no other production caller. On a restore, "no enabled prompt in the snapshot" says nothing about the local file, so the conservative choice is to leave it alone.
- The interactive behavior is unchanged: disabling the last prompt from the UI still clears the file via `PromptService::upsert_prompt`.
- The pre-existing test pinned the wiping behavior (`restored_prompt_projection_clears_a_stale_file_when_none_are_enabled`); it is renamed and now asserts the local content survives.

## Tests

- `restored_prompt_projection_preserves_the_live_file_when_none_are_enabled` (replaces the old clearing test): seeded local file stays intact when the restored set has no enabled prompt. Revert-verified: it fails on `main`.
- Full `cargo test` green (14 test binaries, 0 failed), `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean. No frontend files touched; `pnpm typecheck` / `pnpm format:check` pass on the identical frontend tree.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

Happy to adjust — e.g. if you'd rather surface a note that an unmanaged local file was left untouched, I can add that on top.
