### PR TITLE
fix(codex): plan a live write against the same official-ness the switch path uses

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -3757,6 +3757,30 @@ fn plan_codex_live_write(
     })
 }
 
+/// The category a Codex live write must be planned against.
+///
+/// `provider.category` alone under-reports official-ness. The rest of the
+/// switch path — including its own post-switch `auth.json` cleanup in
+/// `services::provider` — asks `is_codex_official_provider`, which also
+/// recognises the fixed official row and any provider bound to a managed
+/// `codex_oauth` account, whatever their stored category says. The plan only
+/// saw the string, so such a card was planned as a **third-party** switch:
+/// `write_full_auth` stayed false, so its own ChatGPT login never reached
+/// `auth.json`, and `remove_auth_file` became `!preserve_official_login` —
+/// true by default — so the live login was deleted instead. The user was
+/// signed out by switching to their own official card.
+///
+/// One managed-account path (`services::proxy`) already hardcoded
+/// `Some("official")` to sidestep exactly this. Naming the rule here is what
+/// stops the next caller from having to rediscover it, and keeps the
+/// preflight and the write judging the same provider the same way.
+pub fn codex_live_write_category(provider: &crate::provider::Provider) -> Option<&str> {
+    if crate::proxy::providers::is_codex_official_provider(provider) {
+        return Some("official");
+    }
+    provider.category.as_deref()
+}
+
 /// Validate a Codex live write without touching the filesystem. Callers use
 /// this to fail a provider switch BEFORE committing `current`: a write-layer
 /// refusal after `current` moved would let the next switch backfill the old
@@ -5721,6 +5745,123 @@ base_url = "https://bedrock.example/v1"
         );
     }
 
