### PR TITLE
fix(codex-oauth): align identity tests with JWT parsing

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -489,22 +489,31 @@ fn extract_codex_auth_user_identity(auth: &Value) -> Option<String> {
 }
 
 pub(crate) fn extract_codex_id_token_user_identity(id_token: &str) -> Option<String> {
-    match extract_codex_id_token_subject(id_token) {
-        Some(subject) => Some(format!("sub:{subject}")),
-        None => {
-            #[cfg(test)]
-            return Some("test-user".to_string());
-            #[cfg(not(test))]
-            return None;
-        }
-    }
+    extract_codex_id_token_subject(id_token).map(|subject| format!("sub:{subject}"))
 }
 
 pub(crate) fn extract_codex_id_token_subject(id_token: &str) -> Option<String> {
-    let claims: Value = id_token
-        .split('.')
-        .nth(1)
-        .and_then(|payload| URL_SAFE_NO_PAD.decode(payload).ok())
+    let mut segments = id_token.split('.');
+    let header = segments.next()?;
+    let payload = segments.next()?;
+    segments.next()?;
+    if segments.next().is_some() {
+        return None;
+    }
+
+    let header: Value = URL_SAFE_NO_PAD
+        .decode(header)
+        .ok()
+        .and_then(|decoded| serde_json::from_slice(&decoded).ok())?;
+    header
+        .get("alg")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+
+    let claims: Value = URL_SAFE_NO_PAD
+        .decode(payload)
+        .ok()
         .and_then(|decoded| serde_json::from_slice(&decoded).ok())?;
     claims
         .get("sub")
@@ -3237,6 +3246,39 @@ mod tests {
     use serde_json::json;
     use serial_test::serial;
     use std::ffi::OsString;
+
+    #[test]
+    fn codex_id_token_user_identity_requires_a_nonempty_subject() {
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let subject_payload = URL_SAFE_NO_PAD.encode(json!({ "sub": "stable-user" }).to_string());
+        assert_eq!(
+            extract_codex_id_token_user_identity(&test_codex_id_token("stable-user")),
+            Some("sub:stable-user".to_string())
+        );
+        assert_eq!(extract_codex_id_token_user_identity("not-a-jwt"), None);
+        assert_eq!(
+            extract_codex_id_token_user_identity(&format!("{header}.{subject_payload}")),
+            None
+        );
+        assert_eq!(
+            extract_codex_id_token_user_identity(&format!("{header}.{subject_payload}..extra")),
+            None
+        );
+        assert_eq!(
+            extract_codex_id_token_user_identity(&format!("invalid.{subject_payload}.signature")),
+            None
+        );
+        assert_eq!(
+            extract_codex_id_token_user_identity(&test_codex_id_token("   ")),
+            None
+        );
+
+        let payload = URL_SAFE_NO_PAD.encode(json!({ "email": "user@example.test" }).to_string());
+        assert_eq!(
+            extract_codex_id_token_user_identity(&format!("{header}.{payload}.")),
+            None
+        );
+    }
 
     struct CodexLiveTestHome {
         _dir: tempfile::TempDir,

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -1525,6 +1525,18 @@ impl CodexOAuthManager {
     }
 
     #[cfg(test)]
+    pub(crate) async fn add_test_account_with_user_identity(
+        &self,
+        account_id: &str,
+        access_token: &str,
+        subject: &str,
+    ) -> Result<(), CodexOAuthError> {
+        let id_token = crate::codex_config::test_codex_id_token(subject);
+        self.add_test_account_with_access_token(account_id, access_token, Some(&id_token))
+            .await
+    }
+
+    #[cfg(test)]
     pub(crate) async fn add_test_account_with_workspace_and_access_token(
         &self,
         account_id: &str,

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -2694,13 +2694,14 @@ base_url = "https://a.example/v1"
     fn category_less_managed_codex_binding_with_null_config_uses_selected_account_token() {
         let temp = tempfile::tempdir().expect("tempdir");
         let manager = Arc::new(CodexOAuthManager::new(temp.path().to_path_buf()));
+        let id_token = crate::codex_config::test_codex_id_token("managed-user");
         tauri::async_runtime::block_on(async {
             manager
                 .add_test_account_with_workspace_and_access_token(
                     "local-managed",
                     "workspace-shared",
                     "managed-token",
-                    Some("managed-id-token"),
+                    Some(&id_token),
                 )
                 .await
                 .expect("seed managed account");
@@ -2752,7 +2753,7 @@ base_url = "https://a.example/v1"
         );
         assert_eq!(
             tokens.get("id_token").and_then(|v| v.as_str()),
-            Some("managed-id-token")
+            Some(id_token.as_str())
         );
         assert_eq!(
             tokens.get("refresh_token").and_then(|v| v.as_str()),

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -779,10 +779,10 @@ mod tests {
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed",
                         "managed-access-token",
-                        Some("managed-id-token"),
+                        "managed-user",
                     )
                     .await
                     .expect("seed managed account");
@@ -2252,10 +2252,10 @@ requires_openai_auth = true
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed",
                         "managed-token",
-                        Some("managed-id-token"),
+                        "managed-user",
                     )
                     .await
                     .expect("seed managed Codex OAuth account");
@@ -2319,10 +2319,10 @@ requires_openai_auth = true
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed",
                         "managed-token",
-                        Some("managed-id-token"),
+                        "managed-user",
                     )
                     .await
                     .expect("seed managed Codex OAuth account");
@@ -2382,10 +2382,11 @@ requires_openai_auth = true
             // Simulate a bare Codex CLI self-refresh. The app marker still
             // describes the pre-refresh write, while both access and refresh
             // token material on disk have rotated.
+            let rotated_id_token = crate::codex_config::test_codex_id_token("managed-user");
             let rotated_live_auth = crate::codex_config::codex_managed_oauth_auth_value(
                 "acct-managed",
                 "cli-rotated-access",
-                Some("cli-rotated-id"),
+                Some(&rotated_id_token),
                 "cli-rotated-refresh",
                 "2099-01-02T03:04:05Z",
             );
@@ -2434,20 +2435,12 @@ requires_openai_auth = true
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
-                        "acct-a",
-                        "managed-access-a",
-                        Some("managed-id-a"),
-                    )
+                    .add_test_account_with_user_identity("acct-a", "managed-access-a", "user-a")
                     .await
                     .expect("seed account A");
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
-                        "acct-b",
-                        "managed-access-b",
-                        Some("managed-id-b"),
-                    )
+                    .add_test_account_with_user_identity("acct-b", "managed-access-b", "user-b")
                     .await
                     .expect("seed account B");
             });
@@ -2478,12 +2471,13 @@ wire_api = "responses"
 
             ProviderService::switch(state, AppType::Codex, &provider_a.id)
                 .expect("activate managed A");
+            let id_token_a = crate::codex_config::test_codex_id_token("user-a");
             write_json_file(
                 &crate::codex_config::get_codex_auth_path(),
                 &crate::codex_config::codex_managed_oauth_auth_value(
                     "acct-a",
                     "cli-access-a1",
-                    Some("cli-id-a1"),
+                    Some(&id_token_a),
                     "cli-refresh-a1",
                     "2099-01-02T00:00:00Z",
                 ),
@@ -2509,12 +2503,13 @@ wire_api = "responses"
                 Some("acct-b")
             );
 
+            let id_token_b = crate::codex_config::test_codex_id_token("user-b");
             write_json_file(
                 &crate::codex_config::get_codex_auth_path(),
                 &crate::codex_config::codex_managed_oauth_auth_value(
                     "acct-b",
                     "cli-access-b1",
-                    Some("cli-id-b1"),
+                    Some(&id_token_b),
                     "cli-refresh-b1",
                     "2099-01-03T00:00:00Z",
                 ),
@@ -2553,20 +2548,12 @@ wire_api = "responses"
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
-                        "acct-a",
-                        "managed-access-a",
-                        Some("managed-id-a"),
-                    )
+                    .add_test_account_with_user_identity("acct-a", "managed-access-a", "user-a")
                     .await
                     .expect("seed account A");
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
-                        "acct-b",
-                        "managed-access-b",
-                        Some("managed-id-b"),
-                    )
+                    .add_test_account_with_user_identity("acct-b", "managed-access-b", "user-b")
                     .await
                     .expect("seed account B");
             });
