### PR TITLE
feat(settings): add configurable home page with usage dashboard option

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -48,6 +48,18 @@ fn merge_settings_for_save(
     // 开关）后、前端 query 缓存刷新前的一次全量保存会把旧 marker 重放回来，
     // 重新开启时被"复活"的标记挡住而漏迁。
     incoming.local_migrations = existing.local_migrations.clone();
+    // current_provider_* 由 provider 切换命令（settings::set_current_provider）
+    // 单独管理，前端设置表单从不编辑它们。save_settings 的全量 payload 可能
+    // 携带陈旧的 currentProvider 快照（如使用统计首页在供应商切换期间保存），
+    // 若按 incoming 透传会把刚切换的供应商回退，故无条件保留现有值。
+    incoming.current_provider_claude = existing.current_provider_claude.clone();
+    incoming.current_provider_claude_desktop = existing.current_provider_claude_desktop.clone();
+    incoming.current_provider_codex = existing.current_provider_codex.clone();
+    incoming.current_provider_gemini = existing.current_provider_gemini.clone();
+    incoming.current_provider_grokbuild = existing.current_provider_grokbuild.clone();
+    incoming.current_provider_opencode = existing.current_provider_opencode.clone();
+    incoming.current_provider_openclaw = existing.current_provider_openclaw.clone();
+    incoming.current_provider_hermes = existing.current_provider_hermes.clone();
     incoming
 }
 
@@ -617,6 +629,67 @@ mod tests {
         let merged = merge_settings_for_save(incoming, &existing);
 
         assert!(merged.local_migrations.is_none());
+    }
+
+    #[test]
+    fn save_settings_should_preserve_current_provider_over_incoming() {
+        // current_provider_* 由 provider 切换命令（set_current_provider）单独管理，
+        // save_settings 的全量 payload 即使携带陈旧的 currentProvider 快照，
+        // 也不应覆盖现有值（否则首页/设置保存会回退刚切换的供应商）。
+        let existing = AppSettings {
+            current_provider_claude: Some("new-provider".to_string()),
+            current_provider_claude_desktop: Some("desktop-new".to_string()),
+            current_provider_codex: Some("codex-new".to_string()),
+            current_provider_gemini: Some("gemini-new".to_string()),
+            current_provider_grokbuild: Some("grok-new".to_string()),
+            current_provider_opencode: Some("opencode-new".to_string()),
+            current_provider_openclaw: Some("openclaw-new".to_string()),
+            current_provider_hermes: Some("hermes-new".to_string()),
+            ..AppSettings::default()
+        };
+
+        let incoming = AppSettings {
+            current_provider_claude: Some("stale-old".to_string()),
+            current_provider_claude_desktop: Some("stale-old".to_string()),
+            current_provider_codex: Some("stale-old".to_string()),
+            current_provider_gemini: Some("stale-old".to_string()),
+            current_provider_grokbuild: Some("stale-old".to_string()),
+            current_provider_opencode: Some("stale-old".to_string()),
+            current_provider_openclaw: Some("stale-old".to_string()),
+            current_provider_hermes: Some("stale-old".to_string()),
+            ..AppSettings::default()
+        };
+        let merged = merge_settings_for_save(incoming, &existing);
+
+        assert_eq!(
+            merged.current_provider_claude.as_deref(),
+            Some("new-provider")
+        );
+        assert_eq!(
+            merged.current_provider_claude_desktop.as_deref(),
+            Some("desktop-new")
+        );
+        assert_eq!(merged.current_provider_codex.as_deref(), Some("codex-new"));
+        assert_eq!(
+            merged.current_provider_gemini.as_deref(),
+            Some("gemini-new")
+        );
+        assert_eq!(
+            merged.current_provider_grokbuild.as_deref(),
+            Some("grok-new")
+        );
+        assert_eq!(
+            merged.current_provider_opencode.as_deref(),
+            Some("opencode-new")
+        );
+        assert_eq!(
+            merged.current_provider_openclaw.as_deref(),
+            Some("openclaw-new")
+        );
+        assert_eq!(
+            merged.current_provider_hermes.as_deref(),
+            Some("hermes-new")
+        );
     }
 }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -416,6 +416,11 @@ pub struct AppSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub visible_apps: Option<VisibleApps>,
 
