### PR TITLE
fix(usage): stop deferring resumed Codex rollouts on filename/meta ID mismatch

### DIFF
--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -209,6 +209,9 @@ enum ParentResolution {
 #[derive(Debug)]
 struct ParsedCodexFile {
     root_thread_id: Option<String>,
+    /// root `session_meta` 的线程 ID（稳定逻辑线程）：单段文件名与文件名
+    /// UUID 一致，revert/resume 的双段文件名对应前置 UUID。
+    meta_thread_id: Option<String>,
     root_meta_seen: bool,
     root_timestamp: Option<DateTime<Utc>>,
     parent: ParentResolution,
@@ -397,11 +400,13 @@ fn thread_id_from_filename(path: &Path) -> Option<String> {
         .map(|value| value.hyphenated().to_string())
 }
 
-/// 双段文件名（`rollout-…-<threadId>_<sessionId>.jsonl`）里下划线前的线程
+/// 双段文件名（`rollout-…-<threadId>_<rolloutId>.jsonl`）里下划线前的线程
 /// 本体 UUID；单段文件名返回 `None`。
 ///
-/// Codex 恢复线程时新建的双段 rollout：文件名末段是新会话 ID，但 root meta
-/// 的 `id` 仍是原线程 ID，一致性校验需同时接受两个 UUID。
+/// `thread/revert` 为同一线程新建替换 rollout 时产生这种文件名（见
+/// openai/codex#38127）：末段是新生成的 rollout ID，其后的 resume 继续
+/// 向该文件追加。root meta 的 `id` 始终是原线程 ID，一致性校验需同时
+/// 接受两个 UUID。
 fn leading_thread_id_from_filename(path: &Path) -> Option<String> {
     let stem = path.file_stem()?.to_str()?;
     let len = stem.len();
@@ -781,6 +786,7 @@ fn parse_codex_file(
     let reader = BufReader::new(file);
     let mut root_meta_seen = false;
     let mut root_timestamp = None;
+    let mut meta_thread_id = None;
     let mut parent = ParentResolution::None;
     let mut current_model = "unknown".to_string();
     // `total_token_usage` is session-cumulative, including across model and
@@ -834,16 +840,23 @@ fn parse_codex_file(
                 let payload = value.get("payload").unwrap_or(&serde_json::Value::Null);
                 parent = explicit_parent_from_meta(payload);
 
-                let meta_thread_id = non_empty_string(
+                meta_thread_id = non_empty_string(
                     payload
                         .get("id")
                         .or_else(|| payload.get("thread_id"))
                         .or_else(|| payload.get("threadId")),
-                );
-                if let (Some(filename_id), Some(meta_id)) = (&root_thread_id, meta_thread_id) {
+                )
+                .map(|id| {
+                    uuid::Uuid::parse_str(&id)
+                        .map(|value| value.hyphenated().to_string())
+                        .unwrap_or(id)
+                });
+                if let (Some(filename_id), Some(meta_id)) =
+                    (&root_thread_id, meta_thread_id.as_ref())
+                {
                     let leading_id = leading_thread_id_from_filename(file_path);
                     let matches =
-                        filename_id == &meta_id || leading_id.as_deref() == Some(meta_id.as_str());
+                        filename_id == meta_id || leading_id.as_deref() == Some(meta_id.as_str());
                     if !matches {
                         parent = ParentResolution::Deferred(format!(
                             "文件名线程 ID ({filename_id}) 与 root meta ID ({meta_id}) 不一致"
@@ -978,6 +991,7 @@ fn parse_codex_file(
 
     Ok(ParsedCodexFile {
         root_thread_id,
+        meta_thread_id,
         root_meta_seen,
         root_timestamp,
         parent,
@@ -1317,6 +1331,12 @@ fn sync_single_codex_file(
     // journal 建立/fsync/删除）是全量重导的最大耗时项。批内单条插入失败
     // 沿用旧行为跳过该条继续；某批 commit 失败则该批整体回滚且游标不推进，
     // 下一 pass 重扫时由 request_id 主键 + 指纹去重兜底，不会双算。
+    //
+    // session_id 记 root meta 的线程 ID：双段文件名（thread/revert 的替换
+    // rollout）下是前置 UUID，与会话管理器侧的会话身份同口径；尾部 rollout
+    // ID 只承担 request_id 去重键（event_index 按物理文件计数，不能改用
+    // 前置 ID）。
+    let session_thread_id = parsed.meta_thread_id.as_deref().unwrap_or(root_thread_id);
     let batch_count = to_insert.len().div_ceil(CODEX_INSERT_BATCH_SIZE);
     for (batch_index, batch) in to_insert.chunks(CODEX_INSERT_BATCH_SIZE).enumerate() {
         let is_last_batch = batch_index + 1 == batch_count;
@@ -1336,7 +1356,7 @@ fn sync_single_codex_file(
                 &request_id,
                 &event.delta,
                 &event.model,
-                Some(root_thread_id),
+                Some(session_thread_id),
                 event.timestamp.as_deref(),
                 &mut batch_suspected,
                 &mut pass.pricing,
@@ -1676,9 +1696,10 @@ mod tests {
         sync_single_codex_file(db, file, &build_rollout_index(&files), &mut pass)
     }
 
-    /// 恢复会话的 rollout 是 `<threadId>_<sessionId>` 双段文件名，root meta 的
-    /// id 是原线程 ID（第一个 UUID）、forked_from_id 为空。旧校验只认末尾 UUID，
-    /// 会把这类文件永久 deferred，恢复会话后的用量全部丢失。
+    /// revert 产生的替换 rollout 是 `<threadId>_<rolloutId>` 双段文件名，
+    /// root meta 的 id 是原线程 ID（第一个 UUID）、forked_from_id 为空。
+    /// 旧校验只认末尾 UUID，会把这类文件永久 deferred，其后 resume 追加
+    /// 的用量全部丢失。
     #[test]
     fn test_resumed_rollout_meta_id_matching_leading_uuid_is_not_deferred() -> Result<(), AppError>
     {
@@ -1708,12 +1729,50 @@ mod tests {
         Ok(())
     }
 
+    /// 完整同步链路下双段 rollout 的两个 UUID 分工：request_id 用尾部
+    /// rollout ID（event_index 按物理文件计数，去重键不能换），库里
+    /// session_id 记前置线程 ID，与会话管理器侧的会话身份同口径。
+    #[test]
+    fn test_resumed_rollout_session_id_uses_leading_thread_id() -> Result<(), AppError> {
+        let db = Database::memory()?;
+        let temp = tempdir().unwrap();
+        let file = temp.path().join(format!(
+            "rollout-2026-08-26T17-18-13-{PARENT_ID}_{CHILD_A_ID}.jsonl"
+        ));
+        write_jsonl(
+            &file,
+            &[
+                session_meta(PARENT_ID),
+                turn_context(),
+                token_count(100, 50, 10),
+            ],
+        );
+
+        assert_eq!(sync_test_file(&db, &file, &[&file])?.imported, 1);
+
+        let conn = lock_conn!(db.conn);
+        let (request_id, session_id) = conn
+            .prepare(
+                "SELECT request_id, session_id FROM proxy_request_logs
+                 WHERE data_source = 'codex_session'",
+            )?
+            .query_row([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })?;
+        assert_eq!(
+            request_id,
+            format!("{CODEX_THREAD_REQUEST_ID_PREFIX}:{CHILD_A_ID}:1")
+        );
+        assert_eq!(session_id, PARENT_ID);
+        Ok(())
+    }
+
     /// 单段文件名的不一致仍要拒收。
     #[test]
     fn test_single_uuid_filename_meta_mismatch_still_deferred() -> Result<(), AppError> {
         let dir = tempdir().unwrap();
         let file = rollout_path(dir.path(), PARENT_ID);
-        // meta 里写的是另一个线程的 ID —— 这不是恢复会话能解释的形态
+        // meta 里写的是另一个线程的 ID —— 这不是 revert 双段文件名能解释的形态
         write_jsonl(
             &file,
             &[

--- a/src-tauri/src/services/session_usage_codex.rs
+++ b/src-tauri/src/services/session_usage_codex.rs
@@ -397,6 +397,24 @@ fn thread_id_from_filename(path: &Path) -> Option<String> {
         .map(|value| value.hyphenated().to_string())
 }
 
+/// 双段文件名（`rollout-…-<threadId>_<sessionId>.jsonl`）里下划线前的线程
+/// 本体 UUID；单段文件名返回 `None`。
+///
+/// Codex 恢复线程时新建的双段 rollout：文件名末段是新会话 ID，但 root meta
+/// 的 `id` 仍是原线程 ID，一致性校验需同时接受两个 UUID。
+fn leading_thread_id_from_filename(path: &Path) -> Option<String> {
+    let stem = path.file_stem()?.to_str()?;
+    let len = stem.len();
+    // 布局尾部：…<uuidA>_<uuidB>。uuidB 占 36 字符，其前是 '_'（共 37）
+    if !stem.get(len.checked_sub(37)?..)?.starts_with('_') {
+        return None;
+    }
+    let candidate = stem.get(len.checked_sub(73)?..len.checked_sub(37)?)?;
+    uuid::Uuid::parse_str(candidate)
+        .ok()
+        .map(|value| value.hyphenated().to_string())
+}
+
 fn explicit_parent_from_meta(payload: &serde_json::Value) -> ParentResolution {
     let forked_from = non_empty_string(payload.get("forked_from_id"));
     let spawned_from = payload
@@ -823,7 +841,10 @@ fn parse_codex_file(
                         .or_else(|| payload.get("threadId")),
                 );
                 if let (Some(filename_id), Some(meta_id)) = (&root_thread_id, meta_thread_id) {
-                    if filename_id != &meta_id {
+                    let leading_id = leading_thread_id_from_filename(file_path);
+                    let matches =
+                        filename_id == &meta_id || leading_id.as_deref() == Some(meta_id.as_str());
+                    if !matches {
                         parent = ParentResolution::Deferred(format!(
                             "文件名线程 ID ({filename_id}) 与 root meta ID ({meta_id}) 不一致"
                         ));
@@ -1653,6 +1674,58 @@ mod tests {
             .collect::<Vec<_>>();
         let mut pass = CodexSyncPass::load(db)?;
         sync_single_codex_file(db, file, &build_rollout_index(&files), &mut pass)
+    }
+
+    /// 恢复会话的 rollout 是 `<threadId>_<sessionId>` 双段文件名，root meta 的
+    /// id 是原线程 ID（第一个 UUID）、forked_from_id 为空。旧校验只认末尾 UUID，
+    /// 会把这类文件永久 deferred，恢复会话后的用量全部丢失。
+    #[test]
+    fn test_resumed_rollout_meta_id_matching_leading_uuid_is_not_deferred() -> Result<(), AppError>
+    {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join(format!(
+            "rollout-2026-08-26T17-18-13-{PARENT_ID}_{CHILD_A_ID}.jsonl"
+        ));
+        write_jsonl(
+            &file,
+            &[
+                session_meta(PARENT_ID),
+                turn_context(),
+                token_count_at(100, 50, 20, "2026-08-26T09:18:20Z"),
+            ],
+        );
+
+        let parsed = parse_codex_file(&file, thread_id_from_filename(&file))?;
+
+        // 恢复会话没有显式 parent，不应因 ID 不一致被拒
+        assert!(
+            !matches!(parsed.parent, ParentResolution::Deferred(_)),
+            "恢复会话不应被 deferred，实际: {:?}",
+            parsed.parent
+        );
+        assert_eq!(parsed.root_thread_id.as_deref(), Some(CHILD_A_ID));
+        assert!(parsed.has_billable_tokens);
+        Ok(())
+    }
+
+    /// 单段文件名的不一致仍要拒收。
+    #[test]
+    fn test_single_uuid_filename_meta_mismatch_still_deferred() -> Result<(), AppError> {
+        let dir = tempdir().unwrap();
+        let file = rollout_path(dir.path(), PARENT_ID);
+        // meta 里写的是另一个线程的 ID —— 这不是恢复会话能解释的形态
+        write_jsonl(
+            &file,
+            &[
+                session_meta(CHILD_B_ID),
+                turn_context(),
+                token_count_at(1, 1, 1, "2026-07-10T03:00:02Z"),
+            ],
+        );
+
+        let parsed = parse_codex_file(&file, thread_id_from_filename(&file))?;
+        assert!(matches!(parsed.parent, ParentResolution::Deferred(_)));
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

Fixes #6904.

When a Codex thread is **resumed**, Codex creates a rollout with a dual-segment filename `rollout-<ts>-<threadId>_<sessionId>.jsonl`. The root `session_meta` inside keeps `payload.id` = the **original thread id** (the UUID before the underscore; continuation info lives in `history_base`, `forked_from_id` is null).

The consistency check in `parse_codex_file` compared that meta id against only the filename's **trailing** UUID (the new session id, from `thread_id_from_filename`), so every resumed rollout was permanently deferred:

```
[CODEX-SYNC] deferred ...rollout-...-01a03d4c-..._01a03d5c-....jsonl: 文件名线程 ID (01a03d5c...) 与 root meta ID (01a03d4c...) 不一致
```

Once a user resumes an old thread, all subsequent turns append to this dual-ID file which is skipped every sync cycle — usage statistics silently stop (live case: stats stopped at 08/27 17:33; the file held 152 unimported `token_count` events by end of day, deferral warning repeating every 60s cycle).

**Change**: the check now also accepts the pre-underscore UUID of dual-segment filenames (`leading_thread_id_from_filename`). Single-UUID filenames keep the strict check.

`thread_id_from_filename` intentionally still returns the trailing UUID: it is the prefix of the `codex_thread:<id>:<event_index>` dedup key, and `event_index` counts per file — switching it to the leading id would make request ids collide across segments of the same thread.

## Related Issue / 关联 Issue

Fixes #6904

## Screenshots / 截图

Not applicable (no UI change). / 不适用（无 UI 改动）。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] No user-facing text changed, i18n not applicable / 无用户可见文本改动，国际化不适用

**Tests**: two new regression tests — resumed rollout with meta id = leading UUID no longer defers (also asserts `root_thread_id` stays the trailing UUID); single-UUID mismatch still defers. Full codex module suite (46 tests) passes; `cargo test --lib` 2741 pass on top of current `main`.

Verified against a real resumed rollout from the live case (152 accumulated events, fix flips the check from reject to accept); long-running in-app observation pending maintainer review environment.
