### PR TITLE
fix(gemini): resolve thought_signature 400 error in multi-turn tool replay

### DIFF
--- a/src-tauri/src/proxy/providers/gemini_shadow.rs
+++ b/src-tauri/src/proxy/providers/gemini_shadow.rs
@@ -90,6 +90,11 @@ impl GeminiShadowSession {
 struct GeminiShadowInner {
     sessions: HashMap<GeminiShadowKey, GeminiShadowSession>,
     session_order: VecDeque<GeminiShadowKey>,
+    /// Provider-scoped recent turns (aggregated across all sessions of a
+    /// provider). Recovered when a session-scoped lookup misses because the
+    /// client session id is unstable, so thought_signature replay state can
+    /// still be restored.
+    provider_recent: HashMap<String, VecDeque<GeminiAssistantTurn>>,
 }
 
 impl GeminiShadowInner {
@@ -97,6 +102,7 @@ impl GeminiShadowInner {
         Self {
             sessions: HashMap::new(),
             session_order: VecDeque::new(),
+            provider_recent: HashMap::new(),
         }
     }
 }
@@ -159,6 +165,23 @@ impl GeminiShadowStore {
             }
             Self::snapshot_session(&key, session)
         };
+
+        // Keep the provider-scoped recent-turns bucket in sync (LRU across all
+        // sessions of this provider). When the client session id is unstable,
+        // `get_session` misses and this bucket restores thought_signature replay
+        // state so replayed functionCalls still carry their signature.
+        if let Some(latest_turn) = snapshot.turns.last() {
+            let provider_id = &key.provider_id;
+            let bucket = inner
+                .provider_recent
+                .entry(provider_id.clone())
+                .or_insert_with(VecDeque::new);
+            bucket.push_back(latest_turn.clone());
+            while bucket.len() > self.max_turns_per_session {
+                bucket.pop_front();
+            }
+        }
+
         Self::prune_sessions(&mut inner, self.max_sessions);
         snapshot
     }
@@ -202,6 +225,23 @@ impl GeminiShadowStore {
             Self::touch_session_order(&mut inner.session_order, &key);
         }
         snapshot
+    }
+
+    /// Read the most recent assistant turns across all sessions of a provider.
+    ///
+    /// This is the fallback for session-scoped lookups when the client session
+    /// id is unstable (a session key recorded earlier no longer matches the
+    /// follow-up request). Replaying these turns still lets the transform layer
+    /// rebuild its `thought_signature` map keyed by `tool_call.id`.
+    pub fn get_recent_turns(&self, provider_id: &str) -> Vec<GeminiAssistantTurn> {
+        let inner = self.read_inner();
+        inner
+            .provider_recent
+            .get(provider_id)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .collect()
     }
 
     /// Remove a single session from the store.
@@ -395,5 +435,70 @@ mod tests {
         assert_eq!(removed, 1);
         assert!(store.get_session("provider-a", "session-2").is_none());
         assert!(store.get_session("provider-b", "session-3").is_some());
+    }
+
+    #[test]
+    fn get_recent_turns_aggregates_across_sessions() {
+        let store = GeminiShadowStore::with_limits(8, 4);
+
+        store.record_assistant_turn(
+            "provider-a",
+            "session-1",
+            json!({"parts": [{"text": "first", "thought_signature": "sig-1"}]}),
+            vec![GeminiToolCallMeta::new(
+                Some("call-1"),
+                "get_weather",
+                json!({"location": "Tokyo"}),
+                Some("sig-1"),
+            )],
+        );
+        store.record_assistant_turn(
+            "provider-a",
+            "session-2",
+            json!({"parts": [{"text": "second", "thought_signature": "sig-2"}]}),
+            vec![GeminiToolCallMeta::new(
+                Some("call-2"),
+                "search",
+                json!({"q": "alpha"}),
+                Some("sig-2"),
+            )],
+        );
+        // 其他 provider 的 turns 不应混入
+        store.record_assistant_turn("provider-b", "session-1", json!({"text": "other"}), vec![]);
+
+        let turns = store.get_recent_turns("provider-a");
+        assert_eq!(turns.len(), 2);
+        let sigs: Vec<_> = turns
+            .iter()
+            .flat_map(|t| t.tool_calls.iter().filter_map(|c| c.thought_signature.as_deref()))
+            .collect();
+        assert!(sigs.contains(&"sig-1"));
+        assert!(sigs.contains(&"sig-2"));
+    }
+
+    #[test]
+    fn get_recent_turns_recovers_signature_when_session_misses() {
+        let store = GeminiShadowStore::with_limits(8, 4);
+        store.record_assistant_turn(
+            "provider-a",
+            "session-1",
+            json!({"parts": [{"text": "hi", "thought_signature": "sig-1"}]}),
+            vec![GeminiToolCallMeta::new(
+                Some("call-1"),
+                "get_weather",
+                json!({"location": "Tokyo"}),
+                Some("sig-1"),
+            )],
+        );
+
+        // 模拟 session 抖动：后续请求换了一个从未见过的 session_id
+        assert!(store.get_session("provider-a", "session-bogus").is_none());
+
+        // provider 维度仍能取回最近的 turns（含签名），供回放恢复
+        let turns = store.get_recent_turns("provider-a");
+        assert_eq!(turns.len(), 1);
+        let tool_call = &turns[0].tool_calls[0];
+        assert_eq!(tool_call.id.as_deref(), Some("call-1"));
+        assert_eq!(tool_call.thought_signature.as_deref(), Some("sig-1"));
     }
 }