+    // ===== 首页显示 =====
+    /// 首页显示模式：default（默认供应商列表首页）或 usage（使用统计首页）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub home_page_mode: Option<String>,
+
     // ===== 设备级目录覆盖 =====
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub claude_config_dir: Option<String>,
@@ -542,6 +547,7 @@ impl Default for AppSettings {
             common_config_confirmed: None,
             language: None,
             visible_apps: None,
+            home_page_mode: None,
             claude_config_dir: None,
             codex_config_dir: None,
             gemini_config_dir: None,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,13 +25,15 @@ import {
   Shield,
   Cpu,
   LayoutDashboard,
+  Store,
   Loader2,
   RefreshCw,
 } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { Provider, VisibleApps } from "@/types";
+import type { Provider, Settings as SettingsType, VisibleApps } from "@/types";
 import type { EnvConflict } from "@/types/env";
 import { proxyKeys, useProvidersQuery, useSettingsQuery } from "@/lib/query";
+import { enqueueSettingsSave } from "@/lib/settingsSaveQueue";
 import {
   piApi,
   providersApi,
@@ -77,6 +79,7 @@ import { FailoverToggle } from "@/components/proxy/FailoverToggle";
 import { RoutingActivationBrand } from "@/components/proxy/RoutingActivationBrand";
 import UsageScriptModal from "@/components/UsageScriptModal";
 import UnifiedMcpPanel from "@/components/mcp/UnifiedMcpPanel";
+import { UsageDashboard } from "@/components/usage/UsageDashboard";
 import PromptPanel, {
   type PromptPanelHandle,
   type PromptPrimaryAction,
@@ -115,6 +118,7 @@ import {
 
 type View =
   | "providers"
+  | "usageHome"
   | "settings"
   | "prompts"
   | "skills"
@@ -150,6 +154,7 @@ const getInitialApp = (): AppId => {
 const VIEW_STORAGE_KEY = "cc-switch-last-view";
 const VALID_VIEWS: View[] = [
   "providers",
+  "usageHome",
   "settings",
   "prompts",
   "skills",
@@ -217,6 +222,22 @@ function App() {
   const getFirstVisibleApp = (): AppId => {
     return APP_IDS.find((app) => visibleApps[app]) ?? "claude";
   };
+
+  // 当前首页视图：默认首页（供应商列表）或使用统计首页
+  const homeView: View =
+    settingsData?.homePageMode === "usage" ? "usageHome" : "providers";
+
+  // 跟随"首页显示"设置：仅在 homeView 真正变化时，把停留在旧首页
+  // （providers/usageHome）的视图带到新首页。不依赖 settingsData 对象，
+  // 避免每次 settings 刷新（如 Add/Edit 弹窗保存后 invalidate）把用户从
+  // 供应商管理页踢回首页。
+  useEffect(() => {
+    setCurrentView((prev) => {
+      if (prev === homeView) return prev;
+      if (prev === "providers" || prev === "usageHome") return homeView;
+      return prev;
+    });
+  }, [homeView]);
 
   useEffect(() => {
     if (!visibleApps[activeApp]) {
@@ -300,6 +321,7 @@ function App() {
   const isOpenClawView =
     activeApp === "openclaw" &&
     (currentView === "providers" ||
+      currentView === "usageHome" ||
       currentView === "workspace" ||
       currentView === "sessions" ||
       currentView === "openclawEnv" ||
@@ -645,6 +667,8 @@ function App() {
   }, [activeApp]);
 
   const currentViewRef = useRef(currentView);
+  const homeViewRef = useRef<View>(homeView);
+  homeViewRef.current = homeView;
   const managementBusy =
     mcpManagementBusy || skillsNavigationBusy || promptNavigationBusy;
   const managementBusyRef = useRef(false);
@@ -671,13 +695,15 @@ function App() {
       if (document.body.style.overflow === "hidden") return;
 
       const view = currentViewRef.current;
-      if (view === "providers") return;
+      if (view === homeViewRef.current) return;
       if (managementBusyRef.current) return;
 
       if (isTextEditableTarget(event.target)) return;
 
       event.preventDefault();
-      setCurrentView(view === "skillsDiscovery" ? "skills" : "providers");
+      setCurrentView(
+        view === "skillsDiscovery" ? "skills" : homeViewRef.current,
+      );
     };
 
     window.addEventListener("keydown", handleKeyDown);
@@ -690,6 +716,19 @@ function App() {
   const openHermesWebUI = useOpenHermesWebUI(() =>
     setLaunchDashboardOpen(true),
   );
+
+  // 首页级设置（使用统计刷新间隔、会话同步开关）自动保存。
+  // 与设置页共用全局串行队列（任务执行时读取最新后端设置再合并本次字段），
+  // 避免并发基于旧快照的全量保存互相覆盖。
+  const handleSettingsAutoSave = async (
+    updates: Partial<SettingsType>,
+  ): Promise<boolean> => {
+    const res = await enqueueSettingsSave(updates);
+    if (res.ok) {
+      await queryClient.invalidateQueries({ queryKey: ["settings"] });
+    }
+    return res.ok;
+  };
 
   const handleOpenWebsite = async (url: string) => {
     try {
@@ -1007,11 +1046,30 @@ function App() {
   const renderContent = () => {
     const content = (() => {
       switch (currentView) {
+        case "usageHome":
+          return (
+            <div className="px-6 pt-4">
+              <UsageDashboard
+                refreshIntervalMs={
+                  settingsData?.usageDashboardRefreshIntervalMs
+                }
+                onRefreshIntervalChange={(usageDashboardRefreshIntervalMs) =>
+                  handleSettingsAutoSave({ usageDashboardRefreshIntervalMs })
+                }
+                sessionAutoSyncEnabled={
+                  settingsData?.sessionAutoSyncEnabled ?? true
+                }
+                onSessionAutoSyncEnabledChange={(sessionAutoSyncEnabled) =>
+                  handleSettingsAutoSave({ sessionAutoSyncEnabled })
+                }
+              />
+            </div>
+          );
         case "settings":
           return (
             <SettingsPage
               open={true}
-              onOpenChange={() => setCurrentView("providers")}
+              onOpenChange={() => setCurrentView(homeView)}
               onImportSuccess={handleImportSuccess}
               defaultTab={settingsDefaultTab}
             />
@@ -1021,7 +1079,7 @@ function App() {
             <PromptPanel
               ref={promptPanelRef}
               open={true}
-              onOpenChange={() => setCurrentView("providers")}
+              onOpenChange={() => setCurrentView(homeView)}
               appId={sharedFeatureApp}
               onInteractionBlockedChange={setPromptManagementBusy}
               onNavigationBlockedChange={setPromptNavigationBusy}
@@ -1057,14 +1115,12 @@ function App() {
           return (
             <UnifiedMcpPanel
               ref={mcpPanelRef}
-              onOpenChange={() => setCurrentView("providers")}
+              onOpenChange={() => setCurrentView(homeView)}
               onInteractionBlockedChange={setMcpManagementBusy}
             />
           );
         case "agents":
-          return (
-            <AgentsPanel onOpenChange={() => setCurrentView("providers")} />
-          );
+          return <AgentsPanel onOpenChange={() => setCurrentView(homeView)} />;
         case "universal":
           return (
             <div className="px-6 pt-4">
@@ -1277,7 +1333,7 @@ function App() {
             className="flex items-center gap-1"
             style={{ WebkitAppRegion: "no-drag" } as any}
           >
-            {currentView !== "providers" ? (
+            {currentView !== homeView ? (
               <div className="flex items-center gap-2">
                 <Button
                   variant="outline"
@@ -1285,9 +1341,7 @@ function App() {
                   disabled={managementBusy}
                   onClick={() =>
                     setCurrentView(
-                      currentView === "skillsDiscovery"
-                        ? "skills"
-                        : "providers",
+                      currentView === "skillsDiscovery" ? "skills" : homeView,
                     )
                   }
                   className={cn(
@@ -1299,6 +1353,11 @@ function App() {
                 </Button>
                 <h1 className="text-lg font-semibold">
                   {currentView === "settings" && t("settings.title")}
+                  {currentView === "providers" &&
+                    homeView === "usageHome" &&
+                    t("providers.manage", {
+                      defaultValue: "供应商管理",
+                    })}
                   {currentView === "prompts" &&
                     t("prompts.title", {
                       appName: t(`apps.${sharedFeatureApp}`),
@@ -1368,7 +1427,7 @@ function App() {
           </div>
 
           <div className="flex flex-1 min-w-0 items-center justify-end gap-1.5">
-            {currentView === "providers" &&
+            {currentView === homeView &&
               (activeApp === "claude-desktop" || proxyAppId) && (
                 <div
                   className="flex shrink-0 items-center gap-1.5"
@@ -1388,7 +1447,7 @@ function App() {
                   ) : null}
                 </div>
               )}
-            {currentView === "providers" &&
+            {currentView === homeView &&
               (settingsData?.showProfileSwitcher ?? true) && (
                 <div
                   className="flex shrink-0 items-center"
@@ -1400,6 +1459,8 @@ function App() {
             {/* 弹性中段：空间不足时由 AppSwitcher 自行收纳溢出应用；
                 justify-end + overflow-hidden 只裁剪 resize 瞬间的过渡帧 */}
             <div className="flex flex-1 min-w-0 items-center justify-end overflow-hidden py-4">
+              {/* 使用统计首页展示全应用用量，与 activeApp 无关，不显示 CLI 切换；
+                  供应商列表页按应用过滤，保留 AppSwitcher */}
               {currentView === "providers" && (
                 <AppSwitcher
                   activeApp={activeApp}
@@ -1560,7 +1621,7 @@ function App() {
                     )}
                   </>
                 )}
-                {currentView === "providers" && (
+                {currentView === homeView && (
                   <>
                     <div className="flex items-center gap-1 p-1 bg-muted rounded-xl">
                       <AnimatePresence mode="wait">
@@ -1620,6 +1681,19 @@ function App() {
                                   <McpIcon size={16} />
                                 </Button>
                               )}
+                              {homeView === "usageHome" && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setCurrentView("providers")}
+                                  className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
+                                  title={t("providers.manage", {
+                                    defaultValue: "供应商管理",
+                                  })}
+                                >
+                                  <Store className="w-4 h-4" />
+                                </Button>
+                              )}
                             </>
                           ) : activeApp === "openclaw" ? (
                             <>
@@ -1668,6 +1742,19 @@ function App() {
                               >
                                 <History className="w-4 h-4" />
                               </Button>
+                              {homeView === "usageHome" && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setCurrentView("providers")}
+                                  className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
+                                  title={t("providers.manage", {
+                                    defaultValue: "供应商管理",
+                                  })}
+                                >
+                                  <Store className="w-4 h-4" />
+                                </Button>
+                              )}
                             </>
                           ) : (
                             <>
@@ -1721,22 +1808,36 @@ function App() {
                                   <McpIcon size={16} />
                                 </Button>
                               )}
+                              {homeView === "usageHome" && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setCurrentView("providers")}
+                                  className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
+                                  title={t("providers.manage", {
+                                    defaultValue: "供应商管理",
+                                  })}
+                                >
+                                  <Store className="w-4 h-4" />
+                                </Button>
+                              )}
                             </>
                           )}
                         </motion.div>
                       </AnimatePresence>
                     </div>
-
-                    <Button
-                      onClick={() => setIsAddOpen(true)}
-                      size="icon"
-                      className={`ml-2 ${addActionButtonClass}`}
-                      aria-label={t("provider.addNewProvider")}
-                      title={t("provider.addNewProvider")}
-                    >
-                      <Plus className="w-5 h-5" />
-                    </Button>
                   </>
+                )}
+                {currentView === "providers" && (
+                  <Button
+                    onClick={() => setIsAddOpen(true)}
+                    size="icon"
+                    className={`ml-2 ${addActionButtonClass}`}
+                    aria-label={t("provider.addNewProvider")}
+                    title={t("provider.addNewProvider")}
+                  >
+                    <Plus className="w-5 h-5" />
+                  </Button>
                 )}
               </div>
             </div>

--- a/src/components/settings/HomePageSettings.tsx
+++ b/src/components/settings/HomePageSettings.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { LayoutDashboard, BarChart2 } from "lucide-react";
+
+export type HomePageMode = "default" | "usage";
+
+interface HomePageSettingsProps {
+  value: HomePageMode;
+  onChange: (value: HomePageMode) => void;
+}
+
+export function HomePageSettings({ value, onChange }: HomePageSettingsProps) {
+  const { t } = useTranslation();
+
+  return (
+    <section className="space-y-2">
+      <header className="space-y-1">
+        <h3 className="text-sm font-medium">{t("settings.homePage.title")}</h3>
+        <p className="text-xs text-muted-foreground">
+          {t("settings.homePage.description")}
+        </p>
+      </header>
+      <div className="inline-flex gap-1 rounded-md border border-border-default bg-background p-1">
+        <HomePageButton
+          active={value === "default"}
+          onClick={() => onChange("default")}
+        >
+          <LayoutDashboard className="mr-2 h-4 w-4" />
+          {t("settings.homePage.default")}
+        </HomePageButton>
+        <HomePageButton
+          active={value === "usage"}
+          onClick={() => onChange("usage")}
+        >
+          <BarChart2 className="mr-2 h-4 w-4" />
+          {t("settings.homePage.usage")}
+        </HomePageButton>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {value === "usage"
+          ? t("settings.homePage.usageHint")
+          : t("settings.homePage.defaultHint")}
+      </p>
+    </section>
+  );
+}
+
+interface HomePageButtonProps {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function HomePageButton({ active, onClick, children }: HomePageButtonProps) {
+  return (
+    <Button
+      type="button"
+      onClick={onClick}
+      size="sm"
+      variant={active ? "default" : "ghost"}
+      className={cn(
+        "min-w-[120px]",
+        active
+          ? "shadow-sm"
+          : "text-muted-foreground hover:text-foreground hover:bg-muted",
+      )}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -34,9 +34,11 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { settingsApi } from "@/lib/api";
+import { enqueueSettingsSave } from "@/lib/settingsSaveQueue";
 import { LanguageSettings } from "@/components/settings/LanguageSettings";
 import { ThemeSettings } from "@/components/settings/ThemeSettings";
 import { WindowSettings } from "@/components/settings/WindowSettings";
+import { HomePageSettings } from "@/components/settings/HomePageSettings";
 import { AppVisibilitySettings } from "@/components/settings/AppVisibilitySettings";
 import { SkillStorageLocationSettings } from "@/components/settings/SkillStorageLocationSettings";
 import { SkillSyncMethodSettings } from "@/components/settings/SkillSyncMethodSettings";
@@ -56,7 +58,9 @@ import { useInstalledSkills } from "@/hooks/useSkills";
 import { useSettings } from "@/hooks/useSettings";
 import { useImportExport } from "@/hooks/useImportExport";
 import { useTranslation } from "react-i18next";
+import { useQueryClient } from "@tanstack/react-query";
 import type { SettingsFormState } from "@/hooks/useSettings";
+import type { HomePageMode } from "@/components/settings/HomePageSettings";
 
 interface SettingsDialogProps {
   open: boolean;
@@ -210,6 +214,26 @@ export function SettingsPage({
     [autoSaveSettings, settings, t, updateSettings],
   );
 
+  // 首页显示模式：与使用统计首页共用全局串行队列（任务执行时读取最新后端
+  // 设置再合并本次字段），避免陈旧缓存或并发全量保存覆盖其他入口的修改。
+  const queryClient = useQueryClient();
+  const handleHomePageModeChange = async (
+    homePageMode: HomePageMode,
+  ): Promise<boolean> => {
+    const res = await enqueueSettingsSave({ homePageMode });
+    if (res.ok) {
+      updateSettings({ homePageMode });
+      await queryClient.invalidateQueries({ queryKey: ["settings"] });
+    } else {
+      toast.error(
+        t("settings.saveFailedGeneric", {
+          defaultValue: "保存失败，请重试",
+        }),
+      );
+    }
+    return res.ok;
+  };
+
   const isBusy = useMemo(() => isLoading && !settings, [isLoading, settings]);
 
   return (
@@ -257,6 +281,10 @@ export function SettingsPage({
                       onChange={(lang) => handleAutoSave({ language: lang })}
                     />
                     <ThemeSettings />
+                    <HomePageSettings
+                      value={settings.homePageMode ?? "default"}
+                      onChange={handleHomePageModeChange}
+                    />
                     <AppVisibilitySettings
                       settings={settings}
                       onChange={handleAutoSave}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { providersApi, settingsApi } from "@/lib/api";
+import { enqueueSettingsSave } from "@/lib/settingsSaveQueue";
 import { syncCurrentProvidersLiveSafe } from "@/utils/postChangeSync";
 import {
   invalidatePiDirectoryCaches,
@@ -183,58 +184,61 @@ export function useSettings(): UseSettingsResult {
   );
 
   // 即时保存设置（用于 General 标签页的实时更新）
-  // 保存基础配置 + 独立的系统 API 调用（开机自启）
+  // 保存基础配置 + 独立的系统 API 调用（开机自启）。
+  // 实际写入走全局共享串行队列（enqueueSettingsSave）：任务执行时才读取
+  // 最新后端设置并合并本次字段，避免与使用统计首页/首页模式等入口的保存
+  // 并发时基于旧快照互相覆盖；副作用以队列返回的 fresh（保存前最新后端）
+  // 与本次 updates 对比触发。
   const autoSaveSettings = useCallback(
     async (updates: Partial<SettingsFormState>): Promise<SaveResult | null> => {
-      const mergedSettings = settings ? { ...settings, ...updates } : null;
-      if (!mergedSettings) return null;
+      if (!settings) return null;
 
       try {
-        const sanitizedClaudeDir = sanitizeDir(mergedSettings.claudeConfigDir);
-        const sanitizedCodexDir = sanitizeDir(mergedSettings.codexConfigDir);
-        const sanitizedGeminiDir = sanitizeDir(mergedSettings.geminiConfigDir);
-        const sanitizedGrokDir = sanitizeDir(mergedSettings.grokConfigDir);
-        const sanitizedOpencodeDir = sanitizeDir(
-          mergedSettings.opencodeConfigDir,
-        );
-        const sanitizedOpenclawDir = sanitizeDir(
-          mergedSettings.openclawConfigDir,
-        );
-        const sanitizedPiDir = sanitizeDir(mergedSettings.piConfigDir);
+        // 目录字段先做规范化；webdav/s3 由各自独立命令管理，不参与全量保存
         const {
           webdavSync: _ignoredWebdavSync,
           s3Sync: _ignoredS3Sync,
-          ...restSettings
-        } = mergedSettings;
-
-        const payload: Settings = {
-          ...restSettings,
-          claudeConfigDir: sanitizedClaudeDir,
-          codexConfigDir: sanitizedCodexDir,
-          geminiConfigDir: sanitizedGeminiDir,
-          grokConfigDir: sanitizedGrokDir,
-          opencodeConfigDir: sanitizedOpencodeDir,
-          openclawConfigDir: sanitizedOpenclawDir,
-          piConfigDir: sanitizedPiDir,
-          language: mergedSettings.language,
+          ...restUpdates
+        } = updates;
+        // 目录字段仅在本次 updates 确实携带时才做规范化写入；否则不放进
+        // payload，避免把 undefined 铺到最新后端设置上，误清用户的目录覆盖
+        const sanitizedUpdates: Partial<Settings> = {
+          ...restUpdates,
+          ...(updates.claudeConfigDir !== undefined && {
+            claudeConfigDir: sanitizeDir(updates.claudeConfigDir),
+          }),
+          ...(updates.codexConfigDir !== undefined && {
+            codexConfigDir: sanitizeDir(updates.codexConfigDir),
+          }),
+          ...(updates.geminiConfigDir !== undefined && {
+            geminiConfigDir: sanitizeDir(updates.geminiConfigDir),
+          }),
+          ...(updates.grokConfigDir !== undefined && {
+            grokConfigDir: sanitizeDir(updates.grokConfigDir),
+          }),
+          ...(updates.opencodeConfigDir !== undefined && {
+            opencodeConfigDir: sanitizeDir(updates.opencodeConfigDir),
+          }),
+          ...(updates.openclawConfigDir !== undefined && {
+            openclawConfigDir: sanitizeDir(updates.openclawConfigDir),
+          }),
+          ...(updates.piConfigDir !== undefined && {
+            piConfigDir: sanitizeDir(updates.piConfigDir),
+          }),
         };
 
-        // 在 mutate 之前从实时缓存捕获上一次持久化的插件集成状态，
-        // 避免 closure 里的 data 因 React 尚未 re-render 而滞后
-        const prevPluginEnabled = queryClient.getQueryData<Settings>([
-          "settings",
-        ])?.enableClaudePluginIntegration;
-
-        // 保存到配置文件
-        await saveMutation.mutateAsync(payload);
+        const res = await enqueueSettingsSave(sanitizedUpdates);
+        if (!res.ok || !res.fresh) {
+          throw new Error("settings save failed");
+        }
 
         // 如果开机自启状态改变，调用系统 API
         if (
-          payload.launchOnStartup !== undefined &&
-          payload.launchOnStartup !== data?.launchOnStartup
+          updates.launchOnStartup !== undefined &&
+          updates.launchOnStartup !== res.fresh.launchOnStartup
         ) {
           try {
-            await settingsApi.setAutoLaunch(payload.launchOnStartup);
+            await settingsApi.setAutoLaunch(updates.launchOnStartup);
           } catch (error) {
             console.error("Failed to update auto-launch:", error);
             toast.error(
@@ -250,7 +254,7 @@ export function useSettings(): UseSettingsResult {
         const nextSkipClaudeOnboarding = updates.skipClaudeOnboarding;
         if (
           nextSkipClaudeOnboarding !== undefined &&
-          nextSkipClaudeOnboarding !== (data?.skipClaudeOnboarding ?? false)
+          nextSkipClaudeOnboarding !== (res.fresh.skipClaudeOnboarding ?? false)
         ) {
           try {
             if (nextSkipClaudeOnboarding) {
@@ -276,8 +280,8 @@ export function useSettings(): UseSettingsResult {
         }
 
         await syncClaudePluginIfChanged(
-          payload.enableClaudePluginIntegration,
-          prevPluginEnabled,
+          updates.enableClaudePluginIntegration,
+          res.fresh.enableClaudePluginIntegration,
         );
 
         // 持久化语言偏好
@@ -299,6 +303,12 @@ export function useSettings(): UseSettingsResult {
           console.warn("[useSettings] Failed to refresh tray menu", error);
         }
 
+        // 刷新设置缓存
+        await queryClient.invalidateQueries({ queryKey: ["settings"] });
+        await queryClient.invalidateQueries({
+          queryKey: ["opencode", "runtime-models"],
+        });
+
         return { requiresRestart: false };
       } catch (error) {
         console.error("[useSettings] Failed to auto-save settings", error);
@@ -311,7 +321,7 @@ export function useSettings(): UseSettingsResult {
         throw error;
       }
     },
-    [data, queryClient, saveMutation, settings, syncClaudePluginIfChanged, t],
+    [queryClient, settings, syncClaudePluginIfChanged, t],
   );
 
   // 完整保存设置（用于 Advanced 标签页的手动保存）

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -688,6 +688,14 @@
     "languageOptionTraditionalChinese": "繁體中文",
     "languageOptionEnglish": "English",
     "languageOptionJapanese": "日本語",
+    "homePage": {
+      "title": "Home Page",
+      "description": "Choose which home page to show when the app launches",
+      "default": "Default Home",
+      "usage": "Usage Statistics",
+      "defaultHint": "Shows the provider list on launch",
+      "usageHint": "Shows the usage dashboard on launch; the provider list is moved into the Providers button in the header"
+    },
     "windowBehavior": "Window Behavior",
     "windowBehaviorHint": "Configure window minimize and Claude plugin integration policies.",
     "launchOnStartup": "Launch on Startup",
@@ -3254,5 +3262,8 @@
     "expiredHint": "Run the {{tool}} command to refresh your login",
     "queryFailed": "Query failed",
     "refresh": "Refresh"
+  },
+  "providers": {
+    "manage": "Manage Providers"
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -688,6 +688,14 @@
     "languageOptionTraditionalChinese": "繁體中文",
     "languageOptionEnglish": "English",
     "languageOptionJapanese": "日本語",
+    "homePage": {
+      "title": "ホームページ表示",
+      "description": "アプリ起動時に表示するホームページを選択します",
+      "default": "デフォルトホーム",
+      "usage": "使用統計",
+      "defaultHint": "起動時にプロバイダー一覧を表示します",
+      "usageHint": "起動時に使用統計を表示します。プロバイダー一覧はヘッダーのプロバイダーボタンに格納されます"
+    },
     "windowBehavior": "ウィンドウ動作",
     "windowBehaviorHint": "最小化動作や Claude プラグイン連携を設定します。",
     "launchOnStartup": "起動時に自動実行",
@@ -3254,5 +3262,8 @@
     "expiredHint": "{{tool}}コマンドを実行してログインを更新してください",
     "queryFailed": "クエリに失敗しました",
     "refresh": "更新"
+  },
+  "providers": {
+    "manage": "プロバイダー管理"
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -688,6 +688,14 @@
     "languageOptionTraditionalChinese": "繁體中文",
     "languageOptionEnglish": "English",
     "languageOptionJapanese": "日本語",
+    "homePage": {
+      "title": "首頁顯示",
+      "description": "選擇應用程式啟動時顯示的首頁",
+      "default": "預設首頁",
+      "usage": "使用統計",
+      "defaultHint": "啟動時顯示供應商列表",
+      "usageHint": "啟動時直接顯示使用統計頁面，供應商列表收納到頂部的供應商按鈕中"
+    },
     "windowBehavior": "視窗行為",
     "windowBehaviorHint": "設定視窗最小化與 Claude 外掛程式連動策略。",
     "launchOnStartup": "開機自動啟動",
@@ -3255,5 +3263,8 @@
     "expiredHint": "請執行 {{tool}} 命令重新整理登入",
     "queryFailed": "查詢失敗",
     "refresh": "重新整理"
+  },
+  "providers": {
+    "manage": "供應商管理"
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -688,6 +688,14 @@
     "languageOptionTraditionalChinese": "繁體中文",
     "languageOptionEnglish": "English",
     "languageOptionJapanese": "日本語",
+    "homePage": {
+      "title": "首页显示",
+      "description": "选择应用启动时显示的首页",
+      "default": "默认首页",
+      "usage": "使用统计",
+      "defaultHint": "启动时显示供应商列表",
+      "usageHint": "启动时直接显示使用统计页面，供应商列表收纳到顶部的供应商按钮中"
+    },
     "windowBehavior": "窗口行为",
     "windowBehaviorHint": "配置窗口最小化与 Claude 插件联动策略。",
     "launchOnStartup": "开机自启",
@@ -3254,5 +3262,8 @@
     "expiredHint": "请运行 {{tool}} 命令刷新登录",
     "queryFailed": "查询失败",
     "refresh": "刷新"
+  },
+  "providers": {
+    "manage": "供应商管理"
   }
 }

--- a/src/lib/settingsSaveQueue.ts
+++ b/src/lib/settingsSaveQueue.ts
@@ -1,0 +1,43 @@
+import { settingsApi } from "@/lib/api";
+import type { Settings } from "@/types";
+
+// 全局共享的串行保存队列：所有走 save_settings 的入口共用同一条 promise 链，
+// 任务在轮到它时才读取最新后端设置，再合并本次字段后保存。这样多个入口
+// （使用统计首页、设置页首页模式、General 自动保存）并发触发时不会基于
+// 各自的旧快照互相覆盖。
+let chain: Promise<SettingsSaveResult> = Promise.resolve({ ok: true });
+
+export interface SettingsSaveResult {
+  ok: boolean;
+  /** 保存前从后端读取的最新设置（副作用字段对比用） */
+  fresh?: Settings;
+  /** fresh 合并本次 updates 后的完整设置（已落盘） */
+  merged?: Settings;
+}
+
+/**
+ * 入队一次设置保存。队列执行时才读取最新后端设置并合并 updates。
+ * 返回保存是否成功以及保存前后上下文；成功与否不影响后续任务，
+ * 失败不写任何数据，避免基于旧快照覆盖。
+ */
+export function enqueueSettingsSave(
+  updates: Partial<Settings>,
+): Promise<SettingsSaveResult> {
+  const run = async (): Promise<SettingsSaveResult> => {
+    try {
+      const fresh = await settingsApi.get();
+      const merged: Settings = { ...fresh, ...updates };
+      await settingsApi.save(merged);
+      return { ok: true, fresh, merged };
+    } catch (error) {
+      console.error("[settingsSaveQueue] Failed to save settings", error);
+      return { ok: false };
+    }
+  };
+  const next = chain.then(run, run);
+  chain = next.then(
+    () => ({ ok: true }),
+    () => ({ ok: true }),
+  );
+  return next;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -404,6 +404,9 @@ export interface Settings {
   // 主页面显示的应用（默认全部显示）
   visibleApps?: VisibleApps;
 
+  // 首页显示模式：default（默认供应商列表首页）或 usage（使用统计首页）
+  homePageMode?: "default" | "usage";
+
   // ===== 设备级目录覆盖 =====
   // 覆盖 Claude Code 配置目录（可选）
   claudeConfigDir?: string;

--- a/tests/hooks/useSettings.test.tsx
+++ b/tests/hooks/useSettings.test.tsx
@@ -14,9 +14,12 @@ const updateTrayMenuMock = vi.fn();
 const getCurrentMock = vi.fn();
 const getAllMock = vi.fn();
 const getQueryDataMock = vi.fn();
+const invalidateQueriesMock = vi.fn();
 const invalidatePiDirectoryCachesMock = vi.fn();
 const toastErrorMock = vi.fn();
 const toastSuccessMock = vi.fn();
+const settingsGetMock = vi.fn();
+const settingsSaveMock = vi.fn();
 
 let settingsFormMock: any;
 let directorySettingsMock: any;
@@ -60,12 +63,15 @@ vi.mock("@tanstack/react-query", async () => {
     ...actual,
     useQueryClient: () => ({
       getQueryData: (...args: unknown[]) => getQueryDataMock(...args),
+      invalidateQueries: (...args: unknown[]) => invalidateQueriesMock(...args),
     }),
   };
 });
 
 vi.mock("@/lib/api", () => ({
   settingsApi: {
+    get: (...args: unknown[]) => settingsGetMock(...args),
+    save: (...args: unknown[]) => settingsSaveMock(...args),
     setAppConfigDirOverride: (...args: unknown[]) =>
       setAppConfigDirOverrideMock(...args),
     applyClaudePluginConfig: (...args: unknown[]) =>
@@ -155,8 +161,11 @@ describe("useSettings hook", () => {
     getCurrentMock.mockReset();
     getAllMock.mockReset();
     getQueryDataMock.mockReset();
+    invalidateQueriesMock.mockReset();
     toastErrorMock.mockReset();
     toastSuccessMock.mockReset();
+    settingsGetMock.mockReset();
+    settingsSaveMock.mockReset();
     window.localStorage.clear();
 
     serverSettings = {
@@ -198,6 +207,10 @@ describe("useSettings hook", () => {
     getAllMock.mockResolvedValue({});
     // 默认将 queryClient 缓存对齐到 serverSettings，既有断言的 "prev === data" 语义保持不变
     getQueryDataMock.mockImplementation(() => serverSettings);
+    invalidateQueriesMock.mockResolvedValue(undefined);
+    // 共享保存队列读取的最新后端设置对齐到 serverSettings
+    settingsGetMock.mockImplementation(() => serverSettings);
+    settingsSaveMock.mockResolvedValue(true);
   });
 
   it("auto-saves and applies Claude onboarding skip when toggled on", async () => {
@@ -253,6 +266,34 @@ describe("useSettings hook", () => {
     });
 
     expect(clearClaudeOnboardingSkipMock).toHaveBeenCalledTimes(1);
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves server directory overrides when autosaving an unrelated field", async () => {
+    serverSettings = {
+      ...serverSettings,
+      claudeConfigDir: "/server/claude",
+      codexConfigDir: "/server/codex",
+    };
+    useSettingsQueryMock.mockReturnValue({
+      data: serverSettings,
+      isLoading: false,
+    });
+    settingsFormMock = createSettingsFormMock({
+      settings: { ...serverSettings, language: "zh" },
+    });
+
+    const { result } = renderHook(() => useSettings());
+
+    await act(async () => {
+      // 本次只改语言，不含任何目录字段：目录覆盖必须原样保留
+      await result.current.autoSaveSettings({ language: "en" });
+    });
+
+    const calls = settingsSaveMock.mock.calls;
+    const saved = calls[calls.length - 1]?.[0] as Settings;
+    expect(saved.claudeConfigDir).toBe("/server/claude");
+    expect(saved.codexConfigDir).toBe("/server/codex");
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Adds a **"Home Page"** setting under Settings → General so users can choose which page the app opens on:

- **Default Home** — the provider list (unchanged behavior)
- **Usage Statistics** — opens directly on the usage dashboard

In usage mode the provider list moves behind a new **"Providers"** header button (same style as the existing Skills / Prompts / Sessions / MCP buttons), the "add new provider" action lives inside that page, and the page keeps its own back button / app switcher like other sub-pages.

Closes #6949

## Why the save-path changes were necessary

The new feature adds two more settings-save entry points (the usage-dashboard controls and the Home Page setting). The project's existing save flow is "snapshot the whole settings object, then `save_settings` overwrites everything" — which races with concurrent saves and can clobber fields owned elsewhere (notably `currentProvider*`, written only by the provider-switch command). The Codex review surfaced exactly these races, so this PR:

1. **Adds a shared serialized save queue** (`src/lib/settingsSaveQueue.ts`) used by the dashboard controls, the Home Page setting, and the existing General auto-save path. Each queued task re-reads the latest backend settings before writing, merging only the fields being changed — so concurrent saves no longer overwrite each other.
2. **Preserves `currentProvider*` on the backend** (`merge_settings_for_save`): these fields are managed exclusively by the provider-switch command and never edited by the settings form, so a full-object save carrying a stale `currentProvider*` snapshot can no longer revert a switch. Same treatment as the existing `local_migrations` guard. Regression test added.

The change is limited to the save entry points and their merge semantics; no behavior of the existing controls changes unless the new feature is used.

## Changes

- `src-tauri/src/settings.rs` / `src-tauri/src/commands/settings.rs`: preserve `currentProvider*` in `merge_settings_for_save` (+ regression test)
- `src/lib/settingsSaveQueue.ts` (new): shared serialized save queue (fresh-read + merge-touched-fields)
- `src/hooks/useSettings.ts`: `autoSaveSettings` now goes through the shared queue; side effects (auto-launch, Claude plugin/onboarding sync, tray) trigger off `fresh` vs `updates` field comparison
- `src/types.ts`: `Settings.homePageMode?: "default" | "usage"`
- `src/components/settings/HomePageSettings.tsx` (new): segmented setting
- `src/components/settings/SettingsPage.tsx`: render the setting; save it through the shared queue
- `src/App.tsx`: new `usageHome` view; home view follows `homePageMode` (only remaps when the mode actually changes, never on settings refetch); Providers button in all app branches; provider-management page keeps its app switcher; OpenClaw health warnings also show on the usage home
- `src/i18n/locales/*.json`: new keys for zh, zh-TW, en, ja
- `tests/hooks/useSettings.test.tsx`: adapt mocks for the shared queue

## Known boundary

The same full-save staleness pattern exists in the pre-existing `useSettings.ts` `saveSettings` path (advanced-tab manual full save). That path is kept as-is (it is a deliberate full submit, serialized through the same queue); the `autoSaveSettings` path was migrated because it's the one this feature extends. Happy to follow up separately if wanted.

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `pnpm test:unit` passes (173 hook tests incl. adapted `useSettings`)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] settings unit tests pass (10, incl. new `currentProvider*` regression test)
- [x] i18n updated (zh, zh-TW, en, ja)
