### PR TITLE
fix(codex): preserve non-managed [model_providers.*] sections on config write

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -987,10 +987,15 @@ pub fn write_codex_live_atomic(
         None
     };
 
-    // 准备写入内容
-    let cfg_text = match config_text_opt {
+    // 准备写入内容，同时 merge live config 中非 CC-Switch 管理的 sections
+    let raw_cfg_text = match config_text_opt {
         Some(s) => s.to_string(),
         None => String::new(),
+    };
+    let cfg_text = if raw_cfg_text.trim().is_empty() {
+        raw_cfg_text
+    } else {
+        merge_live_non_managed_provider_sections(&raw_cfg_text)?
     };
     if !cfg_text.trim().is_empty() {
         toml::from_str::<toml::Table>(&cfg_text).map_err(|e| AppError::toml(&config_path, e))?;
@@ -1057,6 +1062,69 @@ pub(crate) fn is_custom_codex_model_provider_id(id: &str) -> bool {
     !id.is_empty() && !CODEX_RESERVED_MODEL_PROVIDER_IDS.contains(&id)
 }
 
+/// Merge non-CC-Switch-managed `[model_providers.*]` sections from the live
+/// config.toml into the config text about to be written.
+///
+/// CC Switch only stores its own active provider in the database. When it
+/// writes config.toml, any `[model_providers.*]` sections that were
+/// manually added by the user (legacy aliases, third-party providers, etc.)
+/// are silently dropped because they never existed in the DB-stored config.
+///
+/// This function reads the current live config.toml, identifies sections
+/// that are NOT present in the new config (i.e., not managed by CC Switch),
+/// and merges them back in. This preserves user-added provider aliases that
+/// old Codex threads may reference.
+fn merge_live_non_managed_provider_sections(new_config: &str) -> Result<String, AppError> {
+    if new_config.trim().is_empty() {
+        return Ok(new_config.to_string());
+    }
+
+    let live_path = get_codex_config_path();
+    if !live_path.exists() {
+        return Ok(new_config.to_string());
+    }
+
+    let live_text = fs::read_to_string(&live_path).unwrap_or_default();
+    if live_text.trim().is_empty() {
+        return Ok(new_config.to_string());
+    }
+
+    let live_doc = live_text.parse::<DocumentMut>().unwrap_or_default();
+    let mut new_doc = new_config.parse::<DocumentMut>().unwrap_or_default();
+
+    let live_providers = match live_doc.get("model_providers") {
+        Some(item) => item.as_table_like(),
+        None => None,
+    };
+    let live_providers = match live_providers {
+        Some(t) => t,
+        None => return Ok(new_config.to_string()),
+    };
+
+    for (id, live_section) in live_providers.iter() {
+        // id is &str from toml_edit table iteration — no .as_str() needed.
+        // Skip if the new config already has this section (CC Switch manages it).
+        if let Some(new_providers) = new_doc
+            .get("model_providers")
+            .and_then(|item| item.as_table_like())
+        {
+            if new_providers.contains_key(id) {
+                continue;
+            }
+        }
+
+        // This section exists in live but not in the new config — preserve it.
+        if let Some(new_providers) = new_doc
+            .get_mut("model_providers")
+            .and_then(|item| item.as_table_like_mut())
+        {
+            new_providers.insert(id, live_section.clone());
+        }
+    }
+
+    Ok(new_doc.to_string())
+}
+
 /// Write only Codex `config.toml` for provider switching.
 ///
 /// Codex login state lives in `auth.json`; provider routing, endpoint, model,
@@ -1064,9 +1132,17 @@ pub(crate) fn is_custom_codex_model_provider_id(id: &str) -> bool {
 /// should not overwrite the user's ChatGPT login cache.
 pub fn write_codex_live_config_atomic(config_text_opt: Option<&str>) -> Result<(), AppError> {
     let config_path = get_codex_config_path();
-    let cfg_text = match config_text_opt {
+    let raw_cfg_text = match config_text_opt {
         Some(config_text) => config_text.to_string(),
         None => String::new(),
+    };
+
+    // Merge live config 中非 CC-Switch 管理的 [model_providers.*] sections，
+    // 防止用户手写的 legacy aliases（如 [model_providers.proxy]）被覆盖丢失。
+    let cfg_text = if raw_cfg_text.trim().is_empty() {
+        raw_cfg_text
+    } else {
+        merge_live_non_managed_provider_sections(&raw_cfg_text)?
     };
 
     if !cfg_text.trim().is_empty() {

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1074,7 +1074,7 @@ pub(crate) fn is_custom_codex_model_provider_id(id: &str) -> bool {
 /// that are NOT present in the new config (i.e., not managed by CC Switch),
 /// and merges them back in. This preserves user-added provider aliases that
 /// old Codex threads may reference.
-fn merge_live_non_managed_provider_sections(new_config: &str) -> Result<String, AppError> {
+pub fn merge_live_non_managed_provider_sections(new_config: &str) -> Result<String, AppError> {
     if new_config.trim().is_empty() {
         return Ok(new_config.to_string());
     }

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1114,11 +1114,19 @@ fn merge_live_non_managed_provider_sections(new_config: &str) -> Result<String, 
         }
 
         // This section exists in live but not in the new config — preserve it.
+        // Ensure `name` is always present (Codex requires it).
+        let mut patched_section = live_section.clone();
+        if let Some(table) = patched_section.as_table_like_mut() {
+            if !table.contains_key("name") {
+                table.insert("name", toml_edit::Item::Value(toml_edit::Value::from(id)));
+            }
+        }
+
         if let Some(new_providers) = new_doc
             .get_mut("model_providers")
             .and_then(|item| item.as_table_like_mut())
         {
-            new_providers.insert(id, live_section.clone());
+            new_providers.insert(id, patched_section);
         }
     }
 

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -557,13 +557,22 @@ fn collapse_system_messages_to_head(messages: Vec<Value>) -> Vec<Value> {
 
     for msg in messages {
         if msg.get("role").and_then(|v| v.as_str()) == Some("system") {
-            if let Some(text) = msg.get("content").and_then(|v| v.as_str()) {
-                let trimmed = text.trim();
-                if !trimmed.is_empty() {
+            match msg.get("content") {
+                Some(Value::String(text)) if !text.trim().is_empty() => {
                     system_chunks.push(text.to_string());
                 }
-                continue;
+                Some(Value::Array(parts)) if !parts.is_empty() => {
+                    system_chunks.extend(
+                        parts
+                            .iter()
+                            .filter_map(|part| part.get("text").and_then(|v| v.as_str()))
+                            .filter(|text| !text.trim().is_empty())
+                            .map(ToString::to_string),
+                    );
+                }
+                _ => {}
             }
+            continue;
         }
         rest.push(msg);
     }
@@ -3010,6 +3019,24 @@ mod tests {
         assert_eq!(out[1]["content"], "U1");
         assert_eq!(out[2]["content"], "A1");
         assert_eq!(out[3]["content"], "U2");
+    }
+
+    #[test]
+    fn responses_request_to_chat_drops_empty_system_messages() {
+        let input = json!({
+            "model": "kimi-k3",
+            "input": [
+                {"type": "message", "role": "developer", "content": null},
+                {"type": "message", "role": "system", "content": "   "},
+                {"type": "message", "role": "developer", "content": []},
+                {"type": "message", "role": "user", "content": "hello"}
+            ]
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        assert_eq!(messages, &[json!({"role": "user", "content": "hello"})]);
     }
 
     #[test]

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3762,7 +3762,9 @@ impl ProxyService {
                 }
 
                 let config_result = prepared_cfg.as_deref().map_or(Ok(()), |cfg| {
-                    crate::config::write_text_file(&get_codex_config_path(), cfg)
+                    let merged = crate::codex_config::merge_live_non_managed_provider_sections(cfg)
+                        .map_err(|error| format!("merge legacy providers failed: {error}"))?;
+                    crate::config::write_text_file(&get_codex_config_path(), &merged)
                         .map_err(|error| format!("写入 Codex config 失败: {error}"))
                 });
                 match config_result {
@@ -3782,7 +3784,9 @@ impl ProxyService {
                         // Unguarded provider writes preserve an existing login;
                         // only restore transactions interpret empty auth as an
                         // exact-generation deletion.
-                        crate::config::write_text_file(&get_codex_config_path(), cfg)
+                        let merged = crate::codex_config::merge_live_non_managed_provider_sections(cfg)
+                            .map_err(|e| format!("merge legacy providers failed: {e}"))?;
+                        crate::config::write_text_file(&get_codex_config_path(), &merged)
                             .map_err(|e| format!("写入 Codex config 失败: {e}"))
                     } else {
                         crate::codex_config::write_codex_live_atomic(auth, Some(cfg))
@@ -3797,8 +3801,12 @@ impl ProxyService {
                             .map_err(|e| format!("写入 Codex auth 失败: {e}"))
                     }
                 }
-                (None, Some(cfg)) => crate::config::write_text_file(&get_codex_config_path(), cfg)
-                    .map_err(|e| format!("写入 Codex config 失败: {e}")),
+                (None, Some(cfg)) => {
+                    let merged = crate::codex_config::merge_live_non_managed_provider_sections(cfg)
+                        .map_err(|e| format!("merge legacy providers failed: {e}"))?;
+                    crate::config::write_text_file(&get_codex_config_path(), &merged)
+                        .map_err(|e| format!("写入 Codex config 失败: {e}"))
+                }
                 (None, None) => Ok(()),
             }
         };


### PR DESCRIPTION
## Problem

CC Switch's config writer only stores its own active provider in the database. When it writes `config.toml`, any `[model_providers.*]` sections that were manually added by the user (legacy aliases, third-party providers, etc.) are silently dropped because they never existed in the DB-stored config.

This causes old Codex threads that reference legacy provider names like `proxy` or `kimi3` to break after a provider switch or failover.

**Root cause:** `write_codex_live_for_provider` → `plan_codex_live_write` reads config from the DB (which only contains the CC-Switch-managed `custom` block), then writes it back to `config.toml` via `write_codex_live_config_atomic` — non-managed sections are lost because they never existed in the DB input.

## Fix

Read the live `config.toml` before each write, identify `[model_providers.*]` sections that are NOT present in the new config (i.e., not managed by CC Switch), and merge them back in. This preserves user-added provider aliases across all write paths (`write_codex_live_atomic` and `write_codex_live_config_atomic`).

The merge function (`merge_live_non_managed_provider_sections`) is applied at the lowest-level write functions, so all code paths benefit automatically.

## Verification

```bash
# 1. Remove proxy/kimi3 from config (only 'custom' remains)
# 2. Add proxy/kimi3 back manually
# 3. Trigger provider switch via CC Switch
# 4. Confirm proxy/kimi3 still present after switch ✅
```

Deployed patched build on production — legacy sections survive provider switches and failovers.