@@ -2585,12 +2572,13 @@ wire_api = "responses"
                 "direct update precondition requires no takeover backup"
             );
 
+            let id_token_a = crate::codex_config::test_codex_id_token("user-a");
             write_json_file(
                 &crate::codex_config::get_codex_auth_path(),
                 &crate::codex_config::codex_managed_oauth_auth_value(
                     "acct-a",
                     "cli-access-a1",
-                    Some("cli-id-a1"),
+                    Some(&id_token_a),
                     "cli-refresh-a1",
                     "2099-03-01T00:00:00Z",
                 ),
@@ -2662,10 +2650,10 @@ wire_api = "responses"
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed",
                         "managed-access",
-                        Some("managed-id"),
+                        "managed-user",
                     )
                     .await
                     .expect("seed managed account");
@@ -2688,10 +2676,11 @@ wire_api = "responses"
                     .codex_oauth_manager
                     .test_set_token_updated_at_ms("acct-managed", 1_700_000_000_000),
             );
+            let id_token = crate::codex_config::test_codex_id_token("managed-user");
             let cli_live_auth = crate::codex_config::codex_managed_oauth_auth_value(
                 "acct-managed",
                 "cli-access-r1",
-                Some("cli-id-r1"),
+                Some(&id_token),
                 "cli-refresh-r1",
                 "2023-11-14T22:13:20Z",
             );
