### PR TITLE
refactor: source app type from shared core

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -768,6 +768,7 @@ dependencies = [
  "base64 0.22.1",
  "brotli 7.0.0",
  "bytes",
+ "cc-switch-core",
  "chrono",
  "dirs 5.0.1",
  "flate2",
@@ -828,6 +829,14 @@ dependencies = [
  "winreg 0.52.0",
  "zip 2.4.2",
  "zstd",
+]
+
+[[package]]
+name = "cc-switch-core"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/SaladDay/cc-switch-core?rev=0651b5b30adf1f87123df37d3d5748a07784363a#0651b5b30adf1f87123df37d3d5748a07784363a"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ test-hooks = []
 tauri-build = { version = "2.4.0", features = [] }
 
 [dependencies]
+cc-switch-core = { git = "https://github.com/SaladDay/cc-switch-core", rev = "0651b5b30adf1f87123df37d3d5748a07784363a" }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"

--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::str::FromStr;
+
+pub use cc_switch_core::AppType;
 
 use crate::services::skill::SkillStore;
 
@@ -373,101 +374,6 @@ use crate::config::{copy_file, get_app_config_dir, get_app_config_path, write_js
 use crate::error::AppError;
 use crate::prompt_files::prompt_file_path;
 use crate::provider::ProviderManager;
-
-/// 应用类型
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum AppType {
-    Claude,
-    #[serde(
-        rename = "claude-desktop",
-        alias = "claude_desktop",
-        alias = "claudeDesktop"
-    )]
-    ClaudeDesktop,
-    Codex,
-    Gemini,
-    GrokBuild,
-    OpenCode,
-    OpenClaw,
-    Hermes,
-    Pi,
-}
-
-impl AppType {
-    pub fn as_str(&self) -> &str {
-        match self {
-            AppType::Claude => "claude",
-            AppType::ClaudeDesktop => "claude-desktop",
-            AppType::Codex => "codex",
-            AppType::Gemini => "gemini",
-            AppType::GrokBuild => "grokbuild",
-            AppType::OpenCode => "opencode",
-            AppType::OpenClaw => "openclaw",
-            AppType::Hermes => "hermes",
-            AppType::Pi => "pi",
-        }
-    }
-
-    /// Check if this app uses additive mode
-    ///
-    /// - Switch mode (false): Only the current provider is written to live config (Claude, Codex, Gemini)
-    /// - Additive mode (true): Providers coexist in native config and can be enabled independently
-    ///   (OpenCode, OpenClaw, Hermes, Pi)
-    pub fn is_additive_mode(&self) -> bool {
-        matches!(
-            self,
-            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Pi
-        )
-    }
-
-    pub fn supports_local_proxy(&self) -> bool {
-        matches!(
-            self,
-            AppType::Claude | AppType::Codex | AppType::Gemini | AppType::GrokBuild
-        )
-    }
-
-    /// Return an iterator over all app types
-    pub fn all() -> impl Iterator<Item = AppType> {
-        [
-            AppType::Claude,
-            AppType::ClaudeDesktop,
-            AppType::Codex,
-            AppType::Gemini,
-            AppType::GrokBuild,
-            AppType::OpenCode,
-            AppType::OpenClaw,
-            AppType::Hermes,
-            AppType::Pi,
-        ]
-        .into_iter()
-    }
-}
-
-impl FromStr for AppType {
-    type Err = AppError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let normalized = s.trim().to_lowercase();
-        match normalized.as_str() {
-            "claude" => Ok(AppType::Claude),
-            "claude-desktop" | "claude_desktop" | "claudedesktop" => Ok(AppType::ClaudeDesktop),
-            "codex" => Ok(AppType::Codex),
-            "gemini" => Ok(AppType::Gemini),
-            "grokbuild" | "grok-build" | "grok_build" | "grok" => Ok(AppType::GrokBuild),
-            "opencode" => Ok(AppType::OpenCode),
-            "openclaw" => Ok(AppType::OpenClaw),
-            "hermes" => Ok(AppType::Hermes),
-            "pi" => Ok(AppType::Pi),
-            other => Err(AppError::localized(
-                "unsupported_app",
-                format!("不支持的应用标识: '{other}'。可选值: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, pi。"),
-                format!("Unsupported app id: '{other}'. Allowed: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, pi."),
-            )),
-        }
-    }
-}
 
 /// 通用配置片段（按应用分治）
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]


### PR DESCRIPTION
## Scope

This PR only replaces the existing `AppType` definition with a re-export from the pinned `cc-switch-core` revision. No provider, proxy, database, configuration I/O, frontend, or runtime behavior is changed.

Core dependency: https://github.com/SaladDay/cc-switch-core/pull/1

## Change surface

- `src-tauri/Cargo.toml`: add one revision-pinned dependency
- `src-tauri/Cargo.lock`: lock that dependency
- `src-tauri/src/app_config.rs`: re-export `AppType` and remove the identical local definition

## Validation

- core: 6 unit tests and 1 doctest passed
- core: `cargo clippy --all-targets -- -D warnings` passed
- cc-switch: 2,727 Rust tests passed, 5 ignored, 0 failed
- cc-switch: `cargo clippy --all-targets -- -D warnings` passed
- two independent blind reviews: clean

## Out of scope

Configuration I/O, adapters, ProviderService, storage, UI, plugins, release configuration, and dependency upgrades.