### PR TITLE
fix(proxy): normalize Grok Build response annotations

### DIFF
--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -936,13 +936,17 @@ async fn handle_responses_for_app(
     // Native Responses passthrough to a strict gateway (xAI): restore flattened
     // function-call names *and* rewrite whole-float tool arguments. The integer
     // rewrite must run even when the request had no namespace tools.
-    if super::providers::provider_needs_responses_namespace_flatten(&ctx.provider) {
+    let xai_native = super::providers::provider_needs_responses_namespace_flatten(&ctx.provider);
+    let add_annotations = matches!(app_type, AppType::GrokBuild);
+    if should_use_native_responses_compat(xai_native, add_annotations) {
         return handle_codex_xai_native_responses_rewrite(
             response,
             &ctx,
             &state,
             connection_guard,
             namespace_restore_map,
+            xai_native,
+            add_annotations,
         )
         .await;
     }
@@ -1128,13 +1132,17 @@ async fn handle_responses_compact_for_app(
         .await;
     }
 
-    if super::providers::provider_needs_responses_namespace_flatten(&ctx.provider) {
+    let xai_native = super::providers::provider_needs_responses_namespace_flatten(&ctx.provider);
+    let add_annotations = matches!(app_type, AppType::GrokBuild);
+    if should_use_native_responses_compat(xai_native, add_annotations) {
         return handle_codex_xai_native_responses_rewrite(
             response,
             &ctx,
             &state,
             connection_guard,
             namespace_restore_map,
+            xai_native,
+            add_annotations,
         )
         .await;
     }
@@ -1162,6 +1170,8 @@ async fn handle_codex_xai_native_responses_rewrite(
         String,
         transform_codex_responses_namespace::NamespacedName,
     >,
+    xai_native: bool,
+    add_output_text_annotations: bool,
 ) -> Result<axum::response::Response, ProxyError> {
     let status = response.status();
 
@@ -1186,6 +1196,8 @@ async fn handle_codex_xai_native_responses_rewrite(
             transform_codex_responses_xai_sanitize::create_xai_native_responses_sse_stream(
                 response.bytes_stream(),
                 restore_map,
+                xai_native,
+                add_output_text_annotations,
             );
         let usage_collector =
             create_usage_collector(ctx, state, status.as_u16(), &CODEX_PARSER_CONFIG);
@@ -1199,7 +1211,7 @@ async fn handle_codex_xai_native_responses_rewrite(
 
         let body = axum::body::Body::from_stream(logged_stream);
         return builder.body(body).map_err(|e| {
-            log::error!("[{}] 构建 namespace 还原流式响应失败: {e}", ctx.tag);
+            log::error!("[{}] 构建 Responses 兼容流式响应失败: {e}", ctx.tag);
             ProxyError::Internal(format!("Failed to build streaming response: {e}"))
         });
     }
@@ -1220,15 +1232,22 @@ async fn handle_codex_xai_native_responses_rewrite(
     // Restore names when the body parses as JSON; otherwise pass the bytes
     // through untouched (a native Responses non-stream body is always JSON, so
     // this only guards against a malformed upstream).
-    let restored_bytes = match serde_json::from_slice::<Value>(&body_bytes) {
+    let compatible_bytes = match serde_json::from_slice::<Value>(&body_bytes) {
         Ok(mut value) => {
             transform_codex_responses_namespace::restore_response_namespaces(
                 &mut value,
                 &restore_map,
             );
-            transform_codex_responses_xai_sanitize::normalize_xai_function_call_integer_arguments(
-                &mut value,
-            );
+            if xai_native {
+                transform_codex_responses_xai_sanitize::normalize_xai_function_call_integer_arguments(
+                    &mut value,
+                );
+            }
+            if add_output_text_annotations {
+                super::providers::transform_native_responses::ensure_output_text_annotations(
+                    &mut value,
+                );
+            }
             if let Some(usage) =
                 TokenUsage::from_codex_response_auto(&value).filter(TokenUsage::has_billable_tokens)
             {
@@ -1272,7 +1291,7 @@ async fn handle_codex_xai_native_responses_rewrite(
             match serde_json::to_vec(&value) {
                 Ok(bytes) => Bytes::from(bytes),
                 Err(e) => {
-                    log::error!("[{}] 序列化 namespace 还原响应失败: {e}", ctx.tag);
+                    log::error!("[{}] 序列化 Responses 兼容响应失败: {e}", ctx.tag);
                     body_bytes
                 }
             }
@@ -1292,11 +1311,15 @@ async fn handle_codex_xai_native_responses_rewrite(
         axum::http::HeaderValue::from_static("application/json"),
     );
     builder
-        .body(axum::body::Body::from(restored_bytes))
+        .body(axum::body::Body::from(compatible_bytes))
         .map_err(|e| {
-            log::error!("[{}] 构建 namespace 还原响应失败: {e}", ctx.tag);
+            log::error!("[{}] 构建 Responses 兼容响应失败: {e}", ctx.tag);
             ProxyError::Internal(format!("Failed to build response: {e}"))
         })
+}
+
+fn should_use_native_responses_compat(xai_native: bool, add_annotations: bool) -> bool {
+    xai_native || add_annotations
 }
 
 async fn handle_codex_chat_to_responses_transform(
@@ -2830,8 +2853,8 @@ mod tests {
     use super::{
         body_looks_like_sse, chat_sse_to_response_value, classify_body_for_diagnostics,
         codex_proxy_error_json, responses_sse_stream_to_anthropic_message,
-        responses_sse_to_response_value, should_use_claude_transform_streaming, transform,
-        upstream_body_parse_error,
+        responses_sse_to_response_value, should_use_claude_transform_streaming,
+        should_use_native_responses_compat, transform, upstream_body_parse_error,
     };
     use crate::proxy::ProxyError;
     use bytes::Bytes;
@@ -2839,6 +2862,13 @@ mod tests {
         atomic::{AtomicUsize, Ordering},
         Arc,
     };
+
+    #[test]
+    fn grokbuild_dispatch_uses_responses_compat_without_xai_provider_gate() {
+        assert!(should_use_native_responses_compat(false, true));
+        assert!(should_use_native_responses_compat(true, false));
+        assert!(!should_use_native_responses_compat(false, false));
+    }
 
     #[test]
     fn body_looks_like_sse_detects_unlabeled_sse_prefixes() {

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -37,6 +37,7 @@ pub mod transform_codex_chat;
 pub mod transform_codex_responses_namespace;
 pub mod transform_codex_responses_xai_sanitize;
 pub mod transform_gemini;
+pub mod transform_native_responses;
 pub mod transform_responses;
 pub mod xai_oauth_auth;
 

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
@@ -986,6 +986,8 @@ fn whole_float_to_json_int(number: &Number) -> Option<Number> {
 pub(crate) fn create_xai_native_responses_sse_stream<E>(
     stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
     restore_map: HashMap<String, NamespacedName>,
+    xai_native: bool,
+    add_output_text_annotations: bool,
 ) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send
 where
     E: std::error::Error + Send + 'static,
@@ -1004,7 +1006,7 @@ where
                         if block.trim().is_empty() {
                             continue;
                         }
-                        yield Ok(rewrite_xai_native_sse_block(&block, &restore_map));
+                        yield Ok(rewrite_xai_native_sse_block(&block, &restore_map, xai_native, add_output_text_annotations));
                     }
                 }
                 Err(e) => {
@@ -1019,7 +1021,7 @@ where
         }
         let tail = std::mem::take(&mut buffer);
         if !tail.trim().is_empty() {
-            yield Ok(rewrite_xai_native_sse_block(&tail, &restore_map));
+            yield Ok(rewrite_xai_native_sse_block(&tail, &restore_map, xai_native, add_output_text_annotations));
         }
     }
 }
@@ -1027,6 +1029,8 @@ where
 fn rewrite_xai_native_sse_block(
     block: &str,
     restore_map: &HashMap<String, NamespacedName>,
+    xai_native: bool,
+    add_output_text_annotations: bool,
 ) -> Bytes {
     let mut event_name: Option<&str> = None;
     let mut data_parts: Vec<&str> = Vec::new();
@@ -1053,8 +1057,14 @@ fn rewrite_xai_native_sse_block(
         Err(_) => return Bytes::from(format!("{block}\n\n")),
     };
 
-    let mut changed = restore_sse_event_namespaces(&mut event, restore_map);
-    changed |= normalize_xai_function_call_integer_arguments(&mut event);
+    let mut changed = false;
+    if xai_native {
+        changed |= restore_sse_event_namespaces(&mut event, restore_map);
+        changed |= normalize_xai_function_call_integer_arguments(&mut event);
+    }
+    if add_output_text_annotations {
+        changed |= super::transform_native_responses::ensure_output_text_annotations(&mut event);
+    }
     if !changed {
         return Bytes::from(format!("{block}\n\n"));
     }
@@ -1514,7 +1524,7 @@ mod tests {
             "event: response.function_call_arguments.done\n",
             r#"data: {"type":"response.function_call_arguments.done","arguments":"{\"session_id\":92116.0,\"yield_time_ms\":120000.0}"}"#,
         );
-        let rewritten = rewrite_xai_native_sse_block(done, &HashMap::new());
+        let rewritten = rewrite_xai_native_sse_block(done, &HashMap::new(), true, false);
         let rewritten = String::from_utf8(rewritten.to_vec()).unwrap();
         let data = rewritten
             .lines()
@@ -1531,7 +1541,33 @@ mod tests {
             "event: response.function_call_arguments.delta\n",
             r#"data: {"type":"response.function_call_arguments.delta","delta":"{\"session_id\":92116.0"}"#,
         );
-        let passed = rewrite_xai_native_sse_block(delta, &HashMap::new());
+        let passed = rewrite_xai_native_sse_block(delta, &HashMap::new(), true, false);
+        assert_eq!(
+            String::from_utf8(passed.to_vec()).unwrap(),
+            format!("{delta}\n\n")
+        );
+    }
+
+    #[test]
+    fn sse_content_part_adds_missing_annotations_for_grokbuild() {
+        let added = concat!(
+            "event: response.content_part.added\n",
+            r#"data: {"type":"response.content_part.added","part":{"type":"output_text","text":""}}"#,
+        );
+        let rewritten = rewrite_xai_native_sse_block(added, &HashMap::new(), false, true);
+        let rewritten = String::from_utf8(rewritten.to_vec()).unwrap();
+        let data = rewritten
+            .lines()
+            .find_map(|line| line.strip_prefix("data: "))
+            .unwrap();
+        let event: Value = serde_json::from_str(data).unwrap();
+        assert_eq!(event["part"]["annotations"], json!([]));
+
+        let delta = concat!(
+            "event: response.output_text.delta\n",
+            r#"data: {"type":"response.output_text.delta","delta":"hi"}"#,
+        );
+        let passed = rewrite_xai_native_sse_block(delta, &HashMap::new(), false, true);
         assert_eq!(
             String::from_utf8(passed.to_vec()).unwrap(),
             format!("{delta}\n\n")

--- a/src-tauri/src/proxy/providers/transform_native_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_native_responses.rs
@@ -1,0 +1,72 @@
+//! Compatibility fixes for native Responses API payloads.
+//!
+//! Native upstreams are normally passed through unchanged. Some compatible
+//! gateways omit optional-looking fields that strict clients deserialize as
+//! required, though. Keep the fixes here narrow and protocol-preserving.
+
+use serde_json::{json, Value};
+
+/// Add the Responses API's required `annotations` array to output-text content
+/// parts when an upstream omits it. Existing values are never overwritten.
+pub(crate) fn ensure_output_text_annotations(value: &mut Value) -> bool {
+    let mut changed = false;
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                changed |= ensure_output_text_annotations(item);
+            }
+        }
+        Value::Object(object) => {
+            if object.get("type").and_then(Value::as_str) == Some("output_text")
+                && !object.contains_key("annotations")
+            {
+                object.insert("annotations".to_string(), json!([]));
+                changed = true;
+            }
+            for child in object.values_mut() {
+                changed |= ensure_output_text_annotations(child);
+            }
+        }
+        _ => {}
+    }
+    changed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adds_annotations_to_nested_output_text_parts() {
+        let mut response = json!({
+            "type": "response.completed",
+            "response": {
+                "output": [{
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "hello"}]
+                }]
+            }
+        });
+
+        assert!(ensure_output_text_annotations(&mut response));
+        assert_eq!(
+            response["response"]["output"][0]["content"][0]["annotations"],
+            json!([])
+        );
+    }
+
+    #[test]
+    fn preserves_existing_annotations_and_ignores_delta_events() {
+        let citations = json!([{"type": "url_citation", "url": "https://example.com"}]);
+        let mut value = json!({
+            "parts": [
+                {"type": "output_text", "text": "cited", "annotations": citations},
+                {"type": "response.output_text.delta", "delta": "x"}
+            ]
+        });
+
+        assert!(!ensure_output_text_annotations(&mut value));
+        assert_eq!(value["parts"][0]["annotations"], citations);
+        assert!(value["parts"][1].get("annotations").is_none());
+    }
+}


### PR DESCRIPTION
## Summary / 概述

Fix Grok Build crashes when a native Responses upstream omits the `annotations` field from an `output_text` content part.

- normalize Grok Build native Responses payloads by adding `annotations: []` only when an `output_text` object omits the field
- cover both SSE and JSON responses for `/responses` and `/responses/compact`
- preserve existing annotations, delta events, unrelated payload fields, error responses, usage accounting, and Codex passthrough behavior
- reuse the existing native Responses SSE wrapper so namespace restoration and compatibility normalization happen in one parsing pass

Observed failing proxy event:

```json
{"type":"response.content_part.added","part":{"text":"","type":"output_text"}}
```

Grok Build treats `annotations` as required and exits with:

```text
Internal error: serialization error: missing field annotations
```

The upstream works when accessed directly via Chat Completions, but CC Switch proxy takeover exposes only the Grok Build `/responses` route (`/chat/completions` returns 404), so the proxy path needs to normalize the Responses payload.

## Related Issue / 关联 Issue

Fixes #6819

## Screenshots / 截图

Not applicable; this is a proxy protocol fix.

## Verification / 验证

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml transform_native_responses --lib` (2 passed)
- `cargo test --manifest-path src-tauri/Cargo.toml transform_codex_responses_namespace --lib` (10 passed)
- Full `cargo test --manifest-path src-tauri/Cargo.toml --lib`: 2663 passed, 6 ignored, 3 unrelated failures. Two require Windows symlink privileges; one pre-existing Hermes provider test fails on shared-state count (`left: 2`, `right: 1`).

Manual reproduction confirmed the malformed SSE event through `127.0.0.1:57890/grokbuild/v1`. Bypassing proxy takeover and using the same provider directly produced two successful Grok inference runs, confirming the upstream credentials and model are healthy.

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查 (not run; no TypeScript changes)
- [ ] `pnpm format:check` passes / 通过代码格式检查 (not run; no frontend changes)
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 (no user-facing text changed)