### PR TITLE
fix(proxy): skip foreign live backups during takeover recovery

### DIFF
--- a/src-tauri/src/database/dao/proxy.rs
+++ b/src-tauri/src/database/dao/proxy.rs
@@ -776,18 +776,22 @@ impl Database {
     // ==================== Live Backup ====================
 
     /// 保存 Live 配置备份
+    ///
+    /// `provider_id`：备份归属的供应商（备份写入时的当前供应商），
+    /// 供恢复路径校验备份内容是否仍属于当前供应商。
     pub async fn save_live_backup(
         &self,
         app_type: &str,
         config_json: &str,
+        provider_id: Option<&str>,
     ) -> Result<(), AppError> {
         let conn = lock_conn!(self.conn);
         let now = chrono::Utc::now().to_rfc3339();
 
         conn.execute(
-            "INSERT OR REPLACE INTO proxy_live_backup (app_type, original_config, backed_up_at)
-             VALUES (?1, ?2, ?3)",
-            rusqlite::params![app_type, config_json, now],
+            "INSERT OR REPLACE INTO proxy_live_backup (app_type, original_config, backed_up_at, provider_id)
+             VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![app_type, config_json, now, provider_id],
         )
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -811,13 +815,14 @@ impl Database {
         let conn = lock_conn!(self.conn);
 
         let result = conn.query_row(
-            "SELECT app_type, original_config, backed_up_at FROM proxy_live_backup WHERE app_type = ?1",
+            "SELECT app_type, original_config, backed_up_at, provider_id FROM proxy_live_backup WHERE app_type = ?1",
             rusqlite::params![app_type],
             |row| {
                 Ok(LiveBackup {
                     app_type: row.get(0)?,
                     original_config: row.get(1)?,
                     backed_up_at: row.get(2)?,
+                    provider_id: row.get(3)?,
                 })
             },
         );

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -261,9 +261,12 @@ impl Database {
         // 注意：circuit_breaker_config 已合并到 proxy_config 表中
 
         // 16. Proxy Live Backup 表 (Live 配置备份)
+        // provider_id = 备份归属的供应商（备份写入时的当前供应商），NULL 为旧版本备份；
+        // 恢复路径据此拒绝把外部切换前留下的旧备份内容归到新供应商名下。
         conn.execute(
             "CREATE TABLE IF NOT EXISTS proxy_live_backup (
-            app_type TEXT PRIMARY KEY, original_config TEXT NOT NULL, backed_up_at TEXT NOT NULL
+            app_type TEXT PRIMARY KEY, original_config TEXT NOT NULL, backed_up_at TEXT NOT NULL,
+            provider_id TEXT
         )",
             [],
         )
@@ -410,6 +413,9 @@ impl Database {
             "in_failover_queue",
             "BOOLEAN NOT NULL DEFAULT 0",
         )?;
+
+        // 确保 proxy_live_backup.provider_id 列存在（对于接管备份表已建库的安装）
+        Self::add_column_if_missing(conn, "proxy_live_backup", "provider_id", "TEXT")?;
 
         // 删除旧的 failover_queue 表（如果存在）
         let _ = conn.execute("DROP INDEX IF EXISTS idx_failover_queue_order", []);

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -140,6 +140,12 @@ pub struct LiveBackup {
     pub original_config: String,
     /// 备份时间
     pub backed_up_at: String,
+    /// 备份归属的供应商 id（备份写入时的当前供应商）
+    ///
+    /// None 表示旧版本写入的备份（未记录归属）。恢复路径据此判断备份内容
+    /// 是否仍属于当前供应商：current 在接管期间被外部切换（如无头脚本直写
+    /// 数据库）后，旧备份还原出的 Token 不能再归到新供应商名下。
+    pub provider_id: Option<String>,
 }
 
 /// 全局代理配置（统一字段，三行镜像）

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -1049,6 +1049,7 @@ mod tests {
         db.save_live_backup(
             "claude",
             &serde_json::to_string(&original.settings_config).expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed stale backup");
@@ -1370,7 +1371,7 @@ GEMINI_TIMEOUT_MS=30000
 
         // 关代理时这份快照会被原样写回 live。若清不动它却照样清了片段、置了完成标记，
         // 代理一停凭据就复活，而一次性标记保证不会再清第二次。
-        db.save_live_backup("gemini", "}not json{")
+        db.save_live_backup("gemini", "}not json{", None)
             .await
             .expect("seed backup");
 
@@ -1930,6 +1931,7 @@ requires_openai_auth = true
         db.save_live_backup(
             "codex",
             &serde_json::to_string(&original.settings_config).expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -2043,7 +2045,7 @@ requires_openai_auth = true
 
         // Claude Desktop keeps backup state from takeover startup; this sentinel only
         // marks takeover as active so provider updates rewrite the 3P profile.
-        db.save_live_backup("claude-desktop", "{}")
+        db.save_live_backup("claude-desktop", "{}", None)
             .await
             .expect("seed live backup");
         {
@@ -3364,6 +3366,7 @@ wire_api = "responses"
                             "config": "model = \"gpt-5.4\"\n"
                         }))
                         .expect("serialize baseline backup"),
+                        None,
                     )
                     .await
                     .expect("save baseline backup");
@@ -4239,11 +4242,11 @@ impl ProviderService {
             }
         }
         let backup_restore = match previous_backup {
-            Some(backup) => futures::executor::block_on(
-                state
-                    .db
-                    .save_live_backup(AppType::Codex.as_str(), &backup.original_config),
-            ),
+            Some(backup) => futures::executor::block_on(state.db.save_live_backup(
+                AppType::Codex.as_str(),
+                &backup.original_config,
+                backup.provider_id.as_deref(),
+            )),
             None => {
                 futures::executor::block_on(state.db.delete_live_backup(AppType::Codex.as_str()))
             }
@@ -6134,7 +6137,10 @@ impl ProviderService {
             if cleaned != original {
                 let text = serde_json::to_string(&cleaned)
                     .map_err(|e| AppError::Message(format!("Serialization failed: {e}")))?;
-                state.db.save_live_backup(app.as_str(), &text).await?;
+                state
+                    .db
+                    .save_live_backup(app.as_str(), &text, backup.provider_id.as_deref())
+                    .await?;
                 log::info!("已从 Gemini 代理接管备份中清除泄漏的共享凭据");
             }
         }

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -860,7 +860,11 @@ impl ProxyService {
         let rollback_result = match previous_backup {
             Some(backup) => {
                 self.db
-                    .save_live_backup(app_type.as_str(), &backup.original_config)
+                    .save_live_backup(
+                        app_type.as_str(),
+                        &backup.original_config,
+                        previous_provider_id,
+                    )
                     .await
             }
             None => self.db.delete_live_backup(app_type.as_str()).await,
@@ -1840,7 +1844,13 @@ impl ProxyService {
                 let json_str = serde_json::to_string(&config)
                     .map_err(|e| format!("序列化 Claude 配置失败: {e}"))?;
                 self.db
-                    .save_live_backup("claude", &json_str)
+                    .save_live_backup(
+                        "claude",
+                        &json_str,
+                        self.current_provider_id_for_backup(&AppType::Claude)
+                            .await
+                            .as_deref(),
+                    )
                     .await
                     .map_err(|e| format!("备份 Claude 配置失败: {e}"))?;
             }
@@ -1855,7 +1865,13 @@ impl ProxyService {
                 let json_str = serde_json::to_string(&config)
                     .map_err(|e| format!("序列化 Codex 配置失败: {e}"))?;
                 self.db
-                    .save_live_backup("codex", &json_str)
+                    .save_live_backup(
+                        "codex",
+                        &json_str,
+                        self.current_provider_id_for_backup(&AppType::Codex)
+                            .await
+                            .as_deref(),
+                    )
                     .await
                     .map_err(|e| format!("备份 Codex 配置失败: {e}"))?;
             }
@@ -1869,7 +1885,13 @@ impl ProxyService {
                 let json_str = serde_json::to_string(&config)
                     .map_err(|e| format!("序列化 Gemini 配置失败: {e}"))?;
                 self.db
-                    .save_live_backup("gemini", &json_str)
+                    .save_live_backup(
+                        "gemini",
+                        &json_str,
+                        self.current_provider_id_for_backup(&AppType::Gemini)
+                            .await
+                            .as_deref(),
+                    )
                     .await
                     .map_err(|e| format!("备份 Gemini 配置失败: {e}"))?;
             }
@@ -1883,7 +1905,13 @@ impl ProxyService {
                 let json_str = serde_json::to_string(&config)
                     .map_err(|e| format!("序列化 Grok Build 配置失败: {e}"))?;
                 self.db
-                    .save_live_backup("grokbuild", &json_str)
+                    .save_live_backup(
+                        "grokbuild",
+                        &json_str,
+                        self.current_provider_id_for_backup(&AppType::GrokBuild)
+                            .await
+                            .as_deref(),
+                    )
                     .await
                     .map_err(|e| format!("备份 Grok Build 配置失败: {e}"))?;
             }
@@ -1891,6 +1919,23 @@ impl ProxyService {
 
         log::info!("已备份所有应用的 Live 配置");
         Ok(())
+    }
+
+    /// 备份写入时应记录的归属供应商（当时的当前供应商）
+    ///
+    /// 读取失败时返回 None（记录为"归属未知"），恢复路径对归属未知的备份
+    /// 维持旧行为（照常还原），不因设置读取失败而破坏备份。
+    async fn current_provider_id_for_backup(&self, app_type: &AppType) -> Option<String> {
+        match crate::settings::get_effective_current_provider(&self.db, app_type) {
+            Ok(provider_id) => provider_id,
+            Err(e) => {
+                log::warn!(
+                    "读取 {} 当前供应商失败，备份将以未知归属落盘: {e}",
+                    app_type.as_str()
+                );
+                None
+            }
+        }
     }
 
     /// 备份指定应用的 Live 配置（严格模式：目标配置不存在则返回错误）
@@ -1919,7 +1964,13 @@ impl ProxyService {
         let json_str = serde_json::to_string(&config)
             .map_err(|e| format!("序列化 {app_type_str} 配置失败: {e}"))?;
         self.db
-            .save_live_backup(app_type_str, &json_str)
+            .save_live_backup(
+                app_type_str,
+                &json_str,
+                self.current_provider_id_for_backup(app_type)
+                    .await
+                    .as_deref(),
+            )
             .await
             .map_err(|e| format!("备份 {app_type_str} 配置失败: {e}"))?;
 
@@ -2314,6 +2365,19 @@ impl ProxyService {
                 log::warn!(
                     "{app_type_str} 备份本身已是代理占位符（异常历史状态），跳过备份，改走 SSOT 重建 Live"
                 );
+            } else if self
+                .backup_owner_differs_from_current_provider(&backup, app_type)
+                .await
+            {
+                // 备份归属的不是当前供应商：current 在接管期间被外部切换（如无头
+                // 脚本直写数据库后重启服务）的典型残留。此时备份里是上一个供应商
+                // 的真实 Token，若照常还原，随后的重新接管会把这份 Token「同步」进
+                // 当前供应商的配置，静默互换各家的 Key（#6886）。备份内容在其归属
+                // 供应商的记录里仍有 SSOT 副本，丢弃还原是安全的；落到下面的 SSOT
+                // 兜底，用当前供应商的配置重建 Live。
+                log::warn!(
+                    "{app_type_str} 备份归属于其它供应商（接管期间 current 被外部切换的残留），跳过备份还原，改走 SSOT 重建 Live"
+                );
             } else {
                 self.write_live_config_for_app(app_type, &config)?;
                 log::info!("{app_type_str} Live 配置已从备份恢复");
@@ -2348,6 +2412,24 @@ impl ProxyService {
         self.cleanup_takeover_placeholders_in_live_for_app(app_type)?;
         log::info!("{app_type_str} Live 接管占位符已清理（无备份兜底）");
         Ok(())
+    }
+
+    /// 备份归属的供应商是否已不是当前供应商
+    ///
+    /// 归属未知（旧版本写入的备份，provider_id 为 NULL）或当前供应商无法确定时，
+    /// 视为仍归属当前供应商（维持原有还原行为，不因信息缺失而拒绝恢复）。
+    async fn backup_owner_differs_from_current_provider(
+        &self,
+        backup: &LiveBackup,
+        app_type: &AppType,
+    ) -> bool {
+        let Some(backup_provider_id) = backup.provider_id.as_deref() else {
+            return false;
+        };
+        match crate::settings::get_effective_current_provider(&self.db, app_type) {
+            Ok(Some(current_provider_id)) => current_provider_id != backup_provider_id,
+            Ok(None) | Err(_) => false,
+        }
     }
 
     fn write_live_config_for_app(&self, app_type: &AppType, config: &Value) -> Result<(), String> {
@@ -2933,7 +3015,7 @@ impl ProxyService {
         };
 
         self.db
-            .save_live_backup(app_type, &backup_json)
+            .save_live_backup(app_type, &backup_json, Some(&provider.id))
             .await
             .map_err(|e| format!("更新 {app_type} 备份失败: {e}"))?;
 
@@ -4083,6 +4165,150 @@ mod tests {
         assert!(service.switch_proxy_target("pi", "missing").await.is_err());
     }
 
+    #[tokio::test]
+    #[serial]
+    async fn crash_restore_skips_backup_of_externally_switched_away_provider() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider_a = Provider::with_id(
+            "a".to_string(),
+            "A".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "sk-provider-a",
+                    "ANTHROPIC_BASE_URL": "https://api.a.example"
+                }
+            }),
+            None,
+        );
+        let provider_b = Provider::with_id(
+            "b".to_string(),
+            "B".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "sk-provider-b",
+                    "ANTHROPIC_BASE_URL": "https://api.b.example"
+                }
+            }),
+            None,
+        );
+        db.save_provider("claude", &provider_a)
+            .expect("save provider a");
+        db.save_provider("claude", &provider_b)
+            .expect("save provider b");
+        db.set_current_provider("claude", "a")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("a"))
+            .expect("set local current provider");
+
+        // A 接管中服务异常退出：备份槽记录 A 的真实配置及其归属，
+        // live 文件停留在代理占位符状态。
+        db.save_live_backup(
+            "claude",
+            &serde_json::to_string(&provider_a.settings_config).expect("serialize provider a"),
+            Some("a"),
+        )
+        .await
+        .expect("seed live backup");
+        service
+            .write_claude_live(&json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": PROXY_TOKEN_PLACEHOLDER,
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721"
+                }
+            }))
+            .expect("seed taken-over live file");
+
+        // current 在接管期间被外部（无头脚本直写数据库）切到 B，随后服务重启恢复。
+        db.set_current_provider("claude", "b")
+            .expect("switch current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("b"))
+            .expect("switch local current provider");
+
+        service
+            .restore_live_config_for_app_with_fallback(&AppType::Claude)
+            .await
+            .expect("restore live config");
+
+        let live = service.read_claude_live().expect("read live config");
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_AUTH_TOKEN"))
+                .and_then(|v| v.as_str()),
+            Some("sk-provider-b"),
+            "live 应从当前供应商的配置重建，而不是还原上一个供应商的旧备份"
+        );
+        let stored_b = db
+            .get_provider_by_id("b", "claude")
+            .expect("read provider b")
+            .expect("provider b exists");
+        assert_eq!(
+            stored_b.settings_config["env"]["ANTHROPIC_AUTH_TOKEN"],
+            json!("sk-provider-b"),
+            "上一个供应商的 Token 不得被归到当前供应商名下 (#6886)"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn crash_restore_still_restores_backup_of_unchanged_current_provider() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        let provider_a = Provider::with_id(
+            "a".to_string(),
+            "A".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": "sk-provider-a",
+                    "ANTHROPIC_BASE_URL": "https://api.a.example"
+                }
+            }),
+            None,
+        );
+        db.save_provider("claude", &provider_a)
+            .expect("save provider a");
+        db.set_current_provider("claude", "a")
+            .expect("set current provider");
+        crate::settings::set_current_provider(&AppType::Claude, Some("a"))
+            .expect("set local current provider");
+
+        db.save_live_backup(
+            "claude",
+            &serde_json::to_string(&provider_a.settings_config).expect("serialize provider a"),
+            Some("a"),
+        )
+        .await
+        .expect("seed live backup");
+        service
+            .write_claude_live(&json!({
+                "env": {
+                    "ANTHROPIC_AUTH_TOKEN": PROXY_TOKEN_PLACEHOLDER,
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:15721"
+                }
+            }))
+            .expect("seed taken-over live file");
+
+        service
+            .restore_live_config_for_app_with_fallback(&AppType::Claude)
+            .await
+            .expect("restore live config");
+
+        let live = service.read_claude_live().expect("read live config");
+        assert_eq!(
+            live.get("env")
+                .and_then(|env| env.get("ANTHROPIC_AUTH_TOKEN"))
+                .and_then(|v| v.as_str()),
+            Some("sk-provider-a"),
+            "归属未变的备份应照常还原（不能因归属校验而过度拦截）"
+        );
+    }
+
     async fn running_codex_base_url(service: &ProxyService) -> String {
         let status = service.get_status().await.expect("get proxy status");
         format!("http://127.0.0.1:{}/v1", status.port)
@@ -4699,6 +4925,7 @@ mod tests {
         db.save_live_backup(
             AppType::Codex.as_str(),
             &serde_json::to_string(&provider.settings_config).expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed takeover backup");
@@ -5470,6 +5697,7 @@ wire_api = "responses"
         db.save_live_backup(
             "codex",
             &serde_json::to_string(&previous.settings_config).expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed backup without live takeover marker");
@@ -6078,6 +6306,7 @@ wire_api = "responses"
                 "config": original_deepseek_config
             }))
             .expect("serialize original backup"),
+            None,
         )
         .await
         .expect("seed original live backup");
