### PR TITLE
fix(db): bound database growth from oversized error bodies, backups, and the dedup ledger (#6706)

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -214,7 +214,9 @@ pub fn get_app_config_dir() -> PathBuf {
     #[cfg(windows)]
     {
         let default_db = default_dir.join("cc-switch.db");
-        if !default_db.exists() {
+        // 设置了 CC_SWITCH_TEST_HOME 时跳过遗留探测：Git Bash/MSYS 会注入
+        // 指向真实用户目录的 HOME，把显式隔离的测试重新指回真实数据。
+        if !default_db.exists() && std::env::var_os("CC_SWITCH_TEST_HOME").is_none() {
             if let Ok(home_env) = std::env::var("HOME") {
                 let trimmed = home_env.trim();
                 if !trimmed.is_empty() {

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -444,6 +444,15 @@ impl Database {
             }
         }
 
+        // Retention (count + total-size cap) also runs when no new backup is
+        // due, so an oversized backups folder is bounded on the first launch
+        // after an upgrade instead of waiting up to a full backup interval.
+        let backup_dir = get_app_config_dir().join("backups");
+        if backup_dir.exists() {
+            let _backup_file_guard = lock_backup_file_operations()?;
+            Self::cleanup_db_backups(&backup_dir, &[])?;
+        }
+
         // Periodic maintenance is always enabled, regardless of auto-backup settings.
         let mut reclaimed_rows = 0u64;
         match self.cleanup_old_stream_check_logs(7) {
@@ -460,6 +469,14 @@ impl Database {
             }
             Err(e) => {
                 log::warn!("Periodic rollup_and_prune failed: {e}");
+            }
+        }
+        match self.cap_session_usage_dedup(super::dao::usage_rollup::SESSION_USAGE_DEDUP_MAX_ROWS) {
+            Ok(deleted) => {
+                reclaimed_rows += deleted;
+            }
+            Err(e) => {
+                log::warn!("Periodic session_usage_dedup cap failed: {e}");
             }
         }
         if reclaimed_rows > 0 {
@@ -598,10 +615,12 @@ impl Database {
         }
     }
 
-    /// 清理旧的数据库备份，保留最新的 N 个
+    /// 清理旧的数据库备份：先按份数保留最新的 N 个，再把目录总大小压到
+    /// `backup_max_total_mb` 上限内（至少保留 1 份）。protected_paths
+    /// （新建备份/恢复源）在两轮中都绝不删除。
     fn cleanup_db_backups(dir: &Path, protected_paths: &[&Path]) -> Result<(), AppError> {
         let retain = crate::settings::effective_backup_retain_count();
-        let entries = match fs::read_dir(dir) {
+        let mut entries = match fs::read_dir(dir) {
             Ok(iter) => iter
                 .filter_map(|entry| entry.ok())
                 .filter(|entry| {
@@ -615,31 +634,78 @@ impl Database {
             Err(_) => return Ok(()),
         };
 
-        if entries.len() <= retain {
+        let is_protected = |path: &Path| -> bool {
+            protected_paths
+                .iter()
+                .any(|protected| Self::same_existing_backup_path(path, protected))
+        };
+
+        entries.sort_by_key(|entry| entry.metadata().and_then(|m| m.modified()).ok());
+
+        if entries.len() > retain {
+            let remove_count = entries.len() - retain;
+            let mut removed = 0;
+            entries.retain(|entry| {
+                if removed >= remove_count {
+                    return true;
+                }
+                let path = entry.path();
+                if is_protected(&path) {
+                    return true;
+                }
+
+                match fs::remove_file(&path) {
+                    Ok(()) => {
+                        removed += 1;
+                        false
+                    }
+                    Err(err) => {
+                        log::warn!("删除旧数据库备份失败 {}: {}", path.display(), err);
+                        true
+                    }
+                }
+            });
+        }
+
+        let max_total = crate::settings::effective_backup_max_total_bytes();
+        if max_total == u64::MAX {
             return Ok(());
         }
 
-        let remove_count = entries.len().saturating_sub(retain);
-        let mut sorted = entries;
-        sorted.sort_by_key(|entry| entry.metadata().and_then(|m| m.modified()).ok());
-
-        let mut removed = 0;
-        for entry in sorted {
-            if removed >= remove_count {
-                break;
-            }
+        // Newest-first: keep backups until the accumulated size exceeds the
+        // cap. The newest non-protected backup is always kept even when it
+        // alone exceeds the cap, so a restore point always survives.
+        let mut kept = 0usize;
+        let mut total = 0u64;
+        for entry in entries.iter().rev() {
+            let Ok(metadata) = entry.metadata() else {
+                continue;
+            };
+            let size = metadata.len();
             let path = entry.path();
-            if protected_paths
-                .iter()
-                .any(|protected| Self::same_existing_backup_path(&path, protected))
-            {
+            if is_protected(&path) {
+                total = total.saturating_add(size);
                 continue;
             }
 
-            if let Err(err) = fs::remove_file(&path) {
-                log::warn!("删除旧数据库备份失败 {}: {}", path.display(), err);
-            } else {
-                removed += 1;
+            if total.saturating_add(size) <= max_total || kept == 0 {
+                total = total.saturating_add(size);
+                kept += 1;
+                continue;
+            }
+
+            match fs::remove_file(&path) {
+                Ok(()) => {
+                    log::info!(
+                        "删除超限数据库备份 {}（目录总大小超过上限）",
+                        path.display()
+                    );
+                }
+                Err(err) => {
+                    log::warn!("删除超限数据库备份失败 {}: {}", path.display(), err);
+                    total = total.saturating_add(size);
+                    kept += 1;
+                }
             }
         }
         Ok(())
@@ -1242,12 +1308,166 @@ mod tests {
             update_settings(next).expect("set backup retention for test");
             Self { previous }
         }
+
+        fn with_backup_max_total_mb(max_total_mb: u32) -> Self {
+            let previous = get_settings();
+            let mut next = previous.clone();
+            next.backup_max_total_mb = Some(max_total_mb);
+            update_settings(next).expect("set backup size cap for test");
+            Self { previous }
+        }
     }
 
     impl Drop for SettingsGuard {
         fn drop(&mut self) {
             let _ = update_settings(self.previous.clone());
         }
+    }
+
+    fn write_backup_file(
+        backup_dir: &std::path::Path,
+        filename: &str,
+        size_bytes: usize,
+        age_secs: u64,
+    ) -> Result<std::path::PathBuf, AppError> {
+        let path = backup_dir.join(filename);
+        std::fs::write(&path, vec![0u8; size_bytes]).map_err(|e| AppError::io(&path, e))?;
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .map_err(|e| AppError::io(&path, e))?;
+        file.set_modified(std::time::SystemTime::now() - std::time::Duration::from_secs(age_secs))
+            .map_err(|e| AppError::io(&path, e))?;
+        Ok(path)
+    }
+
+    #[test]
+    #[serial]
+    fn cleanup_db_backups_enforces_total_size_cap() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let _retain = SettingsGuard::with_backup_retain_count(10);
+        let _cap = SettingsGuard::with_backup_max_total_mb(1);
+
+        // Reproduces #6706: three full-image backups of a bloated database
+        // under a 1 MB cap must keep only the newest restore point.
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        std::fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        let oldest = write_backup_file(
+            &backup_dir,
+            "db_backup_20260801_000001.db",
+            600 * 1024,
+            3 * 86400,
+        )?;
+        let middle = write_backup_file(
+            &backup_dir,
+            "db_backup_20260802_000002.db",
+            600 * 1024,
+            2 * 86400,
+        )?;
+        let newest = write_backup_file(
+            &backup_dir,
+            "db_backup_20260803_000003.db",
+            600 * 1024,
+            86400,
+        )?;
+
+        Database::cleanup_db_backups(&backup_dir, &[])?;
+
+        assert!(
+            !oldest.exists(),
+            "oldest backup over the size cap must be removed"
+        );
+        assert!(
+            !middle.exists(),
+            "second-oldest backup over the size cap must be removed"
+        );
+        assert!(
+            newest.exists(),
+            "newest backup is always kept even when it alone exceeds the cap"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn cleanup_db_backups_size_cap_never_deletes_protected_paths() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let _retain = SettingsGuard::with_backup_retain_count(10);
+        let _cap = SettingsGuard::with_backup_max_total_mb(1);
+
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        std::fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        let oldest = write_backup_file(
+            &backup_dir,
+            "db_backup_20260801_000001.db",
+            900 * 1024,
+            3 * 86400,
+        )?;
+        let protected = write_backup_file(
+            &backup_dir,
+            "db_backup_20260802_000002.db",
+            900 * 1024,
+            2 * 86400,
+        )?;
+        let newest = write_backup_file(
+            &backup_dir,
+            "db_backup_20260803_000003.db",
+            900 * 1024,
+            86400,
+        )?;
+
+        Database::cleanup_db_backups(&backup_dir, &[&protected])?;
+
+        assert!(protected.exists(), "restore source must never be deleted");
+        assert!(newest.exists(), "newest backup must be kept");
+        assert!(
+            !oldest.exists(),
+            "oldest backup over the size cap must be removed"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn periodic_backup_if_needed_enforces_size_cap_without_new_backup() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let previous = get_settings();
+        let mut next = previous.clone();
+        next.backup_interval_hours = Some(0);
+        next.backup_retain_count = Some(10);
+        next.backup_max_total_mb = Some(1);
+        update_settings(next).expect("set backup settings for test");
+        let _settings = SettingsGuard { previous };
+
+        let db = Database::init()?;
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        // Database::init() may publish its own safety backup; start from a
+        // clean directory so the cap math only sees this test's files.
+        if backup_dir.exists() {
+            std::fs::remove_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        }
+        std::fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        let oldest = write_backup_file(
+            &backup_dir,
+            "db_backup_20260801_000001.db",
+            900 * 1024,
+            2 * 86400,
+        )?;
+        let newest = write_backup_file(
+            &backup_dir,
+            "db_backup_20260802_000002.db",
+            900 * 1024,
+            86400,
+        )?;
+
+        db.periodic_backup_if_needed()?;
+
+        assert!(
+            !oldest.exists(),
+            "startup retention must bound an oversized backups folder"
+        );
+        assert!(newest.exists(), "newest backup must be kept");
+        Ok(())
     }
 
     #[test]

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -615,10 +615,48 @@ impl Database {
         }
     }
 
+    /// 删除备份 `.db` 的 SQLite 侧车文件（`-journal`/`-wal`/`-shm`）。
+    /// 只删本体不删侧车时，残留会永久滞留在 backups 目录里（#6706 的目录
+    /// 截图中即有一个孤儿 `-journal`）。
+    fn remove_backup_sidecars(db_path: &Path) {
+        for suffix in ["-journal", "-wal", "-shm"] {
+            let mut name = db_path.as_os_str().to_os_string();
+            name.push(suffix);
+            let sidecar = PathBuf::from(name);
+            match fs::remove_file(&sidecar) {
+                Ok(()) => log::info!("删除数据库备份侧车文件 {}", sidecar.display()),
+                Err(err) if err.kind() != std::io::ErrorKind::NotFound => {
+                    log::warn!("删除数据库备份侧车文件失败 {}: {}", sidecar.display(), err);
+                }
+                Err(_) => {}
+            }
+        }
+    }
+
     /// 清理旧的数据库备份：先按份数保留最新的 N 个，再把目录总大小压到
     /// `backup_max_total_mb` 上限内（至少保留 1 份）。protected_paths
     /// （新建备份/恢复源）在两轮中都绝不删除。
     fn cleanup_db_backups(dir: &Path, protected_paths: &[&Path]) -> Result<(), AppError> {
+        // 先清掉已无对应 `.db` 的孤儿侧车（如恢复中断后遗留的 `-journal`）；
+        // `.db` 仍在的侧车可能是活跃恢复过程的一部分，保持不动。
+        if let Ok(orphan_iter) = fs::read_dir(dir) {
+            for entry in orphan_iter.filter_map(|entry| entry.ok()) {
+                let path = entry.path();
+                let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                    continue;
+                };
+                let Some(base) = ["-journal", "-wal", "-shm"]
+                    .iter()
+                    .find_map(|suffix| name.strip_suffix(suffix))
+                else {
+                    continue;
+                };
+                if base.ends_with(".db") && !dir.join(base).exists() {
+                    Self::remove_backup_sidecars(&dir.join(base));
+                }
+            }
+        }
+
         let retain = crate::settings::effective_backup_retain_count();
         let mut entries = match fs::read_dir(dir) {
             Ok(iter) => iter
@@ -657,6 +695,7 @@ impl Database {
                 match fs::remove_file(&path) {
                     Ok(()) => {
                         removed += 1;
+                        Self::remove_backup_sidecars(&path);
                         false
                     }
                     Err(err) => {
@@ -700,6 +739,7 @@ impl Database {
                         "删除超限数据库备份 {}（目录总大小超过上限）",
                         path.display()
                     );
+                    Self::remove_backup_sidecars(&path);
                 }
                 Err(err) => {
                     log::warn!("删除超限数据库备份失败 {}: {}", path.display(), err);
@@ -1423,6 +1463,65 @@ mod tests {
         assert!(
             !oldest.exists(),
             "oldest backup over the size cap must be removed"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn cleanup_db_backups_removes_sqlite_sidecars() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let _retain = SettingsGuard::with_backup_retain_count(10);
+        let _cap = SettingsGuard::with_backup_max_total_mb(1);
+
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        std::fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        let oldest = write_backup_file(
+            &backup_dir,
+            "db_backup_20260801_000001.db",
+            900 * 1024,
+            3 * 86400,
+        )?;
+        // 侧车与本体一起会被删除（份数/大小两条路径共用 remove_backup_sidecars）。
+        std::fs::write(
+            backup_dir.join("db_backup_20260801_000001.db-journal"),
+            b"x",
+        )
+        .map_err(|e| AppError::io(&oldest, e))?;
+        // 已无对应 .db 的孤儿侧车必须被清掉；活备份的侧车保持不动。
+        std::fs::write(
+            backup_dir.join("db_backup_20260807_203829.db-journal"),
+            b"x",
+        )
+        .map_err(|e| AppError::io(&backup_dir, e))?;
+        let newest = write_backup_file(
+            &backup_dir,
+            "db_backup_20260803_000003.db",
+            900 * 1024,
+            86400,
+        )?;
+        let newest_journal = backup_dir.join("db_backup_20260803_000003.db-wal");
+        std::fs::write(&newest_journal, b"x").map_err(|e| AppError::io(&newest, e))?;
+
+        Database::cleanup_db_backups(&backup_dir, &[])?;
+
+        assert!(!oldest.exists(), "over-cap backup must be removed");
+        assert!(
+            !backup_dir
+                .join("db_backup_20260801_000001.db-journal")
+                .exists(),
+            "sidecar of a removed backup must be removed with it"
+        );
+        assert!(
+            !backup_dir
+                .join("db_backup_20260807_203829.db-journal")
+                .exists(),
+            "orphan sidecar without its .db must be swept"
+        );
+        assert!(newest.exists(), "newest backup must be kept");
+        assert!(
+            newest_journal.exists(),
+            "sidecar of a surviving backup must be left alone"
         );
         Ok(())
     }

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -633,18 +633,45 @@ impl Database {
         }
     }
 
+    /// 在真正打开数据库连接前先执行一次备份保留清理。
+    ///
+    /// 保留策略默认排在 `init()` 成功之后运行，但满盘（#6706 现场）时
+    /// v17→v18 之类的存量迁移会先因 `SQLITE_FULL` 硬失败，清理永远走不到；
+    /// 而清理本身只依赖 settings.json 和文件系统，不需要可用的数据库连接
+    /// 或磁盘余量，因此提到最前面执行，为随后可能触发的迁移腾出 journal
+    /// 空间。
+    pub(crate) fn preflight_backup_retention() {
+        let backup_dir = get_app_config_dir().join("backups");
+        if !backup_dir.exists() {
+            return;
+        }
+        let Ok(_guard) = lock_backup_file_operations() else {
+            return;
+        };
+        if let Err(e) = Self::cleanup_db_backups(&backup_dir, &[]) {
+            log::warn!("Preflight backup retention failed: {e}");
+        }
+    }
+
     /// 清理旧的数据库备份：先按份数保留最新的 N 个，再把目录总大小压到
     /// `backup_max_total_mb` 上限内（至少保留 1 份）。protected_paths
     /// （新建备份/恢复源）在两轮中都绝不删除。
     fn cleanup_db_backups(dir: &Path, protected_paths: &[&Path]) -> Result<(), AppError> {
-        // 先清掉已无对应 `.db` 的孤儿侧车（如恢复中断后遗留的 `-journal`）；
-        // `.db` 仍在的侧车可能是活跃恢复过程的一部分，保持不动。
+        // 先清掉已无对应 `.db` 的孤儿侧车（如恢复中断后遗留的 `-journal`），
+        // 以及进程崩溃/强杀导致析构未运行而残留的临时快照
+        // (`.cc-switch-backup-*.tmp`，见 `backup_database_file_locked`)。
+        // 持锁期间不存在进行中的备份，两者删除都是安全的。`.db` 仍在的侧车
+        // 可能是活跃恢复过程的一部分，保持不动。
         if let Ok(orphan_iter) = fs::read_dir(dir) {
             for entry in orphan_iter.filter_map(|entry| entry.ok()) {
                 let path = entry.path();
                 let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
                     continue;
                 };
+                if name.starts_with(".cc-switch-backup-") && name.ends_with(".tmp") {
+                    let _ = fs::remove_file(&path);
+                    continue;
+                }
                 let Some(base) = ["-journal", "-wal", "-shm"]
                     .iter()
                     .find_map(|suffix| name.strip_suffix(suffix))
@@ -724,6 +751,7 @@ impl Database {
             let path = entry.path();
             if is_protected(&path) {
                 total = total.saturating_add(size);
+                kept += 1;
                 continue;
             }
 
@@ -1279,6 +1307,7 @@ impl Database {
         }
 
         fs::remove_file(&backup_path).map_err(|e| AppError::io(&backup_path, e))?;
+        Self::remove_backup_sidecars(&backup_path);
         log::info!("Deleted backup: {filename}");
         Ok(())
     }
@@ -1469,6 +1498,53 @@ mod tests {
 
     #[test]
     #[serial]
+    fn cleanup_db_backups_size_cap_counts_protected_toward_kept() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let _retain = SettingsGuard::with_backup_retain_count(10);
+        let _cap = SettingsGuard::with_backup_max_total_mb(1);
+
+        // A protected backup already guarantees a restore point exists, so
+        // the "always keep the first non-protected entry" sentinel must not
+        // re-trigger for the backup right after it. If the protected branch
+        // doesn't increment `kept`, `middle` below is spuriously force-kept
+        // even though protected + middle alone already exceed the cap.
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        std::fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        let protected = write_backup_file(
+            &backup_dir,
+            "db_backup_20260803_000003.db",
+            600 * 1024,
+            3600,
+        )?;
+        let middle = write_backup_file(
+            &backup_dir,
+            "db_backup_20260802_000002.db",
+            600 * 1024,
+            2 * 86400,
+        )?;
+        let oldest = write_backup_file(
+            &backup_dir,
+            "db_backup_20260801_000001.db",
+            600 * 1024,
+            3 * 86400,
+        )?;
+
+        Database::cleanup_db_backups(&backup_dir, &[&protected])?;
+
+        assert!(protected.exists(), "protected backup must never be deleted");
+        assert!(
+            !middle.exists(),
+            "backup right after a protected one must not be spuriously force-kept"
+        );
+        assert!(
+            !oldest.exists(),
+            "oldest backup over the size cap must be removed"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
     fn cleanup_db_backups_removes_sqlite_sidecars() -> Result<(), AppError> {
         let _test_home = TestHomeGuard::new();
         let _retain = SettingsGuard::with_backup_retain_count(10);
@@ -1528,6 +1604,68 @@ mod tests {
 
     #[test]
     #[serial]
+    fn cleanup_db_backups_removes_orphan_crash_snapshots() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let _retain = SettingsGuard::with_backup_retain_count(10);
+
+        // A killed process never runs `TempPath`'s destructor, so a
+        // `.cc-switch-backup-*.tmp` snapshot from `backup_database_file_locked`
+        // can survive indefinitely. Retention only recognized `.db` files, so
+        // this debris counted toward neither the size cap nor cleanup.
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        std::fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        let crash_snapshot = backup_dir.join(".cc-switch-backup-abc123.tmp");
+        std::fs::write(&crash_snapshot, vec![0u8; 1024])
+            .map_err(|e| AppError::io(&crash_snapshot, e))?;
+        let kept = write_backup_file(&backup_dir, "db_backup_20260803_000003.db", 1024, 3600)?;
+
+        Database::cleanup_db_backups(&backup_dir, &[])?;
+
+        assert!(
+            !crash_snapshot.exists(),
+            "orphan crash snapshot must be swept regardless of extension"
+        );
+        assert!(kept.exists(), "unrelated backup must be left alone");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn preflight_backup_retention_runs_before_database_connection_opens() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let _retain = SettingsGuard::with_backup_retain_count(10);
+        let _cap = SettingsGuard::with_backup_max_total_mb(1);
+
+        // Simulates #6706 on a full disk: retention must not depend on a
+        // successful `Database::init()` (which can hard-fail on
+        // `SQLITE_FULL` while migrating), so call it standalone here.
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        std::fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        let oldest = write_backup_file(
+            &backup_dir,
+            "db_backup_20260801_000001.db",
+            900 * 1024,
+            2 * 86400,
+        )?;
+        let newest = write_backup_file(
+            &backup_dir,
+            "db_backup_20260802_000002.db",
+            900 * 1024,
+            86400,
+        )?;
+
+        Database::preflight_backup_retention();
+
+        assert!(
+            !oldest.exists(),
+            "preflight retention must bound the backups folder without an open connection"
+        );
+        assert!(newest.exists(), "newest backup must be kept");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
     fn periodic_backup_if_needed_enforces_size_cap_without_new_backup() -> Result<(), AppError> {
         let _test_home = TestHomeGuard::new();
         let previous = get_settings();
@@ -1566,6 +1704,28 @@ mod tests {
             "startup retention must bound an oversized backups folder"
         );
         assert!(newest.exists(), "newest backup must be kept");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn delete_backup_removes_sqlite_sidecars() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+
+        let backup_dir = crate::config::get_app_config_dir().join("backups");
+        std::fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+        let filename = "db_backup_20260803_000003.db";
+        let target = write_backup_file(&backup_dir, filename, 1024, 0)?;
+        let journal = backup_dir.join(format!("{filename}-journal"));
+        std::fs::write(&journal, b"x").map_err(|e| AppError::io(&journal, e))?;
+
+        Database::delete_backup(filename)?;
+
+        assert!(!target.exists(), "backup file must be deleted");
+        assert!(
+            !journal.exists(),
+            "manual delete must also remove the backup's sidecar files"
+        );
         Ok(())
     }
 

--- a/src-tauri/src/database/dao/usage_rollup.rs
+++ b/src-tauri/src/database/dao/usage_rollup.rs
@@ -8,6 +8,15 @@ use crate::services::sql_helpers::{fresh_input_sql, INPUT_TOKEN_SEMANTICS_FRESH}
 use crate::services::usage_stats::effective_usage_log_filter;
 use chrono::{Duration, Local, TimeZone};
 
+/// Upper bound for the `session_usage_dedup` ledger.
+///
+/// The ledger prevents re-counting session events whose detail rows were
+/// already rolled up; it has no timestamp column and is never pruned by
+/// design, so without a cap it grows forever (#6706). `rowid` order is
+/// insertion order, so the cap evicts the oldest entries — exactly the ones
+/// least likely to be re-scanned.
+pub(crate) const SESSION_USAGE_DEDUP_MAX_ROWS: u64 = 1_000_000;
+
 /// Compute the rollup/prune cutoff aligned to a local-day boundary.
 ///
 /// Anything strictly older than the returned timestamp will be aggregated into
@@ -56,6 +65,21 @@ fn compute_local_midnight_cutoff(
 }
 
 impl Database {
+    /// Trim `session_usage_dedup` to the newest `max_rows` entries
+    /// (`rowid` order is insertion order).
+    pub fn cap_session_usage_dedup(&self, max_rows: u64) -> Result<u64, AppError> {
+        let conn = lock_conn!(self.conn);
+        let deleted = conn
+            .execute(
+                "DELETE FROM session_usage_dedup WHERE rowid IN (
+                    SELECT rowid FROM session_usage_dedup ORDER BY rowid DESC LIMIT -1 OFFSET ?1
+                )",
+                [max_rows],
+            )
+            .map_err(|e| AppError::Database(format!("清理会话用量去重账本失败: {e}")))?;
+        Ok(deleted as u64)
+    }
+
     /// Aggregate proxy_request_logs older than `retain_days` into usage_daily_rollups,
     /// then delete the aggregated detail rows.
     /// Returns the number of deleted detail rows.
@@ -568,6 +592,40 @@ mod tests {
         )?;
         assert_eq!(count, 13, "10 existing + 3 new");
         assert_eq!(input, 1300, "1000 existing + 300 new");
+        Ok(())
+    }
+
+    #[test]
+    fn cap_session_usage_dedup_keeps_newest_rows() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        {
+            let conn = crate::database::lock_conn!(db.conn);
+            for i in 0..5 {
+                conn.execute(
+                    "INSERT INTO session_usage_dedup
+                        (data_source, request_id, semantic_id, has_entry_id)
+                     VALUES ('pi_session', ?1, ?1, 1)",
+                    [format!("req-{i}")],
+                )?;
+            }
+        }
+
+        let deleted = db.cap_session_usage_dedup(3)?;
+        assert_eq!(deleted, 2);
+
+        let conn = crate::database::lock_conn!(db.conn);
+        let mut stmt = conn.prepare("SELECT request_id FROM session_usage_dedup ORDER BY rowid")?;
+        let kept: Vec<String> = stmt
+            .query_map([], |row| row.get(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        assert_eq!(
+            kept,
+            vec![
+                "req-2".to_string(),
+                "req-3".to_string(),
+                "req-4".to_string()
+            ]
+        );
         Ok(())
     }
 }

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -53,7 +53,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 18;
+pub(crate) const SCHEMA_VERSION: i32 = 19;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -98,6 +98,12 @@ impl Database {
     ///
     /// 数据库文件位于 `~/.cc-switch/cc-switch.db`
     pub fn init() -> Result<Self, AppError> {
+        // Run backup retention before touching the database connection: on a
+        // full disk (#6706), a large schema migration below can hard-fail on
+        // SQLITE_FULL before ever reaching post-init cleanup, so retention
+        // must free space first rather than depend on init succeeding.
+        Self::preflight_backup_retention();
+
         let db_path = get_app_config_dir().join("cc-switch.db");
         let db_exists = db_path.exists();
 

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -549,6 +549,11 @@ impl Database {
                         Self::migrate_v17_to_v18(conn)?;
                         Self::set_user_version(conn, 18)?;
                     }
+                    18 => {
+                        log::info!("迁移数据库从 v18 到 v19（截断存量超长错误消息）");
+                        Self::migrate_v18_to_v19(conn)?;
+                        Self::set_user_version(conn, 19)?;
+                    }
                     _ => {
                         return Err(AppError::Database(format!(
                             "未知的数据库版本 {version}，无法迁移到 {SCHEMA_VERSION}"
@@ -1595,6 +1600,46 @@ impl Database {
                 "last_tail_fingerprint",
                 "INTEGER",
             )?;
+        }
+        Ok(())
+    }
+
+    /// v18 -> v19: truncate legacy oversized `error_message` values that were
+    /// stored verbatim before the logger-side cap existed (#6706).
+    /// `substr`/`length` operate on characters, matching `MAX_ERROR_MESSAGE_CHARS`.
+    fn migrate_v18_to_v19(conn: &Connection) -> Result<(), AppError> {
+        // The migration chain also runs on legacy layouts where the table or
+        // the column does not exist yet; fresh creates and the logger-side
+        // cap cover those rows, so there is nothing to truncate here.
+        // `pragma_table_info` on a missing table returns an empty set, which
+        // covers both cases in one query.
+        let has_error_column: bool = conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM pragma_table_info('proxy_request_logs')
+                    WHERE name = 'error_message'
+                )",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| AppError::Database(format!("检查 error_message 列失败: {e}")))?;
+        if !has_error_column {
+            return Ok(());
+        }
+
+        let max_chars = crate::proxy::usage::logger::MAX_ERROR_MESSAGE_CHARS;
+        let changed = conn
+            .execute(
+                &format!(
+                    "UPDATE proxy_request_logs
+                     SET error_message = substr(error_message, 1, {max_chars})
+                     WHERE error_message IS NOT NULL AND length(error_message) > {max_chars}"
+                ),
+                [],
+            )
+            .map_err(|e| AppError::Database(format!("截断存量超长错误消息失败: {e}")))?;
+        if changed > 0 {
+            log::info!("Truncated {changed} oversized proxy_request_logs.error_message values");
         }
         Ok(())
     }
@@ -3709,6 +3754,50 @@ mod tests {
         )?;
         assert_eq!(byte_offset, None, "存量行的字节游标必须为 NULL");
         assert_eq!(fingerprint, None, "存量行的尾部指纹必须为 NULL");
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_v18_to_v19_truncates_oversized_error_messages() -> Result<(), AppError> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute(
+            "CREATE TABLE proxy_request_logs (
+                request_id TEXT PRIMARY KEY,
+                error_message TEXT
+            )",
+            [],
+        )?;
+        let max_chars = crate::proxy::usage::logger::MAX_ERROR_MESSAGE_CHARS;
+        let oversized = "e".repeat(max_chars * 500);
+        let multibyte = "汉".repeat(max_chars + 500);
+        conn.execute(
+            "INSERT INTO proxy_request_logs (request_id, error_message) VALUES ('oversized', ?1)",
+            [&oversized],
+        )?;
+        conn.execute(
+            "INSERT INTO proxy_request_logs (request_id, error_message) VALUES ('multibyte', ?1)",
+            [&multibyte],
+        )?;
+        conn.execute(
+            "INSERT INTO proxy_request_logs (request_id, error_message) VALUES ('short', 'ok')",
+            [],
+        )?;
+        Database::set_user_version(&conn, 18)?;
+
+        Database::apply_schema_migrations_on_conn(&conn)?;
+
+        assert_eq!(Database::get_user_version(&conn)?, SCHEMA_VERSION);
+        let (oversized_len, multibyte_len, short): (i64, i64, Option<String>) = conn.query_row(
+            "SELECT
+                (SELECT length(error_message) FROM proxy_request_logs WHERE request_id = 'oversized'),
+                (SELECT length(error_message) FROM proxy_request_logs WHERE request_id = 'multibyte'),
+                (SELECT error_message FROM proxy_request_logs WHERE request_id = 'short')",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert_eq!(oversized_len, max_chars as i64);
+        assert_eq!(multibyte_len, max_chars as i64);
+        assert_eq!(short, Some("ok".to_string()));
         Ok(())
     }
 }

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -35,6 +35,9 @@ pub(crate) mod tool_media;
 pub(crate) mod types;
 pub mod usage;
 
+#[cfg(test)]
+mod tests_issue_6895;
+
 // 公开导出给外部使用（commands, services等模块需要）
 #[allow(unused_imports)]
 pub use circuit_breaker::{

--- a/src-tauri/src/proxy/tests_issue_6895.rs
+++ b/src-tauri/src/proxy/tests_issue_6895.rs
@@ -1,0 +1,466 @@
+//! 复现测试：Issue #6895 - Codex wire_api=responses 企业网关 502 回归
+//!
+//! v3.16.5 → v3.20.0 回归：企业 Codex 提供商（`wire_api = "responses"`）直接 curl
+//! 返回 HTTP 200 + 自定义非 OpenAI 信封 JSON；通过 CC Switch 本地代理转发后变成
+//! HTTP 502，错误信息为 `"上游错误 (502):"` 带空 cause（`:` 后面什么都没有）。
+//!
+//! issue 评论者 chufeng 推测两个可能原因：
+//! 1. v3.17.0 引入的「Fail Closed on 2xx 失败信封」逻辑（commit 650905af）
+//!    误把正常 200 当错误
+//! 2. v3.17–3.19 引入的「解压/缓冲」502 逻辑变化
+//!
+//! 本测试用 axum 模拟企业网关，验证代理的实际行为。
+
+#[cfg(test)]
+mod tests {
+    use crate::database::Database;
+    use crate::provider::Provider;
+    use crate::proxy::server::ProxyServer;
+    use crate::proxy::types::ProxyConfig;
+    use axum::{extract::State, routing::post, Json, Router};
+    use serde_json::{json, Value};
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener;
+
+    #[derive(Clone, Debug)]
+    struct CapturedRequest {
+        path_and_query: String,
+        authorization: Option<String>,
+        body: Value,
+    }
+
+    /// 模拟企业网关：返回 HTTP 200 + 自定义非 OpenAI-Responses 信封 JSON
+    async fn mock_enterprise_gateway_200_custom_json(
+        State(captured): State<Arc<Mutex<Vec<CapturedRequest>>>>,
+        req: axum::extract::Request,
+    ) -> (axum::http::StatusCode, Json<Value>) {
+        let (parts, body) = req.into_parts();
+        let path_and_query = parts
+            .uri
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or("")
+            .to_string();
+        let authorization = parts
+            .headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        let body_bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        let body_json: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!({}));
+
+        captured.lock().unwrap().push(CapturedRequest {
+            path_and_query,
+            authorization,
+            body: body_json,
+        });
+
+        // 企业网关返回的自定义 JSON（非 OpenAI Responses 标准信封）
+        let custom_response = json!({
+            "success": true,
+            "data": {
+                "completion": "This is a custom enterprise response format.",
+                "tokens_used": 42
+            }
+        });
+
+        (axum::http::StatusCode::OK, Json(custom_response))
+    }
+
+    /// 模拟企业网关：返回真实的 HTTP 502 空 body（上游挂了）
+    async fn mock_enterprise_gateway_502_empty(
+        State(captured): State<Arc<Mutex<Vec<CapturedRequest>>>>,
+        req: axum::extract::Request,
+    ) -> (axum::http::StatusCode, String) {
+        let (parts, body) = req.into_parts();
+        let path_and_query = parts
+            .uri
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or("")
+            .to_string();
+        let authorization = parts
+            .headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        let body_bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        let body_json: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!({}));
+
+        captured.lock().unwrap().push(CapturedRequest {
+            path_and_query,
+            authorization,
+            body: body_json,
+        });
+
+        // 上游真的挂了，返回 502 + 空 body
+        (axum::http::StatusCode::BAD_GATEWAY, String::new())
+    }
+
+    #[tokio::test]
+    async fn native_responses_provider_passes_through_200_custom_json() {
+        // === 启动模拟企业网关（返回 HTTP 200 + 自定义 JSON）===
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route(
+                "/v1/responses",
+                post(mock_enterprise_gateway_200_custom_json),
+            )
+            .with_state(Arc::clone(&captured));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mock_addr = listener.local_addr().unwrap();
+        let mock_base_url = format!("http://{mock_addr}");
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        // === 创建 wire_api=responses 的测试 Provider ===
+        let db = Arc::new(Database::memory().unwrap());
+        let provider = Provider::with_id(
+            "test-enterprise-responses".to_string(),
+            "Enterprise Responses Gateway".to_string(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "test-enterprise-key-123"},
+                "base_url": mock_base_url,
+                "config": r#"model = "gpt-4""#
+            }),
+            None,
+        );
+        db.save_provider("codex", &provider).unwrap();
+        db.set_current_provider("codex", &provider.id).unwrap();
+
+        // === 启动 CC Switch 代理 ===
+        let proxy = ProxyServer::new(
+            ProxyConfig {
+                listen_port: 0,
+                enable_logging: false,
+                non_streaming_timeout: 10,
+                ..ProxyConfig::default()
+            },
+            db.clone(),
+            None,
+        );
+
+        let proxy_info = proxy.start().await.unwrap();
+        let proxy_url = format!("http://127.0.0.1:{}", proxy_info.port);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // === 通过代理转发 /v1/responses 请求 ===
+        let client = reqwest::Client::new();
+        let request_body = json!({
+            "model": "gpt-4",
+            "prompt": "Hello",
+            "max_tokens": 50
+        });
+
+        let response = client
+            .post(format!("{proxy_url}/v1/responses"))
+            .header("Authorization", "Bearer test-enterprise-key-123")
+            .json(&request_body)
+            .send()
+            .await
+            .unwrap();
+
+        // === 断言：代理应透传 HTTP 200 + 自定义 JSON，而非返回 502 ===
+        let status = response.status();
+        let body_text = response.text().await.unwrap();
+
+        assert_eq!(
+            status,
+            reqwest::StatusCode::OK,
+            "代理应透传上游的 200 而非误报 502；实际返回 {status}，body: {body_text}"
+        );
+
+        let body_json: Value = serde_json::from_str(&body_text).unwrap();
+        assert_eq!(
+            body_json.get("success").and_then(|v| v.as_bool()),
+            Some(true),
+            "响应应保留企业网关的自定义 JSON 结构"
+        );
+        assert_eq!(
+            body_json
+                .pointer("/data/completion")
+                .and_then(|v| v.as_str()),
+            Some("This is a custom enterprise response format."),
+            "completion 字段应完整透传"
+        );
+
+        // === 确认上游收到了正确的请求 ===
+        let captured_reqs = captured.lock().unwrap();
+        assert_eq!(captured_reqs.len(), 1, "上游应收到 1 个请求");
+        assert_eq!(
+            captured_reqs[0].path_and_query, "/v1/responses",
+            "base_url 为纯 origin 时，build_url 会补 /v1 前缀"
+        );
+        assert_eq!(
+            captured_reqs[0].authorization.as_deref(),
+            Some("Bearer test-enterprise-key-123"),
+            "认证头应透传"
+        );
+        assert_eq!(
+            captured_reqs[0].body.get("model").and_then(|v| v.as_str()),
+            Some("gpt-4"),
+            "请求 body 应透传"
+        );
+    }
+
+    /// 模拟企业网关：真实 Codex CLI 是流式请求（stream=true + Accept: text/event-stream），
+    /// 但企业网关对流式请求也返回 200 + 普通 JSON（非 SSE）。模拟这一形状。
+    async fn mock_enterprise_gateway_streaming_request_returns_plain_json(
+        State(captured): State<Arc<Mutex<Vec<CapturedRequest>>>>,
+        req: axum::extract::Request,
+    ) -> (axum::http::StatusCode, axum::http::HeaderMap, String) {
+        let (parts, body) = req.into_parts();
+        let path_and_query = parts
+            .uri
+            .path_and_query()
+            .map(|pq| pq.as_str())
+            .unwrap_or("")
+            .to_string();
+        let authorization = parts
+            .headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        let body_bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        let body_json: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!({}));
+
+        captured.lock().unwrap().push(CapturedRequest {
+            path_and_query,
+            authorization,
+            body: body_json,
+        });
+
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("content-type", "application/json".parse().unwrap());
+        let custom_response = json!({
+            "success": true,
+            "data": {
+                "completion": "Custom enterprise streaming-shaped response.",
+            }
+        });
+        (
+            axum::http::StatusCode::OK,
+            headers,
+            custom_response.to_string(),
+        )
+    }
+
+    /// 复现 Issue #6895 的另一种可能：Codex CLI 真实请求是流式的
+    /// （stream=true, Accept: text/event-stream），但上游网关返回 200 + 普通 JSON。
+    /// 验证 v3.20.0 代理不会把这种 200 误判成 502。
+    #[tokio::test]
+    async fn native_responses_provider_passes_through_streaming_200_plain_json() {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route(
+                "/v1/responses",
+                post(mock_enterprise_gateway_streaming_request_returns_plain_json),
+            )
+            .with_state(Arc::clone(&captured));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mock_addr = listener.local_addr().unwrap();
+        let mock_base_url = format!("http://{mock_addr}");
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        let db = Arc::new(Database::memory().unwrap());
+        let provider = Provider::with_id(
+            "test-enterprise-streaming".to_string(),
+            "Enterprise Streaming Gateway".to_string(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "test-stream-key-123"},
+                "base_url": mock_base_url,
+                "config": r#"model = "gpt-4""#
+            }),
+            None,
+        );
+        db.save_provider("codex", &provider).unwrap();
+        db.set_current_provider("codex", &provider.id).unwrap();
+
+        let proxy = ProxyServer::new(
+            ProxyConfig {
+                listen_port: 0,
+                enable_logging: false,
+                non_streaming_timeout: 10,
+                ..ProxyConfig::default()
+            },
+            db.clone(),
+            None,
+        );
+
+        let proxy_info = proxy.start().await.unwrap();
+        let proxy_url = format!("http://127.0.0.1:{}", proxy_info.port);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // 模拟 Codex CLI 的流式请求形状
+        let client = reqwest::Client::new();
+        let request_body = json!({
+            "model": "gpt-4",
+            "input": "Hello",
+            "stream": true
+        });
+
+        let response = client
+            .post(format!("{proxy_url}/v1/responses"))
+            .header("Authorization", "Bearer test-stream-key-123")
+            .header("Accept", "text/event-stream")
+            .header("User-Agent", "codex/0.144.0")
+            .json(&request_body)
+            .send()
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let body_text = response.text().await.unwrap();
+
+        assert_eq!(
+            status,
+            reqwest::StatusCode::OK,
+            "流式请求 + 200 普通 JSON 应透传而非误报 502；实际返回 {status}，body: {body_text}"
+        );
+
+        let body_json: Value = serde_json::from_str(&body_text).unwrap_or(json!({}));
+        assert_eq!(
+            body_json.get("success").and_then(|v| v.as_bool()),
+            Some(true),
+            "响应应保留企业网关的自定义 JSON 结构"
+        );
+
+        let captured_reqs = captured.lock().unwrap();
+        assert_eq!(captured_reqs.len(), 1, "上游应收到 1 个请求");
+        assert_eq!(
+            captured_reqs[0].authorization.as_deref(),
+            Some("Bearer test-stream-key-123"),
+            "认证头应透传"
+        );
+        assert_eq!(
+            captured_reqs[0]
+                .body
+                .get("stream")
+                .and_then(|v| v.as_bool()),
+            Some(true),
+            "stream 字段应透传"
+        );
+    }
+
+    #[tokio::test]
+    async fn native_responses_provider_passes_through_real_502_empty_body() {
+        // === 启动模拟企业网关（返回真实 HTTP 502 空 body）===
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/v1/responses", post(mock_enterprise_gateway_502_empty))
+            .with_state(Arc::clone(&captured));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let mock_addr = listener.local_addr().unwrap();
+        let mock_base_url = format!("http://{mock_addr}");
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        // === 创建 wire_api=responses 的测试 Provider ===
+        let db = Arc::new(Database::memory().unwrap());
+        let provider = Provider::with_id(
+            "test-enterprise-502".to_string(),
+            "Enterprise 502 Gateway".to_string(),
+            json!({
+                "auth": {"OPENAI_API_KEY": "test-502-key"},
+                "config": format!(r#"model_provider = "enterprise"
+model = "gpt-4"
+
+[model_providers.enterprise]
+name = "Enterprise Gateway"
+base_url = "{mock_base_url}"
+wire_api = "responses"
+"#)
+            }),
+            None,
+        );
+        db.save_provider("codex", &provider).unwrap();
+        db.set_current_provider("codex", &provider.id).unwrap();
+
+        // === 启动 CC Switch 代理 ===
+        let proxy = ProxyServer::new(
+            ProxyConfig {
+                listen_port: 0,
+                enable_logging: false,
+                non_streaming_timeout: 10,
+                ..ProxyConfig::default()
+            },
+            db.clone(),
+            None,
+        );
+
+        let proxy_info = proxy.start().await.unwrap();
+        let proxy_url = format!("http://127.0.0.1:{}", proxy_info.port);
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // === 通过代理转发请求 ===
+        let client = reqwest::Client::new();
+        let request_body = json!({
+            "model": "gpt-4",
+            "prompt": "Hello",
+            "max_tokens": 50
+        });
+
+        let response = client
+            .post(format!("{proxy_url}/v1/responses"))
+            .header("Authorization", "Bearer test-502-key")
+            .json(&request_body)
+            .send()
+            .await
+            .unwrap();
+
+        // === 断言：代理应透传上游的真实 502，这是预期行为 ===
+        let status = response.status();
+        let body_text = response.text().await.unwrap();
+
+        assert_eq!(
+            status,
+            reqwest::StatusCode::BAD_GATEWAY,
+            "代理应透传上游的真实 502"
+        );
+
+        // 解析 Codex proxy 错误格式：cause 是拼接进 error.message 里的一段文本
+        // （形如 "...; cause: 上游错误 (502):"），不是独立的 JSON 字段
+        let body_json: Value = serde_json::from_str(&body_text).unwrap_or(json!({}));
+        let message = body_json
+            .pointer("/error/message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        // 上游返回空 body 时，cause 应为 "上游错误 (502):" 带空尾巴（issue 原始症状）
+        assert!(
+            message.contains("cause: 上游错误 (502):"),
+            "message 应包含上游 502 描述，实际: {message}"
+        );
+        // 这是 issue 报告的精确症状：冒号后空白（后面没有 body 内容）
+        assert!(
+            message.trim_end().ends_with("cause: 上游错误 (502):"),
+            "上游空 body 应产生冒号后空白的 cause（issue #6895 症状），实际: '{message}'"
+        );
+
+        // === 确认上游收到了请求 ===
+        let captured_reqs = captured.lock().unwrap();
+        assert_eq!(captured_reqs.len(), 1, "上游应收到 1 个请求");
+    }
+}

--- a/src-tauri/src/proxy/usage/logger.rs
+++ b/src-tauri/src/proxy/usage/logger.rs
@@ -11,6 +11,17 @@ use rust_decimal::Decimal;
 use sha2::{Digest, Sha256};
 use std::str::FromStr;
 
+/// `proxy_request_logs.error_message` 的字符数上限：上游错误体（中转站整页
+/// HTML、长 JSON）会被原样取出入库，不设上限时高频报错能把库撑到数 GB（#6706）。
+pub(crate) const MAX_ERROR_MESSAGE_CHARS: usize = 2000;
+
+fn bound_error_message(message: &str) -> &str {
+    match message.char_indices().nth(MAX_ERROR_MESSAGE_CHARS) {
+        None => message,
+        Some((byte_index, _)) => &message[..byte_index],
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 struct UsageSemantic {
     app_type: String,
@@ -166,6 +177,7 @@ impl<'a> UsageLogger<'a> {
         } else {
             "INSERT OR IGNORE"
         };
+        let error_message = log.error_message.as_deref().map(bound_error_message);
         let sql = format!(
             "{insert_verb} INTO proxy_request_logs (
                 request_id, provider_id, app_type, model, request_model, pricing_model,
@@ -199,7 +211,7 @@ impl<'a> UsageLogger<'a> {
                     log.latency_ms as i64,
                     log.first_token_ms.map(|v| v as i64),
                     log.status_code as i64,
-                    log.error_message,
+                    error_message,
                     log.session_id,
                     log.provider_type,
                     log.is_streaming as i64,
@@ -764,6 +776,47 @@ mod tests {
             .unwrap();
         assert_eq!(status, 500);
         assert_eq!(error, Some("Internal Server Error".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn bound_error_message_truncates_on_char_boundary() {
+        let multibyte = "汉".repeat(MAX_ERROR_MESSAGE_CHARS + 50);
+        let bounded = bound_error_message(&multibyte);
+        assert_eq!(bounded.chars().count(), MAX_ERROR_MESSAGE_CHARS);
+        assert_eq!(bounded, "汉".repeat(MAX_ERROR_MESSAGE_CHARS));
+        assert_eq!(bound_error_message("short"), "short");
+        assert_eq!(bound_error_message(""), "");
+    }
+
+    #[test]
+    fn log_request_bounds_error_message_length() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let logger = UsageLogger::new(&db);
+
+        // Reproduces #6706: a relay returning a multi-megabyte HTML error page
+        // must not be stored verbatim.
+        let huge_body = format!("<html>{}</html>", "e".repeat(MAX_ERROR_MESSAGE_CHARS * 100));
+        logger.log_error(
+            "req-huge-error".to_string(),
+            "provider-1".to_string(),
+            "claude".to_string(),
+            "claude-sonnet-4-5".to_string(),
+            502,
+            huge_body,
+            50,
+        )?;
+
+        let conn = crate::database::lock_conn!(db.conn);
+        let stored: String = conn
+            .query_row(
+                "SELECT error_message FROM proxy_request_logs WHERE request_id = 'req-huge-error'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored.chars().count(), MAX_ERROR_MESSAGE_CHARS);
+        assert!(stored.starts_with("<html>"));
         Ok(())
     }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -487,6 +487,9 @@ pub struct AppSettings {
     /// Maximum number of backup files to retain (default 10)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backup_retain_count: Option<u32>,
+    /// Total size cap for the backups directory in MB (default 2048, 0 = unlimited)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub backup_max_total_mb: Option<u32>,
 
     // ===== 终端设置 =====
     /// 首选终端应用（可选，默认使用系统默认终端）
@@ -565,6 +568,7 @@ impl Default for AppSettings {
             webdav_backup: None,
             backup_interval_hours: None,
             backup_retain_count: None,
+            backup_max_total_mb: None,
             preferred_terminal: None,
             local_migrations: None,
         }
@@ -1125,6 +1129,24 @@ pub fn effective_backup_retain_count() -> usize {
         .backup_retain_count
         .map(|n| (n as usize).max(1))
         .unwrap_or(10)
+}
+
+/// Get the effective total size cap for the backups directory in bytes
+/// (default 2048 MiB; 0 disables the cap)
+pub fn effective_backup_max_total_bytes() -> u64 {
+    const DEFAULT_MAX_TOTAL_MB: u32 = 2048;
+    let configured = settings_store()
+        .read()
+        .unwrap_or_else(|e| {
+            log::warn!("设置锁已毒化，使用恢复值: {e}");
+            e.into_inner()
+        })
+        .backup_max_total_mb;
+    match configured {
+        Some(0) => u64::MAX,
+        Some(mb) => u64::from(mb) * 1024 * 1024,
+        None => u64::from(DEFAULT_MAX_TOTAL_MB) * 1024 * 1024,
+    }
 }
 
 // ===== 终端设置管理函数 =====

--- a/src/components/settings/BackupListSection.tsx
+++ b/src/components/settings/BackupListSection.tsx
@@ -26,9 +26,11 @@ import { extractErrorMessage } from "@/utils/errorUtils";
 interface BackupListSectionProps {
   backupIntervalHours?: number;
   backupRetainCount?: number;
+  backupMaxTotalMb?: number;
   onSettingsChange: (updates: {
     backupIntervalHours?: number;
     backupRetainCount?: number;
+    backupMaxTotalMb?: number;
   }) => void;
 }
 
@@ -64,6 +66,7 @@ function getDisplayName(filename: string): string {
 export function BackupListSection({
   backupIntervalHours,
   backupRetainCount,
+  backupMaxTotalMb,
   onSettingsChange,
 }: BackupListSectionProps) {
   const { t } = useTranslation();
@@ -164,6 +167,7 @@ export function BackupListSection({
 
   const intervalValue = String(backupIntervalHours ?? 24);
   const retainValue = String(backupRetainCount ?? 10);
+  const maxTotalValue = String(backupMaxTotalMb ?? 2048);
 
   return (
     <div className="space-y-4">
@@ -245,6 +249,36 @@ export function BackupListSection({
                   {n}
                 </SelectItem>
               ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-sm">
+            {t("settings.backupManager.maxTotalLabel", {
+              defaultValue: "Backup Size Cap",
+            })}
+          </Label>
+          <Select
+            value={maxTotalValue}
+            onValueChange={(v) =>
+              onSettingsChange({ backupMaxTotalMb: Number(v) })
+            }
+          >
+            <SelectTrigger className="h-9">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="512">512 MB</SelectItem>
+              <SelectItem value="1024">1 GB</SelectItem>
+              <SelectItem value="2048">2 GB</SelectItem>
+              <SelectItem value="5120">5 GB</SelectItem>
+              <SelectItem value="10240">10 GB</SelectItem>
+              <SelectItem value="0">
+                {t("settings.backupManager.maxTotalUnlimited", {
+                  defaultValue: "Unlimited",
+                })}
+              </SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -422,6 +422,7 @@ export function SettingsPage({
                           <BackupListSection
                             backupIntervalHours={settings.backupIntervalHours}
                             backupRetainCount={settings.backupRetainCount}
+                            backupMaxTotalMb={settings.backupMaxTotalMb}
                             onSettingsChange={(updates) =>
                               handleAutoSave(updates)
                             }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -483,6 +483,8 @@
       "safetyBackupId": "Safety Backup ID",
       "intervalLabel": "Auto-backup Interval",
       "retainLabel": "Backup Retention",
+      "maxTotalLabel": "Backup Size Cap",
+      "maxTotalUnlimited": "Unlimited",
       "intervalDisabled": "Disabled",
       "intervalHours": "{{hours}} hours",
       "intervalDays": "{{days}} days",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -483,6 +483,8 @@
       "safetyBackupId": "安全バックアップID",
       "intervalLabel": "自動バックアップ間隔",
       "retainLabel": "バックアップ保持数",
+      "maxTotalLabel": "バックアップ合計サイズ上限",
+      "maxTotalUnlimited": "無制限",
       "intervalDisabled": "無効",
       "intervalHours": "{{hours}} 時間",
       "intervalDays": "{{days}} 日",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -483,6 +483,8 @@
       "safetyBackupId": "安全備份 ID",
       "intervalLabel": "自動備份間隔",
       "retainLabel": "備份保留數量",
+      "maxTotalLabel": "備份總大小上限",
+      "maxTotalUnlimited": "不限制",
       "intervalDisabled": "停用",
       "intervalHours": "{{hours}} 小時",
       "intervalDays": "{{days}} 天",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -483,6 +483,8 @@
       "safetyBackupId": "安全备份ID",
       "intervalLabel": "自动备份间隔",
       "retainLabel": "备份保留数量",
+      "maxTotalLabel": "备份总大小上限",
+      "maxTotalUnlimited": "不限制",
       "intervalDisabled": "禁用",
       "intervalHours": "{{hours}} 小时",
       "intervalDays": "{{days}} 天",

--- a/src/types.ts
+++ b/src/types.ts
@@ -449,6 +449,8 @@ export interface Settings {
   backupIntervalHours?: number;
   // Maximum backup files to retain (default 10)
   backupRetainCount?: number;
+  // Total size cap for the backups directory in MB (0=unlimited, default 2048)
+  backupMaxTotalMb?: number;
 
   // ===== 终端设置 =====
   // 首选终端应用（可选，默认使用系统默认终端）


### PR DESCRIPTION
## Summary

Fixes #6706 (database folder growing to 22 GB). The reporter's folder held ten daily full-image backups of an already-bloated ~2.4 GB database (`db_backup_*.db` × 10 = 22.4 GB) plus an orphaned `.db-journal`. Three independent growth vectors plus backup hygiene, each now bounded:

### 1. Oversized `proxy_request_logs.error_message` (`0e16f0a3`)

Upstream error bodies (relay full-page HTML, long JSON) were persisted verbatim since error request logging was introduced — a chatty failing upstream could push the DB to multiple GB on its own.

- `UsageLogger` truncates `error_message` to `MAX_ERROR_MESSAGE_CHARS = 2000` on char boundaries before insert.
- Schema v17 → v18 migration truncates legacy oversized rows with SQL `substr()`, which is character-based and matches the logger-side cap. The step no-ops on layouts where the column does not exist yet.
- Space actually returns to disk via the existing incremental auto-vacuum path (`ensure_incremental_auto_vacuum` at init converts older DBs with a full VACUUM; startup/periodic maintenance issues `PRAGMA incremental_vacuum` after reclaimed-row maintenance).

### 2. Unbounded backups folder (`c13dc4b6`, `eb15c025`)

Retention only ran when a new backup was created, and only enforced a count.

- New `backup_max_total_mb` setting (default **2048 MB**, `0` = unlimited) with a selector in Settings → Database Backups; localized in en/zh/zh-TW/ja.
- `cleanup_db_backups` still keeps the newest N files first, then trims oldest-first until the folder fits the cap. The newest restore point always survives even when it alone exceeds the cap, and protected paths (just-created backup / restore source) are never deleted in either pass.
- `periodic_backup_if_needed` now runs count + size retention even when no new backup is due, so an oversized folder like the reporter's is bounded on first launch after upgrade instead of waiting up to a full backup interval.
- Deleting a backup now also removes its SQLite sidecar files (`-journal`/`-wal`/`-shm`), and orphan sidecars whose `.db` no longer exists are swept during cleanup — the reporter's folder contained exactly such residue. Sidecars of surviving backups stay untouched (they may belong to an in-progress restore).

### 3. Uncapped `session_usage_dedup` ledger (`c13dc4b6`)

The ledger added by #6463 has no timestamp column and is never pruned by design, so it grows forever. It is now trimmed to its newest 1M rows during periodic maintenance (rowid order = insertion order). Only the pi session importer consults this ledger, and per-file sync cursors remain the primary guard against re-counting, so evicting the oldest entries cannot resurrect historical usage.

### Test-only prerequisite (`9a679306`)

On Windows, the v3.10.3 legacy-database probe read `$HOME` unconditionally; Git Bash/MSYS injects a HOME pointing at the real user profile, redirecting explicitly test-isolated runs back to real user data. Tests now skip that probe when `CC_SWITCH_TEST_HOME` is set. Production behavior unchanged.

## Upgrading-user outcome

After upgrading with this PR, the first launch migrates v17→v18 (truncating oversized error bodies), converts pre-incremental-vacuum databases if needed, runs retention once immediately — the 22.4 GB backups folder drops to ≤ the size cap while keeping one restore point — and periodic maintenance reclaims freed pages via incremental vacuum.

## Test plan

- [x] New unit tests: logger char-boundary truncation + end-to-end oversized-error insert; v17→v18 migration (oversized/multibyte/short rows); size-cap cleanup incl. protected-path survival; startup retention without a due backup; dedup-ledger cap eviction order; sqlite sidecar removal + orphan sweep
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full `cargo test` (2806 passed)
- [x] `pnpm typecheck`, `pnpm format:check`
