### PR TITLE
fix(proxy): route Claude Copilot models by endpoint capability

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -2664,10 +2664,7 @@ impl RequestForwarder {
 
         let model = body.get("model").and_then(|value| value.as_str());
         if let Some(model_id) = model {
-            if self
-                .is_copilot_openai_vendor_model(provider, model_id)
-                .await
-            {
+            if self.is_copilot_responses_model(provider, model_id).await {
                 return "openai_responses".to_string();
             }
         }
@@ -2718,7 +2715,7 @@ impl RequestForwarder {
         }
     }
 
-    async fn is_copilot_openai_vendor_model(&self, provider: &Provider, model_id: &str) -> bool {
+    async fn is_copilot_responses_model(&self, provider: &Provider, model_id: &str) -> bool {
         let Some(app_handle) = &self.app_handle else {
             log::debug!("[Copilot] AppHandle unavailable, fallback to chat/completions");
             return false;
@@ -2731,26 +2728,22 @@ impl RequestForwarder {
             .as_ref()
             .and_then(|m| m.managed_account_id_for("github_copilot"));
 
-        let vendor_result = match account_id.as_deref() {
-            Some(id) => {
-                copilot_auth
-                    .get_model_vendor_for_account(id, model_id)
-                    .await
-            }
-            None => copilot_auth.get_model_vendor(model_id).await,
+        let model_result = match account_id.as_deref() {
+            Some(id) => copilot_auth.get_model_for_account(id, model_id).await,
+            None => copilot_auth.get_model(model_id).await,
         };
 
-        match vendor_result {
-            Ok(Some(vendor)) => vendor.eq_ignore_ascii_case("openai"),
+        match model_result {
+            Ok(Some(model)) => copilot_model_uses_responses(&model),
             Ok(None) => {
                 log::debug!(
-                    "[Copilot] Model vendor unavailable for {model_id}, fallback to chat/completions"
+                    "[Copilot] Model metadata unavailable for {model_id}, fallback to chat/completions"
                 );
                 false
             }
             Err(err) => {
                 log::warn!(
-                    "[Copilot] Failed to resolve model vendor for {model_id}, fallback to chat/completions: {err}"
+                    "[Copilot] Failed to resolve model metadata for {model_id}, fallback to chat/completions: {err}"
                 );
                 false
             }
@@ -3201,6 +3194,14 @@ fn rewrite_codex_responses_endpoint_to_anthropic(endpoint: &str) -> (String, Opt
     };
 
     (rewritten, passthrough_query)
+}
+
+fn copilot_model_uses_responses(model: &super::providers::copilot_auth::CopilotModel) -> bool {
+    model
+        .supported_endpoints
+        .iter()
+        .any(|endpoint| endpoint == "/responses")
+        || model.supported_endpoints.is_empty() && model.vendor.eq_ignore_ascii_case("openai")
 }
 
 fn rewrite_claude_transform_endpoint(
@@ -4266,6 +4267,38 @@ mod tests {
             Some("openai_chat"),
             true
         ));
+    }
+
+    #[test]
+    fn copilot_responses_capability_overrides_vendor() {
+        use super::super::providers::copilot_auth::CopilotModel;
+
+        let responses_only = CopilotModel {
+            id: "vendor-model".to_string(),
+            name: "Vendor Model".to_string(),
+            vendor: "Other".to_string(),
+            model_picker_enabled: true,
+            supported_endpoints: vec!["/responses".to_string()],
+        };
+        assert!(copilot_model_uses_responses(&responses_only));
+
+        let legacy_openai = CopilotModel {
+            id: "legacy-openai-model".to_string(),
+            name: "Legacy OpenAI Model".to_string(),
+            vendor: "OpenAI".to_string(),
+            model_picker_enabled: true,
+            supported_endpoints: vec![],
+        };
+        assert!(copilot_model_uses_responses(&legacy_openai));
+
+        let chat_only_openai = CopilotModel {
+            id: "chat-only-model".to_string(),
+            name: "Chat Only Model".to_string(),
+            vendor: "OpenAI".to_string(),
+            model_picker_enabled: true,
+            supported_endpoints: vec!["/chat/completions".to_string()],
+        };
+        assert!(!copilot_model_uses_responses(&chat_only_openai));
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/copilot_auth.rs
+++ b/src-tauri/src/proxy/providers/copilot_auth.rs
@@ -198,6 +198,9 @@ pub struct CopilotModel {
     pub vendor: String,
     /// 是否在模型选择器中显示
     pub model_picker_enabled: bool,
+    /// 该模型在 Copilot 上声明支持的推理端点。
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub supported_endpoints: Vec<String>,
 }
 
 /// Copilot Models API 响应
@@ -213,6 +216,8 @@ struct CopilotModelsResponseItem {
     name: String,
     vendor: String,
     model_picker_enabled: bool,
+    #[serde(default)]
+    supported_endpoints: Vec<String>,
 }
 
 /// Copilot 认证错误
@@ -865,6 +870,7 @@ impl CopilotAuthManager {
                 name: m.name,
                 vendor: m.vendor,
                 model_picker_enabled: m.model_picker_enabled,
+                supported_endpoints: m.supported_endpoints,
             })
             .collect();
 
@@ -873,15 +879,23 @@ impl CopilotAuthManager {
         Ok(models)
     }
 
+    pub async fn get_model_for_account(
+        &self,
+        account_id: &str,
+        model_id: &str,
+    ) -> Result<Option<CopilotModel>, CopilotAuthError> {
+        let models = self.fetch_models_for_account(account_id).await?;
+        Ok(models.into_iter().find(|model| model.id == model_id))
+    }
+
     pub async fn get_model_vendor_for_account(
         &self,
         account_id: &str,
         model_id: &str,
     ) -> Result<Option<String>, CopilotAuthError> {
-        let models = self.fetch_models_for_account(account_id).await?;
-        Ok(models
-            .into_iter()
-            .find(|model| model.id == model_id)
+        Ok(self
+            .get_model_for_account(account_id, model_id)
+            .await?
             .map(|model| model.vendor))
     }
 
@@ -893,14 +907,21 @@ impl CopilotAuthManager {
         }
     }
 
+    pub async fn get_model(
+        &self,
+        model_id: &str,
+    ) -> Result<Option<CopilotModel>, CopilotAuthError> {
+        match self.resolve_default_account_id().await {
+            Some(id) => self.get_model_for_account(&id, model_id).await,
+            None => Err(CopilotAuthError::GitHubTokenInvalid),
+        }
+    }
+
     pub async fn get_model_vendor(
         &self,
         model_id: &str,
     ) -> Result<Option<String>, CopilotAuthError> {
-        match self.resolve_default_account_id().await {
-            Some(id) => self.get_model_vendor_for_account(&id, model_id).await,
-            None => Err(CopilotAuthError::GitHubTokenInvalid),
-        }
+        Ok(self.get_model(model_id).await?.map(|model| model.vendor))
     }
 
     /// 获取指定账号的 Copilot 使用量信息
@@ -1731,12 +1752,14 @@ mod tests {
                         name: "GPT-5.4".to_string(),
                         vendor: "OpenAI".to_string(),
                         model_picker_enabled: true,
+                        supported_endpoints: vec!["/responses".to_string()],
                     },
                     CopilotModel {
                         id: "claude-sonnet-4".to_string(),
                         name: "Claude Sonnet 4".to_string(),
                         vendor: "Anthropic".to_string(),
                         model_picker_enabled: true,
+                        supported_endpoints: vec!["/chat/completions".to_string()],
                     },
                 ],
             );
@@ -1747,6 +1770,13 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(vendor.as_deref(), Some("OpenAI"));
+
+        let model = manager
+            .get_model_for_account("12345", "gpt-5.4")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(model.supported_endpoints, vec!["/responses"]);
 
         let default_vendor = manager.get_model_vendor("claude-sonnet-4").await.unwrap();
         assert_eq!(default_vendor.as_deref(), Some("Anthropic"));

--- a/src-tauri/src/proxy/providers/copilot_model_map.rs
+++ b/src-tauri/src/proxy/providers/copilot_model_map.rs
@@ -300,6 +300,7 @@ mod tests {
             name: id.to_string(),
             vendor: "anthropic".to_string(),
             model_picker_enabled: true,
+            supported_endpoints: vec![],
         }
     }
 


### PR DESCRIPTION
## Summary / 概述

Use GitHub Copilot model endpoint capabilities when choosing the Claude/Claude Desktop upstream wire format.

Copilot's `/models` response can advertise a non-OpenAI model with `supported_endpoints: ["/responses"]`. The existing Claude path only checks `vendor == OpenAI`, so such a model is sent to `/chat/completions` and rejected with `unsupported_api_for_model`.

This PR:

- preserves `supported_endpoints` in `CopilotModel`;
- selects Responses when the final model explicitly supports `/responses`;
- keeps the existing OpenAI-vendor behavior only as a backward-compatible fallback when endpoint metadata is absent;
- keeps model selection and Claude Desktop route mapping configuration-driven—there is no model-specific production mapping;
- adds regression coverage for a non-OpenAI Responses-only model, legacy metadata, and an OpenAI chat-only model.

This intentionally limits the change to the existing Claude/Claude Desktop integration. #5336 contains broader capability-based routing work for the Codex integration.

## Related Issue / 关联 Issue

Fixes #6954

Related: #1681, #5336

## Screenshots / 截图

Not applicable; backend proxy routing only.

## Verification

- `pnpm typecheck`
- `pnpm format:check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test --lib proxy::providers::copilot_auth::tests::`
- `cargo test --lib proxy::providers::copilot_model_map::tests::`
- `cargo test --lib proxy::forwarder::tests::`
- Live Claude Desktop proxy request with a configured route targeting a non-OpenAI `/responses`-only model: HTTP 200 via `/v1/responses`
- Existing OpenAI Responses route: HTTP 200 via `/v1/responses`

`cargo clippy --all-targets --all-features -- -D warnings` was also attempted. It is currently blocked by a pre-existing `clippy::redundant_iter_cloned` warning in `src/database/backup.rs:2496`, outside this diff.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / No user-facing text changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