+    /// A managed-OAuth official card whose stored `category` is not the literal
+    /// "official" must still be planned as an official write.
+    ///
+    /// `is_codex_official_provider` — the predicate the switch path uses for its
+    /// own post-switch auth cleanup — returns true for it. The plan used to read
+    /// only the category string, so the same card was planned third-party: its
+    /// ChatGPT login was never written, and with preservation off (the default)
+    /// the live login was deleted. Switching to your own official card signed
+    /// you out.
+    #[test]
+    fn a_managed_oauth_card_is_official_even_when_its_category_is_not() {
+        let mut provider = crate::provider::Provider {
+            id: "managed-official-account".to_string(),
+            name: "ChatGPT".to_string(),
+            settings_config: json!({
+                "auth": {
+                    "auth_mode": "chatgpt",
+                    "OPENAI_API_KEY": null,
+                    "tokens": { "refresh_token": "live-oauth-token" }
+                },
+                "config": ""
+            }),
+            website_url: None,
+            // Not the literal "official" — this is the whole point.
+            category: Some("codex".to_string()),
+            created_at: None,
+            sort_index: None,
+            notes: None,
+            meta: None,
+            icon: None,
+            icon_color: None,
+            in_failover_queue: false,
+        };
+        provider.meta = Some(crate::provider::ProviderMeta {
+            provider_type: Some("codex_oauth".to_string()),
+            auth_binding: Some(crate::provider::AuthBinding {
+                source: crate::provider::AuthBindingSource::ManagedAccount,
+                auth_provider: Some("codex_oauth".to_string()),
+                account_id: Some("acct-managed".to_string()),
+            }),
+            ..Default::default()
+        });
+
+        // Precondition: the rest of the switch path already calls this official.
+        assert!(
+            crate::proxy::providers::is_codex_official_provider(&provider),
+            "precondition: a managed codex_oauth card is official to the predicate the switch path already uses"
+        );
+        let auth = provider.settings_config["auth"].clone();
+        // Preservation OFF is the DEFAULT, which is what makes this bite.
+        let plan =
+            plan_codex_live_write(codex_live_write_category(&provider), &auth, Some(""), false)
+                .expect("official plan");
+
+        // The harm is asserted before the mechanism, so a regression reports what
+        // breaks for the user rather than which string a helper returned.
+        assert!(
+            !plan.remove_auth_file,
+            "planning an official card as third-party deletes the ChatGPT login it switches TO"
+        );
+        assert!(
+            plan.write_full_auth,
+            "an official card carrying login material must write auth.json, or that login never reaches disk"
+        );
+        assert_eq!(
+            codex_live_write_category(&provider),
+            Some("official"),
+            "the live write must be planned against the same official-ness"
+        );
+    }
+
+    /// The guard must not swallow genuine third-party cards.
+    #[test]
+    fn a_third_party_card_keeps_its_own_category() {
+        let provider = crate::provider::Provider {
+            id: "deepseek".to_string(),
+            name: "DeepSeek".to_string(),
+            settings_config: json!({
+                "auth": { "OPENAI_API_KEY": "sk-third-party" },
+                "config": ""
+            }),
+            website_url: None,
+            category: Some("codex".to_string()),
+            created_at: None,
+            sort_index: None,
+            notes: None,
+            meta: None,
+            icon: None,
+            icon_color: None,
+            in_failover_queue: false,
+        };
+
+        assert!(!crate::proxy::providers::is_codex_official_provider(
+            &provider
+        ));
+        assert_eq!(codex_live_write_category(&provider), Some("codex"));
+
+        let auth = provider.settings_config["auth"].clone();
+        // A real table to carry the bearer token: an empty config with a key is
+        // refused outright, which would pass this test for the wrong reason.
+        let config = "model_provider = \"relay\"\n\n[model_providers.relay]\nname = \"Relay\"\nbase_url = \"https://relay.example/v1\"\nwire_api = \"responses\"\n";
+        let plan = plan_codex_live_write(
+            codex_live_write_category(&provider),
+            &auth,
+            Some(config),
+            false,
+        )
+        .expect("third-party plan");
+        assert!(
+            plan.remove_auth_file,
+            "a real third-party switch with preservation off still deletes auth.json"
+        );
+        assert!(
+            !plan.write_full_auth,
+            "third-party switches are config-only"
+        );
+    }
     #[test]
     fn requires_openai_auth_stamp_only_touches_tables_with_a_request_auth_short_circuit() {
         // Keyless header-auth card: no env_key / bearer short-circuit, so

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -169,7 +169,7 @@ impl ConfigService {
 
         crate::codex_config::write_codex_provider_live_with_catalog(
             &provider.settings_config,
-            provider.category.as_deref(),
+            crate::codex_config::codex_live_write_category(provider),
             auth,
             cfg_text,
             profile,

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -738,7 +738,11 @@ pub(crate) fn preflight_codex_live_write_for_state(
         .get("auth")
         .ok_or_else(|| AppError::Config("Codex 供应商配置缺少 'auth' 字段".to_string()))?;
     let config_str = obj.get("config").and_then(|v| v.as_str());
-    crate::codex_config::preflight_codex_live_write(effective.category.as_deref(), auth, config_str)
+    crate::codex_config::preflight_codex_live_write(
+        crate::codex_config::codex_live_write_category(&effective),
+        auth,
+        config_str,
+    )
 }
 
 pub(crate) fn write_live_with_common_config_for_codex_oauth_manager(
@@ -1306,7 +1310,7 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
 
             crate::codex_config::write_codex_provider_live_with_catalog(
                 &provider.settings_config,
-                provider.category.as_deref(),
+                crate::codex_config::codex_live_write_category(provider),
                 auth,
                 config_str,
                 profile,

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3108,7 +3108,7 @@ impl ProxyService {
 
                 crate::codex_config::write_codex_provider_live_with_catalog(
                     effective_settings,
-                    effective_provider.category.as_deref(),
+                    crate::codex_config::codex_live_write_category(&effective_provider),
                     auth,
                     config_str,
                     profile,
@@ -3593,7 +3593,7 @@ impl ProxyService {
 
         crate::codex_config::write_codex_provider_live_with_catalog(
             config,
-            provider.category.as_deref(),
+            crate::codex_config::codex_live_write_category(provider),
             auth,
             config_str,
             profile,


### PR DESCRIPTION
## Two definitions of "official", and the live write uses the weaker one

`plan_codex_live_write` decides official-ness from one thing:

```rust
if category == Some("official") {
```

The rest of the switch path asks a different question. `services/provider/mod.rs` — including the block that cleans up `auth.json` **after** the very write this plan produces — uses:

```rust
provider.category.as_deref() == Some("official")
    || crate::proxy::providers::is_codex_official_provider(provider)
```

And `is_codex_official_provider` is broader on purpose. It returns true for the fixed official row, and it returns true for **any provider bound to a managed `codex_oauth` account**, regardless of what `category` holds:

```rust
if has_managed_account {
    return true;
}
```

So a card that every other part of the switch treats as official can reach the plan and be judged third-party.

## What that costs

The third-party branch does two things the official branch explicitly does not:

| | official branch | third-party branch |
|---|---|---|
| `write_full_auth` | `codex_auth_has_login_material(auth)` | `false` |
| `remove_auth_file` | `false` | `!preserve_official_login` |

Preservation is **opt-in and defaults to false**, so for such a card:

1. its own ChatGPT login, sitting in `auth`, is never written to `auth.json` — the plan is config-only; and
2. the live `auth.json` is deleted.

Switching to your own official card signs you out. Then `services/provider/mod.rs` runs `clear_stale_codex_live_auth_after_official_switch` — which *does* use the broad predicate — finds no file, and returns `Ok(false)`. Nothing is logged, because from that block's point of view there was nothing stale to clean.

`record_codex_managed_oauth_live_auth`, which runs right after the write, does not rescue it: it writes the ownership *marker* file, not `auth.json`.

## The fix

The evidence that this is a known-shaped problem is already in the tree — one managed-account path in `services/proxy.rs` hardcodes the category:

```rust
// An explicitly managed official account is different from the
// unbound native-login passthrough: the selected account owns
// auth.json and must replace any previously active account.
crate::codex_config::write_codex_live_for_provider(Some("official"), auth, ...)
```

That is the right call made in one place. This PR names the rule once instead:

```rust
pub fn codex_live_write_category(provider: &Provider) -> Option<&str> {
    if crate::proxy::providers::is_codex_official_provider(provider) {
        return Some("official");
    }
    provider.category.as_deref()
}
```

and routes the five sites that build a Codex live write through it — `services/config.rs`, `services/provider/live.rs` (both the **preflight** and the write), and the two `services/proxy.rs` sites.

Including the preflight is the part I would not want dropped. `plan_codex_live_write`'s own doc says validation and execution live in one builder so they cannot drift; that guarantee is only worth anything if both are handed the same provider identity. A preflight that judged a card third-party while the write judged it official would refuse switches that would have succeeded, or pass ones that then behave differently.

I deliberately did **not** touch `is_codex_official_provider` itself. Widening the predicate would change proxy routing and base-URL resolution, which is a much larger blast radius than the write-planning bug actually needs.

## Verification

Two tests, and the first is red against `main`.

```
thread 'codex_config::tests::a_managed_oauth_card_is_official_even_when_its_category_is_not'
panicked at src\codex_config.rs:5715:9:
planning an official card as third-party deletes the ChatGPT login it switches TO
```

The harm is asserted before the mechanism on purpose — with the assertions the other way round, the failure reads "expected `Some("official")`, got `Some("codex")`", which says what a helper returned rather than what breaks for the user. It also opens with a precondition assert that `is_codex_official_provider` already calls the fixture official, so the test cannot quietly become vacuous if that predicate changes.

The second test pins the other direction: a genuine third-party card keeps its own category, still deletes `auth.json` with preservation off, and stays config-only. Its fixture carries a real `[model_providers.relay]` table — my first attempt used an empty config, which is refused outright (`provider.codex.config.missing`) and would have passed for the wrong reason.

**`cargo test --lib`: 2713 passed, 2 failed.** Both failures are pre-existing and environmental — `resolve_catalog_rejects_symlink_escaping_config_dir` and `symlink_cycle_does_not_cause_stack_overflow` both die on `Os { code: 1314, "A required privilege is not held by the client." }`, this Windows box having no symlink privilege. Neither is in a file this branch touches.

`cargo clippy --all-targets -- -D warnings` → clean. `cargo fmt --all` applied.

## Scope note

This is not a fix for #6925, which reports the reverse direction (official → third-party with preservation **on**). I went looking for that one and could not reproduce it in the plan — `remove_auth_file = !preserve_official_login` is correct there and covered by existing tests — so I am not claiming it. This is a different reachable path to the same symptom, found on the way.
