### PR TITLE
fix(tests): skip symlink-based tests gracefully without SeCreateSymbolicLinkPrivilege on Windows

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -7669,7 +7669,10 @@ model_catalog_json = "cc-switch-model-catalog.json"
         #[cfg(unix)]
         std::os::unix::fs::symlink(&outside_dir, base_dir.join("link")).expect("symlink");
         #[cfg(windows)]
-        std::os::windows::fs::symlink_dir(&outside_dir, base_dir.join("link")).expect("symlink");
+        if let Err(e) = std::os::windows::fs::symlink_dir(&outside_dir, base_dir.join("link")) {
+            eprintln!("[SKIP] no symlink privilege on this Windows account: {e}");
+            return;
+        }
 
         let config_text = r#"model_catalog_json = "link/cc-switch-model-catalog.json"
 "#;

--- a/src-tauri/src/services/session_usage_grokbuild.rs
+++ b/src-tauri/src/services/session_usage_grokbuild.rs
@@ -1309,7 +1309,10 @@ mod tests {
         #[cfg(unix)]
         std::os::unix::fs::symlink(&enc, sub.join("cycle")).expect("symlink");
         #[cfg(windows)]
-        std::os::windows::fs::symlink_dir(&enc, sub.join("cycle")).expect("symlink");
+        if let Err(e) = std::os::windows::fs::symlink_dir(&enc, sub.join("cycle")) {
+            eprintln!("[SKIP] no symlink privilege on this Windows account: {e}");
+            return;
+        }
 
         // 也放一个真实的目标文件，确认正常遍历仍工作
         std::fs::write(enc.join("updates.jsonl"), b"{}\n").expect("write real file");


### PR DESCRIPTION
## Summary
- Two tests unconditionally `.expect()`'d `std::os::windows::fs::symlink_dir`, which requires `SeCreateSymbolicLinkPrivilege` (admin or Developer Mode enabled).
- On a standard Windows dev account they panic with OS error 1314 (`ERROR_PRIVILEGE_NOT_HELD`) instead of skipping, unlike the graceful-skip idiom already used elsewhere in this codebase (`session_usage_codex.rs`'s `replay_real_codex_corpus`).

## Test plan
- [x] Reproduced the panic on a non-admin Windows account before the fix (`cargo test --lib`: both tests failed with `symlink: Os { code: 1314, ... }`)
- [x] After the fix, ran `cargo test --lib -- symlink --nocapture`: both tests print `[SKIP] no symlink privilege on this Windows account: ...` and pass