### PR TITLE
feat(provider): extend PPIO presets for Pi

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -425,6 +425,7 @@ export const providerPresets: ProviderPreset[] = [
     isPartner: true,
     partnerPromotionKey: "ppio",
     endpointCandidates: ["https://api.ppio.com/anthropic"],
+    modelsUrl: "https://api.ppio.com/openai/v1/models",
     icon: "ppio",
     iconColor: "#2874FF",
   },

--- a/src/config/piProviderPresets.ts
+++ b/src/config/piProviderPresets.ts
@@ -466,6 +466,35 @@ const piProviderPresetDefinitions: PiProviderPreset[] = [
     icon: "teamorouter",
   },
   {
+    name: "PPIO",
+    providerKey: "cc-switch-ppio",
+    websiteUrl: "https://ppio.com",
+    apiKeyUrl: "https://ppio.com/activity/ccswitch",
+    settingsConfig: {
+      name: "PPIO",
+      baseUrl: "https://api.ppio.com/openai/v1",
+      api: "openai-completions",
+      apiKey: "",
+      models: [
+        {
+          ...piModel("deepseek/deepseek-v4-flash", {
+            id: "deepseek/deepseek-v4-flash-0731",
+            name: "Deepseek V4 Flash 0731",
+            contextWindow: 1_048_576,
+            maxTokens: 393_216,
+            thinkingProfile: "deepseekV4",
+          }),
+          compat: { ...DEEPSEEK_THINKING_COMPAT },
+        },
+      ],
+    },
+    category: "aggregator",
+    isPartner: true,
+    partnerPromotionKey: "ppio",
+    icon: "ppio",
+    iconColor: "#2874FF",
+  },
+  {
     name: "ClaudeCN",
     providerKey: "cc-switch-claude-cn",
     websiteUrl: "https://claudecn.top",
@@ -1469,35 +1498,6 @@ const piProviderPresetDefinitions: PiProviderPreset[] = [
     category: "cloud_provider",
     icon: "aws",
     iconColor: "#FF9900",
-  },
-  {
-    name: "PPIO",
-    providerKey: "cc-switch-ppio",
-    websiteUrl: "https://ppio.com",
-    apiKeyUrl: "https://ppio.com/activity/ccswitch",
-    settingsConfig: {
-      name: "PPIO",
-      baseUrl: "https://api.ppio.com/openai/v1",
-      api: "openai-completions",
-      apiKey: "",
-      models: [
-        {
-          ...piModel("deepseek/deepseek-v4-flash", {
-            id: "deepseek/deepseek-v4-flash-0731",
-            name: "Deepseek V4 Flash 0731",
-            contextWindow: 1_048_576,
-            maxTokens: 393_216,
-            thinkingProfile: "deepseekV4",
-          }),
-          compat: { ...DEEPSEEK_THINKING_COMPAT },
-        },
-      ],
-    },
-    category: "aggregator",
-    isPartner: true,
-    partnerPromotionKey: "ppio",
-    icon: "ppio",
-    iconColor: "#2874FF",
   },
 ];
 

--- a/src/config/piProviderPresets.ts
+++ b/src/config/piProviderPresets.ts
@@ -1470,6 +1470,35 @@ const piProviderPresetDefinitions: PiProviderPreset[] = [
     icon: "aws",
     iconColor: "#FF9900",
   },
