### PR TITLE
fix(proxy): preserve mid-conversation system messages for prefix cache

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -180,7 +180,6 @@ pub fn anthropic_to_openai_with_reasoning_content(
         }
     }
 
-    normalize_openai_system_messages(&mut messages);
     result["messages"] = json!(messages);
 
     // 转换参数 — o-series 模型需要 max_completion_tokens
@@ -302,57 +301,6 @@ fn map_tool_choice_to_chat(tool_choice: &Value) -> Value {
             _ => tool_choice.clone(),
         },
         _ => tool_choice.clone(),
-    }
-}
-
-fn normalize_openai_system_messages(messages: &mut Vec<Value>) {
-    let system_count = messages
-        .iter()
-        .filter(|message| message.get("role").and_then(|value| value.as_str()) == Some("system"))
-        .count();
-
-    if system_count == 0 {
-        return;
-    }
-
-    if system_count == 1 {
-        if let Some(index) = messages.iter().position(|message| {
-            message.get("role").and_then(|value| value.as_str()) == Some("system")
-        }) {
-            if index > 0 {
-                let message = messages.remove(index);
-                messages.insert(0, message);
-            }
-        }
-        return;
-    }
-
-    let mut parts = Vec::new();
-    messages.retain(|message| {
-        if message.get("role").and_then(|value| value.as_str()) != Some("system") {
-            return true;
-        }
-
-        match message.get("content") {
-            Some(Value::String(text)) if !text.is_empty() => parts.push(text.clone()),
-            Some(Value::Array(content_parts)) => {
-                let text = content_parts
-                    .iter()
-                    .filter_map(|part| part.get("text").and_then(|value| value.as_str()))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                if !text.is_empty() {
-                    parts.push(text);
-                }
-            }
-            _ => {}
-        }
-
-        false
-    });
-
-    if !parts.is_empty() {
-        messages.insert(0, json!({"role": "system", "content": parts.join("\n")}));
     }
 }
 

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -158,14 +158,19 @@ pub fn anthropic_to_openai_with_reasoning_content(
                 messages.push(json!({"role": "system", "content": text}));
             }
         } else if let Some(arr) = system.as_array() {
+            // 顶层 system 数组合并为一条 system 消息（跨轮字节稳定，不影响前缀缓存）
+            let mut parts = Vec::new();
             for msg in arr {
                 if let Some(text) = msg.get("text").and_then(|t| t.as_str()) {
                     let text = strip_leading_anthropic_billing_header(text);
                     if text.is_empty() {
                         continue;
                     }
-                    messages.push(json!({"role": "system", "content": text}));
+                    parts.push(text.to_string());
                 }
+            }
+            if !parts.is_empty() {
+                messages.push(json!({"role": "system", "content": parts.join("\n")}));
             }
         }
     }
@@ -934,6 +939,40 @@ mod tests {
             "You are Claude Code.\nBe concise."
         );
         assert!(result["messages"][0].get("cache_control").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_preserves_mid_conversation_system_in_place() {
+        // Claude Code 会在对话中间注入 system 消息（如 <total_tokens>），
+        // 必须保持原位，不合并不上提，否则破坏前缀缓存。
+        let input = json!({
+            "model": "claude-3-sonnet",
+            "max_tokens": 1024,
+            "system": "You are Claude Code.",
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi there!"},
+                {"role": "system", "content": "<total_tokens>14963538 tokens left</total_tokens>"},
+                {"role": "user", "content": "Continue"}
+            ]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+        let messages = result["messages"].as_array().unwrap();
+
+        // 顶层 system 在最前面
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "You are Claude Code.");
+
+        // 中途 system 保持原位（第 3 条，index=3），不被合并或上提
+        assert_eq!(messages[3]["role"], "system");
+        assert_eq!(
+            messages[3]["content"],
+            "<total_tokens>14963538 tokens left</total_tokens>"
+        );
+
+        // 总共 5 条消息，没有合并
+        assert_eq!(messages.len(), 5);
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

Remove `normalize_openai_system_messages` which merged ALL system messages to the head of the messages array. When Claude Code injects `<total_tokens>` metadata as a mid-conversation system message, this caused the merged system prompt to change every turn, breaking radix prefix cache on sglang/GLM-5.2.

移除 `normalize_openai_system_messages` 函数。该函数会将所有 system 消息合并到消息数组头部。当 Claude Code 在对话中间注入 `<total_tokens>` 元数据时，合并后的 system prompt 每轮都会变化，导致 sglang/GLM-5.2 上的前缀缓存无法命中。

The conversion flow now:
1. Top-level `system` field → placed as the first system message
2. All messages from the `messages` array (including mid-conversation system) → extended in their original order, no merging or reordering

转换流程现在：
1. 顶层 `system` 字段 → 作为第一条 system 消息放在最前面
2. `messages` 数组中的所有消息（包括对话中间的 system）→ 按原始顺序 extend，不合并、不重排

This preserves prefix stability across turns while keeping all system content intact.

这样保证了跨轮次的前缀稳定性，同时保留了所有 system 内容。

## Background / 背景

This fix targets the OpenAI-compatible `/v1/chat/completions` endpoint (not the Anthropic messages endpoint). The OpenAI API does not restrict system messages to the head of the array — messages are processed in order regardless of role. sglang's OpenAI-compatible endpoint behaves the same way, processing mid-conversation system messages in place without merging.

本修复针对的是 OpenAI 兼容的 `/v1/chat/completions` 接口（非 Anthropic messages 接口）。OpenAI API 不限制 system 消息只能出现在数组开头——messages 按顺序处理，与 role 无关。sglang 的 OpenAI 兼容接口行为一致，对话中间的 system 消息按原位处理，不合并。

For reference, new-api also preserves system message positions when converting to the chat endpoint, without merging.

作为参考，new-api 在转换到 chat 接口时也保持 system 消息原位，不合并。

## Related Issue / 关联 Issue

Fixes #6789

## Screenshots / 截图

<img width="3442" height="872" alt="image" src="https://github.com/user-attachments/assets/527993b0-a883-4002-9ec8-588d51f93ca0" />

## Validation / 验证

- `cargo build --release --features custom-protocol` passed.
- Manually tested: CC Switch proxy with Claude Code → sglang/GLM-5.2 via `/v1/chat/completions`, prefix cache hit rate significantly improved.

## Checklist / 检查清单

- [ ] `pnpm typecheck` was not run; this is a Rust-only change /
      未运行；本次仅修改 Rust 后端代码
- [ ] `pnpm format:check` was not run; this is a Rust-only change /
      未运行；本次仅修改 Rust 后端代码
- [x] `cargo test` passes /
      `cargo test` 已通过
- [x] `cargo clippy` passes /
      `cargo clippy` 已通过
- [x] No user-facing text changed; i18n update is not applicable /
      未修改用户可见文本，不需要更新国际化文件
