### PR TITLE
feat(provider): 添加 HopsAPI Claude 与 Codex 预设

### DIFF
--- a/src/config/claudeProviderPresets.ts
+++ b/src/config/claudeProviderPresets.ts
@@ -135,6 +135,19 @@ export const providerPresets: ProviderPreset[] = [
     iconColor: "#6366F1",
   },
   {
+    name: "HopsAPI",
+    websiteUrl: "https://hopsapi.com",
+    apiKeyUrl: "https://hopsapi.com/keys?from=cc-switch",
+    settingsConfig: {
+      env: {
+        ANTHROPIC_BASE_URL: "https://hopsapi.com",
+        ANTHROPIC_AUTH_TOKEN: "",
+      },
+    },
+    endpointCandidates: ["https://hopsapi.com"],
+    category: "third_party",
+  },
+  {
     name: "PackyCode",
     websiteUrl: "https://www.packyapi.ai",
     apiKeyUrl: "https://www.packyapi.ai/register?aff=cc-switch",

--- a/src/config/codexProviderPresets.ts
+++ b/src/config/codexProviderPresets.ts
@@ -251,6 +251,19 @@ export const codexProviderPresets: CodexProviderPreset[] = [
     iconColor: "#6366F1",
   },
   {
+    name: "HopsAPI",
+    websiteUrl: "https://hopsapi.com",
+    apiKeyUrl: "https://hopsapi.com/keys?from=cc-switch",
+    category: "third_party",
+    auth: generateThirdPartyAuth(""),
+    config: generateThirdPartyConfig(
+      "HopsAPI",
+      "https://hopsapi.com/v1",
+      "gpt-5.6-sol",
+    ),
+    endpointCandidates: ["https://hopsapi.com/v1"],
+  },
+  {
     name: "PackyCode",
     websiteUrl: "https://www.packyapi.ai",
     apiKeyUrl: "https://www.packyapi.ai/register?aff=cc-switch",


### PR DESCRIPTION
## 变更

- 为 Claude 添加 HopsAPI 第三方供应商预设
  - `ANTHROPIC_BASE_URL=https://hopsapi.com`
  - API Key 使用 `ANTHROPIC_AUTH_TOKEN`
- 为 Codex 添加 HopsAPI 第三方供应商预设
  - `base_url=https://hopsapi.com/v1`
  - 默认模型为 `gpt-5.6-sol`
- 两套预设均提供 HopsAPI 官网、API Key 获取地址和请求地址候选

## 验证

- 已人工核对 Claude 与 Codex 预设结构与仓库现有第三方供应商格式一致
- 按当前任务授权边界，未运行 build、typecheck、测试或格式化命令

关联：storyclaw-official/storyclaw-token-gateway#221