--- a/src-tauri/src/proxy/providers/gemini_shadow.rs
+++ b/src-tauri/src/proxy/providers/gemini_shadow.rs
@@ -91,9 +91,10 @@ struct GeminiShadowInner {
     sessions: HashMap<GeminiShadowKey, GeminiShadowSession>,
     session_order: VecDeque<GeminiShadowKey>,
     /// Provider-scoped recent turns (aggregated across all sessions of a
-    /// provider). Recovered when a session-scoped lookup misses because the
-    /// client session id is unstable, so thought_signature replay state can
-    /// still be restored.
+    /// provider). This is a raw, cross-session bucket — callers MUST narrow it
+    /// back to one conversation (e.g. by the request's tool-call ids) before
+    /// replay, or another session's assistant content / thought signature could
+    /// leak into the current request. See [`GeminiShadowStore::get_recent_turns`].
     provider_recent: HashMap<String, VecDeque<GeminiAssistantTurn>>,
 }
 
@@ -175,7 +176,7 @@ impl GeminiShadowStore {
             let bucket = inner
                 .provider_recent
                 .entry(provider_id.clone())
-                .or_insert_with(VecDeque::new);
+                .or_default();
             bucket.push_back(latest_turn.clone());
             while bucket.len() > self.max_turns_per_session {
                 bucket.pop_front();
@@ -227,12 +228,17 @@ impl GeminiShadowStore {
         snapshot
     }
 
-    /// Read the most recent assistant turns across all sessions of a provider.
+    /// Read the most recent assistant turns across ALL sessions of a provider.
     ///
-    /// This is the fallback for session-scoped lookups when the client session
-    /// id is unstable (a session key recorded earlier no longer matches the
-    /// follow-up request). Replaying these turns still lets the transform layer
-    /// rebuild its `thought_signature` map keyed by `tool_call.id`.
+    /// This is the fallback source for session-scoped lookups when the client
+    /// session id is unstable (a session key recorded earlier no longer matches
+    /// the follow-up request). Because the bucket is provider-wide, callers MUST
+    /// scope the result back to the current conversation before replaying —
+    /// filter by the tool-call ids referenced in the incoming request, which are
+    /// a stable, globally-unique conversation key. Feeding the raw bucket into
+    /// the transform layer would let replay pick another session's turn by tool
+    /// name or position and leak that conversation's content + thought signature
+    /// upstream.
     pub fn get_recent_turns(&self, provider_id: &str) -> Vec<GeminiAssistantTurn> {
         let inner = self.read_inner();
         inner
@@ -470,7 +476,11 @@ mod tests {
         assert_eq!(turns.len(), 2);
         let sigs: Vec<_> = turns
             .iter()
-            .flat_map(|t| t.tool_calls.iter().filter_map(|c| c.thought_signature.as_deref()))
+            .flat_map(|t| {
+                t.tool_calls
+                    .iter()
+                    .filter_map(|c| c.thought_signature.as_deref())
+            })
             .collect();
         assert!(sigs.contains(&"sig-1"));
         assert!(sigs.contains(&"sig-2"));

--- a/src-tauri/src/proxy/providers/streaming_gemini.rs
+++ b/src-tauri/src/proxy/providers/streaming_gemini.rs
@@ -72,8 +72,8 @@ fn extract_tool_calls(
                     .get("args")
                     .cloned()
                     .unwrap_or_else(|| json!({})),
-                part.get("thoughtSignature")
-                    .or_else(|| part.get("thought_signature"))
+                part.get("thought_signature")
+                    .or_else(|| part.get("thoughtSignature"))
                     .and_then(|value| value.as_str()),
             ))
         })
@@ -85,8 +85,8 @@ fn extract_text_thought_signature(parts: &[Value]) -> Option<String> {
         .iter()
         .filter(|part| part.get("text").is_some() && part.get("functionCall").is_none())
         .filter_map(|part| {
-            part.get("thoughtSignature")
-                .or_else(|| part.get("thought_signature"))
+            part.get("thought_signature")
+                .or_else(|| part.get("thoughtSignature"))
                 .and_then(|value| value.as_str())
         })
         .next_back()

--- a/src-tauri/src/proxy/providers/transform_gemini.rs
+++ b/src-tauri/src/proxy/providers/transform_gemini.rs
@@ -58,29 +58,48 @@ pub fn anthropic_to_gemini_with_shadow(
     session_id: Option<&str>,
 ) -> Result<Value, ProxyError> {
     let mut result = json!({});
+    let messages = body.get("messages").and_then(|value| value.as_array());
     let mut shadow_turns = shadow_store
         .zip(provider_id)
         .zip(session_id)
         .and_then(|((store, provider_id), session_id)| store.get_session(provider_id, session_id))
         .map(|snapshot| snapshot.turns)
         .unwrap_or_default();
-    // Fallback: when the client session id is unstable, `get_session` misses and
-    // the shadow turns (and their thought_signatures) are lost. Recover the most
-    // recent turns of this provider so replayed functionCalls still carry their
-    // signature and upstream does not reject with 400 (missing/unknown signature).
+    // Fallback: when the client session id is unstable, `get_session` misses
+    // and the shadow turns (and their thought_signatures) are lost. Recover the
+    // most recent turns of this provider — but scope them back to THIS
+    // conversation first. The provider-wide bucket aggregates every session, so
+    // feeding it in raw would let `convert_messages_to_contents` select another
+    // conversation's turn by tool name or position and leak its assistant
+    // content + thought signature upstream. Tool-call ids referenced in the
+    // request are a stable, globally-unique conversation key, so keep only the
+    // turns that recorded one of those ids.
     if shadow_turns.is_empty() {
         if let Some(provider_id) = provider_id {
-            shadow_turns = shadow_store
+            let recent_turns = shadow_store
                 .map(|store| store.get_recent_turns(provider_id))
                 .unwrap_or_default();
+            if !recent_turns.is_empty() {
+                let request_tool_ids = collect_request_tool_ids(messages.map(Vec::as_slice));
+                if !request_tool_ids.is_empty() {
+                    shadow_turns = recent_turns
+                        .into_iter()
+                        .filter(|turn| {
+                            turn.tool_calls.iter().any(|call| {
+                                call.id
+                                    .as_deref()
+                                    .is_some_and(|id| request_tool_ids.contains(id))
+                            })
+                        })
+                        .collect();
+                }
+            }
         }
     }
     let supports_multimodal_function_response = body
         .get("model")
         .and_then(Value::as_str)
         .is_some_and(is_gemini_3_series);
-
-    let messages = body.get("messages").and_then(|value| value.as_array());
 
     let system_instruction = build_system_instruction(
         body.get("system"),
@@ -542,6 +561,48 @@ fn find_matching_shadow_turn_for_assistant_message(
             })
             .then_some(index)
     })
+}
+
+/// Collect every tool-call id referenced in the request body: both the
+/// `tool_use.id` (assistant messages) and the `tool_result.tool_use_id`
+/// (user messages). These ids are a stable, globally-unique conversation
+/// key — the same id cannot belong to two conversations — so they are the
+/// safe way to scope a provider-wide fallback bucket back down to a single
+/// conversation when the client session id is unstable.
+fn collect_request_tool_ids(messages: Option<&[Value]>) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    let Some(messages) = messages else {
+        return ids;
+    };
+    for message in messages {
+        let Some(blocks) = message.get("content").and_then(|c| c.as_array()) else {
+            continue;
+        };
+        for block in blocks {
+            match block.get("type").and_then(|v| v.as_str()) {
+                Some("tool_use") => {
+                    if let Some(id) = block
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                    {
+                        ids.insert(id.to_string());
+                    }
+                }
+                Some("tool_result") => {
+                    if let Some(id) = block
+                        .get("tool_use_id")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                    {
+                        ids.insert(id.to_string());
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    ids
 }
 
 fn extract_assistant_tool_use_keys(content: Option<&Value>) -> (HashSet<String>, HashSet<String>) {
@@ -2235,6 +2296,167 @@ mod tests {
         assert_eq!(
             result["contents"][0]["parts"][0]["thought_signature"],
             "sig-lookup"
+        );
+    }
+
+    /// Regression for P1 (Codex review): the provider-wide fallback bucket
+    /// aggregates turns from every session of the provider. When a session
+    /// lookup misses, replay must be scoped back to the current conversation by
+    /// the request's tool-call ids. Without the filter, a name-matched turn from
+    /// ANOTHER conversation could be substituted in — leaking that
+    /// conversation's assistant content and thought signature upstream.
+    #[test]
+    fn shadow_fallback_scopes_replay_to_request_tool_ids() {
+        let store = GeminiShadowStore::with_limits(8, 4);
+        // Conversation A recorded a `search` turn.
+        store.record_assistant_turn(
+            "prov",
+            "session-a",
+            json!({
+                "parts": [{
+                    "functionCall": { "id": "call_a", "name": "search", "args": { "q": "from-A" } }
+                }]
+            }),
+            vec![GeminiToolCallMeta::new(
+                Some("call_a"),
+                "search",
+                json!({ "q": "from-A" }),
+                Some("sig-a"),
+            )],
+        );
+        // Conversation B (same provider) recorded a `get_weather` turn whose
+        // name matches the incoming request's tool name.
+        store.record_assistant_turn(
+            "prov",
+            "session-b",
+            json!({
+                "parts": [{
+                    "functionCall": { "id": "call_b", "name": "get_weather", "args": { "city": "Paris" } }
+                }]
+            }),
+            vec![GeminiToolCallMeta::new(
+                Some("call_b"),
+                "get_weather",
+                json!({ "city": "Paris" }),
+                Some("sig-b"),
+            )],
+        );
+
+        // Current request: session id drifted (`get_session` misses). It calls
+        // `get_weather` with a fresh id that exists in NO recorded turn.
+        let input = json!({
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        { "type": "tool_use", "id": "call_fresh", "name": "get_weather", "input": { "city": "Osaka" } }
+                    ]
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        { "type": "tool_result", "tool_use_id": "call_fresh", "content": "cloudy" }
+                    ]
+                }
+            ]
+        });
+
+        let result = anthropic_to_gemini_with_shadow(
+            input,
+            Some(&store),
+            Some("prov"),
+            Some("session-drifted"),
+        )
+        .unwrap();
+
+        // The fallback must NOT replay conversation B's turn. With the id
+        // filter active, no provider turn shares `call_fresh`, so the assistant
+        // message is converted directly — no foreign content/signature leaks.
+        let parts = result["contents"][0]["parts"].as_array().unwrap();
+        assert_eq!(parts.len(), 1);
+        assert_eq!(parts[0]["functionCall"]["name"], "get_weather");
+        assert_eq!(parts[0]["functionCall"]["args"]["city"], "Osaka");
+        assert!(parts[0].get("thought_signature").is_none());
+    }
+
+    /// P1 regression counterpart: when the drifted request DOES reference a
+    /// recorded tool id, the id-filtered fallback must still recover that turn
+    /// so its original Gemini `functionCall` + thought signature replay intact —
+    /// even when another session of the same provider also exists.
+    #[test]
+    fn shadow_fallback_recovers_own_turn_by_request_tool_id() {
+        let store = GeminiShadowStore::with_limits(8, 4);
+        store.record_assistant_turn(
+            "prov",
+            "session-a",
+            json!({
+                "parts": [{
+                    "functionCall": { "id": "call_a", "name": "get_weather", "args": { "city": "Tokyo" } },
+                    "thought_signature": "sig-a"
+                }]
+            }),
+            vec![GeminiToolCallMeta::new(
+                Some("call_a"),
+                "get_weather",
+                json!({ "city": "Tokyo" }),
+                Some("sig-a"),
+            )],
+        );
+        // Another conversation on the same provider must not interfere.
+        store.record_assistant_turn(
+            "prov",
+            "session-b",
+            json!({
+                "parts": [{
+                    "functionCall": { "id": "call_b", "name": "get_weather", "args": { "city": "Paris" } },
+                    "thought_signature": "sig-b"
+                }]
+            }),
+            vec![GeminiToolCallMeta::new(
+                Some("call_b"),
+                "get_weather",
+                json!({ "city": "Paris" }),
+                Some("sig-b"),
+            )],
+        );
+
+        let input = json!({
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        { "type": "tool_use", "id": "call_a", "name": "get_weather", "input": { "city": "Tokyo" } }
+                    ]
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        { "type": "tool_result", "tool_use_id": "call_a", "content": "sunny" }
+                    ]
+                }
+            ]
+        });
+
+        let result = anthropic_to_gemini_with_shadow(
+            input,
+            Some(&store),
+            Some("prov"),
+            Some("session-drifted"),
+        )
+        .unwrap();
+
+        // Recovered from conversation A (id call_a), not B.
+        assert_eq!(
+            result["contents"][0]["parts"][0]["functionCall"]["name"],
+            "get_weather"
+        );
+        assert_eq!(
+            result["contents"][0]["parts"][0]["functionCall"]["args"]["city"],
+            "Tokyo"
+        );
+        assert_eq!(
+            result["contents"][0]["parts"][0]["thought_signature"],
+            "sig-a"
         );
     }
 

