### PR TITLE
fix(proxy): treat model-unavailable 400 as retryable

### DIFF
--- a/src-tauri/src/proxy/error.rs
+++ b/src-tauri/src/proxy/error.rs
@@ -204,37 +204,31 @@ pub(crate) fn is_upstream_model_unavailable(error: &ProxyError) -> bool {
         return false;
     };
 
-    let raw = body.to_ascii_lowercase();
-    if has_model_unavailable_phrase(&raw) {
-        return true;
-    }
-
-    let message = extract_upstream_error_text(body).to_ascii_lowercase();
-    has_model_unavailable_phrase(&message)
+    extract_upstream_error_fields(body)
+        .into_iter()
+        .any(|field| has_model_unavailable_phrase(&field.to_ascii_lowercase()))
 }
 
-fn extract_upstream_error_text(body: &str) -> String {
+/// JSON 只看公认的错误字段，避免把回显的请求体/诊断上下文当成模型下线信号。
+/// 非 JSON 时整段 body 就是错误文本。
+fn extract_upstream_error_fields(body: &str) -> Vec<String> {
     let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
-        return body.to_string();
+        return vec![body.to_string()];
     };
 
-    let candidates = [
-        value.pointer("/error/message"),
-        value.pointer("/error/code"),
-        value.pointer("/error/type"),
-        value.pointer("/message"),
-        value.pointer("/detail"),
-        value.pointer("/error"),
+    const POINTERS: &[&str] = &[
+        "/error/message",
+        "/error/code",
+        "/error/type",
+        "/message",
+        "/detail",
+        "/error",
     ];
-    if let Some(message) = candidates
-        .into_iter()
-        .flatten()
-        .find_map(|value| value.as_str())
-    {
-        return message.to_string();
-    }
-
-    serde_json::to_string(&value).unwrap_or_else(|_| body.to_string())
+    POINTERS
+        .iter()
+        .filter_map(|pointer| value.pointer(pointer).and_then(serde_json::Value::as_str))
+        .map(str::to_string)
+        .collect()
 }
 
 fn has_model_unavailable_phrase(text: &str) -> bool {
@@ -321,6 +315,22 @@ mod tests {
         assert!(!is_upstream_model_unavailable(&unavailable_error(
             401,
             r#"{"error":{"message":"Model is unavailable."}}"#
+        )));
+    }
+
+    #[test]
+    fn echoed_request_body_is_not_treated_as_model_unavailable() {
+        let body = r#"{"error":{"message":"invalid json schema"},"input":"please retry if model not found"}"#;
+        assert!(!is_upstream_model_unavailable(&unavailable_error(
+            400, body
+        )));
+    }
+
+    #[test]
+    fn plain_text_body_is_scanned() {
+        assert!(is_upstream_model_unavailable(&unavailable_error(
+            400,
+            "Model is unavailable."
         )));
     }
 }

--- a/src-tauri/src/proxy/error.rs
+++ b/src-tauri/src/proxy/error.rs
@@ -191,6 +191,68 @@ pub enum ErrorCategory {
     ClientAbort, // 客户端主动中断
 }
 
+/// 上游 400/422 明确表示目标模型不可用时，失败在供应商侧（映射目标已下线/不存在），
+/// 换一家 provider 可能成功。不要把这类错误当成客户端请求格式问题（issue #6821）。
+pub(crate) fn is_upstream_model_unavailable(error: &ProxyError) -> bool {
+    let ProxyError::UpstreamError { status, body } = error else {
+        return false;
+    };
+    if !matches!(*status, 400 | 422) {
+        return false;
+    }
+    let Some(body) = body.as_deref() else {
+        return false;
+    };
+
+    let raw = body.to_ascii_lowercase();
+    if has_model_unavailable_phrase(&raw) {
+        return true;
+    }
+
+    let message = extract_upstream_error_text(body).to_ascii_lowercase();
+    has_model_unavailable_phrase(&message)
+}
+
+fn extract_upstream_error_text(body: &str) -> String {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return body.to_string();
+    };
+
+    let candidates = [
+        value.pointer("/error/message"),
+        value.pointer("/error/code"),
+        value.pointer("/error/type"),
+        value.pointer("/message"),
+        value.pointer("/detail"),
+        value.pointer("/error"),
+    ];
+    if let Some(message) = candidates
+        .into_iter()
+        .flatten()
+        .find_map(|value| value.as_str())
+    {
+        return message.to_string();
+    }
+
+    serde_json::to_string(&value).unwrap_or_else(|_| body.to_string())
+}
+
+fn has_model_unavailable_phrase(text: &str) -> bool {
+    const PHRASES: &[&str] = &[
+        "model is unavailable",
+        "model unavailable",
+        "model_not_found",
+        "model not found",
+        "no such model",
+        "model does not exist",
+        "model doesn't exist",
+        "模型不可用",
+        "模型不存在",
+        "模型已下线",
+    ];
+    PHRASES.iter().any(|phrase| text.contains(phrase))
+}
+
 /// 判断错误是否可重试
 #[allow(dead_code)]
 pub fn categorize_error(error: &reqwest::Error) -> ErrorCategory {
@@ -208,5 +270,57 @@ pub fn categorize_error(error: &reqwest::Error) -> ErrorCategory {
         }
     } else {
         ErrorCategory::Retryable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unavailable_error(status: u16, body: &str) -> ProxyError {
+        ProxyError::UpstreamError {
+            status,
+            body: Some(body.to_string()),
+        }
+    }
+
+    #[test]
+    fn issue_body_model_is_unavailable_is_detected() {
+        let body = r#"{"error":{"type":"server_error","message":"Error from provider (Console): Upstream request failed: Model is unavailable."}}"#;
+        assert!(is_upstream_model_unavailable(&unavailable_error(400, body)));
+    }
+
+    #[test]
+    fn openai_model_not_found_code_is_detected() {
+        let body = r#"{"error":{"message":"The model `gpt-5` does not exist","type":"invalid_request_error","code":"model_not_found"}}"#;
+        assert!(is_upstream_model_unavailable(&unavailable_error(400, body)));
+    }
+
+    #[test]
+    fn chinese_model_offline_message_is_detected() {
+        assert!(is_upstream_model_unavailable(&unavailable_error(
+            422,
+            r#"{"error":{"message":"模型已下线"}}"#
+        )));
+    }
+
+    #[test]
+    fn generic_client_400_is_not_treated_as_model_unavailable() {
+        let body = r#"{"error":{"message":"invalid request: missing required field"}}"#;
+        assert!(!is_upstream_model_unavailable(&unavailable_error(
+            400, body
+        )));
+        assert!(!is_upstream_model_unavailable(&unavailable_error(
+            400,
+            r#"{"error":{"message":"field does not exist"}}"#
+        )));
+        assert!(!is_upstream_model_unavailable(&ProxyError::UpstreamError {
+            status: 400,
+            body: None,
+        }));
+        assert!(!is_upstream_model_unavailable(&unavailable_error(
+            401,
+            r#"{"error":{"message":"Model is unavailable."}}"#
+        )));
     }
 }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -2788,12 +2788,24 @@ impl RequestForwarder {
             //   415 Unsupported Media Type                    ← Content-Type 错误
             //   501 Not Implemented                           ← 上游协议确实不支持
             //
+            // 例外：400/422 若错误体明确写模型已下线/不存在，失败在供应商侧
+            // （failover 映射目标已死），换一家可能成功，应参与熔断与故障转移
+            // （issue #6821）。
+            //
             // 其他 4xx（401/403/404/408/409/429/451 等）和全部 5xx 都保留
             // Retryable —— 换一家 provider 可能持有不同的 key、配额、地域或模型映射。
-            ProxyError::UpstreamError { status, .. } => match *status {
-                400 | 405 | 406 | 413 | 414 | 415 | 422 | 501 => ErrorCategory::NonRetryable,
-                _ => ErrorCategory::Retryable,
-            },
+            ProxyError::UpstreamError { status, .. } => {
+                if is_upstream_model_unavailable(error) {
+                    ErrorCategory::Retryable
+                } else {
+                    match *status {
+                        400 | 405 | 406 | 413 | 414 | 415 | 422 | 501 => {
+                            ErrorCategory::NonRetryable
+                        }
+                        _ => ErrorCategory::Retryable,
+                    }
+                }
+            }
             // Provider 级配置/转换问题：换一个 Provider 可能就能成功
             ProxyError::ConfigError(_) => ErrorCategory::Retryable,
             ProxyError::TransformError(_) => ErrorCategory::Retryable,
@@ -4551,6 +4563,37 @@ mod tests {
     }
 
     #[test]
+    fn upstream_400_model_unavailable_is_retryable() {
+        let forwarder = test_forwarder(Duration::ZERO, Duration::ZERO);
+        let provider = test_provider_with_type(None);
+        let error = ProxyError::UpstreamError {
+            status: 400,
+            body: Some(
+                r#"{"error":{"type":"server_error","message":"Error from provider (Console): Upstream request failed: Model is unavailable."}}"#
+                    .to_string(),
+            ),
+        };
+        assert_eq!(
+            forwarder.categorize_proxy_error(&error, &provider),
+            ErrorCategory::Retryable
+        );
+    }
+
+    #[test]
+    fn generic_upstream_400_stays_non_retryable() {
+        let forwarder = test_forwarder(Duration::ZERO, Duration::ZERO);
+        let provider = test_provider_with_type(None);
+        let error = ProxyError::UpstreamError {
+            status: 400,
+            body: Some(r#"{"error":{"message":"invalid json schema"}}"#.to_string()),
+        };
+        assert_eq!(
+            forwarder.categorize_proxy_error(&error, &provider),
+            ErrorCategory::NonRetryable
+        );
+    }
+
+    #[test]
     fn official_codex_failures_are_not_retryable() {
         let forwarder = test_forwarder(Duration::ZERO, Duration::ZERO);
         let mut provider = test_provider_with_type(None);
@@ -4570,6 +4613,10 @@ mod tests {
             ProxyError::UpstreamError {
                 status: 429,
                 body: None,
+            },
+            ProxyError::UpstreamError {
+                status: 400,
+                body: Some(r#"{"error":{"message":"Model is unavailable."}}"#.to_string()),
             },
             ProxyError::Timeout("timeout".to_string()),
         ] {


### PR DESCRIPTION
## Summary / 概述

`categorize_proxy_error()` treated every 400/422 as a client-side request error (`NonRetryable`). When a failover target's mapped model had already been taken offline, the upstream still returned 400 with `"Model is unavailable"`. That never counted toward the circuit breaker and never skipped to the next provider, so Claude Code's concurrent classifier requests kept hanging on the dead card.

This PR only reclassifies 400/422 bodies that explicitly say the model is unavailable / not found / already offline. Generic client 400s (schema, missing fields) stay `NonRetryable`. Official Codex routes still never fail over.

## Related Issue / 关联 Issue

Fixes #6821

## Screenshots / 截图

N/A — backend error classification only.

## Checklist / 检查清单

- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