@@ -2746,10 +2735,10 @@ wire_api = "responses"
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-legacy",
                         "managed-access",
-                        Some("managed-id"),
+                        "legacy-user",
                     )
                     .await
                     .expect("seed managed account");
@@ -2780,10 +2769,11 @@ wire_api = "responses"
                     .codex_oauth_manager
                     .test_set_token_updated_at_ms("acct-legacy", 0),
             );
+            let id_token = crate::codex_config::test_codex_id_token("legacy-user");
             let cli_live_auth = crate::codex_config::codex_managed_oauth_auth_value(
                 "acct-legacy",
                 "cli-access-r1",
-                Some("cli-id-r1"),
+                Some(&id_token),
                 "cli-refresh-r1",
                 "2023-11-14T22:13:20Z",
             );
@@ -2837,10 +2827,10 @@ wire_api = "responses"
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed",
                         "managed-access",
-                        Some("managed-id"),
+                        "managed-user",
                     )
                     .await
                     .expect("seed managed account");
@@ -2882,10 +2872,10 @@ wire_api = "responses"
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed",
                         "managed-access-2",
-                        Some("managed-id-2"),
+                        "managed-user",
                     )
                     .await
                     .expect("re-login managed account");
@@ -2913,10 +2903,10 @@ wire_api = "responses"
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed",
                         "managed-access",
-                        Some("managed-id"),
+                        "managed-user",
                     )
                     .await
                     .expect("seed managed account");
@@ -2968,10 +2958,10 @@ wire_api = "responses"
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed",
                         "managed-access",
-                        Some("managed-id"),
+                        "managed-user",
                     )
                     .await
                     .expect("seed managed account");
@@ -3038,19 +3028,19 @@ wire_api = "responses"
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed-a",
                         "managed-token-a",
-                        Some("managed-id-token-a"),
+                        "user-a",
                     )
                     .await
                     .expect("seed first managed Codex OAuth account");
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed-b",
                         "managed-token-b",
-                        Some("managed-id-token-b"),
+                        "user-b",
                     )
                     .await
                     .expect("seed second managed Codex OAuth account");
@@ -3170,19 +3160,19 @@ wire_api = "responses"
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed-a",
                         "managed-token-a",
-                        Some("managed-id-a"),
+                        "user-a",
                     )
                     .await
                     .expect("seed managed account A");
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed-b",
                         "managed-token-b",
-                        Some("managed-id-b"),
+                        "user-b",
                     )
                     .await
                     .expect("seed managed account B");
