### PR TITLE
fix(claude): stop settings.local.json env from shadowing provider switch

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -199,6 +199,77 @@ pub fn get_claude_settings_path() -> PathBuf {
     settings
 }
 
+/// Claude Code project-local settings that overlay `settings.json`.
+///
+/// Launching Claude from the home directory treats `~/.claude` as the project
+/// config dir, so this file and user `settings.json` are the same folder.
+pub fn get_claude_settings_local_path() -> PathBuf {
+    get_claude_config_dir().join("settings.local.json")
+}
+
+fn is_claude_provider_env_key(name: &str) -> bool {
+    name.to_ascii_uppercase().starts_with("ANTHROPIC")
+}
+
+/// Remove `ANTHROPIC_*` keys from `settings.local.json`.
+///
+/// Claude Code merges local env over `settings.json`. A leftover local proxy
+/// (for example `ANTHROPIC_BASE_URL=http://127.0.0.1:3800`) makes CC Switch
+/// provider switches look successful while Claude still talks to the dead
+/// endpoint. Other local fields such as `permissions` are kept.
+pub fn scrub_claude_settings_local_provider_env() -> Result<bool, AppError> {
+    let path = get_claude_settings_local_path();
+    if !path.exists() {
+        return Ok(false);
+    }
+
+    let mut value: Value = read_json_file(&path)?;
+    let Some(root) = value.as_object_mut() else {
+        return Ok(false);
+    };
+    let Some(env_value) = root.get_mut("env") else {
+        return Ok(false);
+    };
+    let Some(env) = env_value.as_object_mut() else {
+        return Ok(false);
+    };
+
+    let keys: Vec<String> = env
+        .keys()
+        .filter(|key| is_claude_provider_env_key(key))
+        .cloned()
+        .collect();
+    if keys.is_empty() {
+        return Ok(false);
+    }
+
+    for key in &keys {
+        env.remove(key);
+    }
+    if env.is_empty() {
+        root.remove("env");
+    }
+
+    write_json_file(&path, &value)?;
+    log::info!(
+        "Cleared shadowed Claude provider env from {}: {}",
+        path.display(),
+        keys.join(", ")
+    );
+    Ok(true)
+}
+
+/// Write Claude live `settings.json` and drop local env that would shadow it.
+pub fn write_claude_settings_file<T: Serialize>(data: &T) -> Result<(), AppError> {
+    write_json_file(&get_claude_settings_path(), data)?;
+    if let Err(err) = scrub_claude_settings_local_provider_env() {
+        log::warn!(
+            "Wrote Claude settings.json but could not clear settings.local.json ANTHROPIC_* overrides: {err}"
+        );
+    }
+    Ok(())
+}
+
 /// 获取应用配置目录路径 (~/.cc-switch)
 pub fn get_app_config_dir() -> PathBuf {
     if let Some(custom) = crate::app_store::get_app_config_dir_override() {
@@ -750,6 +821,122 @@ mod tests {
             serde_json::to_string(&sorted_a).unwrap(),
             serde_json::to_string(&sorted_b).unwrap(),
         );
+    }
+
+    fn with_test_home<T>(f: impl FnOnce(&Path) -> T) -> T {
+        let dir = tempfile::tempdir().unwrap();
+        let original = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(dir.path())));
+        match original {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+        result.unwrap()
+    }
+
+    #[test]
+    #[serial_test::serial(cc_switch_test_home)]
+    fn scrub_settings_local_removes_anthropic_env_and_keeps_permissions() {
+        with_test_home(|home| {
+            let claude_dir = home.join(".claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            let local = claude_dir.join("settings.local.json");
+            write_json_file(
+                &local,
+                &serde_json::json!({
+                    "permissions": { "allow": ["Bash"] },
+                    "env": {
+                        "ANTHROPIC_BASE_URL": "http://127.0.0.1:3800",
+                        "ANTHROPIC_AUTH_TOKEN": "tasklet-local",
+                        "ANTHROPIC_API_KEY": "tasklet-local",
+                        "NODE_TLS_REJECT_UNAUTHORIZED": "0"
+                    }
+                }),
+            )
+            .unwrap();
+
+            assert!(scrub_claude_settings_local_provider_env().unwrap());
+            let after: Value = read_json_file(&local).unwrap();
+            assert_eq!(
+                after
+                    .pointer("/permissions/allow/0")
+                    .and_then(Value::as_str),
+                Some("Bash")
+            );
+            assert_eq!(
+                after
+                    .pointer("/env/NODE_TLS_REJECT_UNAUTHORIZED")
+                    .and_then(Value::as_str),
+                Some("0")
+            );
+            assert!(after.pointer("/env/ANTHROPIC_BASE_URL").is_none());
+            assert!(after.pointer("/env/ANTHROPIC_API_KEY").is_none());
+            assert!(after.pointer("/env/ANTHROPIC_AUTH_TOKEN").is_none());
+        });
+    }
+
+    #[test]
+    #[serial_test::serial(cc_switch_test_home)]
+    fn scrub_settings_local_drops_empty_env_object() {
+        with_test_home(|home| {
+            let claude_dir = home.join(".claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            let local = claude_dir.join("settings.local.json");
+            write_json_file(
+                &local,
+                &serde_json::json!({
+                    "permissions": { "allow": ["Read"] },
+                    "env": {
+                        "ANTHROPIC_BASE_URL": "http://127.0.0.1:3800"
+                    }
+                }),
+            )
+            .unwrap();
+
+            assert!(scrub_claude_settings_local_provider_env().unwrap());
+            let after: Value = read_json_file(&local).unwrap();
+            assert!(after.get("env").is_none());
+            assert_eq!(
+                after
+                    .pointer("/permissions/allow/0")
+                    .and_then(Value::as_str),
+                Some("Read")
+            );
+        });
+    }
+
+    #[test]
+    #[serial_test::serial(cc_switch_test_home)]
+    fn write_claude_settings_file_scrubs_local_overrides() {
+        with_test_home(|home| {
+            let claude_dir = home.join(".claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            write_json_file(
+                &claude_dir.join("settings.local.json"),
+                &serde_json::json!({
+                    "env": { "ANTHROPIC_BASE_URL": "http://127.0.0.1:3800" }
+                }),
+            )
+            .unwrap();
+
+            write_claude_settings_file(&serde_json::json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "sk-live",
+                    "ANTHROPIC_BASE_URL": "https://api.example.test"
+                }
+            }))
+            .unwrap();
+
+            let live: Value = read_json_file(&get_claude_settings_path()).unwrap();
+            assert_eq!(
+                live.pointer("/env/ANTHROPIC_BASE_URL")
+                    .and_then(Value::as_str),
+                Some("https://api.example.test")
+            );
+            let local: Value = read_json_file(&get_claude_settings_local_path()).unwrap();
+            assert!(local.get("env").is_none());
+        });
     }
 }
 

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -218,7 +218,7 @@ impl ConfigService {
         provider_id: &str,
         provider: &Provider,
     ) -> Result<(), AppError> {
-        use crate::config::{read_json_file, write_json_file};
+        use crate::config::{read_json_file, write_claude_settings_file};
 
         let settings_path = crate::config::get_claude_settings_path();
         if let Some(parent) = settings_path.parent() {
@@ -226,7 +226,7 @@ impl ConfigService {
         }
 
         let settings = sanitize_claude_settings_for_live(&provider.settings_config);
-        write_json_file(&settings_path, &settings)?;
+        write_claude_settings_file(&settings)?;
 
         let live_after = read_json_file::<serde_json::Value>(&settings_path)?;
         if let Some(manager) = config.get_manager_mut(&AppType::Claude) {

--- a/src-tauri/src/services/env_checker.rs
+++ b/src-tauri/src/services/env_checker.rs
@@ -28,6 +28,10 @@ pub fn check_env_conflicts(app: &str) -> Result<Vec<EnvConflict>, String> {
     #[cfg(not(target_os = "windows"))]
     conflicts.extend(check_shell_configs(&keywords)?);
 
+    if app.eq_ignore_ascii_case("claude") {
+        conflicts.extend(check_claude_settings_local(&keywords)?);
+    }
+
     Ok(conflicts)
 }
 
@@ -172,6 +176,40 @@ fn check_shell_configs(keywords: &[EnvKeyword]) -> Result<Vec<EnvConflict>, Stri
     Ok(conflicts)
 }
 
+/// Claude Code overlays `settings.local.json` env on top of `settings.json`.
+fn check_claude_settings_local(keywords: &[EnvKeyword]) -> Result<Vec<EnvConflict>, String> {
+    let path = crate::config::get_claude_settings_local_path();
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let value: serde_json::Value = match crate::config::read_json_file(&path) {
+        Ok(value) => value,
+        Err(_) => return Ok(Vec::new()),
+    };
+    let Some(env) = value.get("env").and_then(|value| value.as_object()) else {
+        return Ok(Vec::new());
+    };
+
+    let mut conflicts = Vec::new();
+    for (name, value) in env {
+        if !matches_env_keyword(name, keywords) {
+            continue;
+        }
+        let var_value = match value {
+            serde_json::Value::String(text) => text.clone(),
+            other => other.to_string(),
+        };
+        conflicts.push(EnvConflict {
+            var_name: name.clone(),
+            var_value,
+            source_type: "file".to_string(),
+            source_path: path.to_string_lossy().to_string(),
+        });
+    }
+    Ok(conflicts)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -231,5 +269,46 @@ mod tests {
         assert!(matches_env_keyword("anthropic_base_url", &keywords));
         assert!(!matches_env_keyword("MY_ANTHROPIC_API_KEY", &keywords));
         assert!(!matches_env_keyword("NOT_ANTHROPIC", &keywords));
+    }
+
+    #[test]
+    #[serial_test::serial(cc_switch_test_home)]
+    fn claude_settings_local_env_is_reported_as_file_conflict() {
+        let dir = tempfile::tempdir().unwrap();
+        let original = std::env::var_os("CC_SWITCH_TEST_HOME");
+        std::env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+        let claude_dir = dir.path().join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(
+            claude_dir.join("settings.local.json"),
+            r#"{
+              "env": {
+                "ANTHROPIC_BASE_URL": "http://127.0.0.1:3800",
+                "NODE_TLS_REJECT_UNAUTHORIZED": "0"
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let result = std::panic::catch_unwind(|| {
+            let conflicts = check_env_conflicts("claude").expect("check claude conflicts");
+            assert!(
+                conflicts.iter().any(|conflict| {
+                    conflict.var_name == "ANTHROPIC_BASE_URL"
+                        && conflict.source_type == "file"
+                        && conflict.var_value == "http://127.0.0.1:3800"
+                }),
+                "expected settings.local.json ANTHROPIC_BASE_URL conflict, got {conflicts:?}"
+            );
+            assert!(!conflicts
+                .iter()
+                .any(|conflict| conflict.var_name == "NODE_TLS_REJECT_UNAUTHORIZED"));
+        });
+
+        match original {
+            Some(value) => std::env::set_var("CC_SWITCH_TEST_HOME", value),
+            None => std::env::remove_var("CC_SWITCH_TEST_HOME"),
+        }
+        result.unwrap();
     }
 }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -10,7 +10,10 @@ use toml_edit::{DocumentMut, Item, TableLike};
 
 use crate::app_config::AppType;
 use crate::codex_config::{get_codex_auth_path, get_codex_config_path};
-use crate::config::{delete_file, get_claude_settings_path, read_json_file, write_json_file};
+use crate::config::{
+    delete_file, get_claude_settings_path, read_json_file, write_claude_settings_file,
+    write_json_file,
+};
 use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
@@ -1189,7 +1192,7 @@ impl LiveSnapshot {
             LiveSnapshot::Claude { settings } => {
                 let path = get_claude_settings_path();
                 if let Some(value) = settings {
-                    write_json_file(&path, value)?;
+                    write_claude_settings_file(value)?;
                 } else if path.exists() {
                     delete_file(&path)?;
                 }
@@ -1242,9 +1245,8 @@ impl LiveSnapshot {
 pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Result<(), AppError> {
     match app_type {
         AppType::Claude => {
-            let path = get_claude_settings_path();
             let settings = sanitize_claude_settings_for_live(&provider.settings_config);
-            write_json_file(&path, &settings)?;
+            write_claude_settings_file(&settings)?;
         }
         AppType::ClaudeDesktop => {
             return Err(AppError::localized(

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3533,9 +3533,9 @@ impl ProxyService {
     }
 
     fn write_claude_live(&self, config: &Value) -> Result<(), String> {
-        let path = get_claude_settings_path();
         let settings = crate::services::provider::sanitize_claude_settings_for_live(config);
-        write_json_file(&path, &settings).map_err(|e| format!("写入 Claude 配置失败: {e}"))
+        crate::config::write_claude_settings_file(&settings)
+            .map_err(|e| format!("写入 Claude 配置失败: {e}"))
     }
 
     fn read_codex_live(&self) -> Result<Value, String> {


### PR DESCRIPTION
## Summary

Claude Code merges `settings.local.json` over `settings.json`. If you launch Claude from the home directory, `~/.claude` is both the user config dir and the project config dir. Leftover `ANTHROPIC_*` keys in `settings.local.json` (a dead `http://127.0.0.1:3800` local proxy in the report that triggered this) keep winning after CC Switch writes live `settings.json`.

The user-visible result is: CC Switch switch/auto-config looks successful, Claude then warns that both `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_API_KEY` are set, and requests fail with `Connection refused`.

## Changes

- When writing Claude live settings, strip `ANTHROPIC_*` from `settings.local.json`
- Keep unrelated local fields such as `permissions`
- Report those keys in env-conflict detection
- Unit tests for scrub, empty-env drop, live write, and conflict listing

## Test plan

- [x] `cargo test --lib settings_local`
- [x] `cargo test --lib write_claude_settings_file_scrubs`
- [x] Reproduced locally: home-dir `claude -p` failed against `:3800`, then succeeded against the live provider after clearing local env
