### PR TITLE
fix(proxy): preserve Responses reasoning summaries for Claude Code

### DIFF
--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -20,6 +20,7 @@ use super::{
         codex_chat_common::extract_reasoning_field_text,
         codex_chat_history::record_responses_sse_stream,
         get_adapter, get_claude_api_format,
+        reasoning_bridge::reasoning_summary_text,
         streaming::create_anthropic_sse_stream,
         streaming_codex_anthropic::{
             create_responses_sse_stream_from_anthropic_with_context,
@@ -27,10 +28,7 @@ use super::{
         },
         streaming_codex_chat::create_responses_sse_stream_from_chat_with_context,
         streaming_gemini::create_anthropic_sse_stream_from_gemini,
-        streaming_responses::{
-            create_anthropic_sse_stream_from_responses,
-            create_anthropic_sse_stream_from_responses_with_web_search_options,
-        },
+        streaming_responses::create_anthropic_sse_stream_from_responses_with_web_search_options_for_client,
         transform, transform_codex_anthropic, transform_codex_chat,
         transform_codex_responses_namespace, transform_codex_responses_xai_sanitize,
         transform_gemini, transform_responses,
@@ -53,6 +51,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use http_body_util::BodyExt;
 use serde_json::{json, Value};
+use std::collections::{BTreeMap, HashMap};
 
 // ============================================================================
 // 健康检查和状态查询（简单端点）
@@ -175,6 +174,7 @@ async fn handle_messages_for_app(
     let method = parts.method.clone();
     let uri = parts.uri;
     let headers = parts.headers;
+    let preserve_redacted_thinking = !is_claude_vscode_client(&headers);
     let extensions = parts.extensions;
     let body_bytes = body
         .collect()
@@ -252,6 +252,7 @@ async fn handle_messages_for_app(
             &body,
             is_stream,
             &api_format,
+            preserve_redacted_thinking,
             connection_guard,
         )
         .await;
@@ -389,6 +390,7 @@ async fn handle_claude_transform(
     original_body: &Value,
     is_stream: bool,
     api_format: &str,
+    preserve_redacted_thinking: bool,
     connection_guard: Option<ActiveConnectionGuard>,
 ) -> Result<axum::response::Response, ProxyError> {
     let status = response.status();
@@ -429,13 +431,21 @@ async fn handle_claude_transform(
             dyn futures::Stream<Item = Result<Bytes, std::io::Error>> + Send + Unpin,
         > = if api_format == "openai_responses" {
             if hosted_web_search_name.is_none() && hosted_web_search_max_uses.is_none() {
-                Box::new(Box::pin(create_anthropic_sse_stream_from_responses(stream)))
+                Box::new(Box::pin(
+                    create_anthropic_sse_stream_from_responses_with_web_search_options_for_client(
+                        stream,
+                        None,
+                        None,
+                        preserve_redacted_thinking,
+                    ),
+                ))
             } else {
                 Box::new(Box::pin(
-                    create_anthropic_sse_stream_from_responses_with_web_search_options(
+                    create_anthropic_sse_stream_from_responses_with_web_search_options_for_client(
                         stream,
                         hosted_web_search_name.clone(),
                         hosted_web_search_max_uses,
+                        preserve_redacted_thinking,
                     ),
                 ))
             }
@@ -557,11 +567,12 @@ async fn handle_claude_transform(
                 )));
             }
             let response_headers = response.headers().clone();
-            let message = responses_sse_stream_to_anthropic_message(
+            let message = responses_sse_stream_to_anthropic_message_for_client(
                 response.bytes_stream(),
                 hosted_web_search_name.clone(),
                 hosted_web_search_max_uses,
                 body_timeout,
+                preserve_redacted_thinking,
             )
             .await?;
             (response_headers, Some(message), None)
@@ -634,10 +645,11 @@ async fn handle_claude_transform(
     let transform_result = match (direct_anthropic_response, upstream_response) {
         (Some(response), _) => Ok(response),
         (None, Some(response)) if api_format == "openai_responses" => {
-            transform_responses::responses_to_anthropic_with_web_search_options(
+            transform_responses::responses_to_anthropic_with_web_search_options_for_client(
                 response,
                 hosted_web_search_name.as_deref(),
                 hosted_web_search_max_uses,
+                preserve_redacted_thinking,
             )
         }
         (None, Some(response)) if api_format == "gemini_native" => {
@@ -2152,6 +2164,13 @@ pub async fn handle_gemini(
     .await
 }
 
+fn is_claude_vscode_client(headers: &axum::http::HeaderMap) -> bool {
+    headers
+        .get(axum::http::header::USER_AGENT)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.to_ascii_lowercase().contains("claude-vscode"))
+}
+
 fn should_use_claude_transform_streaming(
     requested_streaming: bool,
     upstream_is_sse: bool,
@@ -2167,11 +2186,29 @@ async fn responses_sse_stream_to_anthropic_message(
     max_web_search_uses: Option<u64>,
     body_timeout: std::time::Duration,
 ) -> Result<Value, ProxyError> {
+    responses_sse_stream_to_anthropic_message_for_client(
+        stream,
+        hosted_web_search_name,
+        max_web_search_uses,
+        body_timeout,
+        true,
+    )
+    .await
+}
+
+async fn responses_sse_stream_to_anthropic_message_for_client(
+    stream: impl futures::Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
+    hosted_web_search_name: Option<String>,
+    max_web_search_uses: Option<u64>,
+    body_timeout: std::time::Duration,
+    preserve_redacted_thinking: bool,
+) -> Result<Value, ProxyError> {
     let collect = async move {
-        let converted = create_anthropic_sse_stream_from_responses_with_web_search_options(
+        let converted = create_anthropic_sse_stream_from_responses_with_web_search_options_for_client(
             stream,
             hosted_web_search_name,
             max_web_search_uses,
+            preserve_redacted_thinking,
         );
         tokio::pin!(converted);
 
@@ -2207,15 +2244,157 @@ async fn responses_sse_stream_to_anthropic_message(
     transform_codex_anthropic::anthropic_sse_to_message_value(&body)
 }
 
+#[derive(Default)]
+struct ResponsesSseReasoningSummaryState {
+    parts: BTreeMap<u64, String>,
+}
+
+/// Keep one stable identity when a Responses stream alternates between item_id and output_index.
+fn responses_sse_reasoning_summary_key(
+    data: &Value,
+    keys_by_item_id: &mut HashMap<String, String>,
+    keys_by_output_index: &mut HashMap<u64, String>,
+) -> Option<String> {
+    let item_id = data
+        .get("item_id")
+        .and_then(Value::as_str)
+        .or_else(|| data.pointer("/item/id").and_then(Value::as_str))
+        .filter(|value| !value.is_empty());
+    let output_index = data.get("output_index").and_then(Value::as_u64);
+
+    let existing_key = item_id
+        .and_then(|id| keys_by_item_id.get(id).cloned())
+        .or_else(|| output_index.and_then(|index| keys_by_output_index.get(&index).cloned()));
+    let key = existing_key.or_else(|| {
+        item_id
+            .map(|id| format!("id:{id}"))
+            .or_else(|| output_index.map(|index| format!("output:{index}")))
+    })?;
+
+    if let Some(id) = item_id {
+        keys_by_item_id.insert(id.to_string(), key.clone());
+    }
+    if let Some(index) = output_index {
+        keys_by_output_index.insert(index, key.clone());
+    }
+    Some(key)
+}
+
+/// Reconcile incremental deltas with cumulative done/part snapshots without duplicating text.
+fn merge_responses_sse_reasoning_summary_part(current: &mut String, incoming: &str) {
+    if incoming.is_empty() {
+        return;
+    }
+    if current.is_empty() || incoming.starts_with(current.as_str()) {
+        *current = incoming.to_string();
+    } else if current.starts_with(incoming) || current.ends_with(incoming) {
+        return;
+    } else {
+        current.push_str(incoming);
+    }
+}
+
+fn responses_sse_reasoning_summary_text(
+    summaries: &HashMap<String, ResponsesSseReasoningSummaryState>,
+    key: &str,
+) -> String {
+    summaries
+        .get(key)
+        .map(|state| state.parts.values().cloned().collect::<Vec<_>>().join("\n"))
+        .unwrap_or_default()
+}
+
+fn collect_responses_sse_reasoning_item_summary(
+    data: &Value,
+    item: &Value,
+    summaries: &mut HashMap<String, ResponsesSseReasoningSummaryState>,
+    keys_by_item_id: &mut HashMap<String, String>,
+    keys_by_output_index: &mut HashMap<u64, String>,
+) {
+    if item.get("type").and_then(Value::as_str) != Some("reasoning") {
+        return;
+    }
+    let Some(key) = responses_sse_reasoning_summary_key(
+        data,
+        keys_by_item_id,
+        keys_by_output_index,
+    ) else {
+        return;
+    };
+    let state = summaries.entry(key).or_default();
+    match item.get("summary") {
+        Some(Value::Array(parts)) => {
+            for (index, part) in parts.iter().enumerate() {
+                if let Some(text) = part.get("text").and_then(Value::as_str) {
+                    merge_responses_sse_reasoning_summary_part(
+                        state.parts.entry(index as u64).or_default(),
+                        text,
+                    );
+                } else if let Some(text) = part.as_str() {
+                    merge_responses_sse_reasoning_summary_part(
+                        state.parts.entry(index as u64).or_default(),
+                        text,
+                    );
+                }
+            }
+        }
+        Some(Value::String(text)) => {
+            merge_responses_sse_reasoning_summary_part(state.parts.entry(0).or_default(), text);
+        }
+        Some(Value::Object(object)) => {
+            if let Some(text) = object.get("text").and_then(Value::as_str) {
+                merge_responses_sse_reasoning_summary_part(
+                    state.parts.entry(0).or_default(),
+                    text,
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+fn enrich_responses_sse_reasoning_item(
+    data: &Value,
+    item: &mut Value,
+    summaries: &HashMap<String, ResponsesSseReasoningSummaryState>,
+    keys_by_item_id: &mut HashMap<String, String>,
+    keys_by_output_index: &mut HashMap<u64, String>,
+) {
+    if item.get("type").and_then(Value::as_str) != Some("reasoning")
+        || !reasoning_summary_text(item).is_empty()
+    {
+        return;
+    }
+    let Some(key) = responses_sse_reasoning_summary_key(
+        data,
+        keys_by_item_id,
+        keys_by_output_index,
+    ) else {
+        return;
+    };
+    let text = responses_sse_reasoning_summary_text(summaries, &key);
+    if !text.is_empty() {
+        if let Some(object) = item.as_object_mut() {
+            object.insert(
+                "summary".to_string(),
+                json!([{"type": "summary_text", "text": text}]),
+            );
+        }
+    }
+}
+
 /// 把 OpenAI Responses SSE 流聚合成一个完整的 Responses JSON 对象，供下游转成 Anthropic
 /// 非流响应。仅在 Codex OAuth 把 `stream:false` 强制升级为 SSE 的场景下调用。
 ///
-/// 复用 `proxy::sse` 的 `take_sse_block`/`strip_sse_field`：`take_sse_block` 同时支持
-/// `\n\n` 与 `\r\n\r\n` 两种分隔符，`strip_sse_field` 兼容带/不带空格的字段写法。
+/// 除了收集 output_item.done，还要保留 reasoning summary 事件；部分上游只在这些
+/// 增量事件中返回可见摘要，最终 reasoning item 只携带 encrypted_content。
 fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
     let mut buffer = body.trim_start_matches('\u{feff}').to_string();
     let mut completed_response: Option<Value> = None;
-    let mut output_items = Vec::new();
+    let mut output_items: Vec<(Option<u64>, Value)> = Vec::new();
+    let mut reasoning_summaries: HashMap<String, ResponsesSseReasoningSummaryState> = HashMap::new();
+    let mut reasoning_keys_by_item_id: HashMap<String, String> = HashMap::new();
+    let mut reasoning_keys_by_output_index: HashMap<u64, String> = HashMap::new();
 
     // strict=false 用于残余尾块：截断的半截 JSON 忽略而非报错，避免破坏
     // 已聚合好的完整响应（codex_oauth 聚合路径也复用本函数）
@@ -2257,10 +2436,127 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
             }
         };
 
+        let event_name = if event_name.is_empty() {
+            data.get("type").and_then(Value::as_str).unwrap_or("")
+        } else {
+            event_name
+        };
+
         match event_name {
+            "response.output_item.added" => {
+                if let Some(item) = data.get("item") {
+                    collect_responses_sse_reasoning_item_summary(
+                        &data,
+                        item,
+                        &mut reasoning_summaries,
+                        &mut reasoning_keys_by_item_id,
+                        &mut reasoning_keys_by_output_index,
+                    );
+                }
+            }
             "response.output_item.done" => {
                 if let Some(item) = data.get("item") {
-                    output_items.push(item.clone());
+                    let mut item = item.clone();
+                    collect_responses_sse_reasoning_item_summary(
+                        &data,
+                        &item,
+                        &mut reasoning_summaries,
+                        &mut reasoning_keys_by_item_id,
+                        &mut reasoning_keys_by_output_index,
+                    );
+                    enrich_responses_sse_reasoning_item(
+                        &data,
+                        &mut item,
+                        &reasoning_summaries,
+                        &mut reasoning_keys_by_item_id,
+                        &mut reasoning_keys_by_output_index,
+                    );
+                    output_items.push((
+                        data.get("output_index").and_then(Value::as_u64),
+                        item,
+                    ));
+                }
+            }
+            "response.reasoning_summary_text.delta"
+            | "response.reasoning_text.delta"
+            | "response.reasoning.delta" => {
+                if let (Some(text), Some(key)) = (
+                    data.get("delta")
+                        .or_else(|| data.get("text"))
+                        .and_then(Value::as_str),
+                    responses_sse_reasoning_summary_key(
+                        &data,
+                        &mut reasoning_keys_by_item_id,
+                        &mut reasoning_keys_by_output_index,
+                    ),
+                ) {
+                    let summary_index = data
+                        .get("summary_index")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0);
+                    merge_responses_sse_reasoning_summary_part(
+                        reasoning_summaries
+                            .entry(key)
+                            .or_default()
+                            .parts
+                            .entry(summary_index)
+                            .or_default(),
+                        text,
+                    );
+                }
+            }
+            "response.reasoning_summary_text.done" | "response.reasoning_text.done" => {
+                if let (Some(text), Some(key)) = (
+                    data.get("text")
+                        .or_else(|| data.get("delta"))
+                        .and_then(Value::as_str),
+                    responses_sse_reasoning_summary_key(
+                        &data,
+                        &mut reasoning_keys_by_item_id,
+                        &mut reasoning_keys_by_output_index,
+                    ),
+                ) {
+                    let summary_index = data
+                        .get("summary_index")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0);
+                    merge_responses_sse_reasoning_summary_part(
+                        reasoning_summaries
+                            .entry(key)
+                            .or_default()
+                            .parts
+                            .entry(summary_index)
+                            .or_default(),
+                        text,
+                    );
+                }
+            }
+            "response.reasoning_summary_part.added" | "response.reasoning_summary_part.done" => {
+                if let (Some(text), Some(key)) = (
+                    data.get("part").and_then(|part| {
+                        part.get("text")
+                            .and_then(Value::as_str)
+                            .or_else(|| part.as_str())
+                    }),
+                    responses_sse_reasoning_summary_key(
+                        &data,
+                        &mut reasoning_keys_by_item_id,
+                        &mut reasoning_keys_by_output_index,
+                    ),
+                ) {
+                    let summary_index = data
+                        .get("summary_index")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0);
+                    merge_responses_sse_reasoning_summary_part(
+                        reasoning_summaries
+                            .entry(key)
+                            .or_default()
+                            .parts
+                            .entry(summary_index)
+                            .or_default(),
+                        text,
+                    );
                 }
             }
             "response.completed" => {
@@ -2291,12 +2587,43 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
     })?;
 
     if !output_items.is_empty() {
+        let mut output = Vec::with_capacity(output_items.len());
+        for (position, (output_index, mut item)) in output_items.into_iter().enumerate() {
+            let data = json!({
+                "output_index": output_index.unwrap_or(position as u64),
+                "item_id": item.get("id").and_then(Value::as_str),
+            });
+            enrich_responses_sse_reasoning_item(
+                &data,
+                &mut item,
+                &reasoning_summaries,
+                &mut reasoning_keys_by_item_id,
+                &mut reasoning_keys_by_output_index,
+            );
+            output.push(item);
+        }
         if let Some(obj) = response.as_object_mut() {
-            obj.insert("output".to_string(), Value::Array(output_items));
+            obj.insert("output".to_string(), Value::Array(output));
         } else {
             return Err(ProxyError::TransformError(
                 "response.completed payload is not an object".to_string(),
             ));
+        }
+    } else if let Some(output) = response.get_mut("output").and_then(Value::as_array_mut) {
+        // Some gateways put the final reasoning snapshot only in response.completed.
+        // Enrich that snapshot too when its summary was carried by earlier SSE events.
+        for (index, item) in output.iter_mut().enumerate() {
+            let data = json!({
+                "output_index": index as u64,
+                "item_id": item.get("id").and_then(Value::as_str),
+            });
+            enrich_responses_sse_reasoning_item(
+                &data,
+                item,
+                &reasoning_summaries,
+                &mut reasoning_keys_by_item_id,
+                &mut reasoning_keys_by_output_index,
+            );
         }
     }
 
@@ -2858,16 +3185,33 @@ async fn log_usage(
 mod tests {
     use super::{
         body_looks_like_sse, chat_sse_to_response_value, classify_body_for_diagnostics,
-        codex_proxy_error_json, responses_sse_stream_to_anthropic_message,
+        codex_proxy_error_json, is_claude_vscode_client,
+        responses_sse_stream_to_anthropic_message,
         responses_sse_to_response_value, should_use_claude_transform_streaming, transform,
         upstream_body_parse_error,
     };
-    use crate::proxy::ProxyError;
+    use crate::proxy::{providers::transform_responses, ProxyError};
     use bytes::Bytes;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     };
+
+    #[test]
+    fn claude_vscode_user_agent_selects_compatible_reasoning_blocks() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::USER_AGENT,
+            axum::http::HeaderValue::from_static("claude-vscode/1.0.0"),
+        );
+        assert!(is_claude_vscode_client(&headers));
+
+        headers.insert(
+            axum::http::header::USER_AGENT,
+            axum::http::HeaderValue::from_static("claude-code-cli/1.0.0"),
+        );
+        assert!(!is_claude_vscode_client(&headers));
+    }
 
     #[test]
     fn body_looks_like_sse_detects_unlabeled_sse_prefixes() {
@@ -3499,6 +3843,70 @@ data: {"type":"response.completed","response":{"id":"resp_1","status":"completed
         assert_eq!(response["id"], "resp_1");
         assert_eq!(response["output"][0]["type"], "message");
         assert_eq!(response["output"][0]["content"][0]["text"], "hello");
+    }
+
+    #[test]
+    fn responses_sse_to_response_value_preserves_reasoning_summary_events() {
+        // Codex OAuth may leave summary empty on output_item.done even though the
+        // visible summary was delivered through reasoning summary SSE events.
+        let sse = r#"event: response.output_item.added
+ data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[]}}
+
+ event: response.reasoning_summary_part.added
+ data: {"type":"response.reasoning_summary_part.added","item_id":"rs_1","output_index":0,"summary_index":0,"part":{"type":"summary_text","text":""}}
+
+ event: response.reasoning_summary_text.delta
+ data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","output_index":0,"summary_index":0,"delta":"Need a tool."}
+
+ event: response.reasoning_summary_text.done
+ data: {"type":"response.reasoning_summary_text.done","item_id":"rs_1","output_index":0,"summary_index":0,"text":"Need a tool."}
+
+ event: response.output_item.done
+ data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1","type":"reasoning","summary":[],"encrypted_content":"opaque"}}
+
+ event: response.completed
+ data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","model":"gpt-5.6","output":[]}}
+
+"#;
+
+        let response = responses_sse_to_response_value(sse).unwrap();
+        assert_eq!(
+            response["output"][0]["summary"][0]["text"],
+            "Need a tool."
+        );
+
+        let anthropic = transform_responses::responses_to_anthropic_with_web_search_options_for_client(
+            response,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
+        assert_eq!(anthropic["content"][0]["type"], "thinking");
+        assert_eq!(anthropic["content"][0]["thinking"], "Need a tool.");
+    }
+
+    #[test]
+    fn responses_sse_to_response_value_separates_reasoning_summary_parts() {
+        let sse = r#"event: response.reasoning_summary_part.done
+ data: {"type":"response.reasoning_summary_part.done","item_id":"rs_parts","output_index":0,"summary_index":0,"part":{"type":"summary_text","text":"First"}}
+
+ event: response.reasoning_summary_part.done
+ data: {"type":"response.reasoning_summary_part.done","item_id":"rs_parts","output_index":0,"summary_index":1,"part":{"type":"summary_text","text":"Second"}}
+
+ event: response.output_item.done
+ data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_parts","type":"reasoning","summary":[],"encrypted_content":"opaque"}}
+
+ event: response.completed
+ data: {"type":"response.completed","response":{"id":"resp_parts","status":"completed","model":"gpt-5.6","output":[]}}
+
+"#;
+
+        let response = responses_sse_to_response_value(sse).unwrap();
+        assert_eq!(
+            response["output"][0]["summary"][0]["text"],
+            "First\nSecond"
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -2280,7 +2280,10 @@ fn responses_sse_reasoning_summary_key(
     Some(key)
 }
 
-/// Reconcile incremental deltas with cumulative done/part snapshots without duplicating text.
+/// Reconcile cumulative done/part snapshots with what we already collected,
+/// without duplicating text. Raw `...text.delta` events bypass this: they are
+/// authoritative increments and must always be appended verbatim, otherwise
+/// overlapping chunks would be silently dropped.
 fn merge_responses_sse_reasoning_summary_part(current: &mut String, incoming: &str) {
     if incoming.is_empty() {
         return;
@@ -2494,15 +2497,15 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
                         .get("summary_index")
                         .and_then(Value::as_u64)
                         .unwrap_or(0);
-                    merge_responses_sse_reasoning_summary_part(
-                        reasoning_summaries
-                            .entry(key)
-                            .or_default()
-                            .parts
-                            .entry(summary_index)
-                            .or_default(),
-                        text,
-                    );
+                    // Deltas are authoritative increments: append verbatim instead
+                    // of reconciling, so repeated or overlapping chunks stay intact.
+                    reasoning_summaries
+                        .entry(key)
+                        .or_default()
+                        .parts
+                        .entry(summary_index)
+                        .or_default()
+                        .push_str(text);
                 }
             }
             "response.reasoning_summary_text.done" | "response.reasoning_text.done" => {
@@ -3884,6 +3887,35 @@ data: {"type":"response.completed","response":{"id":"resp_1","status":"completed
         .unwrap();
         assert_eq!(anthropic["content"][0]["type"], "thinking");
         assert_eq!(anthropic["content"][0]["thinking"], "Need a tool.");
+    }
+
+    #[test]
+    fn responses_sse_to_response_value_appends_repeated_and_overlapping_deltas() {
+        // Upstreams that only speak incremental chunks can repeat or overlap
+        // them. Prefix/suffix reconciliation would drop the second chunk; deltas
+        // must append verbatim ("foo" + "foo" + "oo" → "foofoooo").
+        let sse = r#"event: response.output_item.added
+ data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_delta","type":"reasoning","summary":[]}}
+
+ event: response.reasoning_summary_text.delta
+ data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_delta","output_index":0,"summary_index":0,"delta":"foo"}
+
+ event: response.reasoning_summary_text.delta
+ data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_delta","output_index":0,"summary_index":0,"delta":"foo"}
+
+ event: response.reasoning_summary_text.delta
+ data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_delta","output_index":0,"summary_index":0,"delta":"oo"}
+
+ event: response.output_item.done
+ data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_delta","type":"reasoning","summary":[],"encrypted_content":"opaque"}}
+
+ event: response.completed
+ data: {"type":"response.completed","response":{"id":"resp_delta","status":"completed","model":"gpt-5.6","output":[]}}
+
+"#;
+
+        let response = responses_sse_to_response_value(sse).unwrap();
+        assert_eq!(response["output"][0]["summary"][0]["text"], "foofoooo");
     }
 
     #[test]

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -245,16 +245,16 @@ async fn handle_messages_for_app(
 
     // Claude 特有：格式转换处理
     if needs_transform {
-        return handle_claude_transform(
+        return handle_claude_transform(ClaudeTransformRequest {
             response,
-            &ctx,
-            &state,
-            &body,
+            ctx: &ctx,
+            state: &state,
+            original_body: &body,
             is_stream,
-            &api_format,
+            api_format: &api_format,
             preserve_redacted_thinking,
             connection_guard,
-        )
+        })
         .await;
     }
 
@@ -383,16 +383,30 @@ fn spawn_claude_usage_log(
     });
 }
 
-async fn handle_claude_transform(
+struct ClaudeTransformRequest<'a> {
     response: super::hyper_client::ProxyResponse,
-    ctx: &RequestContext,
-    state: &ProxyState,
-    original_body: &Value,
+    ctx: &'a RequestContext,
+    state: &'a ProxyState,
+    original_body: &'a Value,
     is_stream: bool,
-    api_format: &str,
+    api_format: &'a str,
     preserve_redacted_thinking: bool,
     connection_guard: Option<ActiveConnectionGuard>,
+}
+
+async fn handle_claude_transform(
+    request: ClaudeTransformRequest<'_>,
 ) -> Result<axum::response::Response, ProxyError> {
+    let ClaudeTransformRequest {
+        response,
+        ctx,
+        state,
+        original_body,
+        is_stream,
+        api_format,
+        preserve_redacted_thinking,
+        connection_guard,
+    } = request;
     let status = response.status();
     let is_codex_oauth = ctx
         .provider
@@ -2180,6 +2194,7 @@ fn should_use_claude_transform_streaming(
     requested_streaming || upstream_is_sse || (is_codex_oauth && api_format == "openai_responses")
 }
 
+#[cfg(test)]
 async fn responses_sse_stream_to_anthropic_message(
     stream: impl futures::Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
     hosted_web_search_name: Option<String>,
@@ -2204,12 +2219,13 @@ async fn responses_sse_stream_to_anthropic_message_for_client(
     preserve_redacted_thinking: bool,
 ) -> Result<Value, ProxyError> {
     let collect = async move {
-        let converted = create_anthropic_sse_stream_from_responses_with_web_search_options_for_client(
-            stream,
-            hosted_web_search_name,
-            max_web_search_uses,
-            preserve_redacted_thinking,
-        );
+        let converted =
+            create_anthropic_sse_stream_from_responses_with_web_search_options_for_client(
+                stream,
+                hosted_web_search_name,
+                max_web_search_uses,
+                preserve_redacted_thinking,
+            );
         tokio::pin!(converted);
 
         let mut body = Vec::new();
@@ -2290,9 +2306,7 @@ fn merge_responses_sse_reasoning_summary_part(current: &mut String, incoming: &s
     }
     if current.is_empty() || incoming.starts_with(current.as_str()) {
         *current = incoming.to_string();
-    } else if current.starts_with(incoming) || current.ends_with(incoming) {
-        return;
-    } else {
+    } else if !current.starts_with(incoming) && !current.ends_with(incoming) {
         current.push_str(incoming);
     }
 }
@@ -2317,11 +2331,9 @@ fn collect_responses_sse_reasoning_item_summary(
     if item.get("type").and_then(Value::as_str) != Some("reasoning") {
         return;
     }
-    let Some(key) = responses_sse_reasoning_summary_key(
-        data,
-        keys_by_item_id,
-        keys_by_output_index,
-    ) else {
+    let Some(key) =
+        responses_sse_reasoning_summary_key(data, keys_by_item_id, keys_by_output_index)
+    else {
         return;
     };
     let state = summaries.entry(key).or_default();
@@ -2346,10 +2358,7 @@ fn collect_responses_sse_reasoning_item_summary(
         }
         Some(Value::Object(object)) => {
             if let Some(text) = object.get("text").and_then(Value::as_str) {
-                merge_responses_sse_reasoning_summary_part(
-                    state.parts.entry(0).or_default(),
-                    text,
-                );
+                merge_responses_sse_reasoning_summary_part(state.parts.entry(0).or_default(), text);
             }
         }
         _ => {}
@@ -2368,11 +2377,9 @@ fn enrich_responses_sse_reasoning_item(
     {
         return;
     }
-    let Some(key) = responses_sse_reasoning_summary_key(
-        data,
-        keys_by_item_id,
-        keys_by_output_index,
-    ) else {
+    let Some(key) =
+        responses_sse_reasoning_summary_key(data, keys_by_item_id, keys_by_output_index)
+    else {
         return;
     };
     let text = responses_sse_reasoning_summary_text(summaries, &key);
@@ -2395,7 +2402,8 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
     let mut buffer = body.trim_start_matches('\u{feff}').to_string();
     let mut completed_response: Option<Value> = None;
     let mut output_items: Vec<(Option<u64>, Value)> = Vec::new();
-    let mut reasoning_summaries: HashMap<String, ResponsesSseReasoningSummaryState> = HashMap::new();
+    let mut reasoning_summaries: HashMap<String, ResponsesSseReasoningSummaryState> =
+        HashMap::new();
     let mut reasoning_keys_by_item_id: HashMap<String, String> = HashMap::new();
     let mut reasoning_keys_by_output_index: HashMap<u64, String> = HashMap::new();
 
@@ -2474,10 +2482,7 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
                         &mut reasoning_keys_by_item_id,
                         &mut reasoning_keys_by_output_index,
                     );
-                    output_items.push((
-                        data.get("output_index").and_then(Value::as_u64),
-                        item,
-                    ));
+                    output_items.push((data.get("output_index").and_then(Value::as_u64), item));
                 }
             }
             "response.reasoning_summary_text.delta"
@@ -3188,8 +3193,7 @@ async fn log_usage(
 mod tests {
     use super::{
         body_looks_like_sse, chat_sse_to_response_value, classify_body_for_diagnostics,
-        codex_proxy_error_json, is_claude_vscode_client,
-        responses_sse_stream_to_anthropic_message,
+        codex_proxy_error_json, is_claude_vscode_client, responses_sse_stream_to_anthropic_message,
         responses_sse_to_response_value, should_use_claude_transform_streaming, transform,
         upstream_body_parse_error,
     };
@@ -3873,18 +3877,13 @@ data: {"type":"response.completed","response":{"id":"resp_1","status":"completed
 "#;
 
         let response = responses_sse_to_response_value(sse).unwrap();
-        assert_eq!(
-            response["output"][0]["summary"][0]["text"],
-            "Need a tool."
-        );
+        assert_eq!(response["output"][0]["summary"][0]["text"], "Need a tool.");
 
-        let anthropic = transform_responses::responses_to_anthropic_with_web_search_options_for_client(
-            response,
-            None,
-            None,
-            false,
-        )
-        .unwrap();
+        let anthropic =
+            transform_responses::responses_to_anthropic_with_web_search_options_for_client(
+                response, None, None, false,
+            )
+            .unwrap();
         assert_eq!(anthropic["content"][0]["type"], "thinking");
         assert_eq!(anthropic["content"][0]["thinking"], "Need a tool.");
     }
@@ -3935,10 +3934,7 @@ data: {"type":"response.completed","response":{"id":"resp_1","status":"completed
 "#;
 
         let response = responses_sse_to_response_value(sse).unwrap();
-        assert_eq!(
-            response["output"][0]["summary"][0]["text"],
-            "First\nSecond"
-        );
+        assert_eq!(response["output"][0]["summary"][0]["text"], "First\nSecond");
     }
 
     #[test]

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -2263,6 +2263,10 @@ async fn responses_sse_stream_to_anthropic_message_for_client(
 #[derive(Default)]
 struct ResponsesSseReasoningSummaryState {
     parts: BTreeMap<u64, String>,
+    // output_item.added mirrors the final item, so content[] there precedes any
+    // streamed delta. Keeping that copy out of `parts` stops verbatim delta
+    // appends from doubling the text on gateways that do both.
+    content_fallback_parts: Vec<(u64, String)>,
 }
 
 /// Keep one stable identity when a Responses stream alternates between item_id and output_index.
@@ -2306,8 +2310,6 @@ fn merge_responses_sse_reasoning_summary_part(current: &mut String, incoming: &s
     }
     if current.is_empty() || incoming.starts_with(current.as_str()) {
         *current = incoming.to_string();
-    } else if !current.starts_with(incoming) && !current.ends_with(incoming) {
-        current.push_str(incoming);
     }
 }
 
@@ -2363,6 +2365,75 @@ fn collect_responses_sse_reasoning_item_summary(
         }
         _ => {}
     }
+
+    // Some compatible gateways put visible reasoning in content[] when summary[]
+    // is absent or empty. Keep that fallback for cross-event aggregation.
+    if !state.parts.values().any(|text| !text.is_empty()) {
+        if let Some(Value::Array(parts)) = item.get("content") {
+            for (index, part) in parts.iter().enumerate() {
+                let text = part
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .or_else(|| part.as_str());
+                if let Some(text) = text {
+                    merge_responses_sse_reasoning_summary_part(
+                        state.parts.entry(index as u64).or_default(),
+                        text,
+                    );
+                }
+            }
+        }
+    }
+
+    // Last resort: content[] mirrored by output_item.added, consumed only when
+    // neither snapshots nor deltas produced any summary text.
+    if !state.parts.values().any(|text| !text.is_empty()) {
+        for (index, text) in std::mem::take(&mut state.content_fallback_parts) {
+            merge_responses_sse_reasoning_summary_part(
+                state.parts.entry(index).or_default(),
+                &text,
+            );
+        }
+    }
+}
+
+/// Record content[] text mirrored on output_item.added without touching
+/// `parts`: deltas that follow are authoritative increments, so merging the
+/// mirrored snapshot there would append them to a full copy of the text.
+fn capture_responses_sse_added_reasoning_content(
+    data: &Value,
+    item: &Value,
+    summaries: &mut HashMap<String, ResponsesSseReasoningSummaryState>,
+    keys_by_item_id: &mut HashMap<String, String>,
+    keys_by_output_index: &mut HashMap<u64, String>,
+) {
+    if item.get("type").and_then(Value::as_str) != Some("reasoning") {
+        return;
+    }
+    let Some(key) =
+        responses_sse_reasoning_summary_key(data, keys_by_item_id, keys_by_output_index)
+    else {
+        return;
+    };
+    let Some(Value::Array(parts)) = item.get("content") else {
+        return;
+    };
+    let texts: Vec<(u64, String)> = parts
+        .iter()
+        .enumerate()
+        .filter_map(|(index, part)| {
+            let text = part
+                .get("text")
+                .and_then(Value::as_str)
+                .or_else(|| part.as_str())
+                .filter(|text| !text.is_empty())?;
+            Some((index as u64, text.to_string()))
+        })
+        .collect();
+    if texts.is_empty() {
+        return;
+    }
+    summaries.entry(key).or_default().content_fallback_parts = texts;
 }
 
 fn enrich_responses_sse_reasoning_item(
@@ -2372,9 +2443,7 @@ fn enrich_responses_sse_reasoning_item(
     keys_by_item_id: &mut HashMap<String, String>,
     keys_by_output_index: &mut HashMap<u64, String>,
 ) {
-    if item.get("type").and_then(Value::as_str) != Some("reasoning")
-        || !reasoning_summary_text(item).is_empty()
-    {
+    if item.get("type").and_then(Value::as_str) != Some("reasoning") {
         return;
     }
     let Some(key) =
@@ -2383,6 +2452,12 @@ fn enrich_responses_sse_reasoning_item(
         return;
     };
     let text = responses_sse_reasoning_summary_text(summaries, &key);
+    let existing_text = reasoning_summary_text(item);
+    // Final snapshots may carry only the first part. Retain the longer collected
+    // summary so both visible text and the replay envelope include every part.
+    if !existing_text.is_empty() && (existing_text == text || !text.starts_with(&existing_text)) {
+        return;
+    }
     if !text.is_empty() {
         if let Some(object) = item.as_object_mut() {
             object.insert(
@@ -2456,7 +2531,7 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
         match event_name {
             "response.output_item.added" => {
                 if let Some(item) = data.get("item") {
-                    collect_responses_sse_reasoning_item_summary(
+                    capture_responses_sse_added_reasoning_content(
                         &data,
                         item,
                         &mut reasoning_summaries,
@@ -2490,8 +2565,8 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
             | "response.reasoning.delta" => {
                 if let (Some(text), Some(key)) = (
                     data.get("delta")
-                        .or_else(|| data.get("text"))
-                        .and_then(Value::as_str),
+                        .and_then(Value::as_str)
+                        .or_else(|| data.get("text").and_then(Value::as_str)),
                     responses_sse_reasoning_summary_key(
                         &data,
                         &mut reasoning_keys_by_item_id,
@@ -2516,8 +2591,8 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
             "response.reasoning_summary_text.done" | "response.reasoning_text.done" => {
                 if let (Some(text), Some(key)) = (
                     data.get("text")
-                        .or_else(|| data.get("delta"))
-                        .and_then(Value::as_str),
+                        .and_then(Value::as_str)
+                        .or_else(|| data.get("delta").and_then(Value::as_str)),
                     responses_sse_reasoning_summary_key(
                         &data,
                         &mut reasoning_keys_by_item_id,
@@ -2567,7 +2642,7 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
                     );
                 }
             }
-            "response.completed" => {
+            "response.completed" | "response.incomplete" => {
                 completed_response = Some(data.get("response").cloned().unwrap_or(data));
             }
             "response.failed" => {
@@ -2586,15 +2661,19 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
         process_block(&block, true)?;
     }
     // 最后一个事件后可能没有空行分隔（错标 SSE 兜底/非规范上游常见）：
-    // 残余 buffer 当最后一块处理，否则尾部的 response.completed 会被丢掉。
+    // 残余 buffer 当最后一块处理，否则尾部的 terminal response 会被丢掉。
     // 已完成时的跳过判定在闭包内（C8）。
     process_block(&buffer, false)?;
 
     let mut response = completed_response.ok_or_else(|| {
-        ProxyError::TransformError("No response.completed event in upstream SSE".to_string())
+        ProxyError::TransformError("No terminal response event in upstream SSE".to_string())
     })?;
 
-    if !output_items.is_empty() {
+    let terminal_output_is_nonempty = response
+        .get("output")
+        .and_then(Value::as_array)
+        .is_some_and(|output| !output.is_empty());
+    if !output_items.is_empty() && !terminal_output_is_nonempty {
         let mut output = Vec::with_capacity(output_items.len());
         for (position, (output_index, mut item)) in output_items.into_iter().enumerate() {
             let data = json!({
@@ -2618,8 +2697,8 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
             ));
         }
     } else if let Some(output) = response.get_mut("output").and_then(Value::as_array_mut) {
-        // Some gateways put the final reasoning snapshot only in response.completed.
-        // Enrich that snapshot too when its summary was carried by earlier SSE events.
+        // Keep terminal-only items: done events are only a fallback when the terminal
+        // response has no output array. Enrich terminal reasoning with collected summaries.
         for (index, item) in output.iter_mut().enumerate() {
             let data = json!({
                 "output_index": index as u64,
@@ -2632,6 +2711,31 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
                 &mut reasoning_keys_by_item_id,
                 &mut reasoning_keys_by_output_index,
             );
+        }
+        // A partial terminal output (e.g. a reasoning-only snapshot) must not
+        // drop items that were fully streamed via output_item.done: append the
+        // types the terminal output never mentioned.
+        for (output_index, mut item) in output_items {
+            let item_type = item.get("type").and_then(Value::as_str);
+            if item_type.is_some_and(|item_type| {
+                output
+                    .iter()
+                    .any(|existing| existing.get("type").and_then(Value::as_str) == Some(item_type))
+            }) {
+                continue;
+            }
+            let data = json!({
+                "output_index": output_index.unwrap_or(output.len() as u64),
+                "item_id": item.get("id").and_then(Value::as_str),
+            });
+            enrich_responses_sse_reasoning_item(
+                &data,
+                &mut item,
+                &reasoning_summaries,
+                &mut reasoning_keys_by_item_id,
+                &mut reasoning_keys_by_output_index,
+            );
+            output.push(item);
         }
     }
 
@@ -3197,8 +3301,12 @@ mod tests {
         responses_sse_to_response_value, should_use_claude_transform_streaming, transform,
         upstream_body_parse_error,
     };
-    use crate::proxy::{providers::transform_responses, ProxyError};
+    use crate::proxy::{
+        providers::{reasoning_bridge::reasoning_summary_text, transform_responses},
+        ProxyError,
+    };
     use bytes::Bytes;
+    use serde_json::json;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -3853,6 +3961,102 @@ data: {"type":"response.completed","response":{"id":"resp_1","status":"completed
     }
 
     #[test]
+    fn responses_sse_to_response_value_accepts_incomplete_terminal_events() {
+        let sse = r#"event: response.incomplete
+	data: {"type":"response.incomplete","response":{"id":"resp_incomplete","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[]}}
+
+"#;
+
+        let response = responses_sse_to_response_value(sse).unwrap();
+
+        assert_eq!(response["id"], "resp_incomplete");
+        assert_eq!(response["status"], "incomplete");
+        assert_eq!(
+            response["incomplete_details"]["reason"],
+            "max_output_tokens"
+        );
+    }
+
+    #[test]
+    fn responses_sse_to_response_value_keeps_terminal_items_when_done_is_partial() {
+        let sse = concat!(
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Done.\"}]}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_mixed\",\"status\":\"completed\",\"output\":[{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Need a tool.\"}],\"encrypted_content\":\"opaque\"},{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Done.\"}]}]}}\n\n"
+        );
+
+        let response = responses_sse_to_response_value(sse).unwrap();
+
+        assert_eq!(response["output"].as_array().unwrap().len(), 2);
+        assert_eq!(response["output"][0]["type"], "reasoning");
+        assert_eq!(response["output"][1]["type"], "message");
+    }
+
+    #[test]
+    fn responses_sse_to_response_value_collects_content_only_reasoning() {
+        let sse = concat!(
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_content\",\"type\":\"reasoning\",\"content\":[{\"type\":\"reasoning_text\",\"text\":\"Visible thought.\"}]}}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_content\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"status\":\"completed\",\"output\":[] }\n\n"
+        );
+
+        let response = responses_sse_to_response_value(sse).unwrap();
+
+        assert_eq!(
+            reasoning_summary_text(&response["output"][0]),
+            "Visible thought."
+        );
+    }
+
+    #[test]
+    fn responses_sse_to_response_value_appends_done_items_missing_from_terminal_output() {
+        // The terminal response only mirrors the reasoning snapshot; the message
+        // that was fully streamed via output_item.done must survive aggregation.
+        let sse = concat!(
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Done.\"}]}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_partial_terminal\",\"status\":\"completed\",\"output\":[{\"id\":\"rs_1\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}]}}\n\n"
+        );
+
+        let response = responses_sse_to_response_value(sse).unwrap();
+
+        let output = response["output"].as_array().unwrap();
+        assert_eq!(output.len(), 2);
+        assert_eq!(output[0]["type"], "reasoning");
+        assert_eq!(output[1]["type"], "message");
+        assert_eq!(output[1]["content"][0]["text"], "Done.");
+    }
+
+    #[test]
+    fn responses_sse_to_response_value_does_not_double_added_content_with_deltas() {
+        // Gateways may mirror the final reasoning content[] on output_item.added
+        // and still stream the same text as deltas; the mirrored copy must not
+        // be appended to.
+        let sse = concat!(
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_mirror\",\"type\":\"reasoning\",\"content\":[{\"type\":\"reasoning_text\",\"text\":\"Visible thought.\"}]}}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_mirror\",\"output_index\":0,\"summary_index\":0,\"delta\":\"Visible \"}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_mirror\",\"output_index\":0,\"summary_index\":0,\"delta\":\"thought.\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_mirror\",\"status\":\"completed\",\"output\":[{\"id\":\"rs_mirror\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}]}}\n\n"
+        );
+
+        let response = responses_sse_to_response_value(sse).unwrap();
+
+        assert_eq!(
+            reasoning_summary_text(&response["output"][0]),
+            "Visible thought."
+        );
+    }
+
+    #[test]
     fn responses_sse_to_response_value_preserves_reasoning_summary_events() {
         // Codex OAuth may leave summary empty on output_item.done even though the
         // visible summary was delivered through reasoning summary SSE events.
@@ -3918,6 +4122,66 @@ data: {"type":"response.completed","response":{"id":"resp_1","status":"completed
     }
 
     #[test]
+    fn responses_sse_to_response_value_ignores_drifting_summary_snapshots() {
+        let sse = concat!(
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_drift\",\"output_index\":0,\"delta\":\"Hello\"}\n\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_drift\",\"output_index\":0,\"delta\":\" world\"}\n\n",
+            "data: {\"type\":\"response.reasoning_summary_text.done\",\"item_id\":\"rs_drift\",\"output_index\":0,\"text\":\"Hello  world\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[{\"id\":\"rs_drift\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}]}}\n\n"
+        );
+        let response = responses_sse_to_response_value(sse).unwrap();
+        assert_eq!(
+            reasoning_summary_text(&response["output"][0]),
+            "Hello world"
+        );
+    }
+
+    #[test]
+    fn responses_sse_to_response_value_preserves_parts_missing_from_final_snapshot() {
+        for terminal_output in [
+            json!([]),
+            json!([{
+                "id": "rs_parts", "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "First"}],
+                "encrypted_content": "opaque"
+            }]),
+        ] {
+            let item_done = if terminal_output.as_array().unwrap().is_empty() {
+                "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_parts\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"First\"}],\"encrypted_content\":\"opaque\"}}\n\n"
+            } else {
+                ""
+            };
+            let sse = format!(
+                "{}{item_done}data: {}\n\n",
+                concat!(
+                    "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_parts\",\"output_index\":0,\"summary_index\":0,\"delta\":\"First\"}\n\n",
+                    "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_parts\",\"output_index\":0,\"summary_index\":1,\"delta\":\"Second\"}\n\n"
+                ),
+                json!({"type": "response.completed", "response": {
+                    "status": "completed", "output": terminal_output
+                }})
+            );
+            let response = responses_sse_to_response_value(&sse).unwrap();
+            assert_eq!(
+                reasoning_summary_text(&response["output"][0]),
+                "First\nSecond"
+            );
+            let anthropic =
+                transform_responses::responses_to_anthropic_with_web_search_options_for_client(
+                    response, None, None, false,
+                )
+                .unwrap();
+            let block = &anthropic["content"][0];
+            assert_eq!(block["thinking"], "First\nSecond");
+            let replay = crate::proxy::providers::reasoning_bridge::decode_openai_reasoning_item(
+                block["signature"].as_str().unwrap(),
+            )
+            .unwrap();
+            assert_eq!(reasoning_summary_text(&replay), "First\nSecond");
+        }
+    }
+
+    #[test]
     fn responses_sse_to_response_value_separates_reasoning_summary_parts() {
         let sse = r#"event: response.reasoning_summary_part.done
  data: {"type":"response.reasoning_summary_part.done","item_id":"rs_parts","output_index":0,"summary_index":0,"part":{"type":"summary_text","text":"First"}}
@@ -3968,7 +4232,7 @@ data: {\"type\":\"response.failed\",\"response\":{\"error\":{\"message\":\"upstr
     }
 
     #[test]
-    fn responses_sse_to_response_value_errors_when_no_completed_event() {
+    fn responses_sse_to_response_value_errors_when_no_terminal_event() {
         let sse = "event: response.output_item.done\n\
 data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"message\"}}\n\n";
 

--- a/src-tauri/src/proxy/providers/reasoning_bridge.rs
+++ b/src-tauri/src/proxy/providers/reasoning_bridge.rs
@@ -69,12 +69,18 @@ pub(crate) fn decode_openai_reasoning_item(encoded: &str) -> Option<Value> {
 }
 
 pub(crate) fn anthropic_block_from_openai_reasoning_item(item: &Value) -> Option<Value> {
-    anthropic_block_from_openai_reasoning_item_for_client(item)
+    anthropic_block_from_openai_reasoning_item_for_client(item, true)
 }
 
 /// Convert an opaque Responses reasoning item into a replayable Anthropic thinking block.
+///
+/// Encrypted reasoning without a visible summary needs a home for the replay
+/// envelope. Claude VSCode cannot render `redacted_thinking`, so those clients
+/// (`preserve_redacted_thinking = false`) get an empty thinking block; every
+/// other client keeps the historical `redacted_thinking` shape.
 pub(crate) fn anthropic_block_from_openai_reasoning_item_for_client(
     item: &Value,
+    preserve_redacted_thinking: bool,
 ) -> Option<Value> {
     if item.get("type").and_then(Value::as_str) != Some("reasoning") {
         return None;
@@ -89,6 +95,12 @@ pub(crate) fn anthropic_block_from_openai_reasoning_item_for_client(
     if has_encrypted_content {
         let envelope = encode_openai_reasoning_item(item)?;
         if text.is_empty() {
+            if preserve_redacted_thinking {
+                return Some(json!({
+                    "type": "redacted_thinking",
+                    "data": envelope
+                }));
+            }
             // Responses reasoning may be encrypted without a visible summary. Keep
             // the replay envelope in a valid thinking block instead of exposing the
             // unsupported redacted_thinking content type or a fake placeholder.
@@ -148,14 +160,14 @@ mod tests {
     }
 
     #[test]
-    fn encrypted_item_without_summary_uses_empty_thinking_signature() {
+    fn encrypted_item_without_summary_uses_empty_thinking_signature_for_vscode() {
         let item = json!({
             "id": "rs_2",
             "type": "reasoning",
             "summary": [],
             "encrypted_content": "opaque"
         });
-        let block = anthropic_block_from_openai_reasoning_item(&item).unwrap();
+        let block = anthropic_block_from_openai_reasoning_item_for_client(&item, false).unwrap();
         assert_eq!(block["type"], "thinking");
         assert_eq!(block["thinking"], "");
         assert!(block.get("data").is_none());
@@ -166,16 +178,16 @@ mod tests {
     }
 
     #[test]
-    fn encrypted_item_without_summary_uses_thinking_for_compatible_clients() {
+    fn encrypted_item_without_summary_keeps_redacted_thinking_for_compatible_clients() {
         let item = json!({
             "id": "rs_compat",
             "type": "reasoning",
             "summary": [],
             "encrypted_content": "opaque"
         });
-        let block = anthropic_block_from_openai_reasoning_item_for_client(&item).unwrap();
-        assert_eq!(block["type"], "thinking");
-        assert_eq!(block["thinking"], "");
+        let block = anthropic_block_from_openai_reasoning_item_for_client(&item, true).unwrap();
+        assert_eq!(block["type"], "redacted_thinking");
+        assert!(block["data"].as_str().is_some_and(|value| value.starts_with("ccswitch-openai-reasoning-v1:")));
         assert_eq!(
             openai_reasoning_item_from_anthropic_block(&block),
             Some(item)

--- a/src-tauri/src/proxy/providers/reasoning_bridge.rs
+++ b/src-tauri/src/proxy/providers/reasoning_bridge.rs
@@ -68,6 +68,7 @@ pub(crate) fn decode_openai_reasoning_item(encoded: &str) -> Option<Value> {
     (item.get("type").and_then(Value::as_str) == Some("reasoning")).then_some(item)
 }
 
+#[cfg(test)]
 pub(crate) fn anthropic_block_from_openai_reasoning_item(item: &Value) -> Option<Value> {
     anthropic_block_from_openai_reasoning_item_for_client(item, true)
 }
@@ -187,7 +188,9 @@ mod tests {
         });
         let block = anthropic_block_from_openai_reasoning_item_for_client(&item, true).unwrap();
         assert_eq!(block["type"], "redacted_thinking");
-        assert!(block["data"].as_str().is_some_and(|value| value.starts_with("ccswitch-openai-reasoning-v1:")));
+        assert!(block["data"]
+            .as_str()
+            .is_some_and(|value| value.starts_with("ccswitch-openai-reasoning-v1:")));
         assert_eq!(
             openai_reasoning_item_from_anthropic_block(&block),
             Some(item)

--- a/src-tauri/src/proxy/providers/reasoning_bridge.rs
+++ b/src-tauri/src/proxy/providers/reasoning_bridge.rs
@@ -11,20 +11,43 @@ use serde_json::{json, Value};
 pub(crate) const OPENAI_REASONING_ITEM_PREFIX: &str = "ccswitch-openai-reasoning-v1:";
 
 pub(crate) fn reasoning_summary_text(item: &Value) -> String {
-    item.get("summary")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(|part| {
-            matches!(
-                part.get("type").and_then(Value::as_str),
-                Some("summary_text" | "reasoning_text")
-            )
-            .then(|| part.get("text").and_then(Value::as_str))
-            .flatten()
-        })
-        .collect::<Vec<_>>()
-        .join("")
+    if let Some(text) = reasoning_parts_text(item.get("summary")) {
+        if !text.is_empty() {
+            return text;
+        }
+    }
+
+    // Responses-compatible gateways disagree about where visible reasoning lives:
+    // the official shape uses summary[], while some gateways expose reasoning_text
+    // in content[]. Prefer summary when both are present so mirrored payloads do
+    // not make the same thought appear twice.
+    reasoning_parts_text(item.get("content")).unwrap_or_default()
+}
+
+fn reasoning_parts_text(parts: Option<&Value>) -> Option<String> {
+    let parts = parts?;
+    match parts {
+        Value::String(value) => Some(value.clone()),
+        Value::Object(object) => object
+            .get("text")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        Value::Array(parts) => {
+            let text = parts
+                .iter()
+                .filter_map(|part| match part {
+                    Value::String(value) if !value.is_empty() => Some(value.as_str()),
+                    Value::Object(object) => object
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .filter(|value| !value.is_empty()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            Some(text.join("\n"))
+        }
+        _ => None,
+    }
 }
 
 pub(crate) fn encode_openai_reasoning_item(item: &Value) -> Option<String> {
@@ -46,6 +69,13 @@ pub(crate) fn decode_openai_reasoning_item(encoded: &str) -> Option<Value> {
 }
 
 pub(crate) fn anthropic_block_from_openai_reasoning_item(item: &Value) -> Option<Value> {
+    anthropic_block_from_openai_reasoning_item_for_client(item)
+}
+
+/// Convert an opaque Responses reasoning item into a replayable Anthropic thinking block.
+pub(crate) fn anthropic_block_from_openai_reasoning_item_for_client(
+    item: &Value,
+) -> Option<Value> {
     if item.get("type").and_then(Value::as_str) != Some("reasoning") {
         return None;
     }
@@ -59,9 +89,13 @@ pub(crate) fn anthropic_block_from_openai_reasoning_item(item: &Value) -> Option
     if has_encrypted_content {
         let envelope = encode_openai_reasoning_item(item)?;
         if text.is_empty() {
+            // Responses reasoning may be encrypted without a visible summary. Keep
+            // the replay envelope in a valid thinking block instead of exposing the
+            // unsupported redacted_thinking content type or a fake placeholder.
             return Some(json!({
-                "type": "redacted_thinking",
-                "data": envelope
+                "type": "thinking",
+                "thinking": "",
+                "signature": envelope
             }));
         }
         return Some(json!({
@@ -114,7 +148,7 @@ mod tests {
     }
 
     #[test]
-    fn encrypted_item_without_summary_uses_redacted_thinking() {
+    fn encrypted_item_without_summary_uses_empty_thinking_signature() {
         let item = json!({
             "id": "rs_2",
             "type": "reasoning",
@@ -122,10 +156,70 @@ mod tests {
             "encrypted_content": "opaque"
         });
         let block = anthropic_block_from_openai_reasoning_item(&item).unwrap();
-        assert_eq!(block["type"], "redacted_thinking");
+        assert_eq!(block["type"], "thinking");
+        assert_eq!(block["thinking"], "");
+        assert!(block.get("data").is_none());
         assert_eq!(
             openai_reasoning_item_from_anthropic_block(&block),
             Some(item)
         );
+    }
+
+    #[test]
+    fn encrypted_item_without_summary_uses_thinking_for_compatible_clients() {
+        let item = json!({
+            "id": "rs_compat",
+            "type": "reasoning",
+            "summary": [],
+            "encrypted_content": "opaque"
+        });
+        let block = anthropic_block_from_openai_reasoning_item_for_client(&item).unwrap();
+        assert_eq!(block["type"], "thinking");
+        assert_eq!(block["thinking"], "");
+        assert_eq!(
+            openai_reasoning_item_from_anthropic_block(&block),
+            Some(item)
+        );
+    }
+
+    #[test]
+    fn summary_text_falls_back_to_reasoning_content() {
+        let item = json!({
+            "type": "reasoning",
+            "summary": [],
+            "content": [
+                {"type": "reasoning_text", "text": "Restored from content."}
+            ]
+        });
+
+        assert_eq!(reasoning_summary_text(&item), "Restored from content.");
+    }
+
+    #[test]
+    fn summary_text_prefers_summary_when_content_mirrors_it() {
+        let item = json!({
+            "type": "reasoning",
+            "summary": [
+                {"type": "summary_text", "text": "Visible summary."}
+            ],
+            "content": [
+                {"type": "reasoning_text", "text": "Visible summary."}
+            ]
+        });
+
+        assert_eq!(reasoning_summary_text(&item), "Visible summary.");
+    }
+
+    #[test]
+    fn summary_text_accepts_string_parts_and_unknown_part_types() {
+        let item = json!({
+            "type": "reasoning",
+            "summary": [
+                "First ",
+                {"type": "future_summary_part", "text": "second"}
+            ]
+        });
+
+        assert_eq!(reasoning_summary_text(&item), "First \nsecond");
     }
 }

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -8,9 +8,9 @@
 //!
 //! 与 Chat Completions 的 delta chunk 模型完全不同，需要独立的状态机处理。
 
-use super::reasoning_bridge::{encode_openai_reasoning_item, reasoning_summary_text};
 #[cfg(test)]
 use super::reasoning_bridge::decode_openai_reasoning_item;
+use super::reasoning_bridge::{encode_openai_reasoning_item, reasoning_summary_text};
 use super::transform_responses::{
     build_anthropic_usage_from_responses, map_responses_stop_reason,
     merge_web_search_result_metadata, responses_to_anthropic_with_web_search_options_for_client,
@@ -2289,7 +2289,8 @@ fn merge_reasoning_items(previous: Option<&Value>, current: &Value) -> Value {
         return current.clone();
     };
     let mut merged = current.clone();
-    let (Some(merged_object), Some(previous_object)) = (merged.as_object_mut(), previous.as_object())
+    let (Some(merged_object), Some(previous_object)) =
+        (merged.as_object_mut(), previous.as_object())
     else {
         return merged;
     };
@@ -2507,12 +2508,14 @@ fn order_anthropic_web_search_result_stream(
 ///
 /// 状态机跟踪: message_id, current_model, has_sent_message_start, item/content index map
 /// SSE 解析支持 named events (event: + data: 行)
+#[cfg(test)]
 pub fn create_anthropic_sse_stream_from_responses<E: std::error::Error + Send + 'static>(
     stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
     create_anthropic_sse_stream_from_responses_with_web_search_options(stream, None, None)
 }
 
+#[cfg(test)]
 pub(crate) fn create_anthropic_sse_stream_from_responses_with_web_search_options<
     E: std::error::Error + Send + 'static,
 >(
@@ -7427,10 +7430,7 @@ mod tests {
         );
         let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(input))]);
         let merged = create_anthropic_sse_stream_from_responses_with_web_search_options_for_client(
-            upstream,
-            None,
-            None,
-            false,
+            upstream, None, None, false,
         )
         .collect::<Vec<_>>()
         .await
@@ -7459,10 +7459,7 @@ mod tests {
         );
         let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(input))]);
         let merged = create_anthropic_sse_stream_from_responses_with_web_search_options_for_client(
-            upstream,
-            None,
-            None,
-            true,
+            upstream, None, None, true,
         )
         .collect::<Vec<_>>()
         .await
@@ -7520,7 +7517,8 @@ mod tests {
                     .map(ToString::to_string)
             })
             .expect("reasoning signature should be emitted");
-        let restored = decode_openai_reasoning_item(&signature).expect("signature should round-trip");
+        let restored =
+            decode_openai_reasoning_item(&signature).expect("signature should round-trip");
         assert_eq!(restored["summary"][0]["text"], "Added snapshot");
     }
 
@@ -7578,7 +7576,8 @@ mod tests {
                     .map(ToString::to_string)
             })
             .expect("reasoning signature should be emitted");
-        let restored = decode_openai_reasoning_item(&signature).expect("signature should round-trip");
+        let restored =
+            decode_openai_reasoning_item(&signature).expect("signature should round-trip");
         assert_eq!(restored["summary"][0]["text"], "Part snapshot");
     }
 
@@ -7612,7 +7611,8 @@ mod tests {
                     .map(ToString::to_string)
             })
             .expect("reasoning signature should be emitted");
-        let restored = decode_openai_reasoning_item(&signature).expect("signature should round-trip");
+        let restored =
+            decode_openai_reasoning_item(&signature).expect("signature should round-trip");
         assert_eq!(restored["summary"][0]["text"], "First \nSecond");
     }
 
@@ -7763,7 +7763,8 @@ mod tests {
                     .map(ToString::to_string)
             })
             .expect("reasoning signature should be emitted");
-        let restored = decode_openai_reasoning_item(&signature).expect("signature should round-trip");
+        let restored =
+            decode_openai_reasoning_item(&signature).expect("signature should round-trip");
         assert_eq!(restored["summary"][0]["text"], "foofoo");
     }
 

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -76,13 +76,13 @@ fn responses_json_to_anthropic_sse_for_client(
     body: Value,
     hosted_web_search_name: Option<&str>,
     max_web_search_uses: Option<u64>,
-    _preserve_redacted_thinking: bool,
+    preserve_redacted_thinking: bool,
 ) -> Vec<Bytes> {
     let message = match responses_to_anthropic_with_web_search_options_for_client(
         body,
         hosted_web_search_name,
         max_web_search_uses,
-        _preserve_redacted_thinking,
+        preserve_redacted_thinking,
     ) {
         Ok(message) => message,
         Err(error) => {
@@ -4191,6 +4191,20 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                                         "delta":{"type":"signature_delta","signature":envelope}
                                                     }),
                                                 ));
+                                            } else if preserve_redacted_thinking {
+                                                // No visible summary was streamed, so the
+                                                // replay envelope needs a fresh block. Claude
+                                                // VSCode cannot render redacted_thinking; other
+                                                // clients keep the historical shape.
+                                                yield Ok(anthropic_sse(
+                                                    "content_block_start",
+                                                    &json!({
+                                                        "type":"content_block_start",
+                                                        "index":index,
+                                                        "content_block":{"type":"redacted_thinking","data":envelope}
+                                                    }),
+                                                ));
+                                                open_indices.insert(index);
                                             } else {
                                                 yield Ok(anthropic_sse(
                                                     "content_block_start",
@@ -4779,6 +4793,23 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                                     let signature_sse = format!("event: content_block_delta\ndata: {}\n\n",
                                                         serde_json::to_string(&signature_event).unwrap_or_default());
                                                     yield Ok(Bytes::from(signature_sse));
+                                                } else if preserve_redacted_thinking {
+                                                    // No visible summary was streamed, so the
+                                                    // replay envelope needs a fresh block. Claude
+                                                    // VSCode cannot render redacted_thinking; other
+                                                    // clients keep the historical shape.
+                                                    let start_event = json!({
+                                                        "type": "content_block_start",
+                                                        "index": index,
+                                                        "content_block": {
+                                                            "type": "redacted_thinking",
+                                                            "data": envelope
+                                                        }
+                                                    });
+                                                    let start_sse = format!("event: content_block_start\ndata: {}\n\n",
+                                                        serde_json::to_string(&start_event).unwrap_or_default());
+                                                    yield Ok(Bytes::from(start_sse));
+                                                    open_indices.insert(index);
                                                 } else {
                                                     let start_event = json!({
                                                         "type": "content_block_start",
@@ -7399,7 +7430,7 @@ mod tests {
             upstream,
             None,
             None,
-            true,
+            false,
         )
         .collect::<Vec<_>>()
         .await
@@ -7411,6 +7442,38 @@ mod tests {
         assert!(merged.contains("\"type\":\"thinking\""));
         assert!(!merged.contains("[redacted thinking]"));
         assert!(merged.contains("\"type\":\"signature_delta\""));
+        assert!(merged.contains("event: message_stop"));
+    }
+
+    #[tokio::test]
+    async fn test_stream_encrypted_reasoning_keeps_redacted_thinking_for_compatible_clients() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_redacted_compat\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_redacted_compat\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_redacted_compat\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(input))]);
+        let merged = create_anthropic_sse_stream_from_responses_with_web_search_options_for_client(
+            upstream,
+            None,
+            None,
+            true,
+        )
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .map(|chunk| String::from_utf8_lossy(chunk.unwrap().as_ref()).to_string())
+        .collect::<String>();
+
+        assert!(merged.contains("\"type\":\"redacted_thinking\""));
+        assert!(merged.contains("\"data\":\"ccswitch-openai-reasoning-v1:"));
+        assert!(!merged.contains("\"type\":\"signature_delta\""));
+        assert!(merged.contains("event: content_block_stop"));
         assert!(merged.contains("event: message_stop"));
     }
 

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -9,9 +9,11 @@
 //! 与 Chat Completions 的 delta chunk 模型完全不同，需要独立的状态机处理。
 
 use super::reasoning_bridge::{encode_openai_reasoning_item, reasoning_summary_text};
+#[cfg(test)]
+use super::reasoning_bridge::decode_openai_reasoning_item;
 use super::transform_responses::{
     build_anthropic_usage_from_responses, map_responses_stop_reason,
-    merge_web_search_result_metadata, responses_to_anthropic_with_web_search_options,
+    merge_web_search_result_metadata, responses_to_anthropic_with_web_search_options_for_client,
     sanitize_anthropic_tool_use_input_json, text_with_url_citations, web_search_action_input,
     web_search_max_uses_exceeded_error, web_search_results_from_action,
     web_search_results_from_output_item, web_search_tool_result_error,
@@ -70,15 +72,17 @@ fn anthropic_ping_sse() -> Bytes {
 /// Convert a compatible gateway's non-streaming Responses JSON into a complete
 /// Anthropic SSE lifecycle. This is used when the client requested streaming but
 /// the upstream ignored `stream:true` and returned `application/json`.
-fn responses_json_to_anthropic_sse(
+fn responses_json_to_anthropic_sse_for_client(
     body: Value,
     hosted_web_search_name: Option<&str>,
     max_web_search_uses: Option<u64>,
+    _preserve_redacted_thinking: bool,
 ) -> Vec<Bytes> {
-    let message = match responses_to_anthropic_with_web_search_options(
+    let message = match responses_to_anthropic_with_web_search_options_for_client(
         body,
         hosted_web_search_name,
         max_web_search_uses,
+        _preserve_redacted_thinking,
     ) {
         Ok(message) => message,
         Err(error) => {
@@ -231,8 +235,22 @@ fn responses_json_to_anthropic_sse(
                 Some("redacted_thinking") => {
                     events.push(anthropic_sse(
                         "content_block_start",
-                        &json!({"type":"content_block_start","index":index,"content_block":block}),
+                        &json!({
+                            "type":"content_block_start",
+                            "index":index,
+                            "content_block":{"type":"thinking","thinking":""}
+                        }),
                     ));
+                    if let Some(signature) = block.get("data").and_then(Value::as_str) {
+                        events.push(anthropic_sse(
+                            "content_block_delta",
+                            &json!({
+                                "type":"content_block_delta",
+                                "index":index,
+                                "delta":{"type":"signature_delta","signature":signature}
+                            }),
+                        ));
+                    }
                     events.push(anthropic_sse(
                         "content_block_stop",
                         &json!({"type":"content_block_stop","index":index}),
@@ -2106,6 +2124,186 @@ fn reasoning_item_key(data: &Value, item: Option<&Value>) -> Option<String> {
         .map(|index| format!("reasoning:out:{index}"))
 }
 
+fn reasoning_field_is_empty(value: Option<&Value>) -> bool {
+    match value {
+        None | Some(Value::Null) => true,
+        Some(Value::String(value)) => value.is_empty(),
+        Some(Value::Object(object)) => object
+            .get("text")
+            .and_then(Value::as_str)
+            .is_none_or(str::is_empty),
+        Some(Value::Array(values)) => {
+            values.is_empty()
+                || values.iter().all(|part| match part {
+                    Value::String(value) => value.is_empty(),
+                    Value::Object(object) => object
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .is_none_or(str::is_empty),
+                    _ => true,
+                })
+        }
+        Some(_) => false,
+    }
+}
+
+fn reasoning_summary_part_key(index: u32, summary_index: u64) -> String {
+    format!("reasoning:{index}:summary:{summary_index}")
+}
+
+fn reasoning_summary_part_separator(
+    summary_index: u64,
+    emitted: &str,
+    previous_part: Option<&str>,
+    incoming: &str,
+) -> &'static str {
+    if summary_index > 0
+        && previous_part.is_none_or(str::is_empty)
+        && !emitted.is_empty()
+        && !emitted.ends_with('\n')
+        && !incoming.starts_with('\n')
+    {
+        "\n"
+    } else {
+        ""
+    }
+}
+
+fn missing_reasoning_summary_part(
+    emitted: &str,
+    previous_part: Option<&str>,
+    summary_index: u64,
+    text: &str,
+) -> String {
+    if let Some(previous_part) = previous_part.filter(|value| !value.is_empty()) {
+        if let Some(suffix) = text.strip_prefix(previous_part) {
+            return suffix.to_string();
+        }
+        if previous_part.starts_with(text) || emitted.starts_with(text) || emitted.ends_with(text) {
+            return String::new();
+        }
+        return text.to_string();
+    }
+
+    if let Some(suffix) = text.strip_prefix(emitted).filter(|value| !value.is_empty()) {
+        return suffix.to_string();
+    }
+    if !emitted.is_empty()
+        && (emitted.starts_with(text) || emitted.ends_with(text) || summary_index == 0)
+    {
+        return String::new();
+    }
+
+    let separator = reasoning_summary_part_separator(summary_index, emitted, Some(""), text);
+    format!("{separator}{text}")
+}
+
+fn resolve_reasoning_index(
+    data: &Value,
+    item: Option<&Value>,
+    reasoning_index_by_item_id: &mut HashMap<String, u32>,
+    index_by_key: &mut HashMap<String, u32>,
+    legacy_reasoning_index: &mut Option<u32>,
+    next_content_index: &mut u32,
+) -> u32 {
+    let item_id = item
+        .and_then(|value| value.get("id"))
+        .and_then(Value::as_str)
+        .or_else(|| data.get("item_id").and_then(Value::as_str));
+    let item_key = reasoning_item_key(data, item);
+    let output_key = data
+        .get("output_index")
+        .and_then(Value::as_u64)
+        .map(|index| format!("reasoning:out:{index}"));
+    let is_keyless = item_id.is_none() && item_key.is_none() && output_key.is_none();
+    let existing = item_id
+        .and_then(|id| reasoning_index_by_item_id.get(id).copied())
+        .or_else(|| {
+            item_key
+                .as_ref()
+                .and_then(|key| index_by_key.get(key).copied())
+        })
+        .or_else(|| {
+            output_key
+                .as_ref()
+                .and_then(|key| index_by_key.get(key).copied())
+        })
+        .or_else(|| is_keyless.then_some(*legacy_reasoning_index).flatten());
+
+    if let Some(index) = existing {
+        // Bind aliases discovered later so a gateway can switch between item_id
+        // and output_index without creating a second Anthropic content block.
+        if let Some(key) = item_key {
+            index_by_key.insert(key, index);
+        }
+        if let Some(key) = output_key {
+            index_by_key.insert(key, index);
+        }
+        if let Some(id) = item_id {
+            reasoning_index_by_item_id.insert(id.to_string(), index);
+        }
+        return index;
+    }
+
+    let assigned = *next_content_index;
+    *next_content_index += 1;
+    if let Some(key) = item_key {
+        index_by_key.insert(key, assigned);
+    }
+    if let Some(key) = output_key {
+        index_by_key.insert(key, assigned);
+    }
+    if let Some(id) = item_id {
+        reasoning_index_by_item_id.insert(id.to_string(), assigned);
+    } else if is_keyless {
+        *legacy_reasoning_index = Some(assigned);
+    }
+    assigned
+}
+
+fn preserve_streamed_reasoning_summary(item: &mut Value, visible_text: &str) {
+    if visible_text.is_empty() {
+        return;
+    }
+    let existing_text = reasoning_summary_text(item);
+    if !existing_text.is_empty()
+        && (existing_text == visible_text || !visible_text.starts_with(&existing_text))
+    {
+        return;
+    }
+
+    // Some gateways put the summary only in delta/part events, or expose only
+    // the first summary part on output_item.done. Keep the signature envelope
+    // replayable instead of returning a thinking block whose visible text is
+    // truncated on the next turn.
+    if let Some(object) = item.as_object_mut() {
+        object.insert(
+            "summary".to_string(),
+            json!([{"type": "summary_text", "text": visible_text}]),
+        );
+    }
+}
+
+fn merge_reasoning_items(previous: Option<&Value>, current: &Value) -> Value {
+    let Some(previous) = previous else {
+        return current.clone();
+    };
+    let mut merged = current.clone();
+    let (Some(merged_object), Some(previous_object)) = (merged.as_object_mut(), previous.as_object())
+    else {
+        return merged;
+    };
+
+    for field in ["id", "encrypted_content", "summary", "content"] {
+        if reasoning_field_is_empty(merged_object.get(field)) {
+            if let Some(value) = previous_object.get(field) {
+                merged_object.insert(field.to_string(), value.clone());
+            }
+        }
+    }
+    merged
+}
+
 /// Resolve content index for a text/refusal content part event.
 ///
 /// Uses `content_part_key` to look up or assign a stable index, falling back to
@@ -2322,6 +2520,22 @@ pub(crate) fn create_anthropic_sse_stream_from_responses_with_web_search_options
     hosted_web_search_name: Option<String>,
     max_web_search_uses: Option<u64>,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
+    create_anthropic_sse_stream_from_responses_with_web_search_options_for_client(
+        stream,
+        hosted_web_search_name,
+        max_web_search_uses,
+        true,
+    )
+}
+
+pub(crate) fn create_anthropic_sse_stream_from_responses_with_web_search_options_for_client<
+    E: std::error::Error + Send + 'static,
+>(
+    stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
+    hosted_web_search_name: Option<String>,
+    max_web_search_uses: Option<u64>,
+    preserve_redacted_thinking: bool,
+) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
     let can_preserve_web_search_citations = hosted_web_search_name
         .as_deref()
         .is_some_and(|name| !name.is_empty());
@@ -2333,6 +2547,7 @@ pub(crate) fn create_anthropic_sse_stream_from_responses_with_web_search_options
         hosted_web_search_name.clone(),
         max_web_search_uses,
         can_preserve_web_search_citations,
+        preserve_redacted_thinking,
     );
     order_anthropic_web_search_result_stream(raw_stream, hosted_web_search_name)
 }
@@ -2342,6 +2557,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
     hosted_web_search_name: String,
     max_web_search_uses: Option<u64>,
     can_preserve_web_search_citations: bool,
+    preserve_redacted_thinking: bool,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send {
     async_stream::stream! {
         let mut buffer = String::new();
@@ -2378,6 +2594,8 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
         let mut reasoning_index_by_item_id: HashMap<String, u32> = HashMap::new();
         let mut reasoning_item_by_index: HashMap<u32, Value> = HashMap::new();
         let mut reasoning_text_by_index: HashMap<u32, String> = HashMap::new();
+        let mut reasoning_part_text_by_key: HashMap<String, String> = HashMap::new();
+        let mut completed_reasoning_indices: HashSet<u32> = HashSet::new();
         let mut legacy_reasoning_index: Option<u32> = None;
         let mut has_substantive_output = false;
         let mut terminated = false;
@@ -2413,10 +2631,11 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                     if looks_like_json && is_eof {
                         match serde_json::from_str::<Value>(buffer.trim()) {
                             Ok(body) => {
-                                for event in responses_json_to_anthropic_sse(
+                                for event in responses_json_to_anthropic_sse_for_client(
                                     body,
                                     Some(hosted_web_search_name.as_str()),
                                     max_web_search_uses,
+                                    preserve_redacted_thinking,
                                 ) {
                                     yield Ok(event);
                                 }
@@ -2463,7 +2682,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                         let data_str = data_parts.join("\n");
 
                         // 解析 JSON 数据
-                        let data: Value = match serde_json::from_str(&data_str) {
+                        let mut data: Value = match serde_json::from_str(&data_str) {
                             Ok(v) => v,
                             Err(_) => continue,
                         };
@@ -2471,11 +2690,45 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                         // Official streams use both a named SSE event and `type` in
                         // the JSON payload. Compatible gateways sometimes omit the
                         // `event:` line, so fall back to the payload type.
-                        let event_name = event_type
+                        let mut event_name = event_type
                             .as_deref()
                             .filter(|name| !name.is_empty())
                             .or_else(|| data.get("type").and_then(Value::as_str))
-                            .unwrap_or("");
+                            .map(ToString::to_string)
+                            .unwrap_or_default();
+
+                        // A few Responses gateways put the complete visible summary in
+                        // output_item.added and omit the later summary-part lifecycle.
+                        // Feed that snapshot through the same deduplicating path so an
+                        // encrypted terminal item cannot collapse into redacted thinking.
+                        if event_name == "response.output_item.added" {
+                            let added_reasoning = data.get("item").and_then(|item| {
+                                (item.get("type").and_then(Value::as_str) == Some("reasoning"))
+                                    .then(|| {
+                                        (
+                                            item.get("id")
+                                                .and_then(Value::as_str)
+                                                .map(ToString::to_string),
+                                            reasoning_summary_text(item),
+                                        )
+                                    })
+                            });
+                            if let Some((item_id, text)) = added_reasoning {
+                                if !text.is_empty() {
+                                    if let Some(object) = data.as_object_mut() {
+                                        if let Some(item_id) = item_id {
+                                            object.insert("item_id".to_string(), json!(item_id));
+                                        }
+                                        object.insert("summary_index".to_string(), json!(0));
+                                        object.insert(
+                                            "part".to_string(),
+                                            json!({"type":"summary_text","text":text}),
+                                        );
+                                    }
+                                    event_name = "response.reasoning_summary_part.done".to_string();
+                                }
+                            }
+                        }
 
                         log::debug!("[Claude/Responses] <<< SSE event: {event_name}");
 
@@ -2487,7 +2740,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                         }
 
                         let delta_requires_message_start = matches!(
-                            event_name,
+                            event_name.as_str(),
                             "response.output_text.delta"
                                 | "response.refusal.delta"
                                 | "response.function_call_arguments.delta"
@@ -2515,7 +2768,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                             has_sent_message_start = true;
                         }
 
-                        match event_name {
+                        match event_name.as_str() {
                             // ================================================
                             // response.created → message_start
                             // ================================================
@@ -3067,27 +3320,14 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                             has_sent_message_start = true;
                                         }
 
-                                        let index = if let Some(key) = reasoning_item_key(&data, Some(item)) {
-                                            if let Some(existing) = index_by_key.get(&key).copied() {
-                                                existing
-                                            } else {
-                                                let assigned = next_content_index;
-                                                next_content_index += 1;
-                                                index_by_key.insert(key, assigned);
-                                                assigned
-                                            }
-                                        } else {
-                                            let assigned = next_content_index;
-                                            next_content_index += 1;
-                                            assigned
-                                        };
-                                        if let Some(item_id) = item
-                                            .get("id")
-                                            .and_then(Value::as_str)
-                                            .or_else(|| data.get("item_id").and_then(Value::as_str))
-                                        {
-                                            reasoning_index_by_item_id.insert(item_id.to_string(), index);
-                                        }
+                                        let index = resolve_reasoning_index(
+                                            &data,
+                                            Some(item),
+                                            &mut reasoning_index_by_item_id,
+                                            &mut index_by_key,
+                                            &mut legacy_reasoning_index,
+                                            &mut next_content_index,
+                                        );
                                         reasoning_item_by_index.insert(index, item.clone());
                                         reasoning_text_by_index.entry(index).or_default();
                                     }
@@ -3315,36 +3555,14 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                             fallback_open_index = None;
                                         }
                                     }
-                                    let item_id = data.get("item_id").and_then(Value::as_str);
-                                    let item_key = reasoning_item_key(&data, None);
-                                    let is_keyless = item_id.is_none() && item_key.is_none();
-                                    let index = item_id
-                                        .and_then(|id| reasoning_index_by_item_id.get(id).copied())
-                                        .or_else(|| {
-                                            item_key
-                                                .as_ref()
-                                                .and_then(|key| index_by_key.get(key).copied())
-                                        })
-                                        .or_else(|| {
-                                            is_keyless
-                                                .then_some(legacy_reasoning_index)
-                                                .flatten()
-                                        })
-                                        .unwrap_or_else(|| {
-                                            let assigned = next_content_index;
-                                            next_content_index += 1;
-                                            if let Some(key) = item_key {
-                                                index_by_key.insert(key, assigned);
-                                            }
-                                            if let Some(id) = item_id {
-                                                reasoning_index_by_item_id
-                                                    .insert(id.to_string(), assigned);
-                                            } else if is_keyless {
-                                                legacy_reasoning_index = Some(assigned);
-                                            }
-                                            assigned
-                                        });
-
+                                    let index = resolve_reasoning_index(
+                                        &data,
+                                        None,
+                                        &mut reasoning_index_by_item_id,
+                                        &mut index_by_key,
+                                        &mut legacy_reasoning_index,
+                                        &mut next_content_index,
+                                    );
                                     if !open_indices.contains(&index) {
                                         let start_event = json!({
                                             "type": "content_block_start",
@@ -3360,8 +3578,29 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                         open_indices.insert(index);
                                     }
 
+                                    let summary_index = data
+                                        .get("summary_index")
+                                        .and_then(Value::as_u64)
+                                        .unwrap_or(0);
+                                    let part_key = reasoning_summary_part_key(index, summary_index);
+                                    let previous_part = reasoning_part_text_by_key.get(&part_key);
+                                    let emitted = reasoning_text_by_index
+                                        .get(&index)
+                                        .map(String::as_str)
+                                        .unwrap_or_default();
+                                    let separator = reasoning_summary_part_separator(
+                                        summary_index,
+                                        emitted,
+                                        previous_part.map(String::as_str),
+                                        delta,
+                                    );
+                                    let visible_delta = format!("{separator}{delta}");
                                     reasoning_text_by_index
                                         .entry(index)
+                                        .or_default()
+                                        .push_str(&visible_delta);
+                                    reasoning_part_text_by_key
+                                        .entry(part_key)
                                         .or_default()
                                         .push_str(delta);
 
@@ -3370,7 +3609,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                         "index": index,
                                         "delta": {
                                             "type": "thinking_delta",
-                                            "thinking": delta
+                                            "thinking": visible_delta
                                         }
                                     });
                                     let sse = format!("event: content_block_delta\ndata: {}\n\n",
@@ -3386,56 +3625,93 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                             // ================================================
                             "response.reasoning_summary_text.done"
                             | "response.reasoning_text.done" => {
-                                let item_id = data.get("item_id").and_then(Value::as_str);
-                                let item_key = reasoning_item_key(&data, None);
-                                let index = item_id
-                                    .and_then(|id| reasoning_index_by_item_id.get(id).copied())
-                                    .or_else(|| {
-                                        item_key
-                                            .as_ref()
-                                            .and_then(|key| index_by_key.get(key).copied())
-                                    })
-                                    .or_else(|| {
-                                        (item_id.is_none() && item_key.is_none())
-                                            .then_some(legacy_reasoning_index)
-                                            .flatten()
-                                    });
-                                if let Some(index) = index {
-                                    let already_emitted = reasoning_text_by_index
-                                        .get(&index)
-                                        .is_some_and(|value| !value.is_empty());
-                                    if !already_emitted {
-                                        if let Some(text) = data
-                                            .get("text")
-                                            .and_then(Value::as_str)
-                                            .filter(|value| !value.is_empty())
-                                        {
-                                            if !open_indices.contains(&index) {
-                                                let start_event = json!({
-                                                    "type": "content_block_start",
-                                                    "index": index,
-                                                    "content_block": {"type": "thinking", "thinking": ""}
-                                                });
-                                                let start_sse = format!("event: content_block_start\ndata: {}\n\n",
-                                                    serde_json::to_string(&start_event).unwrap_or_default());
-                                                yield Ok(Bytes::from(start_sse));
-                                                open_indices.insert(index);
-                                            }
-                                            reasoning_text_by_index
-                                                .entry(index)
-                                                .or_default()
-                                                .push_str(text);
-                                            let event = json!({
-                                                "type": "content_block_delta",
-                                                "index": index,
-                                                "delta": {"type": "thinking_delta", "thinking": text}
-                                            });
-                                            let sse = format!("event: content_block_delta\ndata: {}\n\n",
-                                                serde_json::to_string(&event).unwrap_or_default());
-                                            yield Ok(Bytes::from(sse));
-                                        }
+                                let Some(text) = data
+                                    .get("text")
+                                    .or_else(|| data.get("delta"))
+                                    .and_then(Value::as_str)
+                                    .filter(|value| !value.is_empty())
+                                else {
+                                    continue;
+                                };
+                                let index = resolve_reasoning_index(
+                                    &data,
+                                    None,
+                                    &mut reasoning_index_by_item_id,
+                                    &mut index_by_key,
+                                    &mut legacy_reasoning_index,
+                                    &mut next_content_index,
+                                );
+                                if completed_reasoning_indices.contains(&index) {
+                                    continue;
+                                }
+                                has_substantive_output = true;
+                                if let Some(text_index) = current_text_index.take() {
+                                    if open_indices.remove(&text_index) {
+                                        yield Ok(anthropic_sse(
+                                            "content_block_stop",
+                                            &json!({"type":"content_block_stop","index":text_index}),
+                                        ));
+                                    }
+                                    if fallback_open_index == Some(text_index) {
+                                        fallback_open_index = None;
                                     }
                                 }
+                                if !has_sent_message_start {
+                                    yield Ok(anthropic_sse(
+                                        "message_start",
+                                        &json!({
+                                            "type":"message_start",
+                                            "message":{
+                                                "id":message_id.clone().unwrap_or_default(),
+                                                "type":"message",
+                                                "role":"assistant",
+                                                "model":current_model.clone().unwrap_or_default(),
+                                                "usage":{"input_tokens":0,"output_tokens":0}
+                                            }
+                                        }),
+                                    ));
+                                    has_sent_message_start = true;
+                                }
+                                // 将终结快照绑定到对应摘要分段，避免后续分段被误判为首段的替换内容。
+                                let emitted = reasoning_text_by_index
+                                    .get(&index)
+                                    .cloned()
+                                    .unwrap_or_default();
+                                let summary_index = data
+                                    .get("summary_index")
+                                    .and_then(Value::as_u64)
+                                    .unwrap_or(0);
+                                let part_key = reasoning_summary_part_key(index, summary_index);
+                                let previous_part = reasoning_part_text_by_key.get(&part_key).cloned();
+                                let missing = missing_reasoning_summary_part(
+                                    &emitted,
+                                    previous_part.as_deref(),
+                                    summary_index,
+                                    text,
+                                );
+                                reasoning_part_text_by_key.insert(part_key, text.to_string());
+                                if missing.is_empty() {
+                                    continue;
+                                }
+                                if !open_indices.contains(&index) {
+                                    let start_event = json!({
+                                        "type": "content_block_start",
+                                        "index": index,
+                                        "content_block": {"type": "thinking", "thinking": ""}
+                                    });
+                                    yield Ok(anthropic_sse("content_block_start", &start_event));
+                                    open_indices.insert(index);
+                                }
+                                let event = json!({
+                                    "type": "content_block_delta",
+                                    "index": index,
+                                    "delta": {"type": "thinking_delta", "thinking": missing.clone()}
+                                });
+                                yield Ok(anthropic_sse("content_block_delta", &event));
+                                reasoning_text_by_index
+                                    .entry(index)
+                                    .or_default()
+                                    .push_str(&missing);
                             }
 
                             // Legacy gateways do not emit output_item.done, so retain the
@@ -3516,6 +3792,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                 let mut terminal_web_search_results =
                                     std::mem::take(&mut pending_web_search_results);
                                 let mut terminal_message_items = Vec::new();
+                                let mut terminal_reasoning_items = Vec::new();
                                 let mut terminal_web_search_limit_exceeded = false;
                                 let mut terminal_reusable_text_index = None;
                                 if let Some(output) =
@@ -3550,6 +3827,12 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                             == Some("message")
                                         {
                                             terminal_message_items
+                                                .push((output_index as u64, item.clone()));
+                                        }
+                                        if item.get("type").and_then(Value::as_str)
+                                            == Some("reasoning")
+                                        {
+                                            terminal_reasoning_items
                                                 .push((output_index as u64, item.clone()));
                                         }
                                         if item.get("type").and_then(Value::as_str)
@@ -3810,6 +4093,135 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                     }
                                 }
 
+                                for (output_index, item) in terminal_reasoning_items {
+                                    let terminal_data = json!({
+                                        "output_index": output_index,
+                                        "item_id": item.get("id").cloned().unwrap_or(Value::Null)
+                                    });
+                                    let index = resolve_reasoning_index(
+                                        &terminal_data,
+                                        Some(&item),
+                                        &mut reasoning_index_by_item_id,
+                                        &mut index_by_key,
+                                        &mut legacy_reasoning_index,
+                                        &mut next_content_index,
+                                    );
+                                    if completed_reasoning_indices.contains(&index) {
+                                        continue;
+                                    }
+
+                                    has_substantive_output = true;
+                                    if let Some(text_index) = current_text_index.take() {
+                                        if open_indices.remove(&text_index) {
+                                            yield Ok(anthropic_sse(
+                                                "content_block_stop",
+                                                &json!({"type":"content_block_stop","index":text_index}),
+                                            ));
+                                        }
+                                        if fallback_open_index == Some(text_index) {
+                                            fallback_open_index = None;
+                                        }
+                                    }
+
+                                    let emitted_text = reasoning_text_by_index
+                                        .get(&index)
+                                        .cloned()
+                                        .unwrap_or_default();
+                                    let mut final_item = merge_reasoning_items(
+                                        reasoning_item_by_index.get(&index),
+                                        &item,
+                                    );
+                                    preserve_streamed_reasoning_summary(
+                                        &mut final_item,
+                                        &emitted_text,
+                                    );
+                                    let full_text = reasoning_summary_text(&final_item);
+                                    let missing_text = if full_text.is_empty() {
+                                        String::new()
+                                    } else if emitted_text.is_empty() {
+                                        full_text.clone()
+                                    } else if let Some(suffix) = full_text.strip_prefix(&emitted_text) {
+                                        suffix.to_string()
+                                    } else if emitted_text.starts_with(&full_text) {
+                                        String::new()
+                                    } else {
+                                        log::warn!(
+                                            "[Claude/Responses] Terminal reasoning summary did not extend streamed text; avoiding duplicate replay"
+                                        );
+                                        String::new()
+                                    };
+                                    if !missing_text.is_empty() {
+                                        if !open_indices.contains(&index) {
+                                            yield Ok(anthropic_sse(
+                                                "content_block_start",
+                                                &json!({
+                                                    "type":"content_block_start",
+                                                    "index":index,
+                                                    "content_block":{"type":"thinking","thinking":""}
+                                                }),
+                                            ));
+                                            open_indices.insert(index);
+                                        }
+                                        yield Ok(anthropic_sse(
+                                            "content_block_delta",
+                                            &json!({
+                                                "type":"content_block_delta",
+                                                "index":index,
+                                                "delta":{"type":"thinking_delta","thinking":missing_text.clone()}
+                                            }),
+                                        ));
+                                        reasoning_text_by_index
+                                            .entry(index)
+                                            .or_default()
+                                            .push_str(&missing_text);
+                                    }
+
+                                    let encrypted = final_item
+                                        .get("encrypted_content")
+                                        .and_then(Value::as_str)
+                                        .is_some_and(|value| !value.is_empty());
+                                    if encrypted {
+                                        if let Some(envelope) = encode_openai_reasoning_item(&final_item) {
+                                            if open_indices.contains(&index) {
+                                                yield Ok(anthropic_sse(
+                                                    "content_block_delta",
+                                                    &json!({
+                                                        "type":"content_block_delta",
+                                                        "index":index,
+                                                        "delta":{"type":"signature_delta","signature":envelope}
+                                                    }),
+                                                ));
+                                            } else {
+                                                yield Ok(anthropic_sse(
+                                                    "content_block_start",
+                                                    &json!({
+                                                        "type":"content_block_start",
+                                                        "index":index,
+                                                        "content_block":{"type":"thinking","thinking":""}
+                                                    }),
+                                                ));
+                                                open_indices.insert(index);
+                                                yield Ok(anthropic_sse(
+                                                    "content_block_delta",
+                                                    &json!({
+                                                        "type":"content_block_delta",
+                                                        "index":index,
+                                                        "delta":{"type":"signature_delta","signature":envelope}
+                                                    }),
+                                                ));
+                                            }
+                                        }
+                                    }
+                                    if open_indices.remove(&index) {
+                                        yield Ok(anthropic_sse(
+                                            "content_block_stop",
+                                            &json!({"type":"content_block_stop","index":index}),
+                                        ));
+                                    }
+                                    completed_reasoning_indices.insert(index);
+                                    reasoning_item_by_index.insert(index, final_item);
+                                }
+
                                 for (output_index, item) in terminal_message_items {
                                     let buffered_citations =
                                         preserve_web_search_citations
@@ -3887,7 +4299,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                 let terminal_status = response_obj
                                     .get("status")
                                     .and_then(Value::as_str)
-                                    .or(match event_name {
+                                    .or(match event_name.as_str() {
                                         "response.incomplete" => Some("incomplete"),
                                         "response.completed" => Some("completed"),
                                         _ => None,
@@ -4276,33 +4688,54 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                         }
                                     }
                                     Some("reasoning") => {
+                                        has_substantive_output = true;
                                         let item_id = item
                                             .get("id")
                                             .and_then(Value::as_str)
                                             .or_else(|| data.get("item_id").and_then(Value::as_str));
-                                        let index = item_id
-                                            .and_then(|id| reasoning_index_by_item_id.get(id).copied())
-                                            .or_else(|| {
-                                                reasoning_item_key(&data, Some(item))
-                                                    .and_then(|key| index_by_key.get(&key).copied())
-                                            })
-                                            .unwrap_or_else(|| {
-                                                let assigned = next_content_index;
-                                                next_content_index += 1;
-                                                assigned
-                                            });
-                                        reasoning_item_by_index.insert(index, item.clone());
-
-                                        let final_item = reasoning_item_by_index
-                                            .get(&index)
-                                            .cloned()
-                                            .unwrap_or_else(|| item.clone());
-                                        let full_text = reasoning_summary_text(&final_item);
+                                        let index = resolve_reasoning_index(
+                                            &data,
+                                            Some(item),
+                                            &mut reasoning_index_by_item_id,
+                                            &mut index_by_key,
+                                            &mut legacy_reasoning_index,
+                                            &mut next_content_index,
+                                        );
+                                        if completed_reasoning_indices.contains(&index) {
+                                            continue;
+                                        }
                                         let emitted_text = reasoning_text_by_index
                                             .get(&index)
                                             .cloned()
                                             .unwrap_or_default();
-                                        if emitted_text.is_empty() && !full_text.is_empty() {
+                                        let mut final_item = merge_reasoning_items(
+                                            reasoning_item_by_index.get(&index),
+                                            item,
+                                        );
+                                        preserve_streamed_reasoning_summary(
+                                            &mut final_item,
+                                            &emitted_text,
+                                        );
+                                        let full_text = reasoning_summary_text(&final_item);
+                                        reasoning_item_by_index.insert(index, final_item.clone());
+                                        let missing_text = if full_text.is_empty() {
+                                            String::new()
+                                        } else if emitted_text.is_empty() {
+                                            full_text.clone()
+                                        } else if let Some(suffix) = full_text.strip_prefix(&emitted_text) {
+                                            suffix.to_string()
+                                        } else if emitted_text.starts_with(&full_text) {
+                                            String::new()
+                                        } else {
+                                            // A terminal snapshot can use a different reasoning
+                                            // field than its deltas. Avoid replaying the same
+                                            // visible text twice when the fields diverge.
+                                            log::warn!(
+                                                "[Claude/Responses] Terminal reasoning summary did not extend streamed text; avoiding duplicate replay"
+                                            );
+                                            String::new()
+                                        };
+                                        if !missing_text.is_empty() {
                                             let start_event = json!({
                                                 "type": "content_block_start",
                                                 "index": index,
@@ -4310,16 +4743,22 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                             });
                                             let start_sse = format!("event: content_block_start\ndata: {}\n\n",
                                                 serde_json::to_string(&start_event).unwrap_or_default());
-                                            yield Ok(Bytes::from(start_sse));
-                                            open_indices.insert(index);
+                                            if !open_indices.contains(&index) {
+                                                yield Ok(Bytes::from(start_sse));
+                                                open_indices.insert(index);
+                                            }
                                             let delta_event = json!({
                                                 "type": "content_block_delta",
                                                 "index": index,
-                                                "delta": {"type": "thinking_delta", "thinking": full_text}
+                                                "delta": {"type": "thinking_delta", "thinking": missing_text.clone()}
                                             });
                                             let delta_sse = format!("event: content_block_delta\ndata: {}\n\n",
                                                 serde_json::to_string(&delta_event).unwrap_or_default());
                                             yield Ok(Bytes::from(delta_sse));
+                                            reasoning_text_by_index
+                                                .entry(index)
+                                                .or_default()
+                                                .push_str(&missing_text);
                                         }
 
                                         let encrypted = final_item
@@ -4345,14 +4784,25 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                                         "type": "content_block_start",
                                                         "index": index,
                                                         "content_block": {
-                                                            "type": "redacted_thinking",
-                                                            "data": envelope
+                                                            "type": "thinking",
+                                                            "thinking": ""
                                                         }
                                                     });
                                                     let start_sse = format!("event: content_block_start\ndata: {}\n\n",
                                                         serde_json::to_string(&start_event).unwrap_or_default());
                                                     yield Ok(Bytes::from(start_sse));
                                                     open_indices.insert(index);
+                                                    let signature_event = json!({
+                                                        "type": "content_block_delta",
+                                                        "index": index,
+                                                        "delta": {
+                                                            "type": "signature_delta",
+                                                            "signature": envelope
+                                                        }
+                                                    });
+                                                    let signature_sse = format!("event: content_block_delta\ndata: {}\n\n",
+                                                        serde_json::to_string(&signature_event).unwrap_or_default());
+                                                    yield Ok(Bytes::from(signature_sse));
                                                 }
                                             }
                                         }
@@ -4362,6 +4812,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                                 serde_json::to_string(&stop_event).unwrap_or_default());
                                             yield Ok(Bytes::from(stop_sse));
                                         }
+                                        completed_reasoning_indices.insert(index);
                                         if let Some(id) = item_id {
                                             reasoning_index_by_item_id.remove(id);
                                         }
@@ -4447,8 +4898,101 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                 }
                             }
                             "response.reasoning_summary_part.added"
-                            | "response.reasoning_summary_part.done"
-                            | "response.in_progress" => {}
+                            | "response.reasoning_summary_part.done" => {
+                                let Some(text) = data
+                                    .get("part")
+                                    .and_then(|part| {
+                                        part.get("text")
+                                            .and_then(Value::as_str)
+                                            .or_else(|| part.as_str())
+                                    })
+                                    .filter(|text| !text.is_empty())
+                                else {
+                                    continue;
+                                };
+                                let index = resolve_reasoning_index(
+                                    &data,
+                                    None,
+                                    &mut reasoning_index_by_item_id,
+                                    &mut index_by_key,
+                                    &mut legacy_reasoning_index,
+                                    &mut next_content_index,
+                                );
+                                if completed_reasoning_indices.contains(&index) {
+                                    continue;
+                                }
+                                has_substantive_output = true;
+                                if let Some(text_index) = current_text_index.take() {
+                                    if open_indices.remove(&text_index) {
+                                        yield Ok(anthropic_sse(
+                                            "content_block_stop",
+                                            &json!({"type":"content_block_stop","index":text_index}),
+                                        ));
+                                    }
+                                    if fallback_open_index == Some(text_index) {
+                                        fallback_open_index = None;
+                                    }
+                                }
+                                if !has_sent_message_start {
+                                    yield Ok(anthropic_sse(
+                                        "message_start",
+                                        &json!({
+                                            "type":"message_start",
+                                            "message":{
+                                                "id":message_id.clone().unwrap_or_default(),
+                                                "type":"message",
+                                                "role":"assistant",
+                                                "model":current_model.clone().unwrap_or_default(),
+                                                "usage":{"input_tokens":0,"output_tokens":0}
+                                            }
+                                        }),
+                                    ));
+                                    has_sent_message_start = true;
+                                }
+                                // 将终结快照绑定到对应摘要分段，避免后续分段被误判为首段的替换内容。
+                                let emitted = reasoning_text_by_index
+                                    .get(&index)
+                                    .cloned()
+                                    .unwrap_or_default();
+                                let summary_index = data
+                                    .get("summary_index")
+                                    .and_then(Value::as_u64)
+                                    .unwrap_or(0);
+                                let part_key = reasoning_summary_part_key(index, summary_index);
+                                let previous_part = reasoning_part_text_by_key.get(&part_key).cloned();
+                                let missing = missing_reasoning_summary_part(
+                                    &emitted,
+                                    previous_part.as_deref(),
+                                    summary_index,
+                                    text,
+                                );
+                                reasoning_part_text_by_key.insert(part_key, text.to_string());
+                                if missing.is_empty() {
+                                    continue;
+                                }
+                                if !open_indices.contains(&index) {
+                                    let start_event = json!({
+                                        "type": "content_block_start",
+                                        "index": index,
+                                        "content_block": {"type": "thinking", "thinking": ""}
+                                    });
+                                    yield Ok(anthropic_sse("content_block_start", &start_event));
+                                    open_indices.insert(index);
+                                }
+                                let delta_event = json!({
+                                    "type": "content_block_delta",
+                                    "index": index,
+                                    "delta": {
+                                        "type": "thinking_delta",
+                                        "thinking": missing.clone()
+                                    }
+                                });
+                                yield Ok(anthropic_sse("content_block_delta", &delta_event));
+                                reasoning_text_by_index
+                                    .entry(index)
+                                    .or_default()
+                                    .push_str(&missing);
+                            }
 
                             // Any other unknown/future events — silently skip.
                             _ => {}
@@ -4632,6 +5176,7 @@ mod tests {
             upstream,
             "web_search".to_string(),
             None,
+            true,
             true,
         )
         .collect::<Vec<_>>()
@@ -6835,6 +7380,328 @@ mod tests {
         let stop_position = merged.find("event: content_block_stop").unwrap();
         assert!(signature_position < stop_position);
         assert!(!merged[stop_position..].contains("content_block_delta"));
+    }
+
+    #[tokio::test]
+    async fn test_stream_encrypted_reasoning_uses_supported_empty_thinking_block() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_redacted_vscode\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_redacted_vscode\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_redacted_vscode\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(input))]);
+        let merged = create_anthropic_sse_stream_from_responses_with_web_search_options_for_client(
+            upstream,
+            None,
+            None,
+            true,
+        )
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .map(|chunk| String::from_utf8_lossy(chunk.unwrap().as_ref()).to_string())
+        .collect::<String>();
+
+        assert!(!merged.contains("redacted_thinking"));
+        assert!(merged.contains("\"type\":\"thinking\""));
+        assert!(!merged.contains("[redacted thinking]"));
+        assert!(merged.contains("\"type\":\"signature_delta\""));
+        assert!(merged.contains("event: message_stop"));
+    }
+
+    #[tokio::test]
+    async fn test_completed_response_output_reasoning_is_not_dropped() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_terminal_reasoning\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_terminal_reasoning\",\"status\":\"completed\",\"output\":[{\"type\":\"reasoning\",\"id\":\"rs_terminal\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Terminal summary.\"}],\"encrypted_content\":\"opaque\"},{\"type\":\"message\",\"content\":[{\"type\":\"output_text\",\"text\":\"Done.\"}]}]}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+
+        assert_eq!(merged.matches("\"type\":\"thinking_delta\"").count(), 1);
+        assert!(merged.contains("\"thinking\":\"Terminal summary.\""));
+        assert!(merged.contains("\"type\":\"signature_delta\""));
+        assert!(merged.contains("\"text\":\"Done.\""));
+    }
+
+    #[tokio::test]
+    async fn test_reasoning_summary_part_added_emits_visible_text() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_part_added\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_part_added\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.reasoning_summary_part.added\n",
+            "data: {\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs_part_added\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"Added snapshot\"}}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_part_added\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+
+        assert!(merged.contains("\"thinking\":\"Added snapshot\""));
+        assert_eq!(merged.matches("\"type\":\"thinking_delta\"").count(), 1);
+        let signature = sse_data_values(&merged)
+            .into_iter()
+            .find_map(|event| {
+                event
+                    .pointer("/delta/signature")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .expect("reasoning signature should be emitted");
+        let restored = decode_openai_reasoning_item(&signature).expect("signature should round-trip");
+        assert_eq!(restored["summary"][0]["text"], "Added snapshot");
+    }
+
+    #[tokio::test]
+    async fn test_reasoning_output_item_added_summary_emits_visible_text() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_item_added\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_item_added\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Item snapshot\"}]}}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_item_added\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+
+        assert!(merged.contains("\"thinking\":\"Item snapshot\""));
+        assert_eq!(merged.matches("\"type\":\"thinking_delta\"").count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_reasoning_summary_part_done_emits_visible_text() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_part\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_part\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.reasoning_summary_part.added\n",
+            "data: {\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs_part\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\n",
+            "event: response.reasoning_summary_part.done\n",
+            "data: {\"type\":\"response.reasoning_summary_part.done\",\"item_id\":\"rs_part\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"Part snapshot\"}}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_part\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(input))]);
+        let merged = create_anthropic_sse_stream_from_responses(upstream)
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .map(|chunk| String::from_utf8_lossy(chunk.unwrap().as_ref()).to_string())
+            .collect::<String>();
+
+        assert!(merged.contains("\"thinking\":\"Part snapshot\""));
+        assert_eq!(merged.matches("\"type\":\"thinking_delta\"").count(), 1);
+        assert!(merged.contains("\"type\":\"signature_delta\""));
+        let signature = sse_data_values(&merged)
+            .into_iter()
+            .find_map(|event| {
+                event
+                    .pointer("/delta/signature")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .expect("reasoning signature should be emitted");
+        let restored = decode_openai_reasoning_item(&signature).expect("signature should round-trip");
+        assert_eq!(restored["summary"][0]["text"], "Part snapshot");
+    }
+
+    #[tokio::test]
+    async fn test_reasoning_summary_parts_are_concatenated_without_deltas() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_parts\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_parts\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"First \"}]}}\n\n",
+            "event: response.reasoning_summary_part.done\n",
+            "data: {\"type\":\"response.reasoning_summary_part.done\",\"item_id\":\"rs_parts\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"First \"}}\n\n",
+            "event: response.reasoning_summary_part.done\n",
+            "data: {\"type\":\"response.reasoning_summary_part.done\",\"item_id\":\"rs_parts\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"Second\"}}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_parts\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+
+        assert_eq!(merged.matches("\"type\":\"thinking_delta\"").count(), 2);
+        assert!(merged.contains("\"thinking\":\"First \""));
+        assert!(merged.contains("\"thinking\":\"\\nSecond\""));
+        let signature = sse_data_values(&merged)
+            .into_iter()
+            .find_map(|event| {
+                event
+                    .pointer("/delta/signature")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .expect("reasoning signature should be emitted");
+        let restored = decode_openai_reasoning_item(&signature).expect("signature should round-trip");
+        assert_eq!(restored["summary"][0]["text"], "First \nSecond");
+    }
+
+    #[tokio::test]
+    async fn test_reasoning_summary_delta_parts_keep_newlines_after_empty_snapshots() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_delta_parts\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_delta_parts\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.reasoning_summary_part.added\n",
+            "data: {\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs_delta_parts\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_delta_parts\",\"output_index\":0,\"summary_index\":0,\"delta\":\"Identifying limitations\"}\n\n",
+            "event: response.reasoning_summary_part.added\n",
+            "data: {\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs_delta_parts\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_delta_parts\",\"output_index\":0,\"summary_index\":1,\"delta\":\"Checking the safe path\"}\n\n",
+            "event: response.reasoning_summary_part.added\n",
+            "data: {\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs_delta_parts\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_delta_parts\",\"output_index\":0,\"summary_index\":2,\"delta\":\"Comparing schema details\"}\n\n",
+            "event: response.reasoning_summary_part.added\n",
+            "data: {\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs_delta_parts\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_delta_parts\",\"output_index\":0,\"summary_index\":3,\"delta\":\"Preparing the next action\"}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_delta_parts\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+        let thinking: Vec<String> = sse_data_values(&merged)
+            .into_iter()
+            .filter(|event| {
+                event.pointer("/delta/type").and_then(Value::as_str) == Some("thinking_delta")
+            })
+            .filter_map(|event| {
+                event
+                    .pointer("/delta/thinking")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .collect();
+
+        assert_eq!(
+            thinking,
+            vec![
+                "Identifying limitations",
+                "\nChecking the safe path",
+                "\nComparing schema details",
+                "\nPreparing the next action"
+            ]
+        );
+        let signature = sse_data_values(&merged)
+            .into_iter()
+            .find_map(|event| {
+                event
+                    .pointer("/delta/signature")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .expect("reasoning signature should be emitted");
+        let restored =
+            decode_openai_reasoning_item(&signature).expect("signature should round-trip");
+        assert_eq!(
+            restored["summary"][0]["text"],
+            "Identifying limitations\nChecking the safe path\nComparing schema details\nPreparing the next action"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reasoning_summary_text_done_keeps_newline_after_empty_part() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_done_parts\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_done_parts\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.reasoning_summary_text.done\n",
+            "data: {\"type\":\"response.reasoning_summary_text.done\",\"item_id\":\"rs_done_parts\",\"output_index\":0,\"summary_index\":0,\"text\":\"First thought\"}\n\n",
+            "event: response.reasoning_summary_part.added\n",
+            "data: {\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs_done_parts\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\n",
+            "event: response.reasoning_summary_text.done\n",
+            "data: {\"type\":\"response.reasoning_summary_text.done\",\"item_id\":\"rs_done_parts\",\"output_index\":0,\"summary_index\":1,\"text\":\"Second thought\"}\n\n",
+            "event: response.reasoning_summary_part.added\n",
+            "data: {\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs_done_parts\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\n",
+            "event: response.reasoning_summary_text.done\n",
+            "data: {\"type\":\"response.reasoning_summary_text.done\",\"item_id\":\"rs_done_parts\",\"output_index\":0,\"summary_index\":2,\"text\":\"Third thought\"}\n\n",
+            "event: response.reasoning_summary_part.added\n",
+            "data: {\"type\":\"response.reasoning_summary_part.added\",\"item_id\":\"rs_done_parts\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\n",
+            "event: response.reasoning_summary_text.done\n",
+            "data: {\"type\":\"response.reasoning_summary_text.done\",\"item_id\":\"rs_done_parts\",\"output_index\":0,\"summary_index\":3,\"text\":\"Fourth thought\"}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_done_parts\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+        let thinking: Vec<String> = sse_data_values(&merged)
+            .into_iter()
+            .filter(|event| {
+                event.pointer("/delta/type").and_then(Value::as_str) == Some("thinking_delta")
+            })
+            .filter_map(|event| {
+                event
+                    .pointer("/delta/thinking")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .collect();
+
+        assert_eq!(
+            thinking,
+            vec![
+                "First thought",
+                "\nSecond thought",
+                "\nThird thought",
+                "\nFourth thought"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_reasoning_deltas_preserve_repeated_fragments() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_repeated_reasoning\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_repeated\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_repeated\",\"output_index\":0,\"summary_index\":0,\"delta\":\"foo\"}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_repeated\",\"output_index\":0,\"summary_index\":0,\"delta\":\"foo\"}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_repeated\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"status\":\"completed\"}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+
+        assert_eq!(merged.matches("\"type\":\"thinking_delta\"").count(), 2);
+        let signature = sse_data_values(&merged)
+            .into_iter()
+            .find_map(|event| {
+                event
+                    .pointer("/delta/signature")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .expect("reasoning signature should be emitted");
+        let restored = decode_openai_reasoning_item(&signature).expect("signature should round-trip");
+        assert_eq!(restored["summary"][0]["text"], "foofoo");
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -232,6 +232,20 @@ fn responses_json_to_anthropic_sse_for_client(
                         &json!({"type":"content_block_stop","index":index}),
                     ));
                 }
+                Some("redacted_thinking") if preserve_redacted_thinking => {
+                    events.push(anthropic_sse(
+                        "content_block_start",
+                        &json!({
+                            "type":"content_block_start",
+                            "index":index,
+                            "content_block":block
+                        }),
+                    ));
+                    events.push(anthropic_sse(
+                        "content_block_stop",
+                        &json!({"type":"content_block_stop","index":index}),
+                    ));
+                }
                 Some("redacted_thinking") => {
                     events.push(anthropic_sse(
                         "content_block_start",
@@ -2179,10 +2193,8 @@ fn missing_reasoning_summary_part(
         if let Some(suffix) = text.strip_prefix(previous_part) {
             return suffix.to_string();
         }
-        if previous_part.starts_with(text) || emitted.starts_with(text) || emitted.ends_with(text) {
-            return String::new();
-        }
-        return text.to_string();
+        // A cumulative snapshot that diverges cannot replace already emitted text.
+        return String::new();
     }
 
     if let Some(suffix) = text.strip_prefix(emitted).filter(|value| !value.is_empty()) {
@@ -2204,6 +2216,7 @@ fn resolve_reasoning_index(
     reasoning_index_by_item_id: &mut HashMap<String, u32>,
     index_by_key: &mut HashMap<String, u32>,
     legacy_reasoning_index: &mut Option<u32>,
+    completed_reasoning_indices: &HashSet<u32>,
     next_content_index: &mut u32,
 ) -> u32 {
     let item_id = item
@@ -2228,7 +2241,18 @@ fn resolve_reasoning_index(
                 .as_ref()
                 .and_then(|key| index_by_key.get(key).copied())
         })
-        .or_else(|| is_keyless.then_some(*legacy_reasoning_index).flatten());
+        .or_else(|| {
+            // An anonymous block may receive its item_id only when the terminal
+            // snapshot arrives. Adopt the still-open legacy block before
+            // allocating, but only while no other item already owns it — a
+            // second reasoning item must not silently merge into streamed text.
+            (*legacy_reasoning_index).filter(|index| {
+                !completed_reasoning_indices.contains(index)
+                    && !reasoning_index_by_item_id
+                        .values()
+                        .any(|bound| bound == index)
+            })
+        });
 
     if let Some(index) = existing {
         // Bind aliases discovered later so a gateway can switch between item_id
@@ -2599,6 +2623,10 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
         let mut reasoning_text_by_index: HashMap<u32, String> = HashMap::new();
         let mut reasoning_part_text_by_key: HashMap<String, String> = HashMap::new();
         let mut completed_reasoning_indices: HashSet<u32> = HashSet::new();
+        // Reasoning blocks whose output_item.done arrived but was too sparse to
+        // finalize; they stay open for the terminal snapshot and must not trip
+        // the clean-EOF truncation guard.
+        let mut deferred_done_reasoning: HashSet<u32> = HashSet::new();
         let mut legacy_reasoning_index: Option<u32> = None;
         let mut has_substantive_output = false;
         let mut terminated = false;
@@ -2707,19 +2735,23 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                         if event_name == "response.output_item.added" {
                             let added_reasoning = data.get("item").and_then(|item| {
                                 (item.get("type").and_then(Value::as_str) == Some("reasoning"))
-                                    .then(|| {
-                                        (
-                                            item.get("id")
-                                                .and_then(Value::as_str)
-                                                .map(ToString::to_string),
-                                            reasoning_summary_text(item),
-                                        )
-                                    })
+                                    .then(|| (item.clone(), reasoning_summary_text(item)))
                             });
-                            if let Some((item_id, text)) = added_reasoning {
+                            if let Some((item, text)) = added_reasoning {
+                                let index = resolve_reasoning_index(
+                                    &data,
+                                    Some(&item),
+                                    &mut reasoning_index_by_item_id,
+                                    &mut index_by_key,
+                                    &mut legacy_reasoning_index,
+                                    &completed_reasoning_indices,
+                                    &mut next_content_index,
+                                );
+                                reasoning_item_by_index.insert(index, item.clone());
+                                reasoning_text_by_index.entry(index).or_default();
                                 if !text.is_empty() {
                                     if let Some(object) = data.as_object_mut() {
-                                        if let Some(item_id) = item_id {
+                                        if let Some(item_id) = item.get("id").and_then(Value::as_str) {
                                             object.insert("item_id".to_string(), json!(item_id));
                                         }
                                         object.insert("summary_index".to_string(), json!(0));
@@ -3329,6 +3361,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                             &mut reasoning_index_by_item_id,
                                             &mut index_by_key,
                                             &mut legacy_reasoning_index,
+                                            &completed_reasoning_indices,
                                             &mut next_content_index,
                                         );
                                         reasoning_item_by_index.insert(index, item.clone());
@@ -3541,8 +3574,8 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                             | "response.reasoning.delta" => {
                                 if let Some(delta) = data
                                     .get("delta")
-                                    .or_else(|| data.get("text"))
-                                    .and_then(|d| d.as_str())
+                                    .and_then(Value::as_str)
+                                    .or_else(|| data.get("text").and_then(Value::as_str))
                                 {
                                     if let Some(index) = current_text_index.take() {
                                         if open_indices.remove(&index) {
@@ -3564,8 +3597,12 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                         &mut reasoning_index_by_item_id,
                                         &mut index_by_key,
                                         &mut legacy_reasoning_index,
+                                        &completed_reasoning_indices,
                                         &mut next_content_index,
                                     );
+                                    if completed_reasoning_indices.contains(&index) {
+                                        continue;
+                                    }
                                     if !open_indices.contains(&index) {
                                         let start_event = json!({
                                             "type": "content_block_start",
@@ -3630,8 +3667,8 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                             | "response.reasoning_text.done" => {
                                 let Some(text) = data
                                     .get("text")
-                                    .or_else(|| data.get("delta"))
                                     .and_then(Value::as_str)
+                                    .or_else(|| data.get("delta").and_then(Value::as_str))
                                     .filter(|value| !value.is_empty())
                                 else {
                                     continue;
@@ -3642,6 +3679,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                     &mut reasoning_index_by_item_id,
                                     &mut index_by_key,
                                     &mut legacy_reasoning_index,
+                                    &completed_reasoning_indices,
                                     &mut next_content_index,
                                 );
                                 if completed_reasoning_indices.contains(&index) {
@@ -3835,8 +3873,11 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                         if item.get("type").and_then(Value::as_str)
                                             == Some("reasoning")
                                         {
-                                            terminal_reasoning_items
-                                                .push((output_index as u64, item.clone()));
+                                            terminal_reasoning_items.push((
+                                                None,
+                                                output_index as u64,
+                                                item.clone(),
+                                            ));
                                         }
                                         if item.get("type").and_then(Value::as_str)
                                             == Some("web_search_call")
@@ -4096,19 +4137,41 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                     }
                                 }
 
-                                for (output_index, item) in terminal_reasoning_items {
+                                // A skeletal output_item.done must stay pending until the terminal
+                                // event can provide the final reasoning fields.
+                                let mut pending_reasoning_items: Vec<(Option<u32>, u64, Value)> =
+                                    reasoning_item_by_index
+                                        .iter()
+                                        .filter(|(index, _)| {
+                                            !completed_reasoning_indices.contains(index)
+                                        })
+                                        .map(|(index, item)| {
+                                            (Some(*index), u64::from(*index), item.clone())
+                                        })
+                                        .collect();
+                                // HashMap iteration is unordered; sorting by
+                                // content index keeps identical upstream bytes on
+                                // identical downstream SSE.
+                                pending_reasoning_items
+                                    .sort_unstable_by_key(|(index, _, _)| *index);
+                                terminal_reasoning_items.extend(pending_reasoning_items);
+
+                                for (index_hint, output_index, item) in terminal_reasoning_items {
                                     let terminal_data = json!({
                                         "output_index": output_index,
                                         "item_id": item.get("id").cloned().unwrap_or(Value::Null)
                                     });
-                                    let index = resolve_reasoning_index(
-                                        &terminal_data,
-                                        Some(&item),
-                                        &mut reasoning_index_by_item_id,
-                                        &mut index_by_key,
-                                        &mut legacy_reasoning_index,
-                                        &mut next_content_index,
-                                    );
+                                    let index = index_hint.unwrap_or_else(|| {
+                                        resolve_reasoning_index(
+                                            &terminal_data,
+                                            Some(&item),
+                                            &mut reasoning_index_by_item_id,
+                                            &mut index_by_key,
+                                            &mut legacy_reasoning_index,
+                                            &completed_reasoning_indices,
+                                            &mut next_content_index,
+                                        )
+                                    });
                                     if completed_reasoning_indices.contains(&index) {
                                         continue;
                                     }
@@ -4705,7 +4768,6 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                         }
                                     }
                                     Some("reasoning") => {
-                                        has_substantive_output = true;
                                         let item_id = item
                                             .get("id")
                                             .and_then(Value::as_str)
@@ -4716,6 +4778,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                             &mut reasoning_index_by_item_id,
                                             &mut index_by_key,
                                             &mut legacy_reasoning_index,
+                                            &completed_reasoning_indices,
                                             &mut next_content_index,
                                         );
                                         if completed_reasoning_indices.contains(&index) {
@@ -4782,7 +4845,8 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                             .get("encrypted_content")
                                             .and_then(Value::as_str)
                                             .is_some_and(|value| !value.is_empty());
-                                        if encrypted {
+                                        let can_finalize = encrypted && !full_text.is_empty();
+                                        if can_finalize {
                                             if let Some(envelope) = encode_openai_reasoning_item(&final_item) {
                                                 if open_indices.contains(&index) {
                                                     let signature_event = json!({
@@ -4840,18 +4904,22 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                                 }
                                             }
                                         }
-                                        if open_indices.remove(&index) {
+                                        if can_finalize && open_indices.remove(&index) {
                                             let stop_event = json!({"type": "content_block_stop", "index": index});
                                             let stop_sse = format!("event: content_block_stop\ndata: {}\n\n",
                                                 serde_json::to_string(&stop_event).unwrap_or_default());
                                             yield Ok(Bytes::from(stop_sse));
                                         }
-                                        completed_reasoning_indices.insert(index);
-                                        if let Some(id) = item_id {
-                                            reasoning_index_by_item_id.remove(id);
+                                        if can_finalize {
+                                            completed_reasoning_indices.insert(index);
+                                            if let Some(id) = item_id {
+                                                reasoning_index_by_item_id.remove(id);
+                                            }
+                                            reasoning_item_by_index.remove(&index);
+                                            reasoning_text_by_index.remove(&index);
+                                        } else {
+                                            deferred_done_reasoning.insert(index);
                                         }
-                                        reasoning_item_by_index.remove(&index);
-                                        reasoning_text_by_index.remove(&index);
                                     }
                                     Some("message") => {
                                         let buffered_citations =
@@ -4950,6 +5018,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                     &mut reasoning_index_by_item_id,
                                     &mut index_by_key,
                                     &mut legacy_reasoning_index,
+                                    &completed_reasoning_indices,
                                     &mut next_content_index,
                                 );
                                 if completed_reasoning_indices.contains(&index) {
@@ -5061,9 +5130,13 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
             // unpaired, even if its server_tool_use block was already closed.
             let has_unpaired_server_tool = !web_search_id_order.is_empty();
             let has_open_reasoning = open_indices.iter().any(|index| {
-                reasoning_item_by_index.contains_key(index)
-                    || reasoning_text_by_index.contains_key(index)
-                    || legacy_reasoning_index == Some(*index)
+                // A deferred done is only waiting for a richer terminal snapshot;
+                // at clean EOF that snapshot never comes, so recycle like the
+                // eagerly-closed blocks did.
+                !deferred_done_reasoning.contains(index)
+                    && (reasoning_item_by_index.contains_key(index)
+                        || reasoning_text_by_index.contains_key(index)
+                        || legacy_reasoning_index == Some(*index))
             });
 
             if has_substantive_output
@@ -5149,7 +5222,7 @@ mod tests {
     use super::*;
     use futures::stream;
     use futures::StreamExt;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     async fn convert_stream_text(input: impl Into<Bytes>) -> String {
         let upstream = stream::iter(vec![Ok::<_, std::io::Error>(input.into())]);
@@ -5159,6 +5232,24 @@ mod tests {
             .into_iter()
             .map(|chunk| String::from_utf8_lossy(chunk.unwrap().as_ref()).to_string())
             .collect()
+    }
+
+    async fn convert_stream_text_for_client(
+        input: &'static str,
+        preserve_redacted_thinking: bool,
+    ) -> String {
+        let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(input))]);
+        create_anthropic_sse_stream_from_responses_with_web_search_options_for_client(
+            upstream,
+            None,
+            None,
+            preserve_redacted_thinking,
+        )
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .map(|chunk| String::from_utf8_lossy(chunk.unwrap().as_ref()).to_string())
+        .collect()
     }
 
     async fn convert_stream_text_with_web_search_name(
@@ -5249,6 +5340,42 @@ mod tests {
             ),
             ""
         );
+    }
+
+    #[test]
+    fn test_reasoning_index_reuses_open_legacy_block_until_completion() {
+        let mut reasoning_index_by_item_id = HashMap::new();
+        let mut index_by_key = HashMap::new();
+        let mut legacy_reasoning_index = Some(3);
+        let mut completed_reasoning_indices = HashSet::new();
+        let mut next_content_index = 4;
+
+        let open_index = resolve_reasoning_index(
+            &json!({"output_index": 0}),
+            Some(&json!({"type": "reasoning"})),
+            &mut reasoning_index_by_item_id,
+            &mut index_by_key,
+            &mut legacy_reasoning_index,
+            &completed_reasoning_indices,
+            &mut next_content_index,
+        );
+        assert_eq!(open_index, 3);
+        assert_eq!(index_by_key.get("reasoning:out:0"), Some(&3));
+        assert_eq!(next_content_index, 4);
+
+        completed_reasoning_indices.insert(open_index);
+        let new_index = resolve_reasoning_index(
+            &json!({"output_index": 1}),
+            Some(&json!({"type": "reasoning"})),
+            &mut reasoning_index_by_item_id,
+            &mut index_by_key,
+            &mut legacy_reasoning_index,
+            &completed_reasoning_indices,
+            &mut next_content_index,
+        );
+        assert_eq!(new_index, 4);
+        assert_eq!(index_by_key.get("reasoning:out:1"), Some(&4));
+        assert_eq!(next_content_index, 5);
     }
 
     #[test]
@@ -7045,6 +7172,92 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_terminal_reasoning_without_id_reuses_keyless_streamed_block() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_reasoning_keyless\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"Need a tool.\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_reasoning_keyless\",\"model\":\"gpt-5.6\",\"status\":\"completed\",\"output\":[{\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Need a tool.\"}],\"encrypted_content\":\"opaque\"},{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Done.\"}]}]}}\n\n"
+        );
+        let merged = convert_stream_text_for_client(input, false).await;
+        let thinking: Vec<String> = sse_data_values(&merged)
+            .into_iter()
+            .filter(|event| {
+                event.pointer("/delta/type").and_then(Value::as_str) == Some("thinking_delta")
+            })
+            .filter_map(|event| {
+                event
+                    .pointer("/delta/thinking")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .collect();
+
+        assert_eq!(thinking, vec!["Need a tool."]);
+        assert_eq!(merged.matches("\"type\":\"signature_delta\"").count(), 1);
+        let events = sse_data_values(&merged);
+        let blocks: Vec<_> = events
+            .iter()
+            .filter(|event| event.pointer("/content_block/type") == Some(&json!("thinking")))
+            .collect();
+        assert_eq!(blocks.len(), 1);
+        let index = &blocks[0]["index"];
+        let signature = events
+            .iter()
+            .find(|event| event.pointer("/delta/type") == Some(&json!("signature_delta")))
+            .unwrap();
+        assert_eq!(&signature["index"], index);
+        let replay =
+            decode_openai_reasoning_item(signature["delta"]["signature"].as_str().unwrap())
+                .unwrap();
+        assert_eq!(replay["encrypted_content"], "opaque");
+        assert_eq!(reasoning_summary_text(&replay), "Need a tool.");
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| {
+                    event["type"] == "content_block_stop" && &event["index"] == index
+                })
+                .count(),
+            1
+        );
+        assert!(merged.contains("\"text\":\"Done.\""));
+    }
+
+    #[tokio::test]
+    async fn test_encrypted_reasoning_without_terminal_event_reports_truncation() {
+        let input = concat!(
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_eof\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_eof\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}}\n\n"
+        );
+        for preserve in [false, true] {
+            let merged = convert_stream_text_for_client(input, preserve).await;
+            assert!(merged.contains("stream_truncated"));
+            assert!(!merged.contains("event: message_stop"));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_drifting_reasoning_snapshot_does_not_repeat_streamed_text() {
+        let input = concat!(
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_drift\",\"delta\":\"Hello\"}\n\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_drift\",\"delta\":\" world\"}\n\n",
+            "data: {\"type\":\"response.reasoning_summary_text.done\",\"item_id\":\"rs_drift\",\"text\":\"Hello  world\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[{\"id\":\"rs_drift\",\"type\":\"reasoning\",\"summary\":[],\"encrypted_content\":\"opaque\"}]}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+        let thinking = sse_data_values(&merged)
+            .iter()
+            .filter_map(|event| event.pointer("/delta/thinking").and_then(Value::as_str))
+            .collect::<String>();
+        assert_eq!(thinking, "Hello world");
+        assert!(merged.contains("event: message_stop"));
+    }
+
+    #[tokio::test]
     async fn test_output_item_done_emits_text_when_deltas_are_missing() {
         let input = concat!(
             "event: response.created\n",
@@ -7163,6 +7376,50 @@ mod tests {
         assert!(merged.contains("event: message_start"));
         assert!(merged.contains("\"text\":\"hello\""));
         assert!(merged.contains("event: message_stop"));
+    }
+
+    #[tokio::test]
+    async fn test_stream_request_with_json_response_honors_client_reasoning_format() {
+        let input = r#"{
+            "id":"resp_json_redacted",
+            "status":"completed",
+            "model":"gpt-5.6",
+            "output":[{
+                "type":"reasoning",
+                "id":"rs_json_redacted",
+                "summary":[],
+                "encrypted_content":"opaque"
+            }]
+        }"#;
+        for preserve in [false, true] {
+            let merged = convert_stream_text_for_client(input, preserve).await;
+            let events = sse_data_values(&merged);
+            let blocks: Vec<_> = events
+                .iter()
+                .filter_map(|event| event.get("content_block"))
+                .collect();
+            assert_eq!(blocks.len(), 1);
+            let block = blocks[0];
+            let signatures: Vec<_> = events
+                .iter()
+                .filter_map(|event| event.pointer("/delta/signature").and_then(Value::as_str))
+                .collect();
+            let envelope = if preserve {
+                assert_eq!(block["type"], "redacted_thinking");
+                assert!(signatures.is_empty());
+                block["data"].as_str().unwrap()
+            } else {
+                assert_eq!(block["type"], "thinking");
+                assert_eq!(block["thinking"], "");
+                assert_eq!(signatures.len(), 1);
+                signatures[0]
+            };
+            let replay = decode_openai_reasoning_item(envelope).unwrap();
+            assert_eq!(replay["id"], "rs_json_redacted");
+            assert_eq!(replay["encrypted_content"], "opaque");
+            assert_eq!(merged.matches("event: content_block_stop").count(), 1);
+            assert_eq!(merged.matches("event: message_stop").count(), 1);
+        }
     }
 
     #[tokio::test]
@@ -7490,6 +7747,197 @@ mod tests {
         assert!(merged.contains("\"text\":\"Done.\""));
     }
 
+    #[tokio::test]
+    async fn test_sparse_reasoning_done_waits_for_terminal_snapshot() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_sparse\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_sparse\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_sparse\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_sparse\",\"status\":\"completed\",\"output\":[{\"id\":\"rs_sparse\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Terminal summary.\"}],\"encrypted_content\":\"opaque\"}]}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+        let events = sse_data_values(&merged);
+        let thinking: Vec<&str> = events
+            .iter()
+            .filter_map(|event| event.pointer("/delta/thinking").and_then(Value::as_str))
+            .collect();
+
+        assert_eq!(thinking, vec!["Terminal summary."]);
+        assert_eq!(merged.matches("\"type\":\"signature_delta\"").count(), 1);
+        assert_eq!(merged.matches("event: content_block_start").count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_sparse_reasoning_done_recycles_stream_at_eof() {
+        // output_item.done without text/encrypted_content leaves the block open
+        // for the terminal snapshot; when the stream just ends, the partial
+        // output must still be recycled instead of reported as truncated.
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_eof\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_eof\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_eof\",\"output_index\":0,\"delta\":\"Partial thought.\"}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_eof\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":1,\"item\":{\"id\":\"msg_eof\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"Answer.\"}]}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+
+        assert!(
+            !merged.contains("stream_truncated"),
+            "sparse reasoning done must not turn clean EOF into a truncated stream"
+        );
+        assert!(merged.contains("event: message_delta"));
+        assert!(merged.contains("event: message_stop"));
+        let thinking: Vec<String> = sse_data_values(&merged)
+            .into_iter()
+            .filter_map(|event| {
+                event
+                    .pointer("/delta/thinking")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .collect();
+        assert_eq!(thinking, vec!["Partial thought."]);
+        assert!(
+            merged.contains("\"text\":\"Answer.\"")
+                || merged.contains("\\\"text\\\":\\\"Answer.\\\"")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_second_reasoning_item_keeps_own_block_after_anonymous_deltas() {
+        // An anonymous block is owned by the first item_id that claims it; a
+        // second reasoning item must get its own block instead of silently
+        // merging into (and being dropped with) the first one.
+        let input = concat!(
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"First thought.\"}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_first\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":1,\"item\":{\"id\":\"rs_second\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[{\"id\":\"rs_first\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"First thought.\"}],\"encrypted_content\":\"opaque\"},{\"id\":\"rs_second\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Second thought.\"}],\"encrypted_content\":\"opaque\"}]}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+        let thinking: Vec<String> = sse_data_values(&merged)
+            .into_iter()
+            .filter_map(|event| {
+                event
+                    .pointer("/delta/thinking")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .collect();
+
+        assert!(thinking.contains(&"First thought.".to_string()));
+        assert!(thinking.contains(&"Second thought.".to_string()));
+        assert_eq!(merged.matches("event: content_block_start").count(), 2);
+        assert_eq!(merged.matches("\"type\":\"signature_delta\"").count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_late_reasoning_delta_after_done_is_ignored() {
+        let input = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_late_reasoning\",\"model\":\"gpt-5.6\"}}\n\n",
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_late\",\"type\":\"reasoning\",\"summary\":[]}}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_late\",\"output_index\":0,\"delta\":\"First\"}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_late\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"First\"}],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"item_id\":\"rs_late\",\"output_index\":0,\"delta\":\"late\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+        let thinking: Vec<String> = sse_data_values(&merged)
+            .into_iter()
+            .filter_map(|event| {
+                event
+                    .pointer("/delta/thinking")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .collect();
+
+        assert_eq!(thinking, vec!["First"]);
+        assert_eq!(merged.matches("event: content_block_start").count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_anonymous_reasoning_delta_adopts_later_item_id() {
+        let input = concat!(
+            "event: response.reasoning_summary_text.delta\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"Need a tool.\"}\n\n",
+            "event: response.output_item.done\n",
+            "data: {\"type\":\"response.output_item.done\",\"output_index\":0,\"item\":{\"id\":\"rs_adopted\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Need a tool.\"}],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+        let events = sse_data_values(&merged);
+
+        assert_eq!(merged.matches("event: content_block_start").count(), 1);
+        assert_eq!(merged.matches("\"type\":\"signature_delta\"").count(), 1);
+        assert_eq!(
+            events
+                .iter()
+                .filter_map(|event| event.pointer("/delta/thinking").and_then(Value::as_str))
+                .collect::<String>(),
+            "Need a tool."
+        );
+    }
+
+    #[tokio::test]
+    async fn test_added_reasoning_snapshot_keeps_replay_item_without_done_event() {
+        let input = concat!(
+            "event: response.output_item.added\n",
+            "data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"rs_added_encrypted\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"Added snapshot\"}],\"encrypted_content\":\"opaque\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"output\":[]}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+        let signature = sse_data_values(&merged)
+            .into_iter()
+            .find_map(|event| {
+                event
+                    .pointer("/delta/signature")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .expect("added reasoning item should produce a signature");
+        let replay = decode_openai_reasoning_item(&signature).expect("signature should round-trip");
+
+        assert_eq!(reasoning_summary_text(&replay), "Added snapshot");
+        assert_eq!(replay["encrypted_content"], "opaque");
+    }
+
+    #[tokio::test]
+    async fn test_reasoning_done_uses_text_when_delta_is_not_string() {
+        let input = concat!(
+            "event: response.reasoning_summary_text.done\n",
+            "data: {\"type\":\"response.reasoning_summary_text.done\",\"delta\":null,\"text\":\"Fallback summary\"}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\"}}\n\n"
+        );
+        let merged = convert_stream_text(input).await;
+
+        assert!(
+            merged.contains("\\\"thinking\\\":\\\"Fallback summary\\\"")
+                || merged.contains("\"thinking\":\"Fallback summary\"")
+        );
+    }
     #[tokio::test]
     async fn test_reasoning_summary_part_added_emits_visible_text() {
         let input = concat!(

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -2530,7 +2530,7 @@ pub(crate) fn responses_to_anthropic_with_web_search_options_for_client(
     body: Value,
     hosted_web_search_name: Option<&str>,
     max_web_search_uses: Option<u64>,
-    _preserve_redacted_thinking: bool,
+    preserve_redacted_thinking: bool,
 ) -> Result<Value, ProxyError> {
     // A Responses failure can arrive inside an HTTP 2xx response object. Reject it
     // before looking at `output`; otherwise `{status:"failed", output:[]}` becomes
@@ -2791,6 +2791,7 @@ pub(crate) fn responses_to_anthropic_with_web_search_options_for_client(
             "reasoning" => {
                 if let Some(block) = anthropic_block_from_openai_reasoning_item_for_client(
                     item,
+                    preserve_redacted_thinking,
                 ) {
                     content.push(block);
                 }
@@ -4719,7 +4720,7 @@ mod tests {
             input,
             None,
             None,
-            true,
+            false,
         )
         .unwrap();
         assert_eq!(result["content"][0]["type"], "thinking");
@@ -4727,6 +4728,34 @@ mod tests {
         assert!(result["content"][0]["signature"]
             .as_str()
             .is_some_and(|value| value.starts_with("ccswitch-openai-reasoning-v1:")));
+    }
+
+    #[test]
+    fn test_encrypted_reasoning_without_summary_keeps_redacted_thinking_for_compatible_clients() {
+        let input = json!({
+            "id": "resp_reasoning_compat",
+            "status": "completed",
+            "model": "gpt-5.6",
+            "output": [{
+                "type": "reasoning",
+                "id": "rs_compat",
+                "summary": [],
+                "encrypted_content": "opaque-ciphertext"
+            }]
+        });
+
+        let result = responses_to_anthropic_with_web_search_options_for_client(
+            input,
+            None,
+            None,
+            true,
+        )
+        .unwrap();
+        assert_eq!(result["content"][0]["type"], "redacted_thinking");
+        assert!(result["content"][0]["data"]
+            .as_str()
+            .is_some_and(|value| value.starts_with("ccswitch-openai-reasoning-v1:")));
+        assert!(result["content"][0].get("signature").is_none());
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -19,7 +19,9 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
 use super::reasoning_bridge::{
-    anthropic_block_from_openai_reasoning_item, openai_reasoning_item_from_anthropic_block,
+    anthropic_block_from_openai_reasoning_item,
+    anthropic_block_from_openai_reasoning_item_for_client,
+    openai_reasoning_item_from_anthropic_block,
 };
 
 pub(crate) const TOOL_RESULT_ERROR_MARKER: &str = "[cc-switch:tool-result-error]";
@@ -1821,11 +1823,28 @@ pub fn anthropic_to_responses(
         result["stream"] = v.clone();
     }
 
-    // Map Anthropic thinking → OpenAI Responses reasoning.effort
+    // Map Anthropic thinking → OpenAI Responses reasoning.effort and summary.
+    // Responses makes summary visibility an explicit opt-in; Claude Code commonly
+    // omits thinking.display while still expecting its UI to receive a visible
+    // summary. Request the default summary whenever reasoning is enabled, unless
+    // the client explicitly asks to omit it.
     if let Some(model_name) = body.get("model").and_then(|m| m.as_str()) {
         if super::transform::supports_reasoning_effort(model_name) {
-            if let Some(effort) = super::transform::resolve_reasoning_effort(&body) {
-                result["reasoning"] = json!({ "effort": effort });
+            let effort = super::transform::resolve_reasoning_effort(&body);
+            let summary_requested = body
+                .pointer("/thinking/display")
+                .and_then(Value::as_str)
+                .map(|display| display.eq_ignore_ascii_case("summarized"))
+                .unwrap_or(effort.is_some());
+            if effort.is_some() || summary_requested {
+                let mut reasoning = json!({});
+                if let Some(effort) = effort {
+                    reasoning["effort"] = json!(effort);
+                }
+                if summary_requested {
+                    reasoning["summary"] = json!("auto");
+                }
+                result["reasoning"] = reasoning;
             }
         }
     }
@@ -2499,6 +2518,20 @@ pub(crate) fn responses_to_anthropic_with_web_search_options(
     hosted_web_search_name: Option<&str>,
     max_web_search_uses: Option<u64>,
 ) -> Result<Value, ProxyError> {
+    responses_to_anthropic_with_web_search_options_for_client(
+        body,
+        hosted_web_search_name,
+        max_web_search_uses,
+        true,
+    )
+}
+
+pub(crate) fn responses_to_anthropic_with_web_search_options_for_client(
+    body: Value,
+    hosted_web_search_name: Option<&str>,
+    max_web_search_uses: Option<u64>,
+    _preserve_redacted_thinking: bool,
+) -> Result<Value, ProxyError> {
     // A Responses failure can arrive inside an HTTP 2xx response object. Reject it
     // before looking at `output`; otherwise `{status:"failed", output:[]}` becomes
     // a successful empty Anthropic `end_turn` and hides the upstream error.
@@ -2756,7 +2789,9 @@ pub(crate) fn responses_to_anthropic_with_web_search_options(
             }
 
             "reasoning" => {
-                if let Some(block) = anthropic_block_from_openai_reasoning_item(item) {
+                if let Some(block) = anthropic_block_from_openai_reasoning_item_for_client(
+                    item,
+                ) {
                     content.push(block);
                 }
             }
@@ -3195,6 +3230,51 @@ mod tests {
         assert_eq!(result["input"][0]["content"][0]["text"], "Hello");
         // stop_sequences should not appear
         assert!(result.get("stop_sequences").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_adaptive_thinking_requests_visible_summary_without_display() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "thinking": {"type": "adaptive"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+        assert_eq!(result["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_summarized_thinking_requests_visible_summary() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "thinking": {
+                "type": "adaptive",
+                "display": "summarized"
+            },
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+        assert_eq!(result["reasoning"]["summary"], "auto");
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_honors_explicit_omitted_summary() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "thinking": {
+                "type": "adaptive",
+                "display": "omitted"
+            },
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+        assert!(result["reasoning"].get("summary").is_none());
     }
 
     #[test]
@@ -4538,6 +4618,50 @@ mod tests {
     }
 
     #[test]
+    fn test_responses_to_anthropic_reasoning_content_fallback() {
+        let input = json!({
+            "id": "resp_reasoning_content",
+            "status": "completed",
+            "model": "gpt-5.6",
+            "output": [
+                {
+                    "type": "reasoning",
+                    "summary": [],
+                    "content": [
+                        {"type": "reasoning_text", "text": "Restored from content."}
+                    ]
+                },
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "Done."}]
+                }
+            ]
+        });
+
+        let result = responses_to_anthropic(input).unwrap();
+        assert_eq!(result["content"][0]["type"], "thinking");
+        assert_eq!(result["content"][0]["thinking"], "Restored from content.");
+        assert_eq!(result["content"][1]["type"], "text");
+    }
+
+    #[test]
+    fn test_responses_to_anthropic_reasoning_summary_wins_over_content() {
+        let input = json!({
+            "id": "resp_reasoning_both",
+            "status": "completed",
+            "model": "gpt-5.6",
+            "output": [{
+                "type": "reasoning",
+                "summary": [{"type": "summary_text", "text": "Summary."}],
+                "content": [{"type": "reasoning_text", "text": "Summary."}]
+            }]
+        });
+
+        let result = responses_to_anthropic(input).unwrap();
+        assert_eq!(result["content"][0]["thinking"], "Summary.");
+    }
+
+    #[test]
     fn test_encrypted_reasoning_round_trips_through_anthropic_history() {
         let original = json!({
             "type": "reasoning",
@@ -4575,6 +4699,34 @@ mod tests {
         .unwrap();
         assert_eq!(replay["input"][0], original);
         assert_eq!(replay["input"][1]["type"], "function_call");
+    }
+
+    #[test]
+    fn test_encrypted_reasoning_uses_supported_empty_thinking_block() {
+        let input = json!({
+            "id": "resp_reasoning_vscode",
+            "status": "completed",
+            "model": "gpt-5.6",
+            "output": [{
+                "type": "reasoning",
+                "id": "rs_vscode",
+                "summary": [],
+                "encrypted_content": "opaque-ciphertext"
+            }]
+        });
+
+        let result = responses_to_anthropic_with_web_search_options_for_client(
+            input,
+            None,
+            None,
+            true,
+        )
+        .unwrap();
+        assert_eq!(result["content"][0]["type"], "thinking");
+        assert_eq!(result["content"][0]["thinking"], "");
+        assert!(result["content"][0]["signature"]
+            .as_str()
+            .is_some_and(|value| value.starts_with("ccswitch-openai-reasoning-v1:")));
     }
 
     #[test]
@@ -4818,6 +4970,7 @@ mod tests {
 
         let result = anthropic_to_responses(input, None, false, false).unwrap();
         assert_eq!(result["reasoning"]["effort"], "xhigh");
+        assert_eq!(result["reasoning"]["summary"], "auto");
     }
 
     #[test]
@@ -4832,6 +4985,7 @@ mod tests {
 
         let result = anthropic_to_responses(input, None, false, false).unwrap();
         assert_eq!(result["reasoning"]["effort"], "low");
+        assert_eq!(result["reasoning"]["summary"], "auto");
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -18,8 +18,9 @@ use crate::proxy::{
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 
+#[cfg(test)]
+use super::reasoning_bridge::anthropic_block_from_openai_reasoning_item;
 use super::reasoning_bridge::{
-    anthropic_block_from_openai_reasoning_item,
     anthropic_block_from_openai_reasoning_item_for_client,
     openai_reasoning_item_from_anthropic_block,
 };
@@ -4716,13 +4717,9 @@ mod tests {
             }]
         });
 
-        let result = responses_to_anthropic_with_web_search_options_for_client(
-            input,
-            None,
-            None,
-            false,
-        )
-        .unwrap();
+        let result =
+            responses_to_anthropic_with_web_search_options_for_client(input, None, None, false)
+                .unwrap();
         assert_eq!(result["content"][0]["type"], "thinking");
         assert_eq!(result["content"][0]["thinking"], "");
         assert!(result["content"][0]["signature"]
@@ -4744,13 +4741,9 @@ mod tests {
             }]
         });
 
-        let result = responses_to_anthropic_with_web_search_options_for_client(
-            input,
-            None,
-            None,
-            true,
-        )
-        .unwrap();
+        let result =
+            responses_to_anthropic_with_web_search_options_for_client(input, None, None, true)
+                .unwrap();
         assert_eq!(result["content"][0]["type"], "redacted_thinking");
         assert!(result["content"][0]["data"]
             .as_str()

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -1825,10 +1825,9 @@ pub fn anthropic_to_responses(
     }
 
     // Map Anthropic thinking → OpenAI Responses reasoning.effort and summary.
-    // Responses makes summary visibility an explicit opt-in; Claude Code commonly
-    // omits thinking.display while still expecting its UI to receive a visible
-    // summary. Request the default summary whenever reasoning is enabled, unless
-    // the client explicitly asks to omit it.
+    // Responses makes summary visibility an explicit opt-in. Codex OAuth already
+    // relies on its native client default, while API-key routes must keep their
+    // existing request shape unless the client explicitly opts in.
     if let Some(model_name) = body.get("model").and_then(|m| m.as_str()) {
         if super::transform::supports_reasoning_effort(model_name) {
             let effort = super::transform::resolve_reasoning_effort(&body);
@@ -1836,7 +1835,7 @@ pub fn anthropic_to_responses(
                 .pointer("/thinking/display")
                 .and_then(Value::as_str)
                 .map(|display| display.eq_ignore_ascii_case("summarized"))
-                .unwrap_or(effort.is_some());
+                .unwrap_or(effort.is_some() && is_codex_oauth);
             if effort.is_some() || summary_requested {
                 let mut reasoning = json!({});
                 if let Some(effort) = effort {
@@ -3235,7 +3234,8 @@ mod tests {
     }
 
     #[test]
-    fn test_anthropic_to_responses_adaptive_thinking_requests_visible_summary_without_display() {
+    fn test_anthropic_to_responses_adaptive_thinking_does_not_request_summary_without_display_for_api_key(
+    ) {
         let input = json!({
             "model": "gpt-5.4",
             "thinking": {"type": "adaptive"},
@@ -3243,6 +3243,20 @@ mod tests {
         });
 
         let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+        assert!(result["reasoning"].get("summary").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_adaptive_thinking_requests_summary_without_display_for_codex_oauth(
+    ) {
+        let input = json!({
+            "model": "gpt-5.4",
+            "thinking": {"type": "adaptive"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, true, false).unwrap();
         assert_eq!(result["reasoning"]["effort"], "xhigh");
         assert_eq!(result["reasoning"]["summary"], "auto");
     }
@@ -3274,9 +3288,12 @@ mod tests {
             "messages": [{"role": "user", "content": "Hello"}]
         });
 
-        let result = anthropic_to_responses(input, None, false, false).unwrap();
-        assert_eq!(result["reasoning"]["effort"], "xhigh");
-        assert!(result["reasoning"].get("summary").is_none());
+        for is_codex_oauth in [false, true] {
+            let result =
+                anthropic_to_responses(input.clone(), None, is_codex_oauth, false).unwrap();
+            assert_eq!(result["reasoning"]["effort"], "xhigh");
+            assert!(result["reasoning"].get("summary").is_none());
+        }
     }
 
     #[test]
@@ -4992,7 +5009,7 @@ mod tests {
 
         let result = anthropic_to_responses(input, None, false, false).unwrap();
         assert_eq!(result["reasoning"]["effort"], "xhigh");
-        assert_eq!(result["reasoning"]["summary"], "auto");
+        assert!(result["reasoning"].get("summary").is_none());
     }
 
     #[test]
@@ -5007,7 +5024,7 @@ mod tests {
 
         let result = anthropic_to_responses(input, None, false, false).unwrap();
         assert_eq!(result["reasoning"]["effort"], "low");
-        assert_eq!(result["reasoning"]["summary"], "auto");
+        assert!(result["reasoning"].get("summary").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Request visible Responses reasoning summaries when Claude Code thinking is enabled, while honoring explicit omitted display.
- Translate Responses reasoning summary events into replayable Anthropic thinking blocks instead of exposing unsupported `redacted_thinking` content.
- Preserve encrypted reasoning signatures and reconcile summary events across streaming, aggregation, history replay, and non-streaming fallbacks.
- Keep client-aware Responses conversion on the Messages handler path.

Fixes #5362
Related to #5494
Related to #5643

## Testing

- `cargo test --manifest-path src-tauri/Cargo.toml proxy::providers::reasoning_bridge::tests --lib` (6 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::providers::streaming_responses::tests --lib` (94 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::providers::transform_responses::tests --lib` (121 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml proxy::handlers::tests --lib` (53 passed)
- `git diff --check main...HEAD`