--- a/src-tauri/src/proxy/providers/transform_gemini.rs
+++ b/src-tauri/src/proxy/providers/transform_gemini.rs
@@ -58,12 +58,23 @@ pub fn anthropic_to_gemini_with_shadow(
     session_id: Option<&str>,
 ) -> Result<Value, ProxyError> {
     let mut result = json!({});
-    let shadow_turns = shadow_store
+    let mut shadow_turns = shadow_store
         .zip(provider_id)
         .zip(session_id)
         .and_then(|((store, provider_id), session_id)| store.get_session(provider_id, session_id))
         .map(|snapshot| snapshot.turns)
         .unwrap_or_default();
+    // Fallback: when the client session id is unstable, `get_session` misses and
+    // the shadow turns (and their thought_signatures) are lost. Recover the most
+    // recent turns of this provider so replayed functionCalls still carry their
+    // signature and upstream does not reject with 400 (missing/unknown signature).
+    if shadow_turns.is_empty() {
+        if let Some(provider_id) = provider_id {
+            shadow_turns = shadow_store
+                .map(|store| store.get_recent_turns(provider_id))
+                .unwrap_or_default();
+        }
+    }
     let supports_multimodal_function_response = body
         .get("model")
         .and_then(Value::as_str)
@@ -684,14 +695,16 @@ fn convert_message_content_to_parts(
                 // Re-attach the thought_signature that Gemini originally
                 // associated with this functionCall.  The Anthropic format
                 // strips it from the tool_use block, but Gemini requires it
-                // on every functionCall in a multi-turn tool-use exchange.
-                // Without replaying the stored signature the upstream may
-                // reject with "missing a `thought_signature`".
+                // as a Part-level field (a sibling of `functionCall`), NOT
+                // inside the FunctionCall message itself. Putting it inside
+                // function_call triggers:
+                //   `400 Unknown name "thought_signature" ...function_call: Cannot find field.`
+                let mut part = json!({ "functionCall": function_call });
                 if let Some(sig) = thought_signature_by_id.get(id) {
-                    function_call["thoughtSignature"] = json!(sig);
+                    part["thought_signature"] = json!(sig);
                 }
 
-                parts.push(json!({ "functionCall": function_call }));
+                parts.push(part);
             }
             "tool_result" => {
                 let tool_use_id = block
@@ -1135,8 +1148,8 @@ fn extract_tool_call_meta(parts: &[Value]) -> Vec<GeminiToolCallMeta> {
                     .get("args")
                     .cloned()
                     .unwrap_or_else(|| json!({})),
-                part.get("thoughtSignature")
-                    .or_else(|| part.get("thought_signature"))
+                part.get("thought_signature")
+                    .or_else(|| part.get("thoughtSignature"))
                     .and_then(|value| value.as_str()),
             ))
         })