+  {
+    name: "PPIO",
+    providerKey: "cc-switch-ppio",
+    websiteUrl: "https://ppio.com",
+    apiKeyUrl: "https://ppio.com/activity/ccswitch",
+    settingsConfig: {
+      name: "PPIO",
+      baseUrl: "https://api.ppio.com/openai/v1",
+      api: "openai-completions",
+      apiKey: "",
+      models: [
+        {
+          ...piModel("deepseek/deepseek-v4-flash", {
+            id: "deepseek/deepseek-v4-flash-0731",
+            name: "Deepseek V4 Flash 0731",
+            contextWindow: 1_048_576,
+            maxTokens: 393_216,
+            thinkingProfile: "deepseekV4",
+          }),
+          compat: { ...DEEPSEEK_THINKING_COMPAT },
+        },
+      ],
+    },
+    category: "aggregator",
+    isPartner: true,
+    partnerPromotionKey: "ppio",
+    icon: "ppio",
+    iconColor: "#2874FF",
+  },
 ];
 
 function materializeVerifiedThinkingProfiles(

--- a/src/config/ppioProviderPresets.test.ts
+++ b/src/config/ppioProviderPresets.test.ts
@@ -6,6 +6,7 @@ import { codexProviderPresets } from "./codexProviderPresets";
 import { hermesProviderPresets } from "./hermesProviderPresets";
 import { openclawProviderPresets } from "./openclawProviderPresets";
 import { opencodeProviderPresets } from "./opencodeProviderPresets";
+import { piProviderPresets } from "./piProviderPresets";
 import { getIcon, getIconMetadata } from "../icons/extracted";
 
 const ppioPresetCollections = [
@@ -15,6 +16,7 @@ const ppioPresetCollections = [
   ["OpenCode", opencodeProviderPresets],
   ["OpenClaw", openclawProviderPresets],
   ["Hermes", hermesProviderPresets],
+  ["Pi", piProviderPresets],
 ] as const;
 
 const ppioModelId = "deepseek/deepseek-v4-flash-0731";
@@ -22,6 +24,7 @@ const ppioModelName = "Deepseek V4 Flash 0731";
 const ppioAnthropicEndpoint = "https://api.ppio.com/anthropic";
 const ppioOpenAiEndpoint = "https://api.ppio.com/openai/v1";
 const ppioChatCompletionsEndpoint = `${ppioOpenAiEndpoint}/chat/completions`;
+const ppioModelsEndpoint = `${ppioOpenAiEndpoint}/models`;
 const ppioBrandFields = {
   websiteUrl: "https://ppio.com",
   apiKeyUrl: "https://ppio.com/activity/ccswitch",
@@ -61,8 +64,8 @@ describe("PPIO provider presets", () => {
         },
       },
       endpointCandidates: [ppioAnthropicEndpoint],
+      modelsUrl: ppioModelsEndpoint,
     });
-    expect(claude).not.toHaveProperty("modelsUrl");
   });
 
   it("configures Claude Desktop with the native Anthropic endpoint", () => {
@@ -190,6 +193,47 @@ describe("PPIO provider presets", () => {
       },
     });
     expect(`${hermes.settingsConfig.base_url}/chat/completions`).toBe(
+      ppioChatCompletionsEndpoint,
+    );
+  });
+
+  it("configures Pi with a versioned OpenAI Chat base", () => {
+    const pi = getPpioPreset(piProviderPresets)!;
+    expect(pi).toMatchObject({
+      ...ppioBrandFields,
+      providerKey: "cc-switch-ppio",
+      settingsConfig: {
+        name: "PPIO",
+        baseUrl: ppioOpenAiEndpoint,
+        api: "openai-completions",
+        apiKey: "",
+        models: [
+          {
+            id: ppioModelId,
+            name: ppioModelName,
+            reasoning: true,
+            input: ["text"],
+            contextWindow: 1048576,
+            maxTokens: 393216,
+            thinkingLevelMap: {
+              minimal: null,
+              low: null,
+              medium: null,
+              high: "high",
+              max: "max",
+            },
+            compat: {
+              supportsStore: false,
+              supportsDeveloperRole: false,
+              maxTokensField: "max_tokens",
+              requiresReasoningContentOnAssistantMessages: true,
+              thinkingFormat: "deepseek",
+            },
+          },
+        ],
+      },
+    });
+    expect(`${pi.settingsConfig.baseUrl}/chat/completions`).toBe(
       ppioChatCompletionsEndpoint,
     );
   });


### PR DESCRIPTION
## Summary

- Add a PPIO provider preset for Pi using the OpenAI-compatible endpoint.
- Configure the Claude Code PPIO preset with an explicit models endpoint.
- Extend focused PPIO regression coverage without source-order assertions.

## Related Issue

Fixes #6868

## Screenshots

Not applicable. This change only updates provider presets and tests.

## Checklist

- [x] `pnpm typecheck` passes.
- [x] `pnpm format:check` passes.
- [x] `pnpm test:unit` passes.
- [x] Rust checks are not applicable because no Rust code changed.
- [x] Localization updates are not applicable because no user-facing text changed.

## Validation

- Focused provider tests: 3 test files and 28 tests passed.
- Complete unit suite: 133 test files and 1,014 tests passed.
- Live `GET https://api.ppio.com/openai/v1/models`: HTTP 200, and the configured model is present.
