### PR TITLE
fix(mcp): accept OpenCode array-form command in unified MCP form

### DIFF
--- a/src/components/mcp/McpFormModal.tsx
+++ b/src/components/mcp/McpFormModal.tsx
@@ -20,7 +20,7 @@ import {
   mcpServerToToml,
 } from "@/utils/tomlUtils";
 import { normalizeTomlText } from "@/utils/textNormalization";
-import { parseSmartMcpJson } from "@/utils/formatters";
+import { normalizeMcpServerSpec, parseSmartMcpJson } from "@/utils/formatters";
 import { useMcpValidation } from "./useMcpValidation";
 import { useUpsertMcpServer } from "@/hooks/useMcp";
 import { FullScreenPanel } from "@/components/common/FullScreenPanel";
@@ -338,7 +338,7 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
       } else {
         try {
           const result = parseSmartMcpJson(formConfig);
-          serverSpec = result.config as McpServerSpec;
+          serverSpec = normalizeMcpServerSpec(result.config) as McpServerSpec;
         } catch (e: any) {
           const errorMessage = e?.message || String(e);
           setConfigError(t("mcp.error.jsonInvalid") + ": " + errorMessage);
@@ -348,13 +348,22 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
       }
     }
 
-    if (serverSpec?.type === "stdio" && !serverSpec?.command?.trim()) {
+    // 校验采用类型安全写法：command/url 可能被粘贴成数组/数字等非字符串
+    // （如 OpenCode 原生条目的 command 数组），直接调用 .trim() 会抛 TypeError。
+    // 数组 command 视为有效（normalizeMcpServerSpec 已拆分为 command + args）。
+    const commandValue = (serverSpec as any)?.command;
+    const hasCommand =
+      (typeof commandValue === "string" && commandValue.trim().length > 0) ||
+      (Array.isArray(commandValue) && commandValue.length > 0);
+    if (serverSpec?.type === "stdio" && !hasCommand) {
       toast.error(t("mcp.error.commandRequired"), { duration: 3000 });
       return;
     }
+    const urlValue = (serverSpec as any)?.url;
+    const hasUrl = typeof urlValue === "string" && urlValue.trim().length > 0;
     if (
       (serverSpec?.type === "http" || serverSpec?.type === "sse") &&
-      !serverSpec?.url?.trim()
+      !hasUrl
     ) {
       toast.error(t("mcp.wizard.urlRequired"), { duration: 3000 });
       return;

--- a/src/components/mcp/useMcpValidation.ts
+++ b/src/components/mcp/useMcpValidation.ts
@@ -73,10 +73,20 @@ export function useMcpValidation() {
           }
 
           const typ = (obj as any)?.type;
-          if (typ === "stdio" && !(obj as any)?.command?.trim()) {
+          // 类型安全判断：command 可能是数组（OpenCode 原生条目形状，
+          // 如 ["blender-mcp"]），直接 .trim() 会抛 TypeError；非空数组视为有效。
+          const commandValue = (obj as any)?.command;
+          const hasCommand =
+            (typeof commandValue === "string" &&
+              commandValue.trim().length > 0) ||
+            (Array.isArray(commandValue) && commandValue.length > 0);
+          if (typ === "stdio" && !hasCommand) {
             return t("mcp.error.commandRequired");
           }
-          if ((typ === "http" || typ === "sse") && !(obj as any)?.url?.trim()) {
+          const urlValue = (obj as any)?.url;
+          const hasUrl =
+            typeof urlValue === "string" && urlValue.trim().length > 0;
+          if ((typ === "http" || typ === "sse") && !hasUrl) {
             return t("mcp.wizard.urlRequired");
           }
         }

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -23,6 +23,41 @@ export function formatJSON(value: string): string {
  * @returns { id?: string, config: object, formattedConfig: string }
  * @throws 如果 JSON 格式无效
  */
+/**
+ * 规范化 MCP 服务器 JSON 为统一格式（McpServerSpec）。
+ *
+ * 兼容 OpenCode 原生条目形状（用户常直接粘贴）：
+ * - `command` 为数组（如 ["blender-mcp"]）→ 拆分出 command + args
+ * - `environment` 而非 `env` → 映射为 env
+ *
+ * 非对象/数组输入原样返回，不做校验（校验由调用方负责）。
+ */
+export function normalizeMcpServerSpec(spec: unknown): unknown {
+  if (!spec || typeof spec !== "object" || Array.isArray(spec)) {
+    return spec;
+  }
+  const result: Record<string, unknown> = {
+    ...(spec as Record<string, unknown>),
+  };
+
+  if (Array.isArray(result.command)) {
+    const [cmd, ...rest] = result.command as unknown[];
+    result.command = typeof cmd === "string" ? cmd : "";
+    if (rest.length > 0) {
+      const existing = Array.isArray(result.args)
+        ? (result.args as unknown[])
+        : [];
+      result.args = [...existing, ...rest];
+    }
+  }
+
+  if (result.environment != null && result.env == null) {
+    result.env = result.environment;
+  }
+
+  return result;
+}
+
 export function parseSmartMcpJson(jsonText: string): {
   id?: string;
   config: any;

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -23,41 +23,6 @@ export function formatJSON(value: string): string {
  * @returns { id?: string, config: object, formattedConfig: string }
  * @throws 如果 JSON 格式无效
  */
-/**
- * 规范化 MCP 服务器 JSON 为统一格式（McpServerSpec）。
- *
- * 兼容 OpenCode 原生条目形状（用户常直接粘贴）：
- * - `command` 为数组（如 ["blender-mcp"]）→ 拆分出 command + args
- * - `environment` 而非 `env` → 映射为 env
- *
- * 非对象/数组输入原样返回，不做校验（校验由调用方负责）。
- */
-export function normalizeMcpServerSpec(spec: unknown): unknown {
-  if (!spec || typeof spec !== "object" || Array.isArray(spec)) {
-    return spec;
-  }
-  const result: Record<string, unknown> = {
-    ...(spec as Record<string, unknown>),
-  };
-
-  if (Array.isArray(result.command)) {
-    const [cmd, ...rest] = result.command as unknown[];
-    result.command = typeof cmd === "string" ? cmd : "";
-    if (rest.length > 0) {
-      const existing = Array.isArray(result.args)
-        ? (result.args as unknown[])
-        : [];
-      result.args = [...existing, ...rest];
-    }
-  }
-
-  if (result.environment != null && result.env == null) {
-    result.env = result.environment;
-  }
-
-  return result;
-}
-
 export function parseSmartMcpJson(jsonText: string): {
   id?: string;
   config: any;
@@ -97,6 +62,41 @@ export function parseSmartMcpJson(jsonText: string): {
     config: parsed,
     formattedConfig: JSON.stringify(parsed, null, 2),
   };
+}
+
+/**
+ * 规范化 MCP 服务器 JSON 为统一格式（McpServerSpec）。
+ *
+ * 兼容 OpenCode 原生条目形状（用户常直接粘贴）：
+ * - `command` 为数组（如 ["blender-mcp"]）→ 拆分出 command + args
+ * - `environment` 而非 `env` → 映射为 env
+ *
+ * 非对象/数组输入原样返回，不做校验（校验由调用方负责）。
+ */
+export function normalizeMcpServerSpec(spec: unknown): unknown {
+  if (!spec || typeof spec !== "object" || Array.isArray(spec)) {
+    return spec;
+  }
+  const result: Record<string, unknown> = {
+    ...(spec as Record<string, unknown>),
+  };
+
+  if (Array.isArray(result.command)) {
+    const [cmd, ...rest] = result.command as unknown[];
+    result.command = typeof cmd === "string" ? cmd : "";
+    if (rest.length > 0) {
+      const existing = Array.isArray(result.args)
+        ? (result.args as unknown[])
+        : [];
+      result.args = [...existing, ...rest];
+    }
+  }
+
+  if (result.environment != null && result.env == null) {
+    result.env = result.environment;
+  }
+
+  return result;
 }
 
 /**

--- a/tests/components/McpFormModal.test.tsx
+++ b/tests/components/McpFormModal.test.tsx
@@ -505,4 +505,105 @@ type = "stdio"
     resolveUpsert?.();
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
   });
+
+  // Issue #6882：用户粘贴 OpenCode 原生 MCP 条目（command 为数组）时，
+  // handleSubmit 校验行 `!serverSpec?.command?.trim()` 对数组调用 trim() 抛
+  // TypeError，且位于 try/catch 之外 → async 函数返回 rejected promise →
+  // onClick 不 await → window unhandledrejection，toast/upsert 全部不执行
+  // （用户症状：点击添加完全没反应）。
+  // 修复后：数组 command 被 normalize 为 command + args，environment 映射为
+  // env，添加直接成功。
+  it("#6882：OpenCode 数组格式 command 可正常添加，无 unhandledrejection", async () => {
+    const rejections: unknown[] = [];
+    const handler = (event: PromiseRejectionEvent) =>
+      rejections.push(event.reason);
+    window.addEventListener("unhandledrejection", handler);
+    try {
+      renderForm();
+
+      fireEvent.change(
+        screen.getByPlaceholderText("mcp.form.titlePlaceholder"),
+        { target: { value: "blender-mcp" } },
+      );
+      // 用户从 OpenCode 配置里复制的原生条目：command 是数组
+      fireEvent.change(screen.getByPlaceholderText("mcp.form.jsonPlaceholder"), {
+        target: {
+          value: JSON.stringify({
+            type: "stdio",
+            command: ["blender-mcp"],
+            enabled: true,
+            environment: { BLENDER_HOST: "localhost", BLENDER_PORT: "9876" },
+          }),
+        },
+      });
+
+      fireEvent.click(screen.getByText("common.add"));
+
+      await waitFor(() => expect(upsertMock).toHaveBeenCalledTimes(1));
+      const [entry] = upsertMock.mock.calls.at(-1) ?? [];
+
+      // 数组 command 拆分：首个元素为 command，其余为 args
+      expect(entry.server.command).toBe("blender-mcp");
+      expect(entry.server.args).toBeUndefined();
+      // environment 映射为统一格式的 env
+      expect(entry.server.env).toEqual({
+        BLENDER_HOST: "localhost",
+        BLENDER_PORT: "9876",
+      });
+      // 宽松字段保留
+      expect(entry.server.enabled).toBe(true);
+      // 没有用户无感的 rejection
+      expect(rejections).toEqual([]);
+      expect(toastErrorMock).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("unhandledrejection", handler);
+    }
+  });
+
+  it("#6882：多元素 command 数组拆分出 args，仍可正常添加", async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByPlaceholderText("mcp.form.titlePlaceholder"), {
+      target: { value: "blender-mcp-args" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("mcp.form.jsonPlaceholder"), {
+      target: {
+        value: JSON.stringify({
+          type: "stdio",
+          command: ["npx", "-y", "blender-mcp"],
+          environment: { BLENDER_PORT: "9876" },
+        }),
+      },
+    });
+
+    fireEvent.click(screen.getByText("common.add"));
+
+    await waitFor(() => expect(upsertMock).toHaveBeenCalledTimes(1));
+    const [entry] = upsertMock.mock.calls.at(-1) ?? [];
+    expect(entry.server.command).toBe("npx");
+    expect(entry.server.args).toEqual(["-y", "blender-mcp"]);
+    expect(entry.server.env).toEqual({ BLENDER_PORT: "9876" });
+  });
+
+  it("#6882：非字符串非数组的 command 仍被拒绝并提示", async () => {
+    renderForm();
+
+    fireEvent.change(screen.getByPlaceholderText("mcp.form.titlePlaceholder"), {
+      target: { value: "bad-command" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("mcp.form.jsonPlaceholder"), {
+      target: {
+        value: JSON.stringify({ type: "stdio", command: 42 }),
+      },
+    });
+
+    fireEvent.click(screen.getByText("common.add"));
+
+    await waitFor(() =>
+      expect(toastErrorMock).toHaveBeenCalledWith("mcp.error.commandRequired", {
+        duration: 3000,
+      }),
+    );
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
 });

--- a/tests/components/McpFormModal.test.tsx
+++ b/tests/components/McpFormModal.test.tsx
@@ -585,6 +585,28 @@ type = "stdio"
     expect(entry.server.env).toEqual({ BLENDER_PORT: "9876" });
   });
 
+  it("#6882：粘贴数组 command 时编辑校验不误报 JSON 无效", async () => {
+    renderForm();
+
+    fireEvent.change(
+      screen.getByPlaceholderText("mcp.form.jsonPlaceholder"),
+      {
+        target: {
+          value: JSON.stringify({
+            type: "stdio",
+            command: ["blender-mcp"],
+            environment: { BLENDER_HOST: "localhost" },
+          }),
+        },
+      },
+    );
+
+    // validateJsonConfig 对数组 command 视为有效：不出现错误文案
+    expect(
+      screen.queryByText(/mcp\.error\./),
+    ).not.toBeInTheDocument();
+  });
+
   it("#6882：非字符串非数组的 command 仍被拒绝并提示", async () => {
     renderForm();
 


### PR DESCRIPTION
## Issue Description (Issue #6882)

On Linux + OpenCode, when a user pastes an **OpenCode-native MCP entry** (`"command": ["blender-mcp"]` as an **array**, with `environment` instead of `env`) into the unified MCP form and clicks Add, **nothing happens**. The logs show `[frontend] unhandledrejection`.

## Root Cause

The validation line in `McpFormModal.handleSubmit` is:

```ts
if (serverSpec?.type === "stdio" && !serverSpec?.command?.trim()) {
```

In JavaScript, `?.` only short-circuits null/undefined property access; it does **not** protect against calling a property that exists but is not a function. When `command` is an array, `["blender-mcp"].trim()` immediately throws `TypeError: trim is not a function`.

This line is outside the `try/catch` block, so the async function throws → returns a rejected promise → `onClick` does not await it → `unhandledrejection` is triggered, and neither the toast nor the upsert operation executes.

Reproduction test (Vitest output matching the issue user's logs):

```text
TypeError: serverSpec?.command?.trim is not a function
❯ handleSubmit src/components/mcp/McpFormModal.tsx:351:63
```

`useMcpValidation.validateJsonConfig` contains the same pattern. In that case, the error is swallowed by `catch`, resulting in the misleading **"Invalid JSON"** message.

## Fix

1. **Add `normalizeMcpServerSpec` to `src/utils/formatters.ts`**: Convert the OpenCode-native shape into the unified format — split an array `command` into `command` + `args`, and map `environment` → `env`. Users can now paste OpenCode entries directly and add them successfully. The backend's existing `convert_to_opencode_format` already supports reconstructing the array from the unified format, so writing the configuration back to OpenCode remains seamless.

2. **Update `McpFormModal.handleSubmit`**: Normalize the configuration before submission; change the validation to a type-safe implementation (an array-valued `command` is considered valid). A non-string `command` now produces the correct **"Command cannot be empty"** toast instead of silently crashing.

3. **Update `useMcpValidation.validateJsonConfig`**: Apply the same type-safe validation fix.

## Tests

* Added 3 regression tests:

  * Array `command` entries are added successfully and `env` is mapped correctly.
  * Multi-element `command` arrays are correctly split into `command` and `args`.
  * Numeric `command` values are rejected with the appropriate error message.
* All frontend unit tests pass (**1002 passed**; 2 `App.test.tsx` failures are pre-existing issues and unrelated to this change, verified via stash).
* `pnpm typecheck` / `pnpm format:check` pass.

Fixes #6882