@@ -2005,7 +2018,7 @@ mod tests {
                         "name": "Bash",
                         "args": { "command": "ls -R" }
                     },
-                    "thoughtSignature": "sig-tool-1"
+                    "thought_signature": "sig-tool-1"
                 }]
             }),
             vec![GeminiToolCallMeta::new(
@@ -2053,7 +2066,7 @@ mod tests {
             "Bash"
         );
         assert_eq!(
-            result["contents"][0]["parts"][0]["thoughtSignature"],
+            result["contents"][0]["parts"][0]["thought_signature"],
             "sig-tool-1"
         );
     }
@@ -2077,7 +2090,7 @@ mod tests {
                         "name": "server_a:search",
                         "args": { "q": "alpha" }
                     },
-                    "thoughtSignature": "sig-a"
+                    "thought_signature": "sig-a"
                 }]
             }),
             vec![GeminiToolCallMeta::new(
@@ -2097,7 +2110,7 @@ mod tests {
                         "name": "server_b:search",
                         "args": { "q": "beta" }
                     },
-                    "thoughtSignature": "sig-b"
+                    "thought_signature": "sig-b"
                 }]
             }),
             vec![GeminiToolCallMeta::new(
@@ -2151,7 +2164,7 @@ mod tests {
             "server_b:search"
         );
         assert_eq!(
-            result["contents"][0]["parts"][0]["thoughtSignature"],
+            result["contents"][0]["parts"][0]["thought_signature"],
             "sig-b"
         );
         // msg[2] replays shadow turn 0 (server_a:search) because id=call_a,
@@ -2161,7 +2174,7 @@ mod tests {
             "server_a:search"
         );
         assert_eq!(
-            result["contents"][2]["parts"][0]["thoughtSignature"],
+            result["contents"][2]["parts"][0]["thought_signature"],
             "sig-a"
         );
     }
@@ -2181,7 +2194,7 @@ mod tests {
                         "name": "lookup",
                         "args": {}
                     },
-                    "thoughtSignature": "sig-lookup"
+                    "thought_signature": "sig-lookup"
                 }]
             }),
             vec![GeminiToolCallMeta::new(
@@ -2220,7 +2233,7 @@ mod tests {
             "lookup"
         );
         assert_eq!(
-            result["contents"][0]["parts"][0]["thoughtSignature"],
+            result["contents"][0]["parts"][0]["thought_signature"],
             "sig-lookup"
         );
     }

--- a/src-tauri/src/proxy/providers/transform_gemini.rs
+++ b/src-tauri/src/proxy/providers/transform_gemini.rs
@@ -28,6 +28,14 @@ pub type AnthropicToolSchemaHints = HashMap<String, AnthropicToolSchemaHint>;
 /// to Gemini as `functionResponse.id`.
 pub(crate) const SYNTHESIZED_ID_PREFIX: &str = "gemini_synth_";
 
+/// Google-documented sentinel for `thought_signature` that makes the API skip
+/// signature validation instead of rejecting the request with a 400
+/// ("Function call is missing a thought_signature"). Used when the original
+/// signature cannot be recovered (shadow state lost, session drift, restored
+/// history). See:
+/// https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/thinking/thought-signatures
+const SKIP_THOUGHT_SIGNATURE_VALIDATOR: &str = "skip_thought_signature_validator";
+
 /// Generate a unique tool-call id that is safe to expose to Anthropic clients
 /// but must not be sent upstream to Gemini. Uses UUID v4 simple encoding
 /// (32 lowercase hex chars) so that any number of parallel calls in the same
@@ -763,6 +771,16 @@ fn convert_message_content_to_parts(
                 let mut part = json!({ "functionCall": function_call });
                 if let Some(sig) = thought_signature_by_id.get(id) {
                     part["thought_signature"] = json!(sig);
+                } else {
+                    // Signature unrecoverable (shadow state lost, session
+                    // drift, restored history): an unsigned replayed
+                    // functionCall is rejected by Gemini with a 400, so use
+                    // Google's documented sentinel instead — the API skips
+                    // validation and issues a fresh signature on the next
+                    // turn, keeping the conversation going. Gemini 3 parallel
+                    // calls legitimately carry no signature on non-first
+                    // calls; for them the sentinel is a no-op skip.
+                    part["thought_signature"] = json!(SKIP_THOUGHT_SIGNATURE_VALIDATOR);
                 }
 
                 parts.push(part);
@@ -2372,11 +2390,48 @@ mod tests {
         // The fallback must NOT replay conversation B's turn. With the id
         // filter active, no provider turn shares `call_fresh`, so the assistant
         // message is converted directly — no foreign content/signature leaks.
+        // Without a recoverable signature, the official sentinel is attached so
+        // the request is not rejected with a 400.
         let parts = result["contents"][0]["parts"].as_array().unwrap();
         assert_eq!(parts.len(), 1);
         assert_eq!(parts[0]["functionCall"]["name"], "get_weather");
         assert_eq!(parts[0]["functionCall"]["args"]["city"], "Osaka");
-        assert!(parts[0].get("thought_signature").is_none());
+        assert_eq!(
+            parts[0]["thought_signature"],
+            "skip_thought_signature_validator"
+        );
+    }
+
+    /// When a tool_use cannot be matched to any shadow turn (signature
+    /// unrecoverable), the replayed functionCall must not go out unsigned —
+    /// Gemini rejects unsigned replayed functionCalls with 400. The
+    /// documented sentinel `skip_thought_signature_validator` is attached
+    /// instead, so Gemini skips validation and issues a fresh signature on the
+    /// next turn.
+    #[test]
+    fn unsigned_tool_use_gets_sentinel_thought_signature() {
+        let input = json!({
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": [
+                        { "type": "tool_use", "id": "call_unknown", "name": "get_weather", "input": { "city": "Osaka" } }
+                    ]
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        { "type": "tool_result", "tool_use_id": "call_unknown", "content": "cloudy" }
+                    ]
+                }
+            ]
+        });
+
+        let result = anthropic_to_gemini(input).unwrap();
+        assert_eq!(
+            result["contents"][0]["parts"][0]["thought_signature"],
+            "skip_thought_signature_validator"
+        );
     }
 
     /// P1 regression counterpart: when the drifted request DOES reference a