@@ -3320,19 +3310,19 @@ wire_api = "responses"
             tauri::async_runtime::block_on(async {
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed-a",
                         "managed-token-a",
-                        Some("managed-id-a"),
+                        "user-a",
                     )
                     .await
                     .expect("seed managed account A");
                 state
                     .codex_oauth_manager
-                    .add_test_account_with_access_token(
+                    .add_test_account_with_user_identity(
                         "acct-managed-b",
                         "managed-token-b",
-                        Some("managed-id-b"),
+                        "user-b",
                     )
                     .await
                     .expect("seed managed account B");

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -4660,11 +4660,7 @@ mod tests {
         let state = crate::store::AppState::new(db.clone());
         state
             .codex_oauth_manager
-            .add_test_account_with_access_token(
-                "acct-managed",
-                "managed-access",
-                Some("managed-id"),
-            )
+            .add_test_account_with_user_identity("acct-managed", "managed-access", "managed-user")
             .await
             .expect("seed managed account");
 
@@ -5174,11 +5170,7 @@ wire_api = "responses"
         let service = ProxyService::new(db.clone());
         service
             .codex_oauth_manager
-            .add_test_account_with_access_token(
-                "acct-managed",
-                "managed-access",
-                Some("managed-id"),
-            )
+            .add_test_account_with_user_identity("acct-managed", "managed-access", "managed-user")
             .await
             .expect("seed managed account");
 
@@ -5231,12 +5223,13 @@ wire_api = "responses"
             .set_takeover_for_app("codex", true)
             .await
             .expect("enable managed takeover");
+        let id_token = crate::codex_config::test_codex_id_token("managed-user");
         crate::config::write_json_file(
             &crate::codex_config::get_codex_auth_path(),
             &crate::codex_config::codex_managed_oauth_auth_value(
                 "acct-managed",
                 "cli-access-r1",
-                Some("cli-id-r1"),
+                Some(&id_token),
                 "cli-refresh-r1",
                 "2099-02-01T00:00:00Z",
             ),
@@ -5289,20 +5282,12 @@ wire_api = "responses"
         let service = ProxyService::new(db.clone());
         service
             .codex_oauth_manager
-            .add_test_account_with_access_token(
-                "acct-managed-a",
-                "managed-access-a",
-                Some("managed-id-a"),
-            )
+            .add_test_account_with_user_identity("acct-managed-a", "managed-access-a", "user-a")
             .await
             .expect("seed managed account A");
         service
             .codex_oauth_manager
-            .add_test_account_with_access_token(
-                "acct-managed-b",
-                "managed-access-b",
-                Some("managed-id-b"),
-            )
+            .add_test_account_with_user_identity("acct-managed-b", "managed-access-b", "user-b")
             .await
             .expect("seed managed account B");
 
@@ -5356,12 +5341,13 @@ wire_api = "responses"
             .set_takeover_for_app("codex", true)
             .await
             .expect("enable managed A takeover");
+        let id_token_a = crate::codex_config::test_codex_id_token("user-a");
         crate::config::write_json_file(
             &crate::codex_config::get_codex_auth_path(),
             &crate::codex_config::codex_managed_oauth_auth_value(
                 "acct-managed-a",
                 "cli-access-a1",
-                Some("cli-id-a1"),
+                Some(&id_token_a),
                 "cli-refresh-a1",
                 "2099-02-01T00:00:00Z",
             ),
@@ -5440,11 +5426,7 @@ wire_api = "responses"
         let service = ProxyService::new(db.clone());
         service
             .codex_oauth_manager
-            .add_test_account_with_access_token(
-                "acct-managed",
-                "managed-access",
-                Some("managed-id"),
-            )
+            .add_test_account_with_user_identity("acct-managed", "managed-access", "managed-user")
             .await
             .expect("seed managed account");
 
@@ -5709,11 +5691,7 @@ wire_api = "responses"
         let service = ProxyService::new(db.clone());
         service
             .codex_oauth_manager
-            .add_test_account_with_access_token(
-                "acct-managed",
-                "managed-access",
-                Some("managed-id"),
-            )
+            .add_test_account_with_user_identity("acct-managed", "managed-access", "managed-user")
             .await
             .expect("seed managed account");
 
@@ -7321,11 +7299,7 @@ base_url = "https://codex.example/v1"
         let service = ProxyService::new(db.clone());
         service
             .codex_oauth_manager
-            .add_test_account_with_access_token(
-                "acct-managed",
-                "managed-token",
-                Some("managed-id-token"),
-            )
+            .add_test_account_with_user_identity("acct-managed", "managed-token", "managed-user")
             .await
             .expect("seed managed Codex OAuth account");
 
@@ -7401,11 +7375,7 @@ base_url = "https://codex.example/v1"
         let service = ProxyService::new(db);
         service
             .codex_oauth_manager
-            .add_test_account_with_access_token(
-                "acct-managed",
-                "managed-access",
-                Some("managed-id"),
-            )
+            .add_test_account_with_user_identity("acct-managed", "managed-access", "managed-user")
             .await
             .expect("seed managed account");
 
@@ -8617,11 +8587,7 @@ requires_openai_auth = true
         let service = ProxyService::new(db.clone());
         service
             .codex_oauth_manager
-            .add_test_account_with_access_token(
-                "acct-managed-b",
-                "managed-access-b",
-                Some("managed-id-b"),
-            )
+            .add_test_account_with_user_identity("acct-managed-b", "managed-access-b", "user-b")
             .await
             .expect("seed managed account B");
 


### PR DESCRIPTION
## Summary

- remove the test-only fallback from Codex id-token identity extraction
- require a valid compact JWT shape and algorithm header before trusting the subject claim
- use structurally valid JWT fixtures throughout managed-account identity flows

## Scope

This is the identity-fixture follow-up suggested after #6780. It does not add signature, issuer, or audience verification; change OAuth routing or account state; or implement the separate (sub, workspace) account-deduplication follow-up.

## Testing

- cargo test --lib
- cargo clippy --lib --tests -- -D warnings
- cargo fmt --all -- --check
- two independent blind review passes