### PR TITLE
feat(sessions): 工具消息折叠为两行

### DIFF
--- a/src/components/sessions/SessionMessageItem.tsx
+++ b/src/components/sessions/SessionMessageItem.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import { ChevronDown, ChevronUp, Copy } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
@@ -20,6 +20,21 @@ import {
 const COLLAPSE_THRESHOLD = 3000;
 const COLLAPSED_LENGTH = 1500;
 
+// 工具消息在会话里占了绝大部分篇幅，而它们多是命令输出、文件内容与日志，
+// 扫读对话时并不需要看全文，只要知道「这里调了个工具、大致返回了什么」。
+// 按行折叠而不是按字符：工具输出的排版本来就是按行的，同样的字符数可能是
+// 一行也可能是十几行，按行才能得到可预期的视觉高度；字符上限只是单行超长
+// 时的兜底。
+const TOOL_PREVIEW_LINES = 2;
+const TOOL_PREVIEW_MAX_CHARS = 300;
+
+const clampToLines = (content: string, maxLines: number, maxChars: number) => {
+  const lines = content.split("\n");
+  // 尾部空行不带信息量，去掉可以让预览更紧凑
+  const head = lines.slice(0, maxLines).join("\n").trimEnd();
+  return head.length > maxChars ? head.slice(0, maxChars) : head;
+};
+
 interface SessionMessageItemProps {
   message: SessionMessage;
   isActive: boolean;
@@ -36,7 +51,21 @@ export const SessionMessageItem = memo(function SessionMessageItem({
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
 
-  const isLong = message.content.length > COLLAPSE_THRESHOLD;
+  const isTool = message.role.toLowerCase() === "tool";
+  const toolPreview = useMemo(
+    () =>
+      isTool
+        ? clampToLines(
+            message.content,
+            TOOL_PREVIEW_LINES,
+            TOOL_PREVIEW_MAX_CHARS,
+          )
+        : "",
+    [isTool, message.content],
+  );
+  const isLong = isTool
+    ? toolPreview.length < message.content.length
+    : message.content.length > COLLAPSE_THRESHOLD;
   const hasSearchMatch =
     isLong &&
     !expanded &&
@@ -44,7 +73,9 @@ export const SessionMessageItem = memo(function SessionMessageItem({
     message.content.toLowerCase().includes(searchQuery.toLowerCase());
   const collapsed = isLong && !expanded && !hasSearchMatch;
   const displayContent = collapsed
-    ? message.content.slice(0, COLLAPSED_LENGTH) + "…"
+    ? isTool
+      ? `${toolPreview}…`
+      : message.content.slice(0, COLLAPSED_LENGTH) + "…"
     : message.content;
 
   return (
@@ -86,7 +117,14 @@ export const SessionMessageItem = memo(function SessionMessageItem({
           </span>
         )}
       </div>
-      <div className="whitespace-pre-wrap break-words [overflow-wrap:anywhere] text-sm leading-relaxed min-w-0">
+      <div
+        className={cn(
+          "whitespace-pre-wrap break-words [overflow-wrap:anywhere] text-sm leading-relaxed min-w-0",
+          // 预览取的是前两个源码行，其中的长行折行后视觉上仍可能占三四行；
+          // line-clamp 兜住这种情况，让每条折叠的工具消息高度一致。
+          isTool && collapsed && "line-clamp-2",
+        )}
+      >
         {searchQuery
           ? highlightText(displayContent, searchQuery)
           : displayContent}
@@ -112,7 +150,14 @@ export const SessionMessageItem = memo(function SessionMessageItem({
                 defaultValue: "展开完整内容",
               })}
               <span className="text-muted-foreground/60">
-                ({Math.round(message.content.length / 1000)}k)
+                (
+                {isTool
+                  ? t("sessionManager.lineCount", {
+                      lines: message.content.split("\n").length,
+                      defaultValue: "{{lines}} 行",
+                    })
+                  : `${Math.round(message.content.length / 1000)}k`}
+                )
               </span>
             </>
           )}

--- a/src/components/sessions/SessionMessageItem.tsx
+++ b/src/components/sessions/SessionMessageItem.tsx
@@ -32,7 +32,13 @@ const clampToLines = (content: string, maxLines: number, maxChars: number) => {
   const lines = content.split("\n");
   // 尾部空行不带信息量，去掉可以让预览更紧凑
   const head = lines.slice(0, maxLines).join("\n").trimEnd();
-  return head.length > maxChars ? head.slice(0, maxChars) : head;
+  if (head.length > maxChars) {
+    return { text: head.slice(0, maxChars), truncated: true };
+  }
+  // 命令输出常以换行收尾，被裁掉的部分若只剩空白，展开后并不会多出内容，
+  // 这类消息不应该显示省略号和展开按钮
+  const rest = lines.slice(maxLines).join("\n");
+  return { text: head, truncated: rest.trim().length > 0 };
 };
 
 interface SessionMessageItemProps {
@@ -60,11 +66,11 @@ export const SessionMessageItem = memo(function SessionMessageItem({
             TOOL_PREVIEW_LINES,
             TOOL_PREVIEW_MAX_CHARS,
           )
-        : "",
+        : { text: "", truncated: false },
     [isTool, message.content],
   );
   const isLong = isTool
-    ? toolPreview.length < message.content.length
+    ? toolPreview.truncated
     : message.content.length > COLLAPSE_THRESHOLD;
   const hasSearchMatch =
     isLong &&
@@ -74,7 +80,7 @@ export const SessionMessageItem = memo(function SessionMessageItem({
   const collapsed = isLong && !expanded && !hasSearchMatch;
   const displayContent = collapsed
     ? isTool
-      ? `${toolPreview}…`
+      ? `${toolPreview.text}…`
       : message.content.slice(0, COLLAPSED_LENGTH) + "…"
     : message.content;
 
@@ -153,7 +159,7 @@ export const SessionMessageItem = memo(function SessionMessageItem({
                 (
                 {isTool
                   ? t("sessionManager.lineCount", {
-                      lines: message.content.split("\n").length,
+                      lines: message.content.trimEnd().split("\n").length,
                       defaultValue: "{{lines}} 行",
                     })
                   : `${Math.round(message.content.length / 1000)}k`}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1151,6 +1151,7 @@
     "messageCopied": "Message copied",
     "conversationHistory": "Conversation History",
     "expandContent": "Expand full content",
+    "lineCount": "{{lines}} lines",
     "collapseContent": "Collapse"
   },
   "console": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1151,6 +1151,7 @@
     "messageCopied": "メッセージがコピーされました",
     "conversationHistory": "会話履歴",
     "expandContent": "全文を表示",
+    "lineCount": "{{lines}} 行",
     "collapseContent": "折りたたむ"
   },
   "console": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1152,6 +1152,7 @@
     "messageCopied": "已複製訊息內容",
     "conversationHistory": "對話紀錄",
     "expandContent": "展開完整內容",
+    "lineCount": "{{lines}} 行",
     "collapseContent": "收起"
   },
   "console": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1151,6 +1151,7 @@
     "messageCopied": "已复制消息内容",
     "conversationHistory": "对话记录",
     "expandContent": "展开完整内容",
+    "lineCount": "{{lines}} 行",
     "collapseContent": "收起"
   },
   "console": {

--- a/tests/components/SessionMessageItem.test.tsx
+++ b/tests/components/SessionMessageItem.test.tsx
@@ -38,6 +38,27 @@ describe("SessionMessageItem tool message collapsing", () => {
     expect(screen.queryByRole("button", { name: /展开完整内容/ })).toBeNull();
   });
 
+  it("keeps a tool message that only ends with a newline intact", () => {
+    const { container } = renderMessage("ok\n");
+
+    expect(container.textContent).not.toContain("…");
+    expect(screen.queryByRole("button", { name: /展开完整内容/ })).toBeNull();
+  });
+
+  it("ignores blank tail lines when deciding to collapse", () => {
+    renderMessage(["first line", "second line", "", "  ", ""].join("\n"));
+
+    expect(screen.queryByRole("button", { name: /展开完整内容/ })).toBeNull();
+  });
+
+  it("ignores trailing blank lines in the line count", () => {
+    renderMessage(`${lines(40)}\n\n`);
+
+    expect(
+      screen.getByRole("button", { name: /展开完整内容/ }),
+    ).toHaveTextContent("40");
+  });
+
   it("drops a trailing blank line from the preview", () => {
     const { container } = renderMessage(
       ["heading", "", "body line"].join("\n"),

--- a/tests/components/SessionMessageItem.test.tsx
+++ b/tests/components/SessionMessageItem.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { SessionMessageItem } from "@/components/sessions/SessionMessageItem";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+const renderMessage = (content: string, role = "tool", searchQuery?: string) =>
+  render(
+    <TooltipProvider>
+      <SessionMessageItem
+        message={{ role, content }}
+        isActive={false}
+        searchQuery={searchQuery}
+        onCopy={vi.fn()}
+      />
+    </TooltipProvider>,
+  );
+
+const lines = (count: number, prefix = "line") =>
+  Array.from({ length: count }, (_, i) => `${prefix} ${i}`).join("\n");
+
+describe("SessionMessageItem tool message collapsing", () => {
+  it("collapses a tool message to its first two lines", () => {
+    const { container } = renderMessage(
+      ["first line", "second line", "third line", "fourth line"].join("\n"),
+    );
+
+    expect(container).toHaveTextContent("first line");
+    expect(container).toHaveTextContent("second line");
+    expect(container).not.toHaveTextContent("third line");
+  });
+
+  it("keeps a short tool message intact", () => {
+    const { container } = renderMessage("only one line");
+
+    expect(container).toHaveTextContent("only one line");
+    expect(screen.queryByRole("button", { name: /展开完整内容/ })).toBeNull();
+  });
+
+  it("drops a trailing blank line from the preview", () => {
+    const { container } = renderMessage(
+      ["heading", "", "body line"].join("\n"),
+    );
+
+    expect(container.textContent).toContain("heading…");
+  });
+
+  it("caps an overlong single-line tool message by characters", () => {
+    const { container } = renderMessage("x".repeat(1200));
+    const body = container.querySelector(
+      'div[class*="whitespace-pre-wrap"]',
+    ) as HTMLElement;
+
+    expect(body.textContent?.length).toBeLessThan(400);
+    expect(
+      screen.getByRole("button", { name: /展开完整内容/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("clamps the collapsed preview to two visual lines", () => {
+    const { container } = renderMessage(lines(20));
+    const body = container.querySelector('div[class*="whitespace-pre-wrap"]');
+
+    expect(body?.className).toContain("line-clamp-2");
+  });
+
+  it("reports the line count instead of kilobytes", () => {
+    renderMessage(lines(40));
+
+    expect(
+      screen.getByRole("button", { name: /展开完整内容/ }),
+    ).toHaveTextContent("40");
+  });
+
+  it("expands a tool message to its full content on demand", async () => {
+    const user = userEvent.setup();
+    const { container } = renderMessage(
+      ["first line", "second line", "third line"].join("\n"),
+    );
+
+    await user.click(screen.getByRole("button", { name: /展开完整内容/ }));
+
+    expect(container).toHaveTextContent("third line");
+    expect(
+      container.querySelector('div[class*="whitespace-pre-wrap"]')?.className,
+    ).not.toContain("line-clamp-2");
+  });
+
+  it("does not collapse a tool message whose hidden part matches the search", () => {
+    const { container } = renderMessage(
+      ["first line", "second line", "third line has needle"].join("\n"),
+      "tool",
+      "needle",
+    );
+
+    expect(container).toHaveTextContent("third line has needle");
+    expect(screen.getByText("needle").tagName).toBe("MARK");
+  });
+
+  it("leaves assistant messages on the character threshold", () => {
+    const { container } = renderMessage(
+      lines(40, "assistant line"),
+      "assistant",
+    );
+
+    expect(container).toHaveTextContent("assistant line 39");
+    expect(screen.queryByRole("button", { name: /展开完整内容/ })).toBeNull();
+  });
+
+  it("still collapses a very long assistant message by characters", () => {
+    const { container } = renderMessage("a".repeat(3200), "assistant");
+
+    expect(container.textContent).toContain("…");
+    expect(
+      screen.getByRole("button", { name: /展开完整内容/ }),
+    ).toHaveTextContent("3k");
+  });
+
+  it("leaves user messages untouched", () => {
+    const { container } = renderMessage(lines(40, "user line"), "user");
+
+    expect(container).toHaveTextContent("user line 39");
+    expect(screen.queryByRole("button", { name: /展开完整内容/ })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary / 概述

会话查看器里，工具输出把对话主线埋掉了。给工具消息一套独立的折叠规则：**只显示前两行**，其余收进「展开完整内容」。

同一批样本下，会话视图渲染的内容量减少 **71.5%**，一屏能看到的消息从 3 条变成 6 条。

## Root Cause / 根因

现在所有角色共用 `COLLAPSE_THRESHOLD = 3000` 一个阈值。但工具消息的长度中位数只有 **556 字符**，远在阈值之下——**85% 的工具输出是全文摊开的**。

本机 40 个会话文件、4048 条消息的统计：

| 角色 | 条数 | 占比 | 长度 p50 | p90 | **总字符占比** |
|---|---|---|---|---|---|
| tool | 2632 | 65.0% | 556 | 4054 | **83.7%** |
| assistant | 1123 | 27.7% | 90 | 1008 | 9.5% |
| user | 293 | 7.2% | 97 | 4300 | 6.7% |

**打开一条会话，眼睛看到的内容里有 84% 是命令输出、文件内容和日志，真正的对话只占 16%。**

## Screenshots / 截图

改动前——一屏只装得下用户提问、一条 `Tool: Bash`，然后一条 `vitest` 输出就把剩下的空间吃光了：

![before](https://raw.githubusercontent.com/bigben446/assets/main/cc-switch/fold-tool-messages/01-before.png)

改动后——同一条会话、同一屏，工具输出各缩成两行，对话主线整个浮出来：

![after](https://raw.githubusercontent.com/bigben446/assets/main/cc-switch/fold-tool-messages/02-after.png)

## Why fold instead of rendering Markdown / 为什么是折叠，不是渲染 Markdown

#6844 里我提过另一个方向：让工具消息也走 Markdown 渲染。**数据表明那是错的**，所以这个 PR 换了路子。

对同一批 2511 条工具消息按「结构信号数」（标题 / 围栏 / 表格分隔行 / 加粗 / 列表 / 引用）分档：

- **0 个信号（纯文本）：1931 条，76.9%**
- 1 个信号：466 条，18.6%（灰色地带，多半是日志里的 `- ` 误报）
- ≥2 个信号（确实像 Markdown）：**114 条，4.5%**

同时，6.0% 含日志时间戳、5.3% 含 diff 标记、3.6% 含文件路径。

**给工具消息全量渲染 Markdown，等于为 4.5% 的收益去冒 77% 的误伤风险**：`foo_bar_baz` 的下划线会变斜体、shell 注释的 `#` 会变标题、`ls` 输出的 `-` 会变列表。更要命的是 CommonMark 会把段落内的单换行折成空格——而命令输出、日志、diff 的每一行都是独立的，折掉换行等于毁掉可读性。

折叠没有这些问题：纯削减，不碰解析正确性，需要看全文时点一下展开，展开后仍是保留换行的纯文本，反而更适合读日志。

## Implementation / 实现

```ts
const TOOL_PREVIEW_LINES = 2;
const TOOL_PREVIEW_MAX_CHARS = 300;
```

- **按行折叠，不按字符**。工具输出的排版本来就是按行的：同样 200 个字符，可能是 1 行也可能是 15 行。实测按字符折叠时预览行数的 p90 是 11 行，按行折叠是 8 行——削减比例几乎一样，但按行的视觉高度可预期，每条折叠的工具消息都是整齐的两行
- **字符上限兜底**单行超长的情况（转义路径、压缩过的 JSON）
- **`line-clamp-2` 兜底**：预览取的是前两个源码行，其中的长行折行后视觉上仍可能占三四行，CSS 裁剪保证高度一致（实测折叠后所有工具卡片高度都是 111px，一个不差）
- **去掉尾部空行**，避免预览浪费一行
- 展开按钮、搜索命中自动展开、折叠状态全部复用现有逻辑，未做改动
- 展开按钮的 `(3k)` 字数提示对工具消息改成 `(23 行)`，对命令输出更有意义

assistant 与 user 消息维持原有的 3000 字符行为，不受影响。

## Relation to #6332 / 与 #6332 的关系

两者互补，方向一致——都是让会话记录变得可人工阅读：

- **#6332** 让 AI 的回复按 Markdown 渲染，把最值得读的内容变清晰
- **本 PR** 把工具输出压成两行，把不需要细读的内容压下去

合在一起，会话视图里凸显出来的就只剩**人和模型的对话**，工具调用退成背景中的两行摘要。

两个 PR 都改到 `SessionMessageItem.tsx`，但改的是不同部分，且本 PR 基于当前 `main`、不依赖 #6332。哪个先合并，另一个 rebase 一下即可。

## Related Issue / 关联 Issue

Refs #6844

## Validation / 验证

- `pnpm test:unit` — 新增 `tests/components/SessionMessageItem.test.tsx`，11 条用例；其中 6 条在 revert 组件改动后确认必失败，另外 5 条用于保护 assistant / user 的既有行为
- `pnpm typecheck`
- `pnpm format:check`
- `tests/config/localeCoverage.test.ts` 通过（四个 locale 均已补 `sessionManager.lineCount`）
- Windows 11 上跑 `pnpm dev` 用真实会话确认过效果

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] Cargo checks are not required because no Rust code changed
- [x] i18n updated for en / ja / zh / zh-TW