@@ -6807,7 +7036,7 @@ model = "gpt-5.1-codex"
             .expect("set current provider");
 
         // 模拟"已接管"状态：存在 Live 备份（内容不重要，会被热切换更新）
-        db.save_live_backup("claude", "{\"env\":{}}")
+        db.save_live_backup("claude", "{\"env\":{}}", None)
             .await
             .expect("seed live backup");
 
@@ -6885,6 +7114,7 @@ model = "gpt-5.1-codex"
         db.save_live_backup(
             "claude",
             &serde_json::to_string(&provider_a.settings_config).expect("serialize provider a"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -7035,7 +7265,7 @@ model = "gpt-5.1-codex"
             .expect("set current provider");
         crate::settings::set_current_provider(&AppType::Claude, Some("a"))
             .expect("set local current provider");
-        db.save_live_backup("claude", "{\"env\":{}}")
+        db.save_live_backup("claude", "{\"env\":{}}", None)
             .await
             .expect("seed live backup");
 
@@ -7123,6 +7353,7 @@ model = "gpt-5.1-codex"
         db.save_live_backup(
             "claude",
             &serde_json::to_string(&provider_a.settings_config).expect("serialize provider a"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -7322,6 +7553,7 @@ base_url = "https://codex.example/v1"
                 "config": ""
             }))
             .expect("serialize seed backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -7539,6 +7771,7 @@ base_url = "https://codex.example/v1"
                 "config": "model = \"gpt-5.4\"\n"
             }))
             .expect("serialize stale backup"),