### PR DESCRIPTION
### Summary of Changes

Fixes #6833 (Related #4245)

This PR resolves the frequent `400 Invalid JSON payload received` and `400 Function call is missing a thought_signature` errors during multi-turn tool replay with Gemini Native.

#### Root Causes
1. **Wrong schema location**: In `transform_gemini.rs`, `thought_signature` was serialized inside the `functionCall` object payload rather than at the `Part` level (as a sibling of `functionCall`). Gemini protojson rejects unknown fields on `FunctionCall` with `Unknown name "thought_signature" ... Cannot find field`.
2. **Session ID instability**: In `transform_gemini.rs`, shadow turns lookup relied strictly on `(provider_id, session_id)`. When client session IDs drift or are omitted across tool turns (e.g. Claude Code / Claude Desktop tool calls), `get_session` returns `None`, causing all stored thought signatures to be lost.

#### Key Fixes
1. **Part-level thought_signature**: Moved `thought_signature` attachment to the `Part` level alongside `functionCall`.
2. **Provider-scoped Fallback**: Added a bounded LRU `provider_recent` index and `get_recent_turns(provider_id)` in `gemini_shadow.rs`. When a session-scoped lookup misses, the transform layer recovers the most recent turns for the provider so `thought_signature_by_id` can still be populated by `tool_call.id`.
3. **Naming Alignment**: Aligned extraction and replay to prioritize snake_case `thought_signature`, preserving camelCase `thoughtSignature` purely for backward-compatibility.
4. **Unit Tests**: Added 2 new unit tests in `gemini_shadow.rs` covering cross-session turn aggregation and signature recovery when session lookups miss.

#### Verification
- `cargo check`: Passed
- `cargo test --lib gemini_shadow`: 7/7 passed
- `cargo test --lib transform_gemini`: 30/30 passed
- `cargo test --lib`: All lib unit tests passed
- Full `tauri build` & live verification with Claude Code multi-turn tool calls: Verified working smoothly without 400 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>
