### PR TITLE
fix(terminal): lead launcher command with newline to survive interactive prompts

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -3936,8 +3936,12 @@ fn applescript_launcher_command(script_file: &std::path::Path) -> String {
 /// Build a launcher command that replaces the terminal-created shell session.
 #[cfg(target_os = "macos")]
 fn applescript_exec_launcher_command(script_file: &std::path::Path) -> String {
+    // 前置换行符：交互式 shell 启动时可能有 oh-my-zsh 更新提示等 `read -k 1`
+    // 单行读取，会吞掉 `do script` 键入命令的首字符（exec → xec，#6926）。
+    // 换行符被提示消费后真正的命令完整到达 shell；无提示时换行只是执行
+    // 一条空命令，无害。
     applescript_string_literal(&format!(
-        "exec sh {}",
+        "\nexec sh {}",
         shell_single_quote(&script_file.to_string_lossy())
     ))
 }
@@ -6898,7 +6902,7 @@ mod tests {
             "already-running branch should use bare do script:\n{script}"
         );
         assert!(
-            script.contains(r#"set launcher_script to "exec sh '/tmp/cc_switch_launcher.sh'""#),
+            script.contains("set launcher_script to \"\nexec sh '/tmp/cc_switch_launcher.sh'\""),
             "Terminal should replace the auto-created shell:\n{script}"
         );
     }
@@ -6909,6 +6913,25 @@ mod tests {
         assert_eq!(
             build_macos_dash_c_command(Path::new("/tmp/cc_switch_launcher.sh")),
             "exec sh '/tmp/cc_switch_launcher.sh'"
+        );
+    }
+
+    /// oh-my-zsh's interactive update prompt uses `read -k 1`, which consumes
+    /// the first character `do script` types — turning `exec` into `xec`.
+    /// The launcher command must lead with a newline so the prompt consumes
+    /// that instead of the command itself (#6926).
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn terminal_launcher_command_survives_single_character_prompt() {
+        let literal = applescript_exec_launcher_command(Path::new("/tmp/cc_switch_launcher.sh"));
+        let typed = literal
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .expect("applescript string literal should be double-quoted");
+        let (_first, rest) = typed.split_at(1);
+        assert!(
+            rest.starts_with("exec sh "),
+            "after a single-character prompt read, the launcher command must be intact, got: {rest:?}"
         );
     }
 

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -7023,20 +7023,17 @@ mod tests {
     fn applescript_builders_safely_quote_special_paths() {
         // First shell-quote the path, then wrap the whole command as an AppleScript string.
         let expected = r#""sh '/Users/me/it'\"'\"'s dir/x.sh'""#;
+        let exec_expected = r#""
+exec sh '/Users/me/it'\"'\"'s dir/x.sh'""#;
         let p = Path::new("/Users/me/it's dir/x.sh");
         assert_eq!(applescript_launcher_command(p), expected);
-        assert_eq!(
-            applescript_exec_launcher_command(p),
-            r#""exec sh '/Users/me/it'\"'\"'s dir/x.sh'""#
-        );
+        assert_eq!(applescript_exec_launcher_command(p), exec_expected);
         assert!(
-            build_macos_terminal_applescript(p)
-                .contains(r#""exec sh '/Users/me/it'\"'\"'s dir/x.sh'""#),
+            build_macos_terminal_applescript(p).contains(exec_expected),
             "Terminal did not quote safely"
         );
         assert!(
-            build_macos_iterm2_applescript(p)
-                .contains(r#""exec sh '/Users/me/it'\"'\"'s dir/x.sh'""#),
+            build_macos_iterm2_applescript(p).contains(exec_expected),
             "iTerm2 did not quote safely"
         );
         assert!(


### PR DESCRIPTION
## Summary

Fixes #6926.

Terminal.app's `do script` types the launcher command (`exec sh '...cc_switch_launcher.sh'`) into the shell. When an interactive startup prompt — e.g. oh-my-zsh's update confirmation, which uses `read -k 1` — is active, it consumes the first typed character. The `e` of `exec` is eaten, leaving `xec sh '...'`, and zsh fails with `command not found: xec`.

## Root cause

`applescript_exec_launcher_command` returns the bare `exec sh '<path>'` string, which `build_macos_terminal_applescript` passes to `do script`. AppleScript `do script` sends the string as keystrokes; Terminal's input buffer delivers them to whatever is reading stdin at that moment — including interactive shell prompts.

## Fix

Lead the typed command with a newline:

- **Prompt active**: the prompt's `read -k 1` consumes the newline (answering "no" to the update prompt), and the intact `exec sh '...'` reaches the shell.
- **No prompt**: the newline executes an empty command (harmless), then `exec sh '...'` runs normally.

## Test

New test `terminal_launcher_command_survives_single_character_prompt` extracts the typed content from the AppleScript string literal, simulates `read -k 1` by consuming the first character, and asserts the remaining string starts with `exec sh `.

- **RED** on old code: `after a single-character prompt read, the launcher command must be intact, got: "xec sh '/tmp/cc_switch_launcher.sh'"`
- **GREEN** after fix: the newline is consumed, `exec sh '...'` survives intact.

The existing `terminal_applescript_cold_start_uses_launch_before_do_script` assertion was updated to match the new literal (newline inside the AppleScript string).

`cargo test` (terminal launcher + applescript suites) passes; `cargo clippy -D warnings` and `cargo fmt --check` clean.