+            None,
         )
         .await
         .expect("save stale backup");
@@ -7721,6 +7954,7 @@ wire_api = "responses"
                 "config": ""
             }))
             .expect("serialize seed backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -7782,6 +8016,7 @@ args = ["echo-server"]
 "#
             }))
             .expect("serialize seed backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -7889,6 +8124,7 @@ requires_openai_auth = true
         db.save_live_backup(
             "codex",
             &serde_json::to_string(&provider_a.settings_config).expect("serialize provider a"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -8064,6 +8300,7 @@ requires_openai_auth = true
         db.save_live_backup(
             "codex",
             &serde_json::to_string(&provider_a.settings_config).expect("serialize provider a"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -8151,6 +8388,7 @@ command = "legacy-command"
 "#
             }))
             .expect("serialize seed backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -8320,6 +8558,7 @@ requires_openai_auth = true
         db.save_live_backup(
             "codex",
             &serde_json::to_string(&provider_a.settings_config).expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed restored backup");
@@ -8456,6 +8695,7 @@ requires_openai_auth = true
         db.save_live_backup(
             "codex",
             &serde_json::to_string(&provider_a.settings_config).expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed restored backup");
@@ -8533,6 +8773,7 @@ requires_openai_auth = true
         db.save_live_backup(
             "codex",
             &serde_json::to_string(&provider_a.settings_config).expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed restored backup");
@@ -8730,7 +8971,7 @@ requires_openai_auth = true
             "config": backup_config,
         }))
         .expect("serialize backup");
-        db.save_live_backup("codex", &backup_json)
+        db.save_live_backup("codex", &backup_json, None)
             .await
             .expect("seed live backup");
 
@@ -8788,7 +9029,7 @@ requires_openai_auth = true
             }
         }))
         .expect("serialize backup");
