### PR TITLE
fix(codex): sanitize xAI native Responses for Grok

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
-tauri = { version = "2.8.2", features = ["tray-icon", "protocol-asset", "image-png", "devtools"] }
+tauri = { version = "2.8.2", features = ["tray-icon", "protocol-asset", "image-png"] }
 tauri-plugin-log = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-process = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 [features]
 default = []
 test-hooks = []
+custom-protocol = ["tauri/custom-protocol"]
 
 [build-dependencies]
 tauri-build = { version = "2.4.0", features = [] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
-tauri = { version = "2.8.2", features = ["tray-icon", "protocol-asset", "image-png"] }
+tauri = { version = "2.8.2", features = ["tray-icon", "protocol-asset", "image-png", "devtools"] }
 tauri-plugin-log = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-process = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -389,6 +389,7 @@ pub fn run() {
             {
                 return;
             }
+            #[cfg(target_os = "macos")]
             tray::mark_main_page_ready();
             log::info!("主窗口 page load finished: {}", payload.url());
             if startup_page_handled.swap(true, Ordering::Relaxed) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -394,7 +394,7 @@ pub fn run() {
             if startup_page_handled.swap(true, Ordering::Relaxed) {
                 return;
             }
-            if crate::settings::get_settings().silent_startup {
+            if crate::settings::get_settings().silent_startup && !cfg!(debug_assertions) {
                 log::info!("主页面加载完成（静默启动，保持隐藏）");
                 return;
             }
@@ -1332,7 +1332,7 @@ pub fn run() {
                 // 仅 Linux 生效：解决 Wayland 下系统窗口按钮不可用的问题
                 #[cfg(target_os = "linux")]
                 let _ = window.set_decorations(!settings.use_app_window_controls);
-                if settings.silent_startup {
+                if settings.silent_startup && !cfg!(debug_assertions) {
                     // 静默启动模式：保持窗口隐藏
                     let _ = window.hide();
                     #[cfg(target_os = "windows")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -376,6 +376,8 @@ pub fn run() {
 
             // Show and focus window regardless
             if let Some(window) = app.get_webview_window("main") {
+                #[cfg(target_os = "macos")]
+                tray::apply_tray_policy(app, true);
                 let _ = window.unminimize();
                 let _ = window.show();
                 let _ = window.set_focus();
@@ -1779,10 +1781,10 @@ pub fn run() {
                         {
                             let _ = window.set_skip_taskbar(false);
                         }
+                        tray::apply_tray_policy(app_handle, true);
                         let _ = window.unminimize();
                         let _ = window.show();
                         let _ = window.set_focus();
-                        tray::apply_tray_policy(app_handle, true);
                     } else if crate::lightweight::is_lightweight_mode() {
                         if let Err(e) = crate::lightweight::exit_lightweight_mode(app_handle) {
                             log::error!("退出轻量模式重建窗口失败: {e}");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -390,6 +390,7 @@ pub fn run() {
                 return;
             }
             tray::mark_main_page_ready();
+            log::info!("主窗口 page load finished: {}", payload.url());
             if startup_page_handled.swap(true, Ordering::Relaxed) {
                 return;
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,7 +72,7 @@ pub use store::AppState;
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "macos"))]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{fmt, sync::Arc};
 #[cfg(target_os = "macos")]
@@ -375,33 +375,32 @@ pub fn run() {
             }
 
             // Show and focus window regardless
-            if let Some(window) = app.get_webview_window("main") {
-                #[cfg(target_os = "macos")]
-                tray::apply_tray_policy(app, true);
-                let _ = window.unminimize();
-                let _ = window.show();
-                let _ = window.set_focus();
-                #[cfg(target_os = "linux")]
-                {
-                    linux_fix::nudge_main_window(window.clone());
-                }
-            }
+            tray::reveal_main_window(app);
         }));
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     {
         let startup_page_handled = AtomicBool::new(false);
         builder = builder.on_page_load(move |webview, payload| {
-            if webview.label() == "main"
-                && payload.event() == tauri::webview::PageLoadEvent::Finished
-                && payload.url().scheme() != "about"
-                && !startup_page_handled.swap(true, Ordering::Relaxed)
-                && !crate::settings::get_settings().silent_startup
+            if webview.label() != "main"
+                || payload.event() != tauri::webview::PageLoadEvent::Finished
+                || payload.url().scheme() == "about"
             {
-                let _ = webview.window().show();
-                log::info!("主页面加载完成，主窗口已显示");
+                return;
             }
+            tray::mark_main_page_ready();
+            if startup_page_handled.swap(true, Ordering::Relaxed) {
+                return;
+            }
+            if crate::settings::get_settings().silent_startup {
+                log::info!("主页面加载完成（静默启动，保持隐藏）");
+                return;
+            }
+            #[cfg(target_os = "macos")]
+            tray::apply_tray_policy(webview.app_handle(), true);
+            let _ = webview.window().show();
+            log::info!("主页面加载完成，主窗口已显示");
         });
     }
 
@@ -1341,19 +1340,14 @@ pub fn run() {
                     tray::apply_tray_policy(app.handle(), false);
                     log::info!("静默启动模式：主窗口已隐藏");
                 } else {
-                    // 正常启动模式：显示窗口
-                    #[cfg(not(target_os = "windows"))]
-                    let _ = window.show();
-                    #[cfg(target_os = "windows")]
+                    // Windows/macOS: wait for the first real page load before
+                    // showing, so a blank WKWebView/WebView2 is not exposed.
+                    #[cfg(any(target_os = "windows", target_os = "macos"))]
                     log::info!("正常启动模式：等待主页面加载完成后显示主窗口");
-                    #[cfg(not(target_os = "windows"))]
-                    log::info!("正常启动模式：主窗口已显示");
-
-                    // Linux: 解决首次启动 UI 无响应问题（Tauri #10746 + wry #637）。
-                    // 启动时 webview 未获取焦点 + surface 尺寸协商失败，导致点击无效。
-                    // 这里做 set_focus + 伪 resize，等价于无视觉版本的"最大化-还原"。
                     #[cfg(target_os = "linux")]
                     {
+                        let _ = window.show();
+                        log::info!("正常启动模式：主窗口已显示");
                         linux_fix::nudge_main_window(window.clone());
                     }
                 }
@@ -1776,20 +1770,7 @@ pub fn run() {
             match event {
                 // macOS 在 Dock 图标被点击并重新激活应用时会触发 Reopen 事件，这里手动恢复主窗口
                 RunEvent::Reopen { .. } => {
-                    if let Some(window) = app_handle.get_webview_window("main") {
-                        #[cfg(target_os = "windows")]
-                        {
-                            let _ = window.set_skip_taskbar(false);
-                        }
-                        tray::apply_tray_policy(app_handle, true);
-                        let _ = window.unminimize();
-                        let _ = window.show();
-                        let _ = window.set_focus();
-                    } else if crate::lightweight::is_lightweight_mode() {
-                        if let Err(e) = crate::lightweight::exit_lightweight_mode(app_handle) {
-                            log::error!("退出轻量模式重建窗口失败: {e}");
-                        }
-                    }
+                    tray::reveal_main_window(app_handle);
                 }
                 // 处理通过自定义 URL 协议触发的打开事件（例如 ccswitch://...）
                 RunEvent::Opened { urls } => {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1653,14 +1653,26 @@ impl RequestForwarder {
             && !codex_responses_to_chat
             && !codex_responses_to_anthropic
             && super::providers::provider_needs_responses_namespace_flatten(provider)
-            && super::providers::transform_codex_responses_xai_sanitize::sanitize_xai_responses_request(
-                &mut request_body,
-            )
         {
-            log::debug!(
-                "[Codex] Sanitized xAI-unsupported Responses fields (provider={})",
-                provider.id
-            );
+            if super::providers::transform_codex_responses_xai_sanitize::sanitize_xai_responses_request(
+                &mut request_body,
+            ) {
+                log::debug!(
+                    "[Codex] Sanitized xAI-unsupported Responses fields (provider={})",
+                    provider.id
+                );
+            }
+            // Collaboration mailbox items are a separate rewrite: xAI has no
+            // `agent_message` ModelInput variant, so V2 spawn/wait 422s unless
+            // they become ordinary `message` items.
+            if super::providers::transform_codex_responses_xai_sanitize::rewrite_xai_agent_message_input_items(
+                &mut request_body,
+            ) {
+                log::debug!(
+                    "[Codex] Rewrote xAI-unsupported agent_message input items (provider={})",
+                    provider.id
+                );
+            }
         }
 
         if matches!(app_type, AppType::Codex | AppType::GrokBuild) {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1645,10 +1645,10 @@ impl RequestForwarder {
         // Same native-Responses path: scrub the OpenAI-backend-private fields
         // and tool carriers (`external_web_access`, `prompt_cache_retention`,
         // `additional_tools`, `tool_search`, …) that xAI's strict serde parser
-        // rejects with 400/422. Deterministic field removals only, gated on the
-        // xAI OAuth path, so the prompt-cache prefix stays stable and no other
-        // provider is affected. Runs after the flatten above so lifted
-        // `namespace` tools survive the tool-type whitelist.
+        // rejects with 400/422, plus the #6815 schema collapse. Gated on the
+        // xAI native Responses path so no other provider is affected. Runs after
+        // the flatten above so lifted `namespace` tools survive the tool-type
+        // whitelist.
         if matches!(app_type, AppType::Codex | AppType::GrokBuild)
             && !codex_responses_to_chat
             && !codex_responses_to_anthropic

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1621,71 +1621,29 @@ impl RequestForwarder {
             mapped_body
         };
 
-        // Native Responses passthrough to a strict third-party gateway (xAI):
-        // flatten Codex's private `namespace`/plugin tool declarations into
-        // top-level function tools so the upstream's strict serde parser does
-        // not 422 on `unknown variant "namespace"`. The Chat/Anthropic paths
-        // above already unwrap namespaces, so this only fires on the native
-        // passthrough. The response handler restores the flat names using a map
-        // re-derived from the same request tools.
-        if matches!(app_type, AppType::Codex | AppType::GrokBuild)
-            && !codex_responses_to_chat
-            && !codex_responses_to_anthropic
-            && super::providers::provider_needs_responses_namespace_flatten(provider)
-            && super::providers::transform_codex_responses_namespace::flatten_request_namespaces(
-                &mut request_body,
-            )?
-        {
-            log::debug!(
-                "[Codex] Flattened namespace tools for native Responses upstream (provider={})",
-                provider.id
-            );
-        }
-
-        // Same native-Responses path: scrub the OpenAI-backend-private fields
-        // and tool carriers (`external_web_access`, `prompt_cache_retention`,
-        // `additional_tools`, `tool_search`, …) that xAI's strict serde parser
-        // rejects with 400/422, plus the #6815 schema collapse. Gated on the
-        // xAI native Responses path so no other provider is affected. Runs after
-        // the flatten above so lifted `namespace` tools survive the tool-type
-        // whitelist.
+        // Native Responses passthrough to a strict third-party gateway (xAI).
+        // One gate so rebase conflicts stay here plus the isolate file, not
+        // scattered across sanitizers. Flatten namespaces first; then apply
+        // xAI request rewrites (schema, agent_message, unknown models).
         if matches!(app_type, AppType::Codex | AppType::GrokBuild)
             && !codex_responses_to_chat
             && !codex_responses_to_anthropic
             && super::providers::provider_needs_responses_namespace_flatten(provider)
         {
-            if super::providers::transform_codex_responses_xai_sanitize::sanitize_xai_responses_request(
+            if super::providers::transform_codex_responses_namespace::flatten_request_namespaces(
                 &mut request_body,
-            ) {
+            )? {
                 log::debug!(
-                    "[Codex] Sanitized xAI-unsupported Responses fields (provider={})",
+                    "[Codex] Flattened namespace tools for native Responses upstream (provider={})",
                     provider.id
                 );
             }
-            if super::providers::transform_codex_responses_xai_sanitize::rewrite_xai_agent_message_input_items(
+            super::providers::transform_codex_responses_xai_sanitize::apply_xai_native_responses_request_compat(
                 &mut request_body,
-            ) {
-                log::info!(
-                    "[Codex] Rewrote xAI-unsupported agent_message input items (provider={})",
-                    provider.id
-                );
-            }
-            if let Some(upstream_model) = super::providers::codex_provider_upstream_model(provider)
-            {
-                let allowed = super::providers::transform_codex_responses_xai_sanitize::collect_xai_catalog_model_ids(
-                    &provider.settings_config,
-                );
-                if let Some((from, to)) = super::providers::transform_codex_responses_xai_sanitize::rewrite_xai_unknown_request_model(
-                    &mut request_body,
-                    &upstream_model,
-                    &allowed,
-                ) {
-                    log::info!(
-                        "[Codex] Rewrote xAI-unknown request model {from} -> {to} (provider={})",
-                        provider.id
-                    );
-                }
-            }
+                &provider.id,
+                super::providers::codex_provider_upstream_model(provider).as_deref(),
+                &provider.settings_config,
+            );
         }
 
         if matches!(app_type, AppType::Codex | AppType::GrokBuild) {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1662,9 +1662,6 @@ impl RequestForwarder {
                     provider.id
                 );
             }
-            // Collaboration mailbox items are a separate rewrite: xAI has no
-            // `agent_message` ModelInput variant, so V2 spawn/wait 422s unless
-            // they become ordinary `message` items.
             if super::providers::transform_codex_responses_xai_sanitize::rewrite_xai_agent_message_input_items(
                 &mut request_body,
             ) {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1665,10 +1665,26 @@ impl RequestForwarder {
             if super::providers::transform_codex_responses_xai_sanitize::rewrite_xai_agent_message_input_items(
                 &mut request_body,
             ) {
-                log::debug!(
+                log::info!(
                     "[Codex] Rewrote xAI-unsupported agent_message input items (provider={})",
                     provider.id
                 );
+            }
+            if let Some(upstream_model) = super::providers::codex_provider_upstream_model(provider)
+            {
+                let allowed = super::providers::transform_codex_responses_xai_sanitize::collect_xai_catalog_model_ids(
+                    &provider.settings_config,
+                );
+                if let Some((from, to)) = super::providers::transform_codex_responses_xai_sanitize::rewrite_xai_unknown_request_model(
+                    &mut request_body,
+                    &upstream_model,
+                    &allowed,
+                ) {
+                    log::info!(
+                        "[Codex] Rewrote xAI-unknown request model {from} -> {to} (provider={})",
+                        provider.id
+                    );
+                }
             }
         }
 

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -32,7 +32,8 @@ use super::{
             create_anthropic_sse_stream_from_responses_with_web_search_options,
         },
         transform, transform_codex_anthropic, transform_codex_chat,
-        transform_codex_responses_namespace, transform_gemini, transform_responses,
+        transform_codex_responses_namespace, transform_codex_responses_xai_sanitize,
+        transform_gemini, transform_responses,
     },
     response_processor::{
         create_logged_passthrough_stream, create_usage_collector, process_response,
@@ -932,15 +933,11 @@ async fn handle_responses_for_app(
         .await;
     }
 
-    // Native Responses passthrough to a strict gateway (xAI): the request-side
-    // flatten (in the forwarder) turned Codex `namespace` tools into flat
-    // function tools, so the upstream returns flat function-call names. Restore
-    // them to `{name, namespace}` so the Codex client matches them against its
-    // namespaced tool registry.
-    if super::providers::provider_needs_responses_namespace_flatten(&ctx.provider)
-        && !namespace_restore_map.is_empty()
-    {
-        return handle_codex_responses_namespace_restore(
+    // Native Responses passthrough to a strict gateway (xAI): restore flattened
+    // function-call names *and* rewrite whole-float tool arguments. The integer
+    // rewrite must run even when the request had no namespace tools.
+    if super::providers::provider_needs_responses_namespace_flatten(&ctx.provider) {
+        return handle_codex_xai_native_responses_rewrite(
             response,
             &ctx,
             &state,
@@ -1131,10 +1128,8 @@ async fn handle_responses_compact_for_app(
         .await;
     }
 
-    if super::providers::provider_needs_responses_namespace_flatten(&ctx.provider)
-        && !namespace_restore_map.is_empty()
-    {
-        return handle_codex_responses_namespace_restore(
+    if super::providers::provider_needs_responses_namespace_flatten(&ctx.provider) {
+        return handle_codex_xai_native_responses_rewrite(
             response,
             &ctx,
             &state,
@@ -1154,12 +1149,11 @@ async fn handle_responses_compact_for_app(
     .await
 }
 
-/// Response handler for the native Responses passthrough to a strict gateway
-/// (xAI), restoring the flattened `function_call` names produced by the
-/// request-side namespace flatten. Success bodies only carry a light rename;
-/// error bodies and everything unrelated pass through unchanged. Usage is
-/// collected exactly as `process_response` would (same `CODEX_PARSER_CONFIG`).
-async fn handle_codex_responses_namespace_restore(
+/// Response handler for the native Responses passthrough to xAI: restore
+/// flattened `function_call` names and rewrite whole-float tool arguments.
+/// Error bodies pass through unchanged. Usage is collected exactly as
+/// `process_response` would (same `CODEX_PARSER_CONFIG`).
+async fn handle_codex_xai_native_responses_rewrite(
     response: super::hyper_client::ProxyResponse,
     ctx: &RequestContext,
     state: &ProxyState,
@@ -1189,7 +1183,7 @@ async fn handle_codex_responses_namespace_restore(
         }
 
         let restore_stream =
-            transform_codex_responses_namespace::create_namespace_restore_sse_stream(
+            transform_codex_responses_xai_sanitize::create_xai_native_responses_sse_stream(
                 response.bytes_stream(),
                 restore_map,
             );
@@ -1231,6 +1225,9 @@ async fn handle_codex_responses_namespace_restore(
             transform_codex_responses_namespace::restore_response_namespaces(
                 &mut value,
                 &restore_map,
+            );
+            transform_codex_responses_xai_sanitize::normalize_xai_function_call_integer_arguments(
+                &mut value,
             );
             if let Some(usage) =
                 TokenUsage::from_codex_response_auto(&value).filter(TokenUsage::has_billable_tokens)

--- a/src-tauri/src/proxy/providers/codex.rs
+++ b/src-tauri/src/proxy/providers/codex.rs
@@ -207,16 +207,40 @@ pub fn should_convert_codex_responses_to_anthropic(provider: &Provider, endpoint
 }
 
 /// Whether a native-Responses Codex upstream needs Codex `namespace`/plugin
-/// tool declarations flattened before forwarding.
+/// tool declarations flattened before forwarding, plus xAI schema sanitization.
 ///
 /// Codex 0.142+ emits ChatGPT-backend-private `{"type":"namespace",…}` tool
 /// shapes that strict third-party Responses gateways reject with
-/// `422 unknown variant "namespace"`. Only providers whose upstream is such a
-/// strict native gateway need the flatten+restore pass; the Chat/Anthropic
-/// transform paths already unwrap namespaces on their own. Currently that is the
-/// managed xAI (Grok) OAuth provider — the first strict gateway cc-switch hit.
+/// `422 unknown variant "namespace"`. xAI also rejects root `oneOf`/`anyOf`
+/// function schemas (notably `mcp__codex_app__automation_update`). The
+/// Chat/Anthropic transform paths already unwrap namespaces, so this only
+/// fires on native Responses passthrough.
+///
+/// Covers managed xAI OAuth *and* API-key providers whose live upstream is
+/// `api.x.ai` with `wire_api = "responses"`. See farion1231/cc-switch#6815.
 pub fn provider_needs_responses_namespace_flatten(provider: &Provider) -> bool {
-    provider.is_xai_oauth()
+    provider.is_xai_oauth() || provider_is_xai_native_responses(provider)
+}
+
+/// True when this Codex provider talks native Responses to first-party xAI
+/// (`api.x.ai`), including API-key Grok cards that are not `xai_oauth`.
+fn provider_is_xai_native_responses(provider: &Provider) -> bool {
+    let config_text = provider
+        .settings_config
+        .get("config")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let Some(wire_api) = extract_codex_wire_api_from_toml(config_text) else {
+        return false;
+    };
+    if !wire_api.eq_ignore_ascii_case("responses") {
+        return false;
+    }
+
+    extract_codex_base_url_from_toml(config_text)
+        .map(|url| url.to_ascii_lowercase())
+        .is_some_and(|url| url.contains("api.x.ai"))
 }
 
 fn has_explicit_codex_third_party_upstream(provider: &Provider) -> bool {
@@ -2056,8 +2080,7 @@ wire_api = "responses"
     }
 
     #[test]
-    fn namespace_flatten_gate_only_fires_for_xai_oauth() {
-        // xAI OAuth: strict native gateway → needs namespace flattening.
+    fn namespace_flatten_gate_fires_for_xai_oauth_and_api_xai_responses() {
         let mut xai = create_provider(json!({ "auth": {}, "config": "" }));
         xai.meta = Some(crate::provider::ProviderMeta {
             provider_type: Some("xai_oauth".to_string()),
@@ -2065,11 +2088,30 @@ wire_api = "responses"
         });
         assert!(provider_needs_responses_namespace_flatten(&xai));
 
-        // A plain third-party API-key Codex provider must not be flattened.
-        let plain = create_provider(json!({
+        // API-key Grok cards (no xai_oauth meta) still talk to api.x.ai Responses.
+        let grok_key = create_provider(json!({
             "auth": { "OPENAI_API_KEY": "sk-x" },
-            "config": "base_url = \"https://api.x.ai/v1\"\nwire_api = \"responses\""
+            "config": r#"
+model_provider = "custom"
+model = "grok-4.6"
+
+[model_providers.custom]
+name = "xai"
+base_url = "https://api.x.ai/v1"
+wire_api = "responses"
+"#
         }));
-        assert!(!provider_needs_responses_namespace_flatten(&plain));
+        assert!(provider_needs_responses_namespace_flatten(&grok_key));
+
+        // A non-xAI Responses provider must not be flattened.
+        let other = create_provider(json!({
+            "auth": { "OPENAI_API_KEY": "sk-x" },
+            "config": r#"
+[model_providers.custom]
+base_url = "https://api.deepseek.com"
+wire_api = "responses"
+"#
+        }));
+        assert!(!provider_needs_responses_namespace_flatten(&other));
     }
 }

--- a/src-tauri/src/proxy/providers/transform_codex_responses_namespace.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_namespace.rs
@@ -338,6 +338,7 @@ fn restore_value(value: &mut Value, map: &HashMap<String, NamespacedName>) -> bo
 /// names in each event back to their namespace identity. Events that carry no
 /// affected function call pass through with their inner content preserved
 /// verbatim (only the block delimiter is normalized to `\n\n`).
+#[allow(dead_code)]
 pub(crate) fn create_namespace_restore_sse_stream<E>(
     stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
     map: HashMap<String, NamespacedName>,
@@ -384,6 +385,7 @@ where
 /// Restore one SSE block. When the block's `data:` JSON carries an affected
 /// function call, re-serialize just that line; otherwise the original block text
 /// is preserved and only the `\n\n` delimiter re-appended.
+#[allow(dead_code)]
 fn restore_sse_block(block: &str, map: &HashMap<String, NamespacedName>) -> Bytes {
     let mut event_name: Option<&str> = None;
     let mut data_parts: Vec<&str> = Vec::new();

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
@@ -705,9 +705,7 @@ pub(crate) fn rewrite_xai_unknown_request_model(
         return None;
     }
 
-    let Some(obj) = body.as_object_mut() else {
-        return None;
-    };
+    let obj = body.as_object_mut()?;
     let request = obj
         .get("model")
         .and_then(Value::as_str)

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
@@ -11,9 +11,9 @@
 //! sub2api's `patchGrokResponsesBody`
 //! (`backend/internal/service/openai_gateway_grok.go`) plus the #6815 schema
 //! collapse for root `oneOf`/`anyOf` function parameters. Field removal and
-//! that schema rewrite stay in that function; return-path whole-float tool
-//! argument rewrites are a separate entry point so they cannot be mistaken
-//! for "just delete a field". Gated on
+//! that schema rewrite stay in that function. Collaboration `agent_message`
+//! items and return-path whole-float tool argument rewrites are separate
+//! entry points so they cannot be mistaken for "just delete a field". Gated on
 //! [`super::codex::provider_needs_responses_namespace_flatten`], which covers
 //! xAI OAuth *and* API-key cards whose live upstream is `api.x.ai` Responses.
 //!
@@ -22,11 +22,12 @@
 //! tool-type whitelist below keeps them instead of dropping them.
 //!
 //! Isolation for upstream rebases: keep request sanitizers, schema collapse,
-//! and return-path integer rewriting in this file. Call sites in `forwarder`,
-//! `handlers`, and [`super::codex::provider_needs_responses_namespace_flatten`]
-//! must stay thin so `git rebase upstream/main` only conflicts at those gates.
-//! If upstream later lands equivalent sanitization, delete this layer rather
-//! than dual-pathing.
+//! collaboration `agent_message` rewriting, and return-path integer rewriting
+//! in this file. Call sites in `forwarder`, `handlers`, and
+//! [`super::codex::provider_needs_responses_namespace_flatten`] must stay thin
+//! so `git rebase upstream/main` only conflicts at those gates. If upstream
+//! later lands equivalent sanitization, delete this layer rather than
+//! dual-pathing.
 
 use std::collections::{HashMap, HashSet};
 
@@ -618,6 +619,84 @@ fn normalize_xai_function_tool_parameter_schemas(body: &mut Value) -> bool {
         changed |= normalize_xai_function_tool_parameters(tool);
     }
     changed
+}
+
+/// Rewrite Codex multi-agent v2 `agent_message` input items into ordinary
+/// `message` items. xAI's Responses `ModelInput` enum has no `agent_message`
+/// variant, so a native passthrough 422s (`unknown item type "agent_message"`)
+/// before the child agent can run.
+///
+/// This is a request-side structural rewrite, not a field deletion: keep it
+/// out of [`sanitize_xai_responses_request`]. The collaboration envelope
+/// (NEW_TASK / FINAL_ANSWER text) is preserved as `input_text`. Routed Grok
+/// sessions currently put plaintext task bodies in `encrypted_content` parts;
+/// those are flattened to `input_text` so xAI can deserialize them. Items that
+/// are not `agent_message` are left untouched.
+pub(crate) fn rewrite_xai_agent_message_input_items(body: &mut Value) -> bool {
+    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
+        return false;
+    };
+
+    let mut changed = false;
+    for item in input.iter_mut() {
+        changed |= rewrite_agent_message_item(item);
+    }
+    changed
+}
+
+fn is_agent_message_item(item: &Value) -> bool {
+    item.get("type").and_then(Value::as_str).map(str::trim) == Some("agent_message")
+}
+
+fn rewrite_agent_message_item(item: &mut Value) -> bool {
+    if !is_agent_message_item(item) {
+        return false;
+    }
+
+    let id = item.get("id").cloned();
+    let content = flatten_agent_message_content(item.get("content"));
+    let mut message = serde_json::Map::new();
+    message.insert("type".to_string(), json!("message"));
+    message.insert("role".to_string(), json!("user"));
+    if let Some(id) = id {
+        message.insert("id".to_string(), id);
+    }
+    message.insert("content".to_string(), Value::Array(content));
+    *item = Value::Object(message);
+    true
+}
+
+fn flatten_agent_message_content(content: Option<&Value>) -> Vec<Value> {
+    match content {
+        Some(Value::Array(parts)) => parts.iter().filter_map(part_to_input_text).collect(),
+        Some(Value::String(text)) if !text.is_empty() => vec![input_text_part(text)],
+        _ => Vec::new(),
+    }
+}
+
+fn part_to_input_text(part: &Value) -> Option<Value> {
+    match part.get("type").and_then(Value::as_str).map(str::trim) {
+        Some("input_text" | "output_text" | "text") => part
+            .get("text")
+            .and_then(Value::as_str)
+            .filter(|text| !text.is_empty())
+            .map(input_text_part),
+        Some("encrypted_content") => part
+            .get("encrypted_content")
+            .or_else(|| part.get("text"))
+            .and_then(Value::as_str)
+            .filter(|text| !text.is_empty())
+            .map(input_text_part),
+        _ => part
+            .get("text")
+            .and_then(Value::as_str)
+            .filter(|text| !text.is_empty())
+            .map(input_text_part),
+    }
+}
+
+fn input_text_part(text: &str) -> Value {
+    json!({ "type": "input_text", "text": text })
 }
 
 /// Rewrite whole-number JSON floats (`92116.0`) to integers (`92116`) on
@@ -1236,5 +1315,85 @@ mod tests {
             String::from_utf8(passed.to_vec()).unwrap(),
             format!("{delta}\n\n")
         );
+    }
+
+    #[test]
+    fn rewrites_agent_message_new_task_with_encrypted_content_part() {
+        let mut body = json!({
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "review"}]},
+                {
+                    "type": "agent_message",
+                    "id": "amsg_child",
+                    "author": "/root",
+                    "recipient": "/root/code_review",
+                    "content": [
+                        {"type": "input_text", "text": "Message Type: NEW_TASK\nPayload:\n"},
+                        {"type": "encrypted_content", "encrypted_content": "You are a Senior Code Reviewer."}
+                    ]
+                }
+            ]
+        });
+
+        assert!(!sanitize_xai_responses_request(&mut body));
+        assert!(rewrite_xai_agent_message_input_items(&mut body));
+        assert_eq!(body["input"][0]["type"], "message");
+        let item = &body["input"][1];
+        assert_eq!(item["type"], "message");
+        assert_eq!(item["role"], "user");
+        assert_eq!(item["id"], "amsg_child");
+        assert_eq!(item["content"][0]["type"], "input_text");
+        assert_eq!(item["content"][0]["text"], "Message Type: NEW_TASK\nPayload:\n");
+        assert_eq!(item["content"][1]["text"], "You are a Senior Code Reviewer.");
+        assert!(item.get("author").is_none());
+        assert_eq!(item["content"].as_array().unwrap().len(), 2);
+        assert!(!rewrite_xai_agent_message_input_items(&mut body));
+    }
+
+    #[test]
+    fn rewrites_agent_message_final_answer_without_dropping_neighbors() {
+        let mut body = json!({
+            "input": [
+                {
+                    "type": "function_call",
+                    "name": "wait_agent",
+                    "arguments": "{\"timeout_ms\":180000}"
+                },
+                {
+                    "type": "agent_message",
+                    "id": "amsg_parent",
+                    "author": "/root/code_review",
+                    "recipient": "/root",
+                    "content": [{
+                        "type": "input_text",
+                        "text": "Message Type: FINAL_ANSWER\nPayload:\nAgent errored: unexpected status 422"
+                    }]
+                }
+            ]
+        });
+
+        assert!(rewrite_xai_agent_message_input_items(&mut body));
+        assert_eq!(body["input"][0]["type"], "function_call");
+        assert_eq!(body["input"][0]["name"], "wait_agent");
+        assert_eq!(body["input"][1]["type"], "message");
+        assert_eq!(body["input"][1]["role"], "user");
+        assert!(body["input"][1]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("FINAL_ANSWER"));
+    }
+
+    #[test]
+    fn leaves_ordinary_messages_unchanged() {
+        let mut body = json!({
+            "input": [{
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "hello"}]
+            }]
+        });
+        let original = body.clone();
+        assert!(!rewrite_xai_agent_message_input_items(&mut body));
+        assert_eq!(body, original);
     }
 }

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
@@ -22,8 +22,9 @@
 //! tool-type whitelist below keeps them instead of dropping them.
 //!
 //! Isolation for upstream rebases: keep request sanitizers, schema collapse,
-//! collaboration `agent_message` rewriting, and return-path integer rewriting
-//! in this file. Call sites in `forwarder`, `handlers`, and
+//! collaboration `agent_message` rewriting, unknown-model remapping onto the
+//! provider's configured model, and return-path integer rewriting in this file.
+//! Call sites in `forwarder`, `handlers`, and
 //! [`super::codex::provider_needs_responses_namespace_flatten`] must stay thin
 //! so `git rebase upstream/main` only conflicts at those gates. If upstream
 //! later lands equivalent sanitization, delete this layer rather than
@@ -621,23 +622,113 @@ fn normalize_xai_function_tool_parameter_schemas(body: &mut Value) -> bool {
     changed
 }
 
-/// Rewrite Codex multi-agent v2 `agent_message` input items into ordinary
-/// `message` items. xAI's Responses `ModelInput` enum has no `agent_message`
-/// variant, so a native passthrough 422s before the child agent can run.
+/// Rewrite Codex multi-agent v2 `agent_message` items into ordinary `message`
+/// items. xAI's Responses `ModelInput` enum has no `agent_message` variant, so
+/// a native passthrough 422s (`input[N]: unknown item type "agent_message"`)
+/// before the child agent can run.
 ///
-/// Keep this out of [`sanitize_xai_responses_request`]: it is a structural
-/// rewrite, not a field deletion. Routed Grok sessions currently put plaintext
-/// task bodies in `encrypted_content` parts; flatten those to `input_text`.
+/// Walk the whole request body, not only the top-level `input` array: Codex
+/// may nest the same item under later collaboration turns. Keep this out of
+/// [`sanitize_xai_responses_request`]: it is a structural rewrite, not a field
+/// deletion. Routed Grok sessions currently put plaintext task bodies in
+/// `encrypted_content` parts; flatten those to `input_text`.
 pub(crate) fn rewrite_xai_agent_message_input_items(body: &mut Value) -> bool {
-    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
-        return false;
-    };
+    rewrite_agent_message_value(body)
+}
 
-    let mut changed = false;
-    for item in input.iter_mut() {
-        changed |= rewrite_agent_message_item(item);
+fn rewrite_agent_message_value(value: &mut Value) -> bool {
+    match value {
+        Value::Array(items) => {
+            let mut changed = false;
+            for item in items {
+                changed |= rewrite_agent_message_value(item);
+            }
+            changed
+        }
+        Value::Object(_) => {
+            if rewrite_agent_message_item(value) {
+                true
+            } else {
+                let Some(obj) = value.as_object_mut() else {
+                    return false;
+                };
+                let mut changed = false;
+                for child in obj.values_mut() {
+                    changed |= rewrite_agent_message_value(child);
+                }
+                changed
+            }
+        }
+        _ => false,
     }
-    changed
+}
+
+/// Remap a request `model` that xAI will not serve onto the provider's
+/// configured model (the live main-agent model). Catalog `model`/`slug`/`id`
+/// values are preserved so a user who picked `grok-4.5` is not forced onto
+/// `grok-4.6`. Unknown OpenAI role SKUs such as `gpt-5.6-sol` are rewritten.
+///
+/// Returns `Some((from, to))` when the field changed. Missing or empty
+/// `model` is filled with `upstream_model`. An empty upstream model is a
+/// no-op so we never invent a name.
+pub(crate) fn rewrite_xai_unknown_request_model(
+    body: &mut Value,
+    upstream_model: &str,
+    allowed_models: &HashSet<String>,
+) -> Option<(String, String)> {
+    let upstream = upstream_model.trim();
+    if upstream.is_empty() {
+        return None;
+    }
+
+    let Some(obj) = body.as_object_mut() else {
+        return None;
+    };
+    let request = obj
+        .get("model")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or("")
+        .to_string();
+
+    if !request.is_empty()
+        && (request.eq_ignore_ascii_case(upstream)
+            || allowed_models
+                .iter()
+                .any(|id| id.eq_ignore_ascii_case(&request)))
+    {
+        return None;
+    }
+
+    obj.insert("model".to_string(), Value::String(upstream.to_string()));
+    Some((request, upstream.to_string()))
+}
+
+/// Collect catalog model identifiers from a Codex provider's settings.
+/// Grok catalogs store the live id on `slug`; other providers may use
+/// `model` or `id`. All three are accepted so a catalog hit is not missed.
+pub(crate) fn collect_xai_catalog_model_ids(settings: &Value) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    let Some(models) = settings
+        .get("modelCatalog")
+        .and_then(|catalog| catalog.get("models"))
+        .and_then(Value::as_array)
+    else {
+        return ids;
+    };
+    for entry in models {
+        for key in ["model", "slug", "id"] {
+            if let Some(id) = entry
+                .get(key)
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|id| !id.is_empty())
+            {
+                ids.insert(id.to_string());
+            }
+        }
+    }
+    ids
 }
 
 fn rewrite_agent_message_item(item: &mut Value) -> bool {
@@ -668,15 +759,14 @@ fn flatten_agent_message_content(content: Option<&Value>) -> Vec<Value> {
 }
 
 fn part_to_input_text(part: &Value) -> Option<Value> {
-    let text = if part.get("type").and_then(Value::as_str).map(str::trim)
-        == Some("encrypted_content")
-    {
-        part.get("encrypted_content")
-            .or_else(|| part.get("text"))
-            .and_then(Value::as_str)
-    } else {
-        part.get("text").and_then(Value::as_str)
-    }?;
+    let text =
+        if part.get("type").and_then(Value::as_str).map(str::trim) == Some("encrypted_content") {
+            part.get("encrypted_content")
+                .or_else(|| part.get("text"))
+                .and_then(Value::as_str)
+        } else {
+            part.get("text").and_then(Value::as_str)
+        }?;
     if text.is_empty() {
         None
     } else {
@@ -921,6 +1011,7 @@ fn rewrite_xai_native_sse_block(
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::collections::HashSet;
 
     #[test]
     fn strips_external_web_access_recursively() {
@@ -1332,8 +1423,14 @@ mod tests {
         assert_eq!(item["role"], "user");
         assert_eq!(item["id"], "amsg_child");
         assert_eq!(item["content"][0]["type"], "input_text");
-        assert_eq!(item["content"][0]["text"], "Message Type: NEW_TASK\nPayload:\n");
-        assert_eq!(item["content"][1]["text"], "You are a Senior Code Reviewer.");
+        assert_eq!(
+            item["content"][0]["text"],
+            "Message Type: NEW_TASK\nPayload:\n"
+        );
+        assert_eq!(
+            item["content"][1]["text"],
+            "You are a Senior Code Reviewer."
+        );
         assert!(item.get("author").is_none());
         assert!(!rewrite_xai_agent_message_input_items(&mut body));
     }
@@ -1383,5 +1480,109 @@ mod tests {
         let original = body.clone();
         assert!(!rewrite_xai_agent_message_input_items(&mut body));
         assert_eq!(body, original);
+    }
+
+    #[test]
+    fn rewrites_agent_message_at_input_index_matching_xai_422() {
+        let mut body = json!({
+            "model": "grok-4.6",
+            "input": [
+                {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "go"}]},
+                {"type": "function_call", "name": "spawn_agent", "arguments": "{}"},
+                {"type": "function_call_output", "call_id": "c1", "output": "ok"},
+                {"type": "reasoning", "summary": []},
+                {
+                    "type": "agent_message",
+                    "id": "amsg_child",
+                    "author": "/root",
+                    "recipient": "/root/review_uncommitted",
+                    "content": [
+                        {"type": "input_text", "text": "Message Type: NEW_TASK\nPayload:\n"},
+                        {"type": "encrypted_content", "encrypted_content": "Review the diff."}
+                    ]
+                }
+            ]
+        });
+
+        assert!(rewrite_xai_agent_message_input_items(&mut body));
+        assert_eq!(body["input"][4]["type"], "message");
+        assert_eq!(body["input"][4]["role"], "user");
+        assert_eq!(body["input"][4]["content"][1]["text"], "Review the diff.");
+        assert!(body["input"][4].get("author").is_none());
+        assert_eq!(body["input"][0]["type"], "message");
+        assert_eq!(body["input"][1]["type"], "function_call");
+    }
+
+    #[test]
+    fn rewrites_nested_agent_message_inside_object_wrapper() {
+        let mut body = json!({
+            "input": {
+                "items": [{
+                    "type": "agent_message",
+                    "content": [{"type": "input_text", "text": "nested"}]
+                }]
+            }
+        });
+        assert!(rewrite_xai_agent_message_input_items(&mut body));
+        assert_eq!(body["input"]["items"][0]["type"], "message");
+        assert_eq!(body["input"]["items"][0]["role"], "user");
+    }
+
+    #[test]
+    fn remaps_unknown_openai_role_model_to_upstream() {
+        let allowed = collect_xai_catalog_model_ids(&json!({
+            "modelCatalog": {
+                "models": [
+                    {"slug": "grok-4.6"},
+                    {"slug": "grok-4.5"}
+                ]
+            }
+        }));
+        let mut body = json!({"model": "gpt-5.6-sol", "input": []});
+        assert_eq!(
+            rewrite_xai_unknown_request_model(&mut body, "grok-4.6", &allowed),
+            Some(("gpt-5.6-sol".to_string(), "grok-4.6".to_string()))
+        );
+        assert_eq!(body["model"], "grok-4.6");
+    }
+
+    #[test]
+    fn preserves_catalog_slug_instead_of_forcing_upstream() {
+        let allowed = collect_xai_catalog_model_ids(&json!({
+            "modelCatalog": {
+                "models": [
+                    {"slug": "grok-4.6"},
+                    {"slug": "grok-4.5"}
+                ]
+            }
+        }));
+        let mut body = json!({"model": "grok-4.5"});
+        assert_eq!(
+            rewrite_xai_unknown_request_model(&mut body, "grok-4.6", &allowed),
+            None
+        );
+        assert_eq!(body["model"], "grok-4.5");
+    }
+
+    #[test]
+    fn fills_missing_model_with_upstream() {
+        let allowed = HashSet::new();
+        let mut body = json!({"input": []});
+        assert_eq!(
+            rewrite_xai_unknown_request_model(&mut body, "grok-4.6", &allowed),
+            Some(("".to_string(), "grok-4.6".to_string()))
+        );
+        assert_eq!(body["model"], "grok-4.6");
+    }
+
+    #[test]
+    fn leaves_model_unchanged_when_upstream_is_empty() {
+        let allowed = HashSet::new();
+        let mut body = json!({"model": "gpt-5.6-sol"});
+        assert_eq!(
+            rewrite_xai_unknown_request_model(&mut body, "  ", &allowed),
+            None
+        );
+        assert_eq!(body["model"], "gpt-5.6-sol");
     }
 }

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
@@ -1,5 +1,4 @@
-//! xAI (Grok) `Responses` request field sanitization for native Responses
-//! upstreams.
+//! xAI (Grok) native Responses compatibility for Codex Desktop.
 //!
 //! Codex 0.142+ sends `wire_api="responses"` requests carrying a handful of
 //! OpenAI-backend-private fields and tool carriers that xAI's strict
@@ -8,22 +7,35 @@
 //! *native* Responses passthrough forwards the body verbatim, so we scrub them
 //! here.
 //!
-//! This is a faithful port of sub2api's `patchGrokResponsesBody`
-//! (`backend/internal/service/openai_gateway_grok.go`), the production Go
-//! gateway that routes Codex → Grok subscriptions. Every transform is a
-//! deterministic field removal or structural lift — no semantic rewriting — so
-//! the same input always yields the same output and the upstream prompt-cache
-//! prefix stays stable across requests. Gated on the xAI OAuth path only (see
-//! [`super::codex::provider_needs_responses_namespace_flatten`]), so no other
-//! provider is ever touched.
+//! Request-side [`sanitize_xai_responses_request`] is a faithful port of
+//! sub2api's `patchGrokResponsesBody`
+//! (`backend/internal/service/openai_gateway_grok.go`) plus the #6815 schema
+//! collapse for root `oneOf`/`anyOf` function parameters. Field removal and
+//! that schema rewrite stay in that function; return-path whole-float tool
+//! argument rewrites are a separate entry point so they cannot be mistaken
+//! for "just delete a field". Gated on
+//! [`super::codex::provider_needs_responses_namespace_flatten`], which covers
+//! xAI OAuth *and* API-key cards whose live upstream is `api.x.ai` Responses.
 //!
-//! Run this *after* namespace flattening: by then Codex's `namespace` tools are
-//! already lifted to top-level `function` tools, so the tool-type whitelist
-//! below keeps them instead of dropping them.
+//! Run request sanitizers *after* namespace flattening: by then Codex's
+//! `namespace` tools are already lifted to top-level `function` tools, so the
+//! tool-type whitelist below keeps them instead of dropping them.
+//!
+//! Isolation for upstream rebases: keep request sanitizers, schema collapse,
+//! and return-path integer rewriting in this file. Call sites in `forwarder`,
+//! `handlers`, and [`super::codex::provider_needs_responses_namespace_flatten`]
+//! must stay thin so `git rebase upstream/main` only conflicts at those gates.
+//! If upstream later lands equivalent sanitization, delete this layer rather
+//! than dual-pathing.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use serde_json::Value;
+use bytes::Bytes;
+use futures::stream::{Stream, StreamExt};
+use serde_json::{json, Map, Number, Value};
+
+use super::transform_codex_responses_namespace::{restore_sse_event_namespaces, NamespacedName};
+use crate::proxy::sse::{append_utf8_safe, strip_sse_field, take_sse_block};
 
 /// Codex plugin-private fields removed recursively at any nesting depth.
 const RECURSIVE_UNSUPPORTED_FIELDS: &[&str] = &["external_web_access"];
@@ -97,6 +109,14 @@ pub(crate) fn sanitize_xai_responses_request(body: &mut Value) -> bool {
 
     // 6. Whitelist the tool types and clean a now-dangling `tool_choice`.
     changed |= filter_unsupported_tools(body);
+
+    // 7. Normalize function tool parameter schemas that xAI rejects before
+    //    sampling starts — notably Codex's built-in `automation_update`, which
+    //    arrives flattened as `mcp__codex_app__automation_update` with a root
+    //    `oneOf`/`anyOf` union containing a `null` branch. The Responses→Chat
+    //    bridge already coerces these, but the native Responses passthrough did
+    //    not until this step.
+    changed |= normalize_xai_function_tool_parameter_schemas(body);
 
     changed
 }
@@ -344,6 +364,491 @@ fn should_drop_tool_choice(body: &Value, tools: &[Value]) -> bool {
     false
 }
 
+/// Whether a Responses function tool declares parameters that xAI's strict
+/// validator rejects before sampling begins.
+fn xai_function_parameters_need_simplification(params: &Value) -> bool {
+    match params {
+        Value::Null => true,
+        Value::Object(obj) if obj.is_empty() => true,
+        Value::Object(obj) => {
+            match obj.get("type") {
+                None | Some(Value::Null) => return true,
+                Some(Value::String(type_name)) if type_name != "object" => return true,
+                _ => {}
+            }
+
+            for union_key in ["oneOf", "anyOf"] {
+                let Some(branches) = obj.get(union_key).and_then(Value::as_array) else {
+                    continue;
+                };
+                if branches.is_empty() {
+                    continue;
+                }
+                if branches
+                    .iter()
+                    .any(|branch| branch.get("type").and_then(Value::as_str) != Some("object"))
+                {
+                    return true;
+                }
+            }
+
+            false
+        }
+        _ => true,
+    }
+}
+
+/// Collapse a root-level `oneOf`/`anyOf` union into a plain object schema.
+fn flatten_union_branches_to_object(branches: &[Value]) -> Value {
+    let object_branches: Vec<&Value> = branches
+        .iter()
+        .filter(|branch| branch.get("type").and_then(Value::as_str) == Some("object"))
+        .collect();
+
+    if object_branches.len() == 1 {
+        let mut result = object_branches[0].clone();
+        if let Some(obj) = result.as_object_mut() {
+            obj.insert("type".to_string(), json!("object"));
+            obj.entry("properties".to_string())
+                .or_insert_with(|| json!({}));
+        }
+        return result;
+    }
+
+    if !object_branches.is_empty() {
+        let mut merged_properties = Map::new();
+        let mut merged_required = Vec::new();
+        for branch in object_branches {
+            if let Some(properties) = branch.get("properties").and_then(Value::as_object) {
+                for (key, value) in properties {
+                    merged_properties
+                        .entry(key.clone())
+                        .or_insert_with(|| value.clone());
+                }
+            }
+            if let Some(required) = branch.get("required").and_then(Value::as_array) {
+                for item in required {
+                    if !merged_required.iter().any(|existing| existing == item) {
+                        merged_required.push(item.clone());
+                    }
+                }
+            }
+        }
+
+        let mut result = json!({
+            "type": "object",
+            "properties": Value::Object(merged_properties),
+        });
+        if !merged_required.is_empty() {
+            result["required"] = Value::Array(merged_required);
+        }
+        return result;
+    }
+
+    json!({
+        "type": "object",
+        "properties": {},
+        "additionalProperties": true
+    })
+}
+
+/// Rewrite a function tool's JSON Schema parameters into an xAI-compatible root
+/// object schema.
+fn simplify_xai_function_parameters(params: Option<&Value>) -> Value {
+    match params {
+        None | Some(Value::Null) => {
+            json!({"type": "object", "properties": {}, "additionalProperties": true})
+        }
+        Some(Value::Object(obj)) if obj.is_empty() => {
+            json!({"type": "object", "properties": {}, "additionalProperties": true})
+        }
+        Some(Value::Object(obj)) => {
+            for union_key in ["oneOf", "anyOf"] {
+                if let Some(branches) = obj.get(union_key).and_then(Value::as_array) {
+                    if branches
+                        .iter()
+                        .any(|branch| branch.get("type").and_then(Value::as_str) != Some("object"))
+                    {
+                        return flatten_union_branches_to_object(branches);
+                    }
+                }
+            }
+
+            let mut result = Value::Object(obj.clone());
+            if let Some(obj) = result.as_object_mut() {
+                match obj.get("type").and_then(Value::as_str) {
+                    Some("object") => {}
+                    _ => {
+                        obj.insert("type".to_string(), json!("object"));
+                        obj.entry("properties".to_string())
+                            .or_insert_with(|| json!({}));
+                    }
+                }
+            }
+            result
+        }
+        _ => json!({"type": "object", "properties": {}, "additionalProperties": true}),
+    }
+}
+
+fn function_tool_name(tool: &Value) -> &str {
+    tool.get("name")
+        .and_then(Value::as_str)
+        .or_else(|| {
+            tool.get("function")
+                .and_then(|function| function.get("name"))
+                .and_then(Value::as_str)
+        })
+        .unwrap_or("")
+        .trim()
+}
+
+fn is_automation_update_tool(name: &str) -> bool {
+    name == "codex_app__automation_update"
+        || name == "mcp__codex_app__automation_update"
+        || name.ends_with("__automation_update")
+}
+
+fn rewrite_function_tool_parameters(tool: &mut Value, params: Option<&Value>) -> bool {
+    let simplified = simplify_xai_function_parameters(params);
+    if params == Some(&simplified) {
+        return false;
+    }
+
+    if let Some(obj) = tool.as_object_mut() {
+        if obj.contains_key("parameters") || params.is_some() {
+            obj.insert("parameters".to_string(), simplified);
+            return true;
+        }
+        if let Some(function) = obj.get_mut("function").and_then(Value::as_object_mut) {
+            function.insert("parameters".to_string(), simplified);
+            return true;
+        }
+    }
+
+    false
+}
+
+fn xai_safe_empty_object_schema() -> Value {
+    json!({"type": "object", "properties": {}, "additionalProperties": true})
+}
+
+fn normalize_xai_function_tool_parameters(tool: &mut Value) -> bool {
+    if tool.get("type").and_then(Value::as_str) != Some("function") {
+        return false;
+    }
+
+    // Codex Desktop always injects automation_update with a root oneOf/anyOf
+    // that includes a non-object (null) branch. xAI rejects the whole turn
+    // (farion1231/cc-switch#6815). Keep the tool callable, but force a plain
+    // object root the way CLIProxyAPI does.
+    if is_automation_update_tool(function_tool_name(tool)) {
+        let safe = xai_safe_empty_object_schema();
+        let needs_rewrite = {
+            let current = tool.get("parameters").or_else(|| {
+                tool.get("function")
+                    .and_then(|function| function.get("parameters"))
+            });
+            current != Some(&safe)
+        };
+        let mut changed = needs_rewrite;
+        if let Some(obj) = tool.as_object_mut() {
+            if needs_rewrite {
+                if obj.contains_key("parameters") || obj.get("function").is_none() {
+                    obj.insert("parameters".to_string(), safe);
+                } else if let Some(function) =
+                    obj.get_mut("function").and_then(Value::as_object_mut)
+                {
+                    function.insert("parameters".to_string(), safe);
+                }
+            }
+            if obj.get("strict") == Some(&json!(true)) {
+                obj.insert("strict".to_string(), json!(false));
+                changed = true;
+            }
+            if let Some(function) = obj.get_mut("function").and_then(Value::as_object_mut) {
+                if function.get("strict") == Some(&json!(true)) {
+                    function.insert("strict".to_string(), json!(false));
+                    changed = true;
+                }
+            }
+        }
+        return changed;
+    }
+
+    let params = tool
+        .get("parameters")
+        .or_else(|| {
+            tool.get("function")
+                .and_then(|function| function.get("parameters"))
+        })
+        .cloned();
+
+    let changed = match params.as_ref() {
+        Some(params) if xai_function_parameters_need_simplification(params) => {
+            rewrite_function_tool_parameters(tool, Some(params))
+        }
+        None => rewrite_function_tool_parameters(tool, None),
+        _ => false,
+    };
+
+    if changed && is_automation_update_tool(function_tool_name(tool)) {
+        if let Some(obj) = tool.as_object_mut() {
+            if obj.get("strict") == Some(&json!(true)) {
+                obj.insert("strict".to_string(), json!(false));
+            }
+            if let Some(function) = obj.get_mut("function").and_then(Value::as_object_mut) {
+                if function.get("strict") == Some(&json!(true)) {
+                    function.insert("strict".to_string(), json!(false));
+                }
+            }
+        }
+    }
+
+    changed
+}
+
+fn normalize_xai_function_tool_parameter_schemas(body: &mut Value) -> bool {
+    let Some(tools) = body.get_mut("tools").and_then(Value::as_array_mut) else {
+        return false;
+    };
+
+    let mut changed = false;
+    for tool in tools.iter_mut() {
+        changed |= normalize_xai_function_tool_parameters(tool);
+    }
+    changed
+}
+
+/// Rewrite whole-number JSON floats (`92116.0`) to integers (`92116`) on
+/// completed function-call argument payloads. Grok emits JSON Number floats for
+/// integer tool fields; Codex Desktop then fails local serde (`expected i32` /
+/// `expected u64`) and never runs the tool.
+///
+/// Applies only to `response.function_call_arguments.done` and completed
+/// `function_call` items. SSE `*.delta` fragments are left untouched because
+/// they are not complete JSON. Parse/rewrite failures pass the original bytes
+/// through so Codex still surfaces the error — never replace arguments with
+/// `{}` or otherwise swallow the failure.
+pub(crate) fn normalize_xai_function_call_integer_arguments(value: &mut Value) -> bool {
+    normalize_xai_function_call_integer_arguments_value(value)
+}
+
+fn normalize_xai_function_call_integer_arguments_value(value: &mut Value) -> bool {
+    match value {
+        Value::Array(items) => {
+            let mut changed = false;
+            for item in items {
+                changed |= normalize_xai_function_call_integer_arguments_value(item);
+            }
+            changed
+        }
+        Value::Object(obj) => {
+            let event_type = obj
+                .get("type")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned);
+            if event_type.as_deref() == Some("response.function_call_arguments.delta") {
+                return false;
+            }
+
+            let mut changed = false;
+            if event_type.as_deref() == Some("response.function_call_arguments.done")
+                || event_type.as_deref() == Some("function_call")
+            {
+                changed |= normalize_function_call_arguments_field(obj);
+            }
+            for child in obj.values_mut() {
+                changed |= normalize_xai_function_call_integer_arguments_value(child);
+            }
+            changed
+        }
+        _ => false,
+    }
+}
+
+fn normalize_function_call_arguments_field(obj: &mut Map<String, Value>) -> bool {
+    match obj.get_mut("arguments") {
+        Some(Value::String(arguments)) => match rewrite_whole_float_arguments_json(arguments) {
+            Ok(Some(rewritten)) => {
+                *arguments = rewritten;
+                true
+            }
+            Ok(None) => false,
+            Err(error) => {
+                log::debug!(
+                    "[Codex] xAI function_call arguments were not rewritten; passing through unchanged: {error}"
+                );
+                false
+            }
+        },
+        Some(other) => rewrite_whole_number_floats(other),
+        None => false,
+    }
+}
+
+fn rewrite_whole_float_arguments_json(
+    arguments: &str,
+) -> Result<Option<String>, serde_json::Error> {
+    let mut value: Value = serde_json::from_str(arguments)?;
+    if !rewrite_whole_number_floats(&mut value) {
+        return Ok(None);
+    }
+    Ok(Some(serde_json::to_string(&value)?))
+}
+
+fn rewrite_whole_number_floats(value: &mut Value) -> bool {
+    match value {
+        Value::Number(number) => {
+            if let Some(integer) = whole_float_to_json_int(number) {
+                *number = integer;
+                true
+            } else {
+                false
+            }
+        }
+        Value::Array(items) => {
+            let mut changed = false;
+            for item in items {
+                changed |= rewrite_whole_number_floats(item);
+            }
+            changed
+        }
+        Value::Object(map) => {
+            let mut changed = false;
+            for child in map.values_mut() {
+                changed |= rewrite_whole_number_floats(child);
+            }
+            changed
+        }
+        _ => false,
+    }
+}
+
+/// Convert a JSON Number that is a finite whole float (`92116.0`) into an
+/// integer Number. Non-whole values (`1.5`), actual integers, infinities, and
+/// values that cannot round-trip stay unchanged.
+fn whole_float_to_json_int(number: &Number) -> Option<Number> {
+    if number.is_i64() || number.is_u64() {
+        return None;
+    }
+    let float = number.as_f64()?;
+    if !float.is_finite() || float.fract() != 0.0 {
+        return None;
+    }
+    if float >= 0.0 {
+        if float > u64::MAX as f64 {
+            return None;
+        }
+        let integer = float as u64;
+        if integer as f64 != float {
+            return None;
+        }
+        Some(Number::from(integer))
+    } else {
+        if float < i64::MIN as f64 {
+            return None;
+        }
+        let integer = float as i64;
+        if integer as f64 != float {
+            return None;
+        }
+        Some(Number::from(integer))
+    }
+}
+
+/// Wrap a native Responses SSE byte stream: restore flattened namespace names
+/// and rewrite completed function-call argument JSON. Delta fragments that are
+/// not complete JSON pass through unchanged.
+pub(crate) fn create_xai_native_responses_sse_stream<E>(
+    stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
+    restore_map: HashMap<String, NamespacedName>,
+) -> impl Stream<Item = Result<Bytes, std::io::Error>> + Send
+where
+    E: std::error::Error + Send + 'static,
+{
+    async_stream::stream! {
+        let mut buffer = String::new();
+        let mut utf8_remainder: Vec<u8> = Vec::new();
+
+        tokio::pin!(stream);
+
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(bytes) => {
+                    append_utf8_safe(&mut buffer, &mut utf8_remainder, &bytes);
+                    while let Some(block) = take_sse_block(&mut buffer) {
+                        if block.trim().is_empty() {
+                            continue;
+                        }
+                        yield Ok(rewrite_xai_native_sse_block(&block, &restore_map));
+                    }
+                }
+                Err(e) => {
+                    yield Err(std::io::Error::other(e.to_string()));
+                    return;
+                }
+            }
+        }
+
+        if !utf8_remainder.is_empty() {
+            buffer.push_str(&String::from_utf8_lossy(&utf8_remainder));
+        }
+        let tail = std::mem::take(&mut buffer);
+        if !tail.trim().is_empty() {
+            yield Ok(rewrite_xai_native_sse_block(&tail, &restore_map));
+        }
+    }
+}
+
+fn rewrite_xai_native_sse_block(
+    block: &str,
+    restore_map: &HashMap<String, NamespacedName>,
+) -> Bytes {
+    let mut event_name: Option<&str> = None;
+    let mut data_parts: Vec<&str> = Vec::new();
+    for line in block.lines() {
+        if let Some(event) = strip_sse_field(line, "event") {
+            event_name = Some(event.trim());
+        }
+        if let Some(data) = strip_sse_field(line, "data") {
+            data_parts.push(data);
+        }
+    }
+
+    if data_parts.is_empty() {
+        return Bytes::from(format!("{block}\n\n"));
+    }
+
+    let data = data_parts.join("\n");
+    if data.trim() == "[DONE]" {
+        return Bytes::from(format!("{block}\n\n"));
+    }
+
+    let mut event: Value = match serde_json::from_str(&data) {
+        Ok(value) => value,
+        Err(_) => return Bytes::from(format!("{block}\n\n")),
+    };
+
+    let mut changed = restore_sse_event_namespaces(&mut event, restore_map);
+    changed |= normalize_xai_function_call_integer_arguments(&mut event);
+    if !changed {
+        return Bytes::from(format!("{block}\n\n"));
+    }
+
+    let restored = serde_json::to_string(&event).unwrap_or(data);
+    let mut out = String::new();
+    if let Some(name) = event_name {
+        out.push_str("event: ");
+        out.push_str(name);
+        out.push('\n');
+    }
+    out.push_str("data: ");
+    out.push_str(&restored);
+    out.push_str("\n\n");
+    Bytes::from(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -535,5 +1040,201 @@ mod tests {
         assert!(sanitize_xai_responses_request(&mut body));
         // second pass finds nothing left to change
         assert!(!sanitize_xai_responses_request(&mut body));
+    }
+
+    #[test]
+    fn simplifies_flattened_automation_update_one_of_null_root() {
+        let mut body = json!({
+            "model": "grok-4.6",
+            "tools": [{
+                "type": "function",
+                "name": "mcp__codex_app__automation_update",
+                "strict": true,
+                "parameters": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {"action": {"type": "string"}},
+                            "required": ["action"]
+                        },
+                        {"type": "null"}
+                    ]
+                }
+            }]
+        });
+
+        assert!(sanitize_xai_responses_request(&mut body));
+
+        let tool = &body["tools"][0];
+        assert_eq!(tool["strict"], json!(false));
+        assert_eq!(
+            tool["parameters"],
+            json!({"type": "object", "properties": {}, "additionalProperties": true})
+        );
+    }
+
+    #[test]
+    fn simplifies_null_tool_parameters_without_touching_valid_tools() {
+        let mut body = json!({
+            "model": "grok-4.6",
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "codex_app__automation_update",
+                    "parameters": null
+                },
+                {
+                    "type": "function",
+                    "name": "echo_tool",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"message": {"type": "string"}}
+                    }
+                }
+            ]
+        });
+
+        assert!(sanitize_xai_responses_request(&mut body));
+
+        assert_eq!(
+            body["tools"][0]["parameters"],
+            json!({"type": "object", "properties": {}, "additionalProperties": true})
+        );
+        assert_eq!(
+            body["tools"][1]["parameters"],
+            json!({
+                "type": "object",
+                "properties": {"message": {"type": "string"}}
+            })
+        );
+    }
+
+    #[test]
+    fn automation_update_schema_normalization_is_idempotent() {
+        let mut body = json!({
+            "model": "grok-4.6",
+            "tools": [{
+                "type": "function",
+                "name": "mcp__codex_app__automation_update",
+                "parameters": {
+                    "oneOf": [
+                        {"type": "object", "properties": {"action": {"type": "string"}}},
+                        {"type": "null"}
+                    ]
+                }
+            }]
+        });
+
+        assert!(sanitize_xai_responses_request(&mut body));
+        assert!(!sanitize_xai_responses_request(&mut body));
+    }
+
+    #[test]
+    fn whole_floats_92116_and_120000_become_integers() {
+        let mut value: Value =
+            serde_json::from_str(r#"{"session_id":92116.0,"yield_time_ms":120000.0,"wait":1.5}"#)
+                .unwrap();
+        assert!(rewrite_whole_number_floats(&mut value));
+        assert_eq!(value["session_id"].as_i64(), Some(92116));
+        assert_eq!(value["yield_time_ms"].as_u64(), Some(120000));
+        assert_eq!(value["wait"].as_f64(), Some(1.5));
+        assert!(value["wait"].as_i64().is_none());
+
+        let encoded = serde_json::to_string(&value).unwrap();
+        assert!(encoded.contains(r#""session_id":92116"#));
+        assert!(encoded.contains(r#""yield_time_ms":120000"#));
+        assert!(!encoded.contains("92116.0"));
+        assert!(!encoded.contains("120000.0"));
+        assert!(encoded.contains("1.5"));
+    }
+
+    #[test]
+    fn function_call_arguments_done_rewrites_whole_floats_recursively() {
+        let mut event = json!({
+            "type": "response.function_call_arguments.done",
+            "item_id": "fc_exec",
+            "arguments": r#"{"session_id":92116.0,"yield_time_ms":120000.0,"nested":{"n":92116.0},"arr":[120000.0,1.5]}"#
+        });
+
+        assert!(normalize_xai_function_call_integer_arguments(&mut event));
+        let arguments: Value = serde_json::from_str(event["arguments"].as_str().unwrap()).unwrap();
+        assert_eq!(arguments["session_id"].as_i64(), Some(92116));
+        assert_eq!(arguments["yield_time_ms"].as_u64(), Some(120000));
+        assert_eq!(arguments["nested"]["n"].as_i64(), Some(92116));
+        assert_eq!(arguments["arr"][0].as_u64(), Some(120000));
+        assert_eq!(arguments["arr"][1].as_f64(), Some(1.5));
+        assert!(arguments["arr"][1].as_i64().is_none());
+    }
+
+    #[test]
+    fn completed_function_call_item_rewrites_whole_float_arguments() {
+        let mut body = json!({
+            "output": [{
+                "type": "function_call",
+                "name": "write_stdin",
+                "arguments": r#"{"session_id":92116.0,"yield_time_ms":120000.0}"#
+            }]
+        });
+
+        assert!(normalize_xai_function_call_integer_arguments(&mut body));
+        let arguments: Value =
+            serde_json::from_str(body["output"][0]["arguments"].as_str().unwrap()).unwrap();
+        assert_eq!(arguments["session_id"].as_i64(), Some(92116));
+        assert_eq!(arguments["yield_time_ms"].as_u64(), Some(120000));
+    }
+
+    #[test]
+    fn function_call_argument_deltas_are_not_rewritten() {
+        let mut event = json!({
+            "type": "response.function_call_arguments.delta",
+            "delta": r#"{"session_id":92116.0"#,
+            "item": {
+                "type": "function_call",
+                "arguments": r#"{"session_id":92116.0}"#
+            }
+        });
+        let original = event.clone();
+        assert!(!normalize_xai_function_call_integer_arguments(&mut event));
+        assert_eq!(event, original);
+    }
+
+    #[test]
+    fn invalid_function_call_arguments_pass_through() {
+        let mut event = json!({
+            "type": "response.function_call_arguments.done",
+            "arguments": r#"{"session_id":92116.0"#
+        });
+        assert!(!normalize_xai_function_call_integer_arguments(&mut event));
+        assert_eq!(event["arguments"], r#"{"session_id":92116.0"#);
+    }
+
+    #[test]
+    fn sse_done_event_rewrites_whole_floats_but_delta_bytes_stay_intact() {
+        let done = concat!(
+            "event: response.function_call_arguments.done\n",
+            r#"data: {"type":"response.function_call_arguments.done","arguments":"{\"session_id\":92116.0,\"yield_time_ms\":120000.0}"}"#,
+        );
+        let rewritten = rewrite_xai_native_sse_block(done, &HashMap::new());
+        let rewritten = String::from_utf8(rewritten.to_vec()).unwrap();
+        let data = rewritten
+            .lines()
+            .find_map(|line| line.strip_prefix("data: "))
+            .unwrap();
+        let event: Value = serde_json::from_str(data).unwrap();
+        let arguments: Value = serde_json::from_str(event["arguments"].as_str().unwrap()).unwrap();
+        assert_eq!(arguments["session_id"].as_i64(), Some(92116));
+        assert_eq!(arguments["yield_time_ms"].as_u64(), Some(120000));
+        assert!(!rewritten.contains("92116.0"));
+        assert!(!rewritten.contains("120000.0"));
+
+        let delta = concat!(
+            "event: response.function_call_arguments.delta\n",
+            r#"data: {"type":"response.function_call_arguments.delta","delta":"{\"session_id\":92116.0"}"#,
+        );
+        let passed = rewrite_xai_native_sse_block(delta, &HashMap::new());
+        assert_eq!(
+            String::from_utf8(passed.to_vec()).unwrap(),
+            format!("{delta}\n\n")
+        );
     }
 }

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
@@ -623,15 +623,11 @@ fn normalize_xai_function_tool_parameter_schemas(body: &mut Value) -> bool {
 
 /// Rewrite Codex multi-agent v2 `agent_message` input items into ordinary
 /// `message` items. xAI's Responses `ModelInput` enum has no `agent_message`
-/// variant, so a native passthrough 422s (`unknown item type "agent_message"`)
-/// before the child agent can run.
+/// variant, so a native passthrough 422s before the child agent can run.
 ///
-/// This is a request-side structural rewrite, not a field deletion: keep it
-/// out of [`sanitize_xai_responses_request`]. The collaboration envelope
-/// (NEW_TASK / FINAL_ANSWER text) is preserved as `input_text`. Routed Grok
-/// sessions currently put plaintext task bodies in `encrypted_content` parts;
-/// those are flattened to `input_text` so xAI can deserialize them. Items that
-/// are not `agent_message` are left untouched.
+/// Keep this out of [`sanitize_xai_responses_request`]: it is a structural
+/// rewrite, not a field deletion. Routed Grok sessions currently put plaintext
+/// task bodies in `encrypted_content` parts; flatten those to `input_text`.
 pub(crate) fn rewrite_xai_agent_message_input_items(body: &mut Value) -> bool {
     let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
         return false;
@@ -644,25 +640,22 @@ pub(crate) fn rewrite_xai_agent_message_input_items(body: &mut Value) -> bool {
     changed
 }
 
-fn is_agent_message_item(item: &Value) -> bool {
-    item.get("type").and_then(Value::as_str).map(str::trim) == Some("agent_message")
-}
-
 fn rewrite_agent_message_item(item: &mut Value) -> bool {
-    if !is_agent_message_item(item) {
+    if item.get("type").and_then(Value::as_str).map(str::trim) != Some("agent_message") {
         return false;
     }
 
     let id = item.get("id").cloned();
     let content = flatten_agent_message_content(item.get("content"));
-    let mut message = serde_json::Map::new();
-    message.insert("type".to_string(), json!("message"));
-    message.insert("role".to_string(), json!("user"));
+    let mut message = json!({
+        "type": "message",
+        "role": "user",
+        "content": content,
+    });
     if let Some(id) = id {
-        message.insert("id".to_string(), id);
+        message["id"] = id;
     }
-    message.insert("content".to_string(), Value::Array(content));
-    *item = Value::Object(message);
+    *item = message;
     true
 }
 
@@ -675,23 +668,19 @@ fn flatten_agent_message_content(content: Option<&Value>) -> Vec<Value> {
 }
 
 fn part_to_input_text(part: &Value) -> Option<Value> {
-    match part.get("type").and_then(Value::as_str).map(str::trim) {
-        Some("input_text" | "output_text" | "text") => part
-            .get("text")
-            .and_then(Value::as_str)
-            .filter(|text| !text.is_empty())
-            .map(input_text_part),
-        Some("encrypted_content") => part
-            .get("encrypted_content")
+    let text = if part.get("type").and_then(Value::as_str).map(str::trim)
+        == Some("encrypted_content")
+    {
+        part.get("encrypted_content")
             .or_else(|| part.get("text"))
             .and_then(Value::as_str)
-            .filter(|text| !text.is_empty())
-            .map(input_text_part),
-        _ => part
-            .get("text")
-            .and_then(Value::as_str)
-            .filter(|text| !text.is_empty())
-            .map(input_text_part),
+    } else {
+        part.get("text").and_then(Value::as_str)
+    }?;
+    if text.is_empty() {
+        None
+    } else {
+        Some(input_text_part(text))
     }
 }
 
@@ -1346,7 +1335,6 @@ mod tests {
         assert_eq!(item["content"][0]["text"], "Message Type: NEW_TASK\nPayload:\n");
         assert_eq!(item["content"][1]["text"], "You are a Senior Code Reviewer.");
         assert!(item.get("author").is_none());
-        assert_eq!(item["content"].as_array().unwrap().len(), 2);
         assert!(!rewrite_xai_agent_message_input_items(&mut body));
     }
 

--- a/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_responses_xai_sanitize.rs
@@ -21,12 +21,10 @@
 //! `namespace` tools are already lifted to top-level `function` tools, so the
 //! tool-type whitelist below keeps them instead of dropping them.
 //!
-//! Isolation for upstream rebases: keep request sanitizers, schema collapse,
-//! collaboration `agent_message` rewriting, unknown-model remapping onto the
-//! provider's configured model, and return-path integer rewriting in this file.
-//! Call sites in `forwarder`, `handlers`, and
-//! [`super::codex::provider_needs_responses_namespace_flatten`] must stay thin
-//! so `git rebase upstream/main` only conflicts at those gates. If upstream
+//! Isolation for upstream rebases: keep every xAI-only rewrite in this file.
+//! `forwarder` should call [`apply_xai_native_responses_request_compat`] once;
+//! `handlers` should only wrap SSE/non-stream restore. The live gate is
+//! [`super::codex::provider_needs_responses_namespace_flatten`]. If upstream
 //! later lands equivalent sanitization, delete this layer rather than
 //! dual-pathing.
 
@@ -622,6 +620,36 @@ fn normalize_xai_function_tool_parameter_schemas(body: &mut Value) -> bool {
     changed
 }
 
+/// One request-side entry point for the xAI native Responses gate.
+///
+/// `forwarder` stays a thin `if provider_needs_responses_namespace_flatten`
+/// call so `git rebase upstream/main` conflicts here or at that single site,
+/// not across inlined sanitizers. Logging stays here for the same reason.
+pub(crate) fn apply_xai_native_responses_request_compat(
+    body: &mut Value,
+    provider_id: &str,
+    upstream_model: Option<&str>,
+    settings: &Value,
+) {
+    if sanitize_xai_responses_request(body) {
+        log::debug!("[Codex] Sanitized xAI-unsupported Responses fields (provider={provider_id})");
+    }
+    if rewrite_xai_agent_message_input_items(body) {
+        log::info!(
+            "[Codex] Rewrote xAI-unsupported agent_message input items (provider={provider_id})"
+        );
+    }
+    let Some(upstream_model) = upstream_model else {
+        return;
+    };
+    let allowed = collect_xai_catalog_model_ids(settings);
+    if let Some((from, to)) = rewrite_xai_unknown_request_model(body, upstream_model, &allowed) {
+        log::info!(
+            "[Codex] Rewrote xAI-unknown request model {from} -> {to} (provider={provider_id})"
+        );
+    }
+}
+
 /// Rewrite Codex multi-agent v2 `agent_message` items into ordinary `message`
 /// items. xAI's Responses `ModelInput` enum has no `agent_message` variant, so
 /// a native passthrough 422s (`input[N]: unknown item type "agent_message"`)
@@ -637,6 +665,9 @@ pub(crate) fn rewrite_xai_agent_message_input_items(body: &mut Value) -> bool {
 }
 
 fn rewrite_agent_message_value(value: &mut Value) -> bool {
+    if rewrite_agent_message_item(value) {
+        return true;
+    }
     match value {
         Value::Array(items) => {
             let mut changed = false;
@@ -645,19 +676,12 @@ fn rewrite_agent_message_value(value: &mut Value) -> bool {
             }
             changed
         }
-        Value::Object(_) => {
-            if rewrite_agent_message_item(value) {
-                true
-            } else {
-                let Some(obj) = value.as_object_mut() else {
-                    return false;
-                };
-                let mut changed = false;
-                for child in obj.values_mut() {
-                    changed |= rewrite_agent_message_value(child);
-                }
-                changed
+        Value::Object(obj) => {
+            let mut changed = false;
+            for child in obj.values_mut() {
+                changed |= rewrite_agent_message_value(child);
             }
+            changed
         }
         _ => false,
     }
@@ -691,12 +715,7 @@ pub(crate) fn rewrite_xai_unknown_request_model(
         .unwrap_or("")
         .to_string();
 
-    if !request.is_empty()
-        && (request.eq_ignore_ascii_case(upstream)
-            || allowed_models
-                .iter()
-                .any(|id| id.eq_ignore_ascii_case(&request)))
-    {
+    if !request.is_empty() && request_model_is_allowed(&request, upstream, allowed_models) {
         return None;
     }
 
@@ -731,8 +750,23 @@ pub(crate) fn collect_xai_catalog_model_ids(settings: &Value) -> HashSet<String>
     ids
 }
 
+fn request_model_is_allowed(
+    request: &str,
+    upstream: &str,
+    allowed_models: &HashSet<String>,
+) -> bool {
+    request.eq_ignore_ascii_case(upstream)
+        || allowed_models
+            .iter()
+            .any(|id| id.eq_ignore_ascii_case(request))
+}
+
+fn json_type(value: &Value) -> Option<&str> {
+    value.get("type").and_then(Value::as_str).map(str::trim)
+}
+
 fn rewrite_agent_message_item(item: &mut Value) -> bool {
-    if item.get("type").and_then(Value::as_str).map(str::trim) != Some("agent_message") {
+    if json_type(item) != Some("agent_message") {
         return false;
     }
 
@@ -759,14 +793,13 @@ fn flatten_agent_message_content(content: Option<&Value>) -> Vec<Value> {
 }
 
 fn part_to_input_text(part: &Value) -> Option<Value> {
-    let text =
-        if part.get("type").and_then(Value::as_str).map(str::trim) == Some("encrypted_content") {
-            part.get("encrypted_content")
-                .or_else(|| part.get("text"))
-                .and_then(Value::as_str)
-        } else {
-            part.get("text").and_then(Value::as_str)
-        }?;
+    let text = if json_type(part) == Some("encrypted_content") {
+        part.get("encrypted_content")
+            .or_else(|| part.get("text"))
+            .and_then(Value::as_str)
+    } else {
+        part.get("text").and_then(Value::as_str)
+    }?;
     if text.is_empty() {
         None
     } else {
@@ -1526,6 +1559,25 @@ mod tests {
         assert!(rewrite_xai_agent_message_input_items(&mut body));
         assert_eq!(body["input"]["items"][0]["type"], "message");
         assert_eq!(body["input"]["items"][0]["role"], "user");
+    }
+
+    #[test]
+    fn request_compat_rewrites_agent_message_and_unknown_model_together() {
+        let mut body = json!({
+            "model": "gpt-5.6-sol",
+            "input": [{
+                "type": "agent_message",
+                "content": [{"type": "input_text", "text": "hi"}]
+            }]
+        });
+        let settings = json!({
+            "modelCatalog": {"models": [{"slug": "grok-4.6"}, {"slug": "grok-4.5"}]}
+        });
+        apply_xai_native_responses_request_compat(&mut body, "grok", Some("grok-4.6"), &settings);
+        assert_eq!(body["model"], "grok-4.6");
+        assert_eq!(body["input"][0]["type"], "message");
+        assert_eq!(body["input"][0]["role"], "user");
+        assert_eq!(body["input"][0]["content"][0]["text"], "hi");
     }
 
     #[test]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -992,37 +992,54 @@ pub fn apply_tray_policy(app: &tauri::AppHandle, dock_visible: bool) {
     }
 }
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static MAIN_PAGE_READY: AtomicBool = AtomicBool::new(false);
+
+pub fn mark_main_page_ready() {
+    MAIN_PAGE_READY.store(true, Ordering::Release);
+}
+
+/// Bring the main window on-screen. On macOS, a window that stayed hidden
+/// from silent startup can paint as a blank WKWebView; reload once if the
+/// first page load never finished while hidden.
+pub fn reveal_main_window(app: &tauri::AppHandle) {
+    if let Some(window) = app.get_webview_window("main") {
+        #[cfg(target_os = "windows")]
+        {
+            let _ = window.set_skip_taskbar(false);
+        }
+        #[cfg(target_os = "macos")]
+        {
+            apply_tray_policy(app, true);
+        }
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+        #[cfg(target_os = "linux")]
+        {
+            crate::linux_fix::nudge_main_window(window.clone());
+        }
+        #[cfg(target_os = "macos")]
+        if !MAIN_PAGE_READY.load(Ordering::Acquire) {
+            log::warn!("主窗口已显示但页面尚未加载完成，正在重新加载");
+            if let Err(err) = window.reload() {
+                log::warn!("重新加载主窗口失败: {err}");
+            }
+        }
+    } else if crate::lightweight::is_lightweight_mode() {
+        if let Err(e) = crate::lightweight::exit_lightweight_mode(app) {
+            log::error!("退出轻量模式重建窗口失败: {e}");
+        }
+    }
+}
+
 /// 处理托盘菜单事件
 pub fn handle_tray_menu_event(app: &tauri::AppHandle, event_id: &str) {
     log::info!("处理托盘菜单事件: {event_id}");
 
     match event_id {
-        "show_main" => {
-            if let Some(window) = app.get_webview_window("main") {
-                #[cfg(target_os = "windows")]
-                {
-                    let _ = window.set_skip_taskbar(false);
-                }
-                #[cfg(target_os = "macos")]
-                {
-                    // Accessory + hidden (silent startup) must become Regular
-                    // before show(), otherwise macOS can present an empty
-                    // WKWebView and the proxy keeps running in the background.
-                    apply_tray_policy(app, true);
-                }
-                let _ = window.unminimize();
-                let _ = window.show();
-                let _ = window.set_focus();
-                #[cfg(target_os = "linux")]
-                {
-                    crate::linux_fix::nudge_main_window(window.clone());
-                }
-            } else if crate::lightweight::is_lightweight_mode() {
-                if let Err(e) = crate::lightweight::exit_lightweight_mode(app) {
-                    log::error!("退出轻量模式重建窗口失败: {e}");
-                }
-            }
-        }
+        "show_main" => reveal_main_window(app),
         "open_website" => {
             if let Err(e) = app.opener().open_url("https://ccswitch.io", None::<String>) {
                 log::error!("打开官方网站失败: {e}");

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1003,16 +1003,19 @@ pub fn handle_tray_menu_event(app: &tauri::AppHandle, event_id: &str) {
                 {
                     let _ = window.set_skip_taskbar(false);
                 }
+                #[cfg(target_os = "macos")]
+                {
+                    // Accessory + hidden (silent startup) must become Regular
+                    // before show(), otherwise macOS can present an empty
+                    // WKWebView and the proxy keeps running in the background.
+                    apply_tray_policy(app, true);
+                }
                 let _ = window.unminimize();
                 let _ = window.show();
                 let _ = window.set_focus();
                 #[cfg(target_os = "linux")]
                 {
                     crate::linux_fix::nudge_main_window(window.clone());
-                }
-                #[cfg(target_os = "macos")]
-                {
-                    apply_tray_policy(app, true);
                 }
             } else if crate::lightweight::is_lightweight_mode() {
                 if let Err(e) = crate::lightweight::exit_lightweight_mode(app) {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1016,8 +1016,6 @@ pub fn reveal_main_window(app: &tauri::AppHandle) {
         let _ = window.unminimize();
         let _ = window.show();
         let _ = window.set_focus();
-        window.open_devtools();
-        log::info!("已打开 WebView inspector");
         #[cfg(target_os = "linux")]
         {
             crate::linux_fix::nudge_main_window(window.clone());

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1016,6 +1016,8 @@ pub fn reveal_main_window(app: &tauri::AppHandle) {
         let _ = window.unminimize();
         let _ = window.show();
         let _ = window.set_focus();
+        window.open_devtools();
+        log::info!("已打开 WebView inspector");
         #[cfg(target_os = "linux")]
         {
             crate::linux_fix::nudge_main_window(window.clone());

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -992,10 +992,13 @@ pub fn apply_tray_policy(app: &tauri::AppHandle, dock_visible: bool) {
     }
 }
 
+#[cfg(target_os = "macos")]
 use std::sync::atomic::{AtomicBool, Ordering};
 
+#[cfg(target_os = "macos")]
 static MAIN_PAGE_READY: AtomicBool = AtomicBool::new(false);
 
+#[cfg(target_os = "macos")]
 pub fn mark_main_page_ready() {
     MAIN_PAGE_READY.store(true, Ordering::Release);
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,6 +20,7 @@
         "minWidth": 900,
         "minHeight": 600,
         "visible": false,
+        "devtools": true,
         "resizable": true,
         "fullscreen": false,
         "center": true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,6 @@
         "minWidth": 900,
         "minHeight": 600,
         "visible": false,
-        "devtools": true,
         "resizable": true,
         "fullscreen": false,
         "center": true


### PR DESCRIPTION
## Summary / 概述

Keep Codex Desktop on native `api.x.ai/v1/responses` instead of a Chat/Anthropic bridge, and make Grok requests survive Codex-private payload shapes.

xAI request/response compatibility (isolated in `transform_codex_responses_xai_sanitize.rs`, thin gate in `forwarder`/`handlers`):

- Collapse root `oneOf`/`anyOf` function schemas that xAI rejects (#6815)
- Rewrite collaboration `agent_message` items into ordinary `message` items
- Remap unknown OpenAI role SKUs (`gpt-5.6-sol` / `luna` / `terra`) onto the provider's configured model; keep catalog slugs such as `grok-4.5`
- Rewrite whole-number JSON floats in completed function-call arguments (`92116.0` → `92116`)

macOS production packaging:

- Enable `custom-protocol` so release builds embed `dist` instead of loading Vite at `localhost:3000` (blank window)
- Keep Web Inspector off by default after the white-screen diagnosis

## Related Issue / 关联 Issue

Fixes #6815

## Screenshots / 截图

N/A

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [ ] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo test --lib transform_codex_responses_xai_sanitize` passes
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件