### PR TITLE
fix(ci): stabilize WSL2 nightly backend test workflow

### DIFF
--- a/.github/workflows/wsl2-nightly.yml
+++ b/.github/workflows/wsl2-nightly.yml
@@ -60,15 +60,51 @@ jobs:
 
       - name: Compile backend tests with native temp
         # link.exe/mt.exe cannot create manifests when TEMP points at a WSL UNC path.
-        run: cargo test --tests --manifest-path src-tauri/Cargo.toml --no-run
+        # Record the built test binary paths so the run steps below can execute
+        # them directly instead of re-invoking cargo with TEMP on \\wsl.localhost.
+        env:
+          TEMP: ${{ runner.temp }}
+          TMP: ${{ runner.temp }}
+        shell: pwsh
+        run: |
+          $binariesFile = Join-Path $env:RUNNER_TEMP "cc-switch-test-binaries.txt"
+          "TEST_BINARIES_FILE=$binariesFile" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $testBinary = $null
+          $binaries = cargo test --tests --manifest-path src-tauri/Cargo.toml --no-run --message-format=json |
+            ForEach-Object {
+              if ($_ -match '"reason":"compiler-artifact"') {
+                $artifact = $_ | ConvertFrom-Json
+                if ($artifact.executable -and $artifact.profile.test) {
+                  if ($artifact.target.name -eq 'cc_switch_lib') {
+                    $testBinary = $artifact.executable
+                  }
+                  $artifact.executable
+                }
+              }
+            } |
+            Sort-Object -Unique
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          if (-not $testBinary) {
+            throw "cc_switch_lib test binary not found in cargo compiler artifacts"
+          }
+          if (-not $binaries -or $binaries.Count -eq 0) {
+            throw "No test binaries found in cargo compiler artifacts"
+          }
+          "CC_SWITCH_TEST_EXE=$testBinary" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          $binaries | Set-Content -LiteralPath $binariesFile
 
       - name: Run Windows-to-WSL2 filesystem contract
+        # Run the test binary built in the previous step directly. Invoking cargo
+        # here with TEMP pointing at a WSL UNC path can re-link the crate, and
+        # link.exe/mt.exe cannot create manifest temp files on \\wsl.localhost.
         shell: pwsh
         run: |
           $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $testName = "config::tests::atomic_write_replaces_existing_wsl_unc_file"
-          $testList = cargo test --tests --manifest-path src-tauri/Cargo.toml -- --ignored --list
+          $testList = & $env:CC_SWITCH_TEST_EXE --list --ignored
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -76,7 +112,7 @@ jobs:
           if ($testList -notcontains $expected) {
             throw "Expected ignored test was not discovered: $testName"
           }
-          cargo test --tests --manifest-path src-tauri/Cargo.toml $testName -- --ignored --exact --nocapture
+          & $env:CC_SWITCH_TEST_EXE $testName --ignored --exact --nocapture
           if ($LASTEXITCODE -ne 0) {
             exit $LASTEXITCODE
           }
@@ -86,4 +122,13 @@ jobs:
         run: |
           $env:TEMP = $env:CC_SWITCH_WSL_TEST_TEMP
           $env:TMP = $env:CC_SWITCH_WSL_TEST_TEMP
-          cargo test --tests --manifest-path src-tauri/Cargo.toml -- --test-threads=1
+          $binaries = @(Get-Content -LiteralPath $env:TEST_BINARIES_FILE)
+          if ($binaries.Count -eq 0) {
+            throw "No test binaries recorded in $env:TEST_BINARIES_FILE"
+          }
+          foreach ($bin in $binaries) {
+            & $bin --test-threads=1
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
+          }


### PR DESCRIPTION
## Summary / 概述

<!-- Briefly describe what this PR does and why. / 简要描述这个 PR 做了什么以及为什么。 -->

Reintroduce the WSL2 nightly backend test workflow with a more stable execution flow.

The previous workflow could trigger a cargo relink after switching `TEMP` to the WSL2 UNC path (`\\wsl.localhost`), which could cause `link.exe`/`mt.exe` manifest creation failures on Windows.

This PR builds the test binaries with the native Windows temporary directory first, then executes the already-built binaries against the WSL2-backed test environment. This keeps the WSL2 filesystem compatibility coverage while avoiding the previous relinking issue.

## Related Issue / 关联 Issue

<!-- Link the related issue. Use "Fixes #123" to auto-close it when merged. -->
<!-- 关联相关 Issue。使用 "Fixes #123" 可在合并时自动关闭。 -->

Related to #6472 
 

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件