-        db.save_live_backup("codex", &backup_json)
+        db.save_live_backup("codex", &backup_json, None)
             .await
             .expect("seed live backup");
         write_json_file(
@@ -8863,7 +9104,7 @@ requires_openai_auth = true
             }
         }))
         .expect("serialize backup");
-        db.save_live_backup("codex", &backup_json)
+        db.save_live_backup("codex", &backup_json, None)
             .await
             .expect("seed live backup");
 
@@ -8927,7 +9168,7 @@ requires_openai_auth = true
             }
         }))
         .expect("serialize corrupted backup");
-        db.save_live_backup("claude", &corrupted_backup)
+        db.save_live_backup("claude", &corrupted_backup, None)
             .await
             .expect("seed corrupted backup");
 
@@ -9016,6 +9257,7 @@ base_url = "https://third.example/v1"
 "#
             }))
             .expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -9089,6 +9331,7 @@ base_url = "https://third.example/v1"
                 "config": "model_provider = \"any\"\n"
             }))
             .expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -9146,6 +9389,7 @@ base_url = "https://third.example/v1"
                 "config": "model_provider = \"any\"\n"
             }))
             .expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -9193,6 +9437,7 @@ base_url = "https://third.example/v1"
                 "config": "model_provider = \"any\"\n"
             }))
             .expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -9282,6 +9527,7 @@ base_url = "https://third.example/v1"
                 "config": null
             }))
             .expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -9478,6 +9724,7 @@ base_url = "https://third.example/v1"
                 "config": "model_provider = \"any\"\n"
             }))
             .expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -9536,6 +9783,7 @@ base_url = "https://third.example/v1"
                 "config": "model_provider = \"any\"\n"
             }))
             .expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -9591,6 +9839,7 @@ base_url = "https://third.example/v1"
                 "config": "model_provider = \"any\"\n"
             }))
             .expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -9639,6 +9888,7 @@ base_url = "https://third.example/v1"
                 "config": "model_provider = \"any\"\n"
             }))
             .expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed live backup");
