### PR TITLE
fix(model-catalog): add glm-5.3 to confirmed text-only model list (#6836)

### DIFF
--- a/src-tauri/src/model_capabilities.rs
+++ b/src-tauri/src/model_capabilities.rs
@@ -79,6 +79,7 @@ pub(crate) fn is_confirmed_text_only_model(model: &str) -> bool {
         // Exact rather than prefix matching: GLM visual models use a `v`
         // suffix (for example glm-5.2v), which must remain image-capable.
         "glm-5.2",
+        "glm-5.3",
         "kat-coder",
         "kat-coder-pro",
         "kat-coder-pro v1",


### PR DESCRIPTION
## What Problem This Solves

Zhipu GLM-5.3 does not support image input, but CC Switch's model catalog marks it as image-capable. When Codex sends a screenshot to GLM-5.3, the upstream rejects it with HTTP 400: `messages.content.type 参数非法，取值范围 ['text']`.

## Why This Change Was Made

The `CONFIRMED_TAILS` list in `model_capabilities.rs` contains `glm-5.1` and `glm-5.2` as confirmed text-only models, but `glm-5.3` was missing. The fail-open default (`Unknown → Supported`) treated it as image-capable.

## User Impact

GLM-5.3 is now correctly identified as text-only. Codex will not send image content to this model, preventing the HTTP 400 error.

## Evidence

- Issue: https://github.com/farion1231/cc-switch/issues/6836
- Root cause: `glm-5.3` missing from `CONFIRMED_TAILS` in `model_capabilities.rs:72-102`
- Fix: added `"glm-5.3"` to the list, matching the pattern of `glm-5.1` and `glm-5.2`
- 1 file changed, 1 insertion
