### PR TITLE
fix(provider): gate provider form on live config load and scope changes

### DIFF
--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -795,10 +795,62 @@ pub async fn testUsageScript(
     .map_err(|e| e.to_string())
 }
 
+/// True for the per-app "live file missing" errors (`*.missing` localized
+/// keys such as `claude.live.missing` / `gemini.env.missing`). Only this
+/// command exempts them: the edit form treats null as "no live config yet"
+/// (fall back to the DB snapshot, keep saving allowed) instead of tripping
+/// the retryable failure gate, which could never succeed while the file is
+/// absent — e.g. a DB synced to a new machine before live was written.
+/// Generic `read_live_settings` keeps its Err contract for its other callers
+/// (startup snippet extraction, switch-away backfill).
+fn is_live_settings_missing(err: &AppError) -> bool {
+    matches!(err, AppError::Localized { key, .. } if key.ends_with(".missing"))
+}
+
 #[tauri::command]
 pub fn read_live_provider_settings(app: String) -> Result<serde_json::Value, String> {
     let app_type = AppType::from_str(&app).map_err(|e| e.to_string())?;
-    ProviderService::read_live_settings(app_type).map_err(|e| e.to_string())
+    match ProviderService::read_live_settings(app_type) {
+        Err(err) if is_live_settings_missing(&err) => Ok(serde_json::Value::Null),
+        result => result.map_err(|e| e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod read_live_provider_settings_tests {
+    use super::is_live_settings_missing;
+    use crate::error::AppError;
+
+    #[test]
+    fn missing_localized_keys_are_recognized() {
+        for key in [
+            "claude.live.missing",
+            "gemini.env.missing",
+            "hermes.config.missing",
+            "grokbuild.config.missing",
+            "codex.live.missing",
+        ] {
+            let err = AppError::localized(key, "配置文件不存在", "config file is missing");
+            assert!(is_live_settings_missing(&err), "{key} should match");
+        }
+    }
+
+    #[test]
+    fn other_errors_keep_the_failure_contract() {
+        let cases = [
+            AppError::localized(
+                "claude_desktop.live.read_unsupported",
+                "不支持",
+                "unsupported",
+            ),
+            AppError::localized("claude.live.missing_backup", "x", "x"), // suffix must be exact
+            AppError::InvalidInput("bad".to_string()),
+            AppError::Message("read failed".to_string()),
+        ];
+        for err in &cases {
+            assert!(!is_live_settings_missing(err));
+        }
+    }
 }
 
 #[tauri::command]

--- a/src/components/JsonEditor.tsx
+++ b/src/components/JsonEditor.tsx
@@ -98,6 +98,8 @@ const JsonEditor: React.FC<JsonEditorProps> = ({
   const { t } = useTranslation();
   const editorRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
+  // 外部 value 写入时抑制回声 onChange（避免把归一化后的值再写回表单）。
+  const isApplyingExternalValueRef = useRef(false);
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
   const hasExplicitHeight = height !== undefined;
@@ -210,6 +212,7 @@ const JsonEditor: React.FC<JsonEditorProps> = ({
       ),
       EditorView.updateListener.of((update) => {
         if (!readOnly && update.docChanged) {
+          if (isApplyingExternalValueRef.current) return;
           const newValue = update.state.doc.toString();
           onChangeRef.current(newValue);
         }
@@ -317,7 +320,12 @@ const JsonEditor: React.FC<JsonEditorProps> = ({
           viewRef.current.state.selection.mainIndex,
         ),
       });
-      viewRef.current.dispatch(transaction);
+      isApplyingExternalValueRef.current = true;
+      try {
+        viewRef.current.dispatch(transaction);
+      } finally {
+        isApplyingExternalValueRef.current = false;
+      }
     }
   }, [value]);
 

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -134,8 +134,19 @@ export function EditProviderDialog({
     unknown
   > | null>(null);
 
-  // 使用 ref 标记是否已经加载过，防止重复读取覆盖用户编辑
+  // 标记是否已经完成 live 读取（成功、不存在、或跳过读取都视为完成）
   const [hasLoadedLive, setHasLoadedLive] = useState(false);
+
+  // live 读取失败时禁止保存，避免用 DB 快照覆盖实时配置
+  const [liveLoadFailed, setLiveLoadFailed] = useState(false);
+
+  // 记录已完成 live 加载的 scope，切换 provider/app 后首个 commit 不会把旧结果当作当前结果
+  const [loadedScope, setLoadedScope] = useState<string | null>(null);
+
+  // 失败后的手动重试计数：自增触发加载 effect 重新执行
+  const [loadAttempt, setLoadAttempt] = useState(0);
+
+  const currentScope = `${appId}:${provider?.id ?? "new"}`;
 
   const closeDialog = useCallback(() => {
     setAuthSettingsTarget(null);
@@ -152,15 +163,16 @@ export function EditProviderDialog({
 
   useEffect(() => {
     let cancelled = false;
+
+    // 打开、切换 provider 或切换 app 时，在 effect 同步阶段先重置加载状态
+    setLiveSettings(null);
+    setHasLoadedLive(false);
+    setLiveLoadFailed(false);
+    setLoadedScope(null);
+
+    const scope = currentScope;
     const load = async () => {
       if (!open || !provider) {
-        setLiveSettings(null);
-        setHasLoadedLive(false);
-        return;
-      }
-
-      // 关键修复：只在首次打开时加载一次
-      if (hasLoadedLive) {
         return;
       }
 
@@ -168,8 +180,8 @@ export function EditProviderDialog({
       // 因此直接回退到 SSOT（数据库）配置，避免用户困惑与误保存
       if (isProxyTakeover) {
         if (!cancelled) {
-          setLiveSettings(null);
           setHasLoadedLive(true);
+          setLoadedScope(scope);
         }
         return;
       }
@@ -179,8 +191,8 @@ export function EditProviderDialog({
       // snapshot that may replace the DB aggregate in this form.
       if (appId === "opencode" || appId === "pi") {
         if (!cancelled) {
-          setLiveSettings(null);
           setHasLoadedLive(true);
+          setLoadedScope(scope);
         }
         return;
       }
@@ -188,18 +200,18 @@ export function EditProviderDialog({
       if (appId === "openclaw") {
         try {
           const live = await openclawApi.getLiveProvider(provider.id);
-          if (!cancelled && live && typeof live === "object") {
-            setLiveSettings(live);
-          } else if (!cancelled) {
-            setLiveSettings(null);
+          if (!cancelled) {
+            if (live && typeof live === "object") {
+              setLiveSettings(live);
+            }
+            setHasLoadedLive(true);
+            setLoadedScope(scope);
           }
         } catch {
           if (!cancelled) {
-            setLiveSettings(null);
-          }
-        } finally {
-          if (!cancelled) {
+            setLiveLoadFailed(true);
             setHasLoadedLive(true);
+            setLoadedScope(scope);
           }
         }
         return;
@@ -212,32 +224,38 @@ export function EditProviderDialog({
             const live = (await vscodeApi.getLiveProviderSettings(
               appId,
             )) as Record<string, unknown>;
-            if (!cancelled && live && typeof live === "object") {
-              setLiveSettings(live);
+            if (!cancelled) {
+              if (live && typeof live === "object") {
+                setLiveSettings(live);
+              }
               setHasLoadedLive(true);
+              setLoadedScope(scope);
             }
           } catch {
-            // 读取实时配置失败则回退到 SSOT（不打断编辑流程）
             if (!cancelled) {
-              setLiveSettings(null);
+              setLiveLoadFailed(true);
               setHasLoadedLive(true);
+              setLoadedScope(scope);
             }
           }
-        } else {
-          if (!cancelled) {
-            setLiveSettings(null);
-            setHasLoadedLive(true);
-          }
+        } else if (!cancelled) {
+          setHasLoadedLive(true);
+          setLoadedScope(scope);
         }
-      } finally {
-        // no-op
+      } catch {
+        // 无法确认当前供应商时也按 live 读取失败处理，避免用 DB 快照覆盖 live
+        if (!cancelled) {
+          setLiveLoadFailed(true);
+          setHasLoadedLive(true);
+          setLoadedScope(scope);
+        }
       }
     };
     void load();
     return () => {
       cancelled = true;
     };
-  }, [open, provider?.id, appId, hasLoadedLive, isProxyTakeover]); // 只依赖 provider.id，不依赖整个 provider 对象
+  }, [open, provider?.id, appId, isProxyTakeover, loadAttempt]); // 只依赖 provider.id，不依赖整个 provider 对象
 
   const initialSettingsConfig = useMemo(() => {
     const storedSettings = asRecord(provider?.settingsConfig);
@@ -330,8 +348,58 @@ export function EditProviderDialog({
     [appId, onSubmit, closeDialog, provider],
   );
 
+  const isLiveReady = loadedScope === currentScope && hasLoadedLive;
+  const isCurrentFailure = liveLoadFailed && loadedScope === currentScope;
+
   if (!provider || !initialData) {
     return null;
+  }
+
+  if (!isLiveReady || isCurrentFailure) {
+    return (
+      <FullScreenPanel
+        isOpen={open}
+        title={t("provider.editProvider")}
+        onClose={() => onOpenChange(false)}
+        footer={
+          <Button
+            type="submit"
+            form="provider-form"
+            disabled
+            className="bg-primary text-primary-foreground hover:bg-primary/90"
+          >
+            <Save className="h-4 w-4 mr-2" />
+            {t("common.save")}
+          </Button>
+        }
+      >
+        <div
+          className={`p-8 text-sm ${
+            isCurrentFailure ? "text-destructive" : "text-muted-foreground"
+          }`}
+          data-testid={isCurrentFailure ? "live-load-error" : undefined}
+          role={isCurrentFailure ? "alert" : undefined}
+        >
+          {isCurrentFailure
+            ? t("providerForm.liveLoadFailed", {
+                defaultValue: "读取实时配置失败，为避免覆盖实时配置已禁用保存",
+              })
+            : t("common.loading", { defaultValue: "加载中..." })}
+        </div>
+        {isCurrentFailure && (
+          <div className="px-8 pb-6">
+            <Button
+              type="button"
+              variant="outline"
+              data-testid="live-load-retry"
+              onClick={() => setLoadAttempt((n) => n + 1)}
+            >
+              {t("common.retry", { defaultValue: "重试" })}
+            </Button>
+          </div>
+        )}
+      </FullScreenPanel>
+    );
   }
 
   return (

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -17,6 +17,7 @@ import {
   type ManagedAuthProvider,
 } from "@/lib/api";
 import { extractCodexExperimentalBearerToken } from "@/utils/providerConfigUtils";
+import { hermesApi } from "@/lib/api/hermes";
 
 interface EditProviderDialogProps {
   open: boolean;
@@ -188,11 +189,17 @@ export function EditProviderDialog({
 
       // OpenCode uses additive mode, while Pi's shared models.json is owned by
       // the catalog coordinator. Neither has a per-provider generic live
-      // snapshot that may replace the DB aggregate in this form. Claude
+      // snapshot that may replace the DB aggregate in this form, so on the
+      // read side the DB snapshot is their sole legitimate source. Claude
       // Desktop's 3P config bundles multiple providers in one file, so the
       // backend read_live_settings() reports "unsupported" by design — a
-      // permanent error the failure gate would never let the user past. For
-      // these apps the DB snapshot is the form's sole legitimate source.
+      // permanent error the failure gate would never let the user past.
+      // NOTE this exemption only covers the READ side: when such a
+      // provider's node already exists in the live file, saving still
+      // overwrites that node with the DB-sourced form values (backend
+      // update()'s additive branch). Hermes reads its live fragment through
+      // the dedicated branch below; the OpenCode gap needs a single-provider
+      // live-read command and is tracked in a #6962 follow-up.
       if (
         appId === "opencode" ||
         appId === "pi" ||
@@ -205,9 +212,19 @@ export function EditProviderDialog({
         return;
       }
 
-      if (appId === "openclaw") {
+      // Additive apps with a dedicated per-provider live-read command
+      // (Option contract: null = no live node yet → DB fallback). The generic
+      // path below cannot serve them: ProviderService::current() returns ""
+      // for additive apps, so the getCurrent check would never reach a live
+      // read. The Hermes fragment already matches the DB's UI shape
+      // (snake_case, models array, `_cc_source` marker — write side drops
+      // the marker and re-normalizes models back to the YAML dict).
+      if (appId === "openclaw" || appId === "hermes") {
         try {
-          const live = await openclawApi.getLiveProvider(provider.id);
+          const live =
+            appId === "hermes"
+              ? await hermesApi.getLiveProvider(provider.id)
+              : await openclawApi.getLiveProvider(provider.id);
           if (!cancelled) {
             if (live && typeof live === "object") {
               setLiveSettings(live);

--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -188,8 +188,16 @@ export function EditProviderDialog({
 
       // OpenCode uses additive mode, while Pi's shared models.json is owned by
       // the catalog coordinator. Neither has a per-provider generic live
-      // snapshot that may replace the DB aggregate in this form.
-      if (appId === "opencode" || appId === "pi") {
+      // snapshot that may replace the DB aggregate in this form. Claude
+      // Desktop's 3P config bundles multiple providers in one file, so the
+      // backend read_live_settings() reports "unsupported" by design — a
+      // permanent error the failure gate would never let the user past. For
+      // these apps the DB snapshot is the form's sole legitimate source.
+      if (
+        appId === "opencode" ||
+        appId === "pi" ||
+        appId === "claude-desktop"
+      ) {
         if (!cancelled) {
           setHasLoadedLive(true);
           setLoadedScope(scope);

--- a/src/components/providers/forms/CommonConfigEditor.tsx
+++ b/src/components/providers/forms/CommonConfigEditor.tsx
@@ -19,6 +19,7 @@ interface CommonConfigEditorProps {
   onModalClose: () => void;
   onExtract?: () => void;
   isExtracting?: boolean;
+  isLoading?: boolean;
 }
 
 export function CommonConfigEditor({
@@ -34,6 +35,7 @@ export function CommonConfigEditor({
   onModalClose,
   onExtract,
   isExtracting,
+  isLoading = false,
 }: CommonConfigEditorProps) {
   const { t } = useTranslation();
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -168,6 +170,7 @@ export function CommonConfigEditor({
                 id="useCommonConfig"
                 checked={useCommonConfig}
                 onChange={(e) => onCommonConfigToggle(e.target.checked)}
+                disabled={isLoading}
                 className="w-4 h-4 text-blue-500 bg-white dark:bg-gray-800 border-border-default rounded focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-2"
               />
               <span>

--- a/src/components/providers/forms/GeminiConfigEditor.tsx
+++ b/src/components/providers/forms/GeminiConfigEditor.tsx
@@ -18,6 +18,7 @@ interface GeminiConfigEditorProps {
   configError: string;
   onExtract?: () => void;
   isExtracting?: boolean;
+  commonConfigLoading?: boolean;
 }
 
 const GeminiConfigEditor: React.FC<GeminiConfigEditorProps> = ({
@@ -36,6 +37,7 @@ const GeminiConfigEditor: React.FC<GeminiConfigEditorProps> = ({
   configError,
   onExtract,
   isExtracting,
+  commonConfigLoading = false,
 }) => {
   const [isCommonConfigModalOpen, setIsCommonConfigModalOpen] = useState(false);
 
@@ -56,6 +58,7 @@ const GeminiConfigEditor: React.FC<GeminiConfigEditorProps> = ({
         onCommonConfigToggle={onCommonConfigToggle}
         onEditCommonConfig={() => setIsCommonConfigModalOpen(true)}
         commonConfigError={commonConfigError}
+        commonConfigLoading={commonConfigLoading}
       />
 
       {/* Config JSON Section */}

--- a/src/components/providers/forms/GeminiConfigSections.tsx
+++ b/src/components/providers/forms/GeminiConfigSections.tsx
@@ -11,6 +11,7 @@ interface GeminiEnvSectionProps {
   onCommonConfigToggle: (checked: boolean) => void;
   onEditCommonConfig: () => void;
   commonConfigError?: string;
+  commonConfigLoading?: boolean;
 }
 
 /**
@@ -25,6 +26,7 @@ export const GeminiEnvSection: React.FC<GeminiEnvSectionProps> = ({
   onCommonConfigToggle,
   onEditCommonConfig,
   commonConfigError,
+  commonConfigLoading = false,
 }) => {
   const { t } = useTranslation();
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -66,6 +68,7 @@ export const GeminiEnvSection: React.FC<GeminiEnvSectionProps> = ({
             type="checkbox"
             checked={useCommonConfig}
             onChange={(e) => onCommonConfigToggle(e.target.checked)}
+            disabled={commonConfigLoading}
             className="w-4 h-4 text-blue-500 bg-white dark:bg-gray-800 border-border-default rounded focus:ring-blue-500 dark:focus:ring-blue-400 focus:ring-2"
           />
           {t("geminiConfig.writeCommonConfig", {

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, useCallback } from "react";
+import { useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -339,6 +340,8 @@ function ProviderFormFull({
   const [selectedPresetId, setSelectedPresetId] = useState<string | null>(
     initialData ? null : "custom",
   );
+  const presetInitScopeRef = useRef<string | null>(null);
+  const initializedRef = useRef(false);
   const [activePreset, setActivePreset] = useState<{
     id: string;
     category?: ProviderCategory;
@@ -392,6 +395,9 @@ function ProviderFormFull({
   const isAnyOmoCategory = isOmoCategory || isOmoSlimCategory;
 
   useEffect(() => {
+    const scope = `${appId}:${providerId ?? "new"}`;
+    if (presetInitScopeRef.current === scope) return;
+    presetInitScopeRef.current = scope;
     setSelectedPresetId(initialData ? null : "custom");
     setActivePreset(null);
 
@@ -432,7 +438,7 @@ function ProviderFormFull({
         initialData?.meta?.localProxyRequestOverrides?.body,
       ),
     );
-  }, [appId, initialData, supportsFullUrl]);
+  }, [appId, providerId, initialData, supportsFullUrl]);
 
   const defaultValues: ProviderFormData = useMemo(
     () => ({
@@ -464,6 +470,7 @@ function ProviderFormFull({
     mode: "onSubmit",
   });
   const { isSubmitting } = form.formState;
+  const settingsConfigValue = form.watch("settingsConfig");
 
   const handleSettingsConfigChange = useCallback(
     (config: string) => {
@@ -726,6 +733,9 @@ function ProviderFormFull({
   }, [appId, initialData, selectedPresetId, resetCodexConfig]);
 
   useEffect(() => {
+    // 只在首次渲染时用 defaultValues 初始化一次，之后不再因 scope 重复 reset
+    if (initializedRef.current) return;
+    initializedRef.current = true;
     form.reset(defaultValues);
   }, [defaultValues, form]);
 
@@ -841,8 +851,9 @@ function ProviderFormFull({
     handleCommonConfigSnippetChange,
     isExtracting: isClaudeExtracting,
     handleExtract: handleClaudeExtract,
+    isLoading: isClaudeCommonConfigLoading,
   } = useCommonConfigSnippet({
-    settingsConfig: form.getValues("settingsConfig"),
+    settingsConfig: settingsConfigValue,
     onConfigChange: handleSettingsConfigChange,
     initialData: appId === "claude" ? initialData : undefined,
     initialEnabled:
@@ -944,6 +955,7 @@ function ProviderFormFull({
     isExtracting: isGeminiExtracting,
     handleExtract: handleGeminiExtract,
     clearCommonConfigError: clearGeminiCommonConfigError,
+    isLoading: isGeminiCommonConfigLoading,
   } = useGeminiCommonConfig({
     envValue: geminiEnv,
     onEnvChange: handleGeminiEnvChange,
@@ -2672,6 +2684,7 @@ function ProviderFormFull({
                 commonConfigError={geminiCommonConfigError}
                 envError={envError}
                 configError={geminiConfigError}
+                commonConfigLoading={isGeminiCommonConfigLoading}
                 onExtract={handleGeminiExtract}
                 isExtracting={isGeminiExtracting}
               />
@@ -2759,8 +2772,8 @@ function ProviderFormFull({
           ) : (
             <>
               <CommonConfigEditor
-                value={form.getValues("settingsConfig")}
-                onChange={(value) => form.setValue("settingsConfig", value)}
+                value={settingsConfigValue}
+                onChange={handleSettingsConfigChange}
                 useCommonConfig={useCommonConfig}
                 onCommonConfigToggle={handleCommonConfigToggle}
                 commonConfigSnippet={commonConfigSnippet}
@@ -2770,6 +2783,7 @@ function ProviderFormFull({
                 isModalOpen={isCommonConfigModalOpen}
                 onModalClose={() => setIsCommonConfigModalOpen(false)}
                 onExtract={handleClaudeExtract}
+                isLoading={isClaudeCommonConfigLoading}
                 isExtracting={isClaudeExtracting}
               />
               {settingsConfigErrorField}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -4,6 +4,7 @@
     "description": "All-in-One Assistant for Claude Code, Codex & Gemini CLI"
   },
   "common": {
+    "retry": "Retry",
     "add": "Add",
     "edit": "Edit",
     "delete": "Delete",
@@ -1352,6 +1353,7 @@
     "fetchModelsNotSupported": "This provider does not support fetching model list",
     "fetchModelsEndpointNotFound": "No reachable models endpoint found. Please check the Base URL or confirm whether the provider exposes this API.",
     "fetchModelsTimeout": "Request timed out, please check network connection",
+    "liveLoadFailed": "Failed to read live config; saving is disabled to avoid overwriting it",
     "requiredFields": "Please fill in provider name, API endpoint, API Key and model"
   },
   "copilot": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -4,6 +4,7 @@
     "description": "Claude Code・Codex・Gemini CLI のためのオールインワンアシスタント"
   },
   "common": {
+    "retry": "再試行",
     "add": "追加",
     "edit": "編集",
     "delete": "削除",
@@ -1352,6 +1353,7 @@
     "fetchModelsNotSupported": "このプロバイダーはモデル一覧の取得に対応していません",
     "fetchModelsEndpointNotFound": "利用可能なモデル一覧エンドポイントが見つかりません。Base URL を確認するか、プロバイダーが該当 API を公開しているかご確認ください",
     "fetchModelsTimeout": "リクエストがタイムアウトしました。ネットワーク接続を確認してください",
+    "liveLoadFailed": "リアルタイム設定の読み込みに失敗しました。上書きを避けるため保存は無効です",
     "requiredFields": "プロバイダー名、API エンドポイント、API Key、モデルを入力してください"
   },
   "copilot": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -4,6 +4,7 @@
     "description": "Claude Code / Codex / Gemini CLI 全方位輔助工具"
   },
   "common": {
+    "retry": "重試",
     "add": "新增",
     "edit": "編輯",
     "delete": "刪除",
@@ -1353,6 +1354,7 @@
     "fetchModelsNotSupported": "該供應商不支援取得模型清單",
     "fetchModelsEndpointNotFound": "未找到可用的模型清單端點，請檢查 Base URL 或確認供應商是否開放該 API",
     "fetchModelsTimeout": "請求逾時，請檢查網路連線",
+    "liveLoadFailed": "讀取即時設定失敗，為避免覆蓋即時設定已停用儲存",
     "requiredFields": "請填寫供應商名稱、API 位址、API Key 和模型"
   },
   "copilot": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -4,6 +4,7 @@
     "description": "Claude Code / Codex / Gemini CLI 全方位辅助工具"
   },
   "common": {
+    "retry": "重试",
     "add": "添加",
     "edit": "编辑",
     "delete": "删除",
@@ -1352,6 +1353,7 @@
     "fetchModelsNotSupported": "该供应商不支持获取模型列表",
     "fetchModelsEndpointNotFound": "未找到可用的模型列表端点，请检查 Base URL 或确认供应商是否开放该接口",
     "fetchModelsTimeout": "请求超时，请检查网络连接",
+    "liveLoadFailed": "读取实时配置失败，为避免覆盖实时配置已禁用保存",
     "requiredFields": "请填写供应商名称、API 地址、API Key 和模型"
   },
   "copilot": {

--- a/src/lib/api/hermes.ts
+++ b/src/lib/api/hermes.ts
@@ -64,4 +64,17 @@ export const hermesApi = {
   ): Promise<void> {
     await invoke("set_hermes_memory_enabled", { kind, enabled });
   },
+
+  /**
+   * Read one provider fragment from Hermes' live config.yaml
+   * (`custom_providers` entry, sanitized to the same UI shape the DB stores:
+   * snake_case keys, models as an ordered array, `_cc_source` marker).
+   * Returns null when no live node exists for the provider id — the edit
+   * form then falls back to the DB snapshot.
+   */
+  async getLiveProvider(
+    providerId: string,
+  ): Promise<Record<string, unknown> | null> {
+    return await invoke("get_hermes_live_provider", { providerId });
+  },
 };

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -6,6 +6,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { useEffect } from "react";
+import ReactDOM from "react-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Provider } from "@/types";
 
@@ -88,6 +89,7 @@ vi.mock("@/components/providers/forms/ProviderForm", () => ({
     return (
       <form
         id="provider-form"
+        data-testid="provider-form"
         onSubmit={(event) => {
           event.preventDefault();
           onSubmit({
@@ -405,6 +407,8 @@ describe("EditProviderDialog", () => {
     };
     const { rerender } = render(<EditProviderDialog open {...props} />);
 
+    // 分支保留 P2-2 live 加载 gate：表单在 live 状态就绪后才渲染，先等按钮出现。
+    await screen.findByRole("button", { name: "manage-auth" });
     fireEvent.click(screen.getByRole("button", { name: "manage-auth" }));
     expect(screen.getByTestId("auth-settings-panel")).toHaveTextContent(
       "codex_oauth",
@@ -440,7 +444,12 @@ describe("EditProviderDialog", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "common.save" }));
+    // 分支保留 P2-2 live 加载 gate：等保存按钮就绪（启用）后再点击。
+    const saveButton = await screen.findByRole("button", {
+      name: "common.save",
+    });
+    await waitFor(() => expect(saveButton).toBeEnabled());
+    fireEvent.click(saveButton);
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmit).toHaveBeenCalledWith(
@@ -472,7 +481,12 @@ describe("EditProviderDialog", () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "common.save" }));
+    // 分支保留 P2-2 live 加载 gate：等保存按钮就绪（启用）后再点击。
+    const saveButton = await screen.findByRole("button", {
+      name: "common.save",
+    });
+    await waitFor(() => expect(saveButton).toBeEnabled());
+    fireEvent.click(saveButton);
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     const submitted = onSubmit.mock.calls[0][0];
@@ -558,5 +572,355 @@ describe("EditProviderDialog", () => {
 
     act(() => staleCallback?.(true));
     expect(reopenedButton).toBeDisabled();
+  });
+});
+
+describe("EditProviderDialog live 加载 gate 与失败处理", () => {
+  beforeEach(() => {
+    mockFormReady = true;
+    mockCodexManagedAccountSelected = false;
+    submitReadyCallbacks = [];
+    apiMocks.getCurrent.mockReset();
+    apiMocks.getLiveProviderSettings.mockReset();
+    apiMocks.getOpenClawLiveProvider.mockReset();
+  });
+  it("live 配置加载完成前不渲染表单，加载完成后出现", async () => {
+    const provider: Provider = {
+      id: "deepseek",
+      name: "DeepSeek",
+      category: "aggregator",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "db-key" },
+      },
+    };
+    let resolveLive: (value: Record<string, unknown>) => void = () => {};
+    const livePromise = new Promise<Record<string, unknown>>((resolve) => {
+      resolveLive = resolve;
+    });
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings.mockReturnValue(livePromise);
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+    );
+
+    expect(screen.queryByTestId("provider-form")).not.toBeInTheDocument();
+
+    resolveLive({});
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-form")).toBeInTheDocument(),
+    );
+  });
+
+  it("live 配置加载失败时禁用保存且不渲染表单", async () => {
+    const provider: Provider = {
+      id: "deepseek",
+      name: "DeepSeek",
+      category: "aggregator",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "db-key" },
+      },
+    };
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings.mockRejectedValue(new Error("boom"));
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "common.save" }),
+      ).toBeDisabled(),
+    );
+    expect(screen.queryByTestId("provider-form")).not.toBeInTheDocument();
+    expect(screen.getByTestId("live-load-error")).toHaveTextContent(
+      /读取实时配置失败/,
+    );
+  });
+
+  it("OpenClaw live 配置加载失败时禁用保存且不渲染表单", async () => {
+    const provider: Provider = {
+      id: "openclaw-provider",
+      name: "OpenClaw Provider",
+      category: "custom",
+      settingsConfig: { base_url: "https://db.example.com" },
+    };
+
+    apiMocks.getOpenClawLiveProvider.mockRejectedValue(new Error("boom"));
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="openclaw"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "common.save" }),
+      ).toBeDisabled(),
+    );
+    expect(screen.queryByTestId("provider-form")).not.toBeInTheDocument();
+    expect(screen.getByTestId("live-load-error")).toHaveTextContent(
+      /读取实时配置失败/,
+    );
+  });
+
+  it("providersApi.getCurrent 失败时禁用保存并显示 live 读取失败", async () => {
+    const provider: Provider = {
+      id: "deepseek",
+      name: "DeepSeek",
+      category: "aggregator",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "db-key" },
+      },
+    };
+
+    apiMocks.getCurrent.mockRejectedValue(new Error("boom"));
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("live-load-error")).toHaveTextContent(
+        /读取实时配置失败/,
+      );
+    });
+    expect(screen.getByRole("button", { name: "common.save" })).toBeDisabled();
+    expect(screen.queryByTestId("provider-form")).not.toBeInTheDocument();
+    expect(apiMocks.getLiveProviderSettings).not.toHaveBeenCalled();
+  });
+
+  it("切换 provider 后的首个 commit 不渲染旧 live 表单", async () => {
+    const providerA: Provider = {
+      id: "deepseek",
+      name: "DeepSeek",
+      category: "aggregator",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "db-key-a" },
+      },
+    };
+    const providerB: Provider = {
+      id: "kimi",
+      name: "Kimi",
+      category: "aggregator",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "db-key-b" },
+      },
+    };
+    const liveA = { auth: { OPENAI_API_KEY: "live-key-a" } };
+    const liveB = { auth: { OPENAI_API_KEY: "live-key-b" } };
+    let resolveA: (value: Record<string, unknown>) => void = () => {};
+    const livePromiseA = new Promise<Record<string, unknown>>((resolve) => {
+      resolveA = resolve;
+    });
+
+    apiMocks.getCurrent
+      .mockResolvedValueOnce(providerA.id)
+      .mockResolvedValueOnce(providerB.id);
+    apiMocks.getLiveProviderSettings
+      .mockReturnValueOnce(livePromiseA)
+      .mockReturnValueOnce(liveB);
+
+    const view = render(
+      <EditProviderDialog
+        open
+        provider={providerA}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+      { legacyRoot: true },
+    );
+
+    resolveA(liveA);
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+      ).toEqual(liveA);
+    });
+
+    // 直接 ReactDOM.render 绕开 RTL 的 act，让断言落在切换后的首个 commit 上
+    ReactDOM.render(
+      <EditProviderDialog
+        open
+        provider={providerB}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+      view.container,
+    );
+
+    expect(apiMocks.getCurrent).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("加载中...")).toBeInTheDocument();
+    expect(screen.queryByTestId("provider-form")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "common.save" })).toBeDisabled();
+  });
+
+  it("同一会话切换 provider 时重新进入加载 gate，避免短暂用旧 live 配置渲染", async () => {
+    const providerA: Provider = {
+      id: "deepseek",
+      name: "DeepSeek",
+      category: "aggregator",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "db-key-a" },
+      },
+    };
+    const providerB: Provider = {
+      id: "kimi",
+      name: "Kimi",
+      category: "aggregator",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "db-key-b" },
+      },
+    };
+    let resolveA: (value: Record<string, unknown>) => void = () => {};
+    let resolveB: (value: Record<string, unknown>) => void = () => {};
+    const liveA = new Promise<Record<string, unknown>>((resolve) => {
+      resolveA = resolve;
+    });
+    const liveB = new Promise<Record<string, unknown>>((resolve) => {
+      resolveB = resolve;
+    });
+
+    apiMocks.getCurrent
+      .mockResolvedValueOnce(providerA.id)
+      .mockResolvedValueOnce(providerB.id);
+    apiMocks.getLiveProviderSettings
+      .mockReturnValueOnce(liveA)
+      .mockReturnValueOnce(liveB);
+
+    const view = render(
+      <EditProviderDialog
+        open
+        provider={providerA}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+    );
+
+    resolveA({ auth: { OPENAI_API_KEY: "live-key-a" } });
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+      ).toEqual({ auth: { OPENAI_API_KEY: "live-key-a" } });
+    });
+
+    view.rerender(
+      <EditProviderDialog
+        open
+        provider={providerB}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+    );
+    expect(screen.getByText("加载中...")).toBeInTheDocument();
+    expect(screen.queryByTestId("provider-form")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "common.save" })).toBeDisabled();
+
+    resolveB({ auth: { OPENAI_API_KEY: "live-key-b" } });
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+      ).toEqual({ auth: { OPENAI_API_KEY: "live-key-b" } });
+    });
+  });
+
+  it("live 配置不存在时仍使用数据库快照渲染并允许保存", async () => {
+    const provider: Provider = {
+      id: "deepseek",
+      name: "DeepSeek",
+      category: "aggregator",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "db-key" },
+      },
+    };
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings.mockResolvedValue(null);
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-form")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: "common.save" })).toBeEnabled();
+    expect(
+      JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+    ).toEqual(provider.settingsConfig);
+  });
+
+  it("live 读取失败后点击重试可恢复表单", async () => {
+    const provider: Provider = {
+      id: "deepseek",
+      name: "DeepSeek",
+      category: "aggregator",
+      settingsConfig: {
+        auth: { OPENAI_API_KEY: "db-key" },
+      },
+    };
+
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValue({ auth: { OPENAI_API_KEY: "live-key" } });
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="codex"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("live-load-error")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("provider-form")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("live-load-retry"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-form")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("live-load-error")).not.toBeInTheDocument();
   });
 });

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -923,4 +923,46 @@ describe("EditProviderDialog live 加载 gate 与失败处理", () => {
     );
     expect(screen.queryByTestId("live-load-error")).not.toBeInTheDocument();
   });
+
+  it("claude-desktop 编辑激活供应商：不走 live 读取门，直接用数据库快照渲染表单", async () => {
+    const provider: Provider = {
+      id: "cd-current",
+      name: "CD Current",
+      settingsConfig: {
+        ANTHROPIC_AUTH_TOKEN: "db-token",
+        ANTHROPIC_BASE_URL: "https://db.example.com",
+      },
+    };
+
+    // 后端 read_live_settings 对 claude-desktop 永远返回"不支持"错误；
+    // 豁免名单生效时应压根不发起这两次调用
+    apiMocks.getCurrent.mockResolvedValue(provider.id);
+    apiMocks.getLiveProviderSettings.mockRejectedValue(
+      new Error("Claude Desktop 3P 配置不支持作为通用 live 配置导入"),
+    );
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="claude-desktop"
+      />,
+    );
+
+    expect(apiMocks.getLiveProviderSettings).not.toHaveBeenCalled();
+    expect(apiMocks.getCurrent).not.toHaveBeenCalled();
+
+    expect(screen.queryByTestId("live-load-error")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("live-load-retry")).not.toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-form")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: "common.save" })).toBeEnabled();
+    expect(
+      JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+    ).toEqual(provider.settingsConfig);
+  });
 });

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -14,6 +14,7 @@ const apiMocks = vi.hoisted(() => ({
   getCurrent: vi.fn(),
   getLiveProviderSettings: vi.fn(),
   getOpenClawLiveProvider: vi.fn(),
+  getHermesLiveProvider: vi.fn(),
 }));
 let mockFormReady = true;
 let mockCodexManagedAccountSelected = false;
@@ -28,6 +29,12 @@ vi.mock("@/lib/api", () => ({
   },
   openclawApi: {
     getLiveProvider: apiMocks.getOpenClawLiveProvider,
+  },
+}));
+
+vi.mock("@/lib/api/hermes", () => ({
+  hermesApi: {
+    getLiveProvider: apiMocks.getHermesLiveProvider,
   },
 }));
 
@@ -145,6 +152,7 @@ describe("EditProviderDialog", () => {
     apiMocks.getCurrent.mockReset();
     apiMocks.getLiveProviderSettings.mockReset();
     apiMocks.getOpenClawLiveProvider.mockReset();
+    apiMocks.getHermesLiveProvider.mockReset();
   });
 
   it("保留 Codex 数据库中的 modelCatalog，避免 live 配置缺字段时清空模型映射", async () => {
@@ -583,6 +591,7 @@ describe("EditProviderDialog live 加载 gate 与失败处理", () => {
     apiMocks.getCurrent.mockReset();
     apiMocks.getLiveProviderSettings.mockReset();
     apiMocks.getOpenClawLiveProvider.mockReset();
+    apiMocks.getHermesLiveProvider.mockReset();
   });
   it("live 配置加载完成前不渲染表单，加载完成后出现", async () => {
     const provider: Provider = {
@@ -684,6 +693,114 @@ describe("EditProviderDialog live 加载 gate 与失败处理", () => {
     );
   });
 
+  it("Hermes 编辑时用 live fragment 替换数据库快照作为表单初值", async () => {
+    const provider: Provider = {
+      id: "my-hermes",
+      name: "My Hermes",
+      category: "custom",
+      settingsConfig: {
+        name: "my-hermes",
+        base_url: "https://db.example.com",
+      },
+    };
+    const liveFragment = {
+      name: "my-hermes",
+      base_url: "https://live.example.com",
+      api_key: "live-key",
+      models: [{ id: "m1", displayName: "M1" }],
+      _cc_source: "custom_providers",
+    };
+
+    apiMocks.getHermesLiveProvider.mockResolvedValue(liveFragment);
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="hermes"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-form")).toBeInTheDocument(),
+    );
+    expect(
+      JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+    ).toEqual(liveFragment);
+    expect(screen.getByRole("button", { name: "common.save" })).toBeEnabled();
+    // Hermes 走专用分支读取 live，不经 getCurrent（additive 应用 current() 恒为空串）
+    expect(apiMocks.getCurrent).not.toHaveBeenCalled();
+    expect(apiMocks.getLiveProviderSettings).not.toHaveBeenCalled();
+  });
+
+  it("Hermes live 节点不存在时用数据库快照渲染并允许保存", async () => {
+    const provider: Provider = {
+      id: "my-hermes",
+      name: "My Hermes",
+      category: "custom",
+      settingsConfig: {
+        name: "my-hermes",
+        base_url: "https://db.example.com",
+      },
+    };
+
+    apiMocks.getHermesLiveProvider.mockResolvedValue(null);
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="hermes"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("provider-form")).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: "common.save" })).toBeEnabled();
+    expect(
+      JSON.parse(screen.getByTestId("settings-config").textContent ?? "{}"),
+    ).toEqual(provider.settingsConfig);
+  });
+
+  it("Hermes live 配置加载失败时禁用保存且不渲染表单", async () => {
+    const provider: Provider = {
+      id: "my-hermes",
+      name: "My Hermes",
+      category: "custom",
+      settingsConfig: {
+        name: "my-hermes",
+        base_url: "https://db.example.com",
+      },
+    };
+
+    apiMocks.getHermesLiveProvider.mockRejectedValue(new Error("boom"));
+
+    render(
+      <EditProviderDialog
+        open
+        provider={provider}
+        onOpenChange={vi.fn()}
+        onSubmit={vi.fn()}
+        appId="hermes"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "common.save" }),
+      ).toBeDisabled(),
+    );
+    expect(screen.queryByTestId("provider-form")).not.toBeInTheDocument();
+    expect(screen.getByTestId("live-load-error")).toHaveTextContent(
+      /读取实时配置失败/,
+    );
+  });
+
   it("providersApi.getCurrent 失败时禁用保存并显示 live 读取失败", async () => {
     const provider: Provider = {
       id: "deepseek",
@@ -765,7 +882,9 @@ describe("EditProviderDialog live 加载 gate 与失败处理", () => {
       ).toEqual(liveA);
     });
 
-    // 直接 ReactDOM.render 绕开 RTL 的 act，让断言落在切换后的首个 commit 上
+    // 直接 ReactDOM.render 绕开 RTL 的 act，让断言落在切换后的首个 commit 上。
+    // 升级债：ReactDOM.render + legacyRoot 是 React 18 遗留 API，React 19 已移除，
+    // 升级时本用例需改写为 createRoot（同步 render 的语义需另行补偿）。
     ReactDOM.render(
       <EditProviderDialog
         open

--- a/tests/components/EditProviderDialog.test.tsx
+++ b/tests/components/EditProviderDialog.test.tsx
@@ -854,6 +854,8 @@ describe("EditProviderDialog live 加载 gate 与失败处理", () => {
     });
   });
 
+  // null 是后端对"live 文件缺失"的真实契约（read_live_provider_settings 对
+  // *.missing 错误码返回 Ok(null)），不再是只有测试才会构造的假分支。
   it("live 配置不存在时仍使用数据库快照渲染并允许保存", async () => {
     const provider: Provider = {
       id: "deepseek",

--- a/tests/components/ProviderForm.initializedRef.test.tsx
+++ b/tests/components/ProviderForm.initializedRef.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { ProviderForm } from "@/components/providers/forms/ProviderForm";
+import { createTestQueryClient } from "../utils/testQueryClient";
+
+describe("ProviderForm initializedRef", () => {
+  it("首次渲染使用 initialData，后续 initialData 变化不再 reset 用户编辑", () => {
+    const queryClient = createTestQueryClient();
+    const onSubmit = vi.fn();
+    const { container, rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <ProviderForm
+          appId="claude"
+          providerId="provider-a"
+          submitLabel="保存"
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            name: "DB Provider",
+            settingsConfig: {
+              env: {
+                ANTHROPIC_AUTH_TOKEN: "db-token",
+              },
+            },
+          }}
+          showButtons={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    const getNameInput = () =>
+      container.querySelector<HTMLInputElement>('input[name="name"]');
+
+    expect(getNameInput()).toHaveValue("DB Provider");
+    fireEvent.change(getNameInput()!, { target: { value: "Edited Provider" } });
+    expect(getNameInput()).toHaveValue("Edited Provider");
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <ProviderForm
+          appId="claude"
+          providerId="provider-a"
+          submitLabel="保存"
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            name: "Live Provider",
+            settingsConfig: {
+              env: {
+                ANTHROPIC_AUTH_TOKEN: "live-token",
+              },
+            },
+          }}
+          showButtons={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(getNameInput()).toHaveValue("Edited Provider");
+  });
+
+  it("首次渲染 reset 一次，provider scope 变化不再 reset 用户编辑", () => {
+    const queryClient = createTestQueryClient();
+    const onSubmit = vi.fn();
+    const { container, rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <ProviderForm
+          appId="claude"
+          providerId="provider-a"
+          submitLabel="保存"
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            name: "DB Provider A",
+            settingsConfig: {
+              env: {
+                ANTHROPIC_AUTH_TOKEN: "db-token-a",
+              },
+            },
+          }}
+          showButtons={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    const getNameInput = () =>
+      container.querySelector<HTMLInputElement>('input[name="name"]');
+
+    expect(getNameInput()).toHaveValue("DB Provider A");
+    fireEvent.change(getNameInput()!, { target: { value: "Edited Provider" } });
+    expect(getNameInput()).toHaveValue("Edited Provider");
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <ProviderForm
+          appId="claude"
+          providerId="provider-b"
+          submitLabel="保存"
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            name: "Live Provider B",
+            settingsConfig: {
+              env: {
+                ANTHROPIC_AUTH_TOKEN: "live-token-b",
+              },
+            },
+          }}
+          showButtons={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(getNameInput()).toHaveValue("Edited Provider");
+  });
+
+  it("首次渲染 reset 一次，appId 变化不再 reset 用户编辑", () => {
+    const queryClient = createTestQueryClient();
+    const onSubmit = vi.fn();
+    const { container, rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <ProviderForm
+          appId="claude"
+          providerId="provider-a"
+          submitLabel="保存"
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            name: "DB Provider A",
+            settingsConfig: {
+              env: {
+                ANTHROPIC_AUTH_TOKEN: "db-token-a",
+              },
+            },
+          }}
+          showButtons={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    const getNameInput = () =>
+      container.querySelector<HTMLInputElement>('input[name="name"]');
+
+    expect(getNameInput()).toHaveValue("DB Provider A");
+    fireEvent.change(getNameInput()!, { target: { value: "Edited Provider" } });
+    expect(getNameInput()).toHaveValue("Edited Provider");
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <ProviderForm
+          appId="codex"
+          providerId="provider-a"
+          submitLabel="保存"
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          initialData={{
+            name: "Codex Provider A",
+            settingsConfig: {
+              auth: {
+                OPENAI_API_KEY: "live-token-a",
+              },
+              config: 'model_provider = "custom"\nmodel = "gpt-5"\n',
+            },
+          }}
+          showButtons={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(getNameInput()).toHaveValue("Edited Provider");
+  });
+});

--- a/tests/components/ProviderForm.presetReset.test.tsx
+++ b/tests/components/ProviderForm.presetReset.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { ProviderForm } from "@/components/providers/forms/ProviderForm";
+import { createTestQueryClient } from "../utils/testQueryClient";
+
+describe("ProviderForm preset/template reset", () => {
+  it("选择 Claude preset 会重置表单字段（spec §2.2/§7）", async () => {
+    const queryClient = createTestQueryClient();
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <ProviderForm
+          appId="claude"
+          submitLabel="保存"
+          onSubmit={onSubmit}
+          onCancel={vi.fn()}
+          showButtons={false}
+        />
+      </QueryClientProvider>,
+    );
+
+    const getNameInput = () =>
+      container.querySelector<HTMLInputElement>('input[name="name"]');
+
+    // 新增模式初始 name 为空
+    expect(getNameInput()).toHaveValue("");
+
+    // 点击第一个 Claude 官方 preset，表单应重置为该 preset
+    const presetButton = await screen.findByRole("button", {
+      name: /Claude Official/i,
+    });
+    fireEvent.click(presetButton);
+
+    await waitFor(() => {
+      expect(getNameInput()).toHaveValue("Claude Official");
+    });
+  });
+});


### PR DESCRIPTION
---

## Summary / 概述

修复"**编辑当前激活的供应商时，表单显示的是数据库快照而非 live 配置**"的问题（即 #5652 review 中的 **P2-2**）。现在：

- 打开编辑对话框时实时读取 live 配置，成功后表单才渲染，显示的是 live 内容；
- live 读取**失败时禁止保存**（避免用 DB 旧快照覆盖实时配置），并提供"重试"；
- 同一会话内切换 provider 会重新进入加载态，不会短暂渲染上一个供应商的 live 配置；
- `ProviderForm` 仅在首次渲染用 `defaultValues` 初始化（`initializedRef`），预设初始化按 `appId:providerId` 作用域键控——编辑过程中的 query 重取 / props 变化不再清空用户输入；
- `JsonEditor` 应用外部值时抑制回声 `onChange`，格式化归一化不再写回表单；
- 通用配置加载态（`isLoading`）贯通到 Claude / Gemini 编辑区。

这是 #5652 拆分系列的 **2/5**（总跟踪：#6962），~~纯前端修复（13 文件，+720/−37）~~（review 后包含 Rust 命令层改动），不依赖系列其他 PR。

> [!NOTE]
> 以下两条为 review 修复（313c3100 / 2ad52a54）后补充：

- **live 文件缺失**（DB 云同步到新机、手删文件等）映射为 null：DB 快照回退且**允许保存**——缺失时无 live 可覆盖，保留旧行为"打开→保存重建 live"的自愈流（`read_live_provider_settings` 对 `*.missing` 错误码返回 `Ok(null)`，通用 `read_live_settings` 的 Err 契约不变）；
- Hermes 编辑表单的初值改用 live fragment（`get_hermes_live_provider`，Option 契约同 OpenClaw），补齐 additive 应用读侧缺口；OpenCode 侧缺单供应商读取命令，开 follow-up：#7026。

## Why / 背景

> [!WARNING]
> 下方删除线部分为原始表述，经 review 指出对 main 不成立：其复现链依赖的 `formResetScopeRef` 只存在于 #5652 的分支，从未进入 main（main 上 live 异步到达后表单会正常刷新显示）。原文保留以留痕，正确表述见下方。

~~旧行为里，编辑当前激活供应商时表单读的是 DB 快照：live 配置（最近一次切换/写入的内容）与 DB 不同步时，用户看到的是旧值，**点一次保存就把 live 覆盖回旧值**——对直连用户等于"打开编辑框再保存"就丢配置。该问题由 #5652 review 中维护者亲自指出（P2-2），本 PR 即其修复。~~

main 上真实存在、也是本 PR 真正修掉的缺陷是：

1. **live 读取失败时静默回退 DB 快照且允许保存**——数据丢失的真实路径（手改 live 后读取失败的场景下，"打开编辑→保存"即覆盖手改，无提示）；
2. **live 到达前约一个 IPC 往返的 DB 快照窗口**——此间的用户输入会被无门控的 `form.reset(defaultValues)` 吞掉；
3. **JsonEditor 的受控回声**——外部值应用期间的 onChange 回传会覆盖用户编辑。

配套的三个衍生修复同在本 PR：表单初始化恰好一次（否则 react-query 重取会打断编辑）；预设切换的作用域键控（切换 provider/app 后首个 commit 不会把旧表单当新结果）；JsonEditor 的受控回声抑制（外部值应用期间不触发 onChange）。

## Non-goals / 边界

- 窗口业务逻辑（`contextWindows` 等 DB 回显、Claude 侧 `isProxyTakeover`/迁移接线）属于系列 PR-3，本 PR 不含；
- Codex 编辑器的通用配置加载态接线随 PR-1 合并后补（接收端 prop 定义在 PR-1 的 `CodexConfigSection` 中）；Claude / Gemini 侧已包含；
- `App.tsx` 的 `isProxyTakeover` 传递修正随 PR-3 处理。

## Tests

> [!NOTE]
> 以下为 review 修复（313c3100 / 2ad52a54）后更新的测试数据。

- `vitest` 全量 **1028 通过**；
- `EditProviderDialog` 测试 **22 用例**：live 加载 gate / 失败禁存 / OpenClaw 与 Hermes 失败门 / getCurrent 失败 / 切换 provider 重入 gate / live 缺失回退 DB（现为后端真实契约）/ Hermes live 命中与 null 回退 / 重试恢复 / claude-desktop 豁免等失败与边界用例；`ProviderForm.initializedRef` 与 `presetReset` 行为锁定测试；
- Rust：`read_live_provider_settings_tests` 2 个单测（`.missing` 错误码命中 / 非缺失错误不命中）；全量 `cargo test` 全绿（lib 2737 + 集成 128，0 失败）；
- `typecheck` 通过。

## Related / 关联

- Fixes #6964（对应 #5652 review P2-2）
- 系列：#5652（拆分来源）→ tracking #6962；OpenCode 读侧缺口 follow-up：#7026