@@ -9696,7 +9946,7 @@ base_url = "https://third.example/v1"
             }
         }))
         .expect("serialize good backup");
-        db.save_live_backup("claude", &good_backup)
+        db.save_live_backup("claude", &good_backup, None)
             .await
             .expect("seed good backup");
 
@@ -9748,7 +9998,7 @@ base_url = "https://third.example/v1"
             }
         }))
         .expect("serialize good backup");
-        db.save_live_backup("claude", &good_backup)
+        db.save_live_backup("claude", &good_backup, None)
             .await
             .expect("seed claude backup");
 
@@ -9756,7 +10006,7 @@ base_url = "https://third.example/v1"
             "auth": { "OPENAI_API_KEY": "real-codex-token" }
         }))
         .expect("serialize codex good backup");
-        db.save_live_backup("codex", &codex_good_backup)
+        db.save_live_backup("codex", &codex_good_backup, None)
             .await
             .expect("seed codex backup");
 
@@ -9764,7 +10014,7 @@ base_url = "https://third.example/v1"
             "env": { "GEMINI_API_KEY": "real-gemini-key" }
         }))
         .expect("serialize gemini good backup");
-        db.save_live_backup("gemini", &gemini_good_backup)
+        db.save_live_backup("gemini", &gemini_good_backup, None)
             .await
             .expect("seed gemini backup");
 
