### PR TITLE
fix(codex): mark glm-5.3 as text-only

### DIFF
--- a/src-tauri/src/model_capabilities.rs
+++ b/src-tauri/src/model_capabilities.rs
@@ -79,6 +79,7 @@ pub(crate) fn is_confirmed_text_only_model(model: &str) -> bool {
         // Exact rather than prefix matching: GLM visual models use a `v`
         // suffix (for example glm-5.2v), which must remain image-capable.
         "glm-5.2",
+        "glm-5.3",
         "kat-coder",
         "kat-coder-pro",
         "kat-coder-pro v1",
@@ -217,6 +218,7 @@ mod tests {
     fn confirmed_text_only_registry_normalizes_namespaces_and_context_markers() {
         assert!(is_confirmed_text_only_model("deepseek/deepseek-v4-pro"));
         assert!(is_confirmed_text_only_model("GLM-5.2[1M]"));
+        assert!(is_confirmed_text_only_model("GLM-5.3[1M]"));
         assert!(is_confirmed_text_only_model("qwen/qwen3-coder-plus"));
         assert!(is_confirmed_text_only_model(
             "Qwen/Qwen3-Coder-480B-A35B-Instruct"
@@ -224,6 +226,7 @@ mod tests {
         assert!(is_confirmed_text_only_model("MiniMax-M2.7-Highspeed"));
         assert!(is_confirmed_text_only_model("step-3.5-flash-2603"));
         assert!(!is_confirmed_text_only_model("glm-5.2v"));
+        assert!(!is_confirmed_text_only_model("glm-5.3v"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `glm-5.3` to the exact text-only model capability registry
- keep `glm-5.3v` fail-open as image-capable
- extend the existing registry regression coverage

Fixes #6836

## Validation

Locally verified the registry behavior.