@@ -9873,6 +10123,7 @@ experimental_bearer_token = "PROXY_MANAGED"
         db.save_live_backup(
             "grokbuild",
             &serde_json::to_string(&original_settings).expect("serialize backup"),
+            None,
         )
         .await
         .expect("seed backup");
@@ -9933,7 +10184,7 @@ experimental_bearer_token = "PROXY_MANAGED"
 
         let original_backup =
             serde_json::to_string(&provider_a.settings_config).expect("serialize backup");
-        db.save_live_backup("grokbuild", &original_backup)
+        db.save_live_backup("grokbuild", &original_backup, None)
             .await
             .expect("seed backup");
         let takeover = crate::grok_config::apply_proxy_takeover(

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -859,11 +859,14 @@ impl ProxyService {
 
         let rollback_result = match previous_backup {
             Some(backup) => {
+                // 保留备份原记录的归属（而非回滚目标的 current）：残留备份的
+                // 内容属于其原 owner，重打 previous_provider_id 会把「内容与
+                // 归属不符」洗白，让后续恢复重新接受外供应商凭据。
                 self.db
                     .save_live_backup(
                         app_type.as_str(),
                         &backup.original_config,
-                        previous_provider_id,
+                        backup.provider_id.as_deref(),
                     )
                     .await
             }
@@ -4306,6 +4309,53 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("sk-provider-a"),
             "归属未变的备份应照常还原（不能因归属校验而过度拦截）"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn hot_switch_rollback_preserves_backup_owner_stamp() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        let db = Arc::new(Database::memory().expect("init db"));
+        let service = ProxyService::new(db.clone());
+
+        // 残留态：备份内容属于 a，但热切换前的 current 是 b；切换失败回滚时
+        // 备份槽重存的内容必须保留其原归属 a，而不是被洗白成 b。
+        let stale_backup = crate::proxy::types::LiveBackup {
+            app_type: "claude".to_string(),
+            original_config: serde_json::to_string(&json!({
+                "env": { "ANTHROPIC_AUTH_TOKEN": "sk-provider-a" }
+            }))
+            .expect("serialize stale backup"),
+            backed_up_at: "2026-08-28T00:00:00Z".to_string(),
+            provider_id: Some("a".to_string()),
+        };
+
+        service
+            .rollback_hot_switch_preparation(
+                &AppType::Claude,
+                Some(&stale_backup),
+                Some("b"),
+                true,
+                false,
+                None,
+            )
+            .await;
+
+        let restored = db
+            .get_live_backup("claude")
+            .await
+            .expect("read live backup")
+            .expect("backup exists");
+        assert_eq!(
+            restored.provider_id.as_deref(),
+            Some("a"),
+            "回滚重存的备份必须保留原归属，不能改打成回滚目标的 current"
+        );
+        assert!(
+            restored.original_config.contains("sk-provider-a"),
+            "备份内容应原样保留"
         );
     }
 

--- a/src-tauri/tests/provider_service.rs
+++ b/src-tauri/tests/provider_service.rs
@@ -2096,7 +2096,7 @@ fn sync_current_provider_for_app_keeps_live_takeover_and_updates_restore_backup(
     )
     .expect("write taken over live");
 
-    futures::executor::block_on(state.db.save_live_backup("claude", "{\"env\":{}}"))
+    futures::executor::block_on(state.db.save_live_backup("claude", "{\"env\":{}}", None))
         .expect("seed live backup");
 
     let mut proxy_config = futures::executor::block_on(state.db.get_proxy_config_for_app("claude"))
@@ -2225,6 +2225,7 @@ wire_api = "responses"
                 "config": old_provider_config
             }))
             .expect("serialize backup"),
+            None,
         ),
     )
     .expect("seed Codex live backup");


### PR DESCRIPTION
Hi! Picking up #6886 — the root-cause analysis in the report (down to the exact call path in `services/proxy.rs`) made this straightforward to fix. 👍

## Summary

- Record which provider a live backup belongs to: new `provider_id` column on `proxy_live_backup`, stamped at every write site (takeover backup for all four apps, hot-switch backup refresh, hot-switch rollback, Gemini shared-credential cleanup re-save).
- On restore (`restore_live_config_for_app_with_fallback_inner`), when the backup's owner is no longer the current provider — the residue of "current was switched externally during takeover, then the service restarted" — skip restoring that backup and fall through to the existing SSOT rebuild from the current provider. This mirrors the move the code already makes for placeholder backups.
- Why this closes the key-shuffle: today's recovery sequence restores the previous provider's real token into live, then the re-takeover backs it up and `sync_live_config_to_provider` attributes that token to the *new* current provider, silently overwriting its key (#6886). With the gate, live is rebuilt from the current provider's own config before any backup/sync runs, so the foreign token never reaches the sync.
- Backups with unknown ownership (rows written before this change, `provider_id` NULL) keep the old restore behavior — no behavior change on upgrade. The column is added via the existing `add_column_if_missing` startup backfill.

## Scope

Deliberately did not touch `sync_live_config_to_provider` itself: its "the live token belongs to the current provider" assumption is what the normal first-takeover capture flow (live → provider record) relies on, and I couldn't find a way to distinguish "user updated the token in live" from "live holds a foreign provider's token" at the sync call site. Restoring the invariant at the restore entry point — where the stale content enters — fixes the reported path without weakening that flow.

## Testing

- `cargo test --lib` — 2729 passed, including two new regression tests:
  - backup owned by a previous provider + externally-switched current → live is rebuilt from the current provider, its stored key untouched;
  - backup owned by the still-current provider → restored as before (no over-blocking).
- `cargo test --test provider_service` — 43 passed
- `cargo clippy --all-targets`
- `cargo fmt`

Fixes #6886

Happy to adjust the approach or the migration shape if you see a cleaner fit.
