### PR TITLE
fix(codex): repair legacy managed account bindings

### DIFF
--- a/src-tauri/src/database/dao/providers.rs
+++ b/src-tauri/src/database/dao/providers.rs
@@ -193,11 +193,15 @@ impl Database {
             .map_err(|e| AppError::Database(e.to_string()))?;
         let rows = {
             let mut stmt = tx
-                .prepare("SELECT id, meta FROM providers WHERE app_type = 'codex'")
+                .prepare("SELECT id, app_type, meta FROM providers")
                 .map_err(|e| AppError::Database(e.to_string()))?;
             let rows = stmt
                 .query_map([], |row| {
-                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
                 })
                 .map_err(|e| AppError::Database(e.to_string()))?;
             rows.collect::<Result<Vec<_>, _>>()
@@ -205,7 +209,7 @@ impl Database {
         };
 
         let mut repaired = 0;
-        for (provider_id, meta_text) in rows {
+        for (provider_id, app_type, meta_text) in rows {
             let mut meta: serde_json::Value = serde_json::from_str(&meta_text)
                 .map_err(|e| AppError::Database(format!("Invalid provider meta JSON: {e}")))?;
             let Some(binding) = meta
@@ -235,10 +239,11 @@ impl Database {
                 serde_json::Value::String(local_account_id.clone()),
             );
             tx.execute(
-                "UPDATE providers SET meta = ?1 WHERE id = ?2 AND app_type = 'codex'",
+                "UPDATE providers SET meta = ?1 WHERE id = ?2 AND app_type = ?3",
                 params![
                     serde_json::to_string(&meta).map_err(|e| AppError::Database(e.to_string()))?,
-                    provider_id
+                    provider_id,
+                    app_type
                 ],
             )
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -884,7 +889,7 @@ mod codex_binding_repair_tests {
     use crate::provider::{AuthBinding, AuthBindingSource, Provider, ProviderMeta};
 
     #[test]
-    fn repairs_legacy_codex_oauth_binding_once() {
+    fn repairs_legacy_codex_oauth_bindings_across_apps_once() {
         let db = Database::memory().expect("memory db");
         let mut provider = Provider::with_id(
             "managed-official".to_string(),
@@ -900,24 +905,29 @@ mod codex_binding_repair_tests {
             }),
             ..Default::default()
         });
-        db.save_provider("codex", &provider).expect("save provider");
+        for app_type in ["codex", "claude"] {
+            db.save_provider(app_type, &provider)
+                .expect("save provider");
+        }
 
         let aliases =
             HashMap::from([("legacy-workspace".to_string(), "local-account".to_string())]);
         assert_eq!(
             db.repair_codex_oauth_binding_account_ids(&aliases)
                 .expect("repair binding"),
-            1
+            2
         );
-        assert_eq!(
-            db.get_provider_by_id("managed-official", "codex")
-                .expect("read provider")
-                .expect("provider exists")
-                .meta
-                .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
-                .as_deref(),
-            Some("local-account")
-        );
+        for app_type in ["codex", "claude"] {
+            assert_eq!(
+                db.get_provider_by_id("managed-official", app_type)
+                    .expect("read provider")
+                    .expect("provider exists")
+                    .meta
+                    .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
+                    .as_deref(),
+                Some("local-account")
+            );
+        }
         assert_eq!(
             db.repair_codex_oauth_binding_account_ids(&aliases)
                 .expect("repair is idempotent"),

--- a/src-tauri/src/database/dao/providers.rs
+++ b/src-tauri/src/database/dao/providers.rs
@@ -177,6 +177,78 @@ impl Database {
         }
     }
 
+    /// Repair Codex OAuth provider bindings written before local account IDs
+    /// were separated from upstream ChatGPT workspace IDs.
+    pub fn repair_codex_oauth_binding_account_ids(
+        &self,
+        aliases: &HashMap<String, String>,
+    ) -> Result<usize, AppError> {
+        if aliases.is_empty() {
+            return Ok(0);
+        }
+
+        let mut conn = lock_conn!(self.conn);
+        let tx = conn
+            .transaction()
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let rows = {
+            let mut stmt = tx
+                .prepare("SELECT id, meta FROM providers WHERE app_type = 'codex'")
+                .map_err(|e| AppError::Database(e.to_string()))?;
+            let rows = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .map_err(|e| AppError::Database(e.to_string()))?;
+            rows.collect::<Result<Vec<_>, _>>()
+                .map_err(|e| AppError::Database(e.to_string()))?
+        };
+
+        let mut repaired = 0;
+        for (provider_id, meta_text) in rows {
+            let mut meta: serde_json::Value = serde_json::from_str(&meta_text)
+                .map_err(|e| AppError::Database(format!("Invalid provider meta JSON: {e}")))?;
+            let Some(binding) = meta
+                .get_mut("authBinding")
+                .and_then(serde_json::Value::as_object_mut)
+            else {
+                continue;
+            };
+            if binding.get("source").and_then(serde_json::Value::as_str) != Some("managed_account")
+                || binding
+                    .get("authProvider")
+                    .and_then(serde_json::Value::as_str)
+                    != Some("codex_oauth")
+            {
+                continue;
+            }
+            let Some(account_id) = binding.get("accountId").and_then(serde_json::Value::as_str)
+            else {
+                continue;
+            };
+            let Some(local_account_id) = aliases.get(account_id) else {
+                continue;
+            };
+
+            binding.insert(
+                "accountId".to_string(),
+                serde_json::Value::String(local_account_id.clone()),
+            );
+            tx.execute(
+                "UPDATE providers SET meta = ?1 WHERE id = ?2 AND app_type = 'codex'",
+                params![
+                    serde_json::to_string(&meta).map_err(|e| AppError::Database(e.to_string()))?,
+                    provider_id
+                ],
+            )
+            .map_err(|e| AppError::Database(e.to_string()))?;
+            repaired += 1;
+        }
+
+        tx.commit().map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(repaired)
+    }
+
     pub fn save_provider(&self, app_type: &str, provider: &Provider) -> Result<(), AppError> {
         let mut conn = lock_conn!(self.conn);
         let tx = conn
@@ -803,6 +875,54 @@ impl Database {
         self.save_provider(app_type_str, &provider)?;
 
         Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod codex_binding_repair_tests {
+    use super::*;
+    use crate::provider::{AuthBinding, AuthBindingSource, Provider, ProviderMeta};
+
+    #[test]
+    fn repairs_legacy_codex_oauth_binding_once() {
+        let db = Database::memory().expect("memory db");
+        let mut provider = Provider::with_id(
+            "managed-official".to_string(),
+            "Managed Official".to_string(),
+            serde_json::json!({"auth": {}}),
+            None,
+        );
+        provider.meta = Some(ProviderMeta {
+            auth_binding: Some(AuthBinding {
+                source: AuthBindingSource::ManagedAccount,
+                auth_provider: Some("codex_oauth".to_string()),
+                account_id: Some("legacy-workspace".to_string()),
+            }),
+            ..Default::default()
+        });
+        db.save_provider("codex", &provider).expect("save provider");
+
+        let aliases =
+            HashMap::from([("legacy-workspace".to_string(), "local-account".to_string())]);
+        assert_eq!(
+            db.repair_codex_oauth_binding_account_ids(&aliases)
+                .expect("repair binding"),
+            1
+        );
+        assert_eq!(
+            db.get_provider_by_id("managed-official", "codex")
+                .expect("read provider")
+                .expect("provider exists")
+                .meta
+                .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
+                .as_deref(),
+            Some("local-account")
+        );
+        assert_eq!(
+            db.repair_codex_oauth_binding_account_ids(&aliases)
+                .expect("repair is idempotent"),
+            0
+        );
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -651,6 +651,22 @@ pub fn run() {
 
             let app_state = AppState::new(db);
 
+            let codex_binding_aliases = tauri::async_runtime::block_on(
+                app_state
+                    .codex_oauth_manager
+                    .legacy_binding_account_id_aliases(),
+            );
+            match app_state
+                .db
+                .repair_codex_oauth_binding_account_ids(&codex_binding_aliases)
+            {
+                Ok(count) if count > 0 => {
+                    log::info!("✓ Repaired {count} legacy Codex OAuth provider binding(s)")
+                }
+                Ok(_) => {}
+                Err(error) => log::warn!("Failed to repair Codex OAuth provider bindings: {error}"),
+            }
+
             // 设置 AppHandle 用于代理故障转移时的 UI 更新
             app_state.proxy_service.set_app_handle(app.handle().clone());
 

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -1348,6 +1348,42 @@ impl CodexOAuthManager {
         Self::sorted_accounts(&accounts, default_id.as_deref())
     }
 
+    /// Map legacy workspace-based provider bindings to their unique local
+    /// account IDs. Ambiguous workspaces are intentionally omitted because
+    /// multiple ChatGPT users can share one workspace.
+    pub(crate) async fn legacy_binding_account_id_aliases(&self) -> HashMap<String, String> {
+        let accounts = self.accounts.read().await;
+        let mut candidates: HashMap<String, Option<String>> = HashMap::new();
+
+        for (local_id, account) in accounts.iter() {
+            let Some(workspace_id) = account.chatgpt_account_id.as_deref() else {
+                continue;
+            };
+            if account
+                .id_token
+                .as_deref()
+                .and_then(crate::codex_config::extract_codex_id_token_user_identity)
+                .is_none()
+            {
+                continue;
+            }
+
+            candidates
+                .entry(workspace_id.to_string())
+                .and_modify(|candidate| *candidate = None)
+                .or_insert_with(|| Some(local_id.clone()));
+        }
+
+        candidates
+            .into_iter()
+            .filter_map(|(workspace_id, local_id)| {
+                local_id
+                    .filter(|local_id| local_id != &workspace_id)
+                    .map(|local_id| (workspace_id, local_id))
+            })
+            .collect()
+    }
+
     pub async fn remove_account(&self, account_id: &str) -> Result<(), CodexOAuthError> {
         log::info!("[CodexOAuth] 移除账号: {account_id}");
         // Wait for all in-flight refresh/adopt operations before deleting. New
@@ -2213,6 +2249,44 @@ mod tests {
         let accounts = manager.accounts.read().await;
         assert_eq!(accounts.get(&first.id).unwrap().refresh_token, "rt-first");
         assert_eq!(accounts.get(&second.id).unwrap().refresh_token, "rt-second");
+    }
+
+    #[tokio::test]
+    async fn legacy_binding_aliases_only_include_unique_ready_accounts() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+
+        manager
+            .add_test_account_with_workspace_and_access_token(
+                "legacy-workspace",
+                "legacy-workspace",
+                "stale-access-token",
+                None,
+            )
+            .await
+            .unwrap();
+
+        for (local_id, workspace_id, user) in [
+            ("local-a", "legacy-workspace", "user-a"),
+            ("local-b", "shared-workspace", "user-b"),
+            ("local-c", "shared-workspace", "user-c"),
+        ] {
+            let id_token = crate::codex_config::test_codex_id_token(user);
+            manager
+                .add_test_account_with_workspace_and_access_token(
+                    local_id,
+                    workspace_id,
+                    "access-token",
+                    Some(&id_token),
+                )
+                .await
+                .unwrap();
+        }
+
+        assert_eq!(
+            manager.legacy_binding_account_id_aliases().await,
+            HashMap::from([("legacy-workspace".to_string(), "local-a".to_string())])
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -1365,6 +1365,10 @@ impl CodexOAuthManager {
                 .and_then(crate::codex_config::extract_codex_id_token_user_identity)
                 .is_none()
             {
+                candidates
+                    .entry(workspace_id.to_string())
+                    .and_modify(|candidate| *candidate = None)
+                    .or_insert(None);
                 continue;
             }
 
@@ -2252,7 +2256,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn legacy_binding_aliases_only_include_unique_ready_accounts() {
+    async fn legacy_binding_aliases_only_include_uncontested_ready_accounts() {
         let temp = tempfile::tempdir().unwrap();
         let manager = CodexOAuthManager::new(temp.path().to_path_buf());
 
@@ -2270,6 +2274,7 @@ mod tests {
             ("local-a", "legacy-workspace", "user-a"),
             ("local-b", "shared-workspace", "user-b"),
             ("local-c", "shared-workspace", "user-c"),
+            ("local-d", "unique-workspace", "user-d"),
         ] {
             let id_token = crate::codex_config::test_codex_id_token(user);
             manager
@@ -2285,7 +2290,7 @@ mod tests {
 
         assert_eq!(
             manager.legacy_binding_account_id_aliases().await,
-            HashMap::from([("legacy-workspace".to_string(), "local-a".to_string())])
+            HashMap::from([("unique-workspace".to_string(), "local-d".to_string())])
         );
     }
 

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -1383,6 +1383,8 @@ impl CodexOAuthManager {
             .filter_map(|(workspace_id, local_id)| {
                 local_id
                     .filter(|local_id| local_id != &workspace_id)
+                    // A binding storing a live local key already resolves; do not rewrite it.
+                    .filter(|_| !accounts.contains_key(&workspace_id))
                     .map(|local_id| (workspace_id, local_id))
             })
             .collect()
@@ -2260,15 +2262,18 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let manager = CodexOAuthManager::new(temp.path().to_path_buf());
 
-        manager
-            .add_test_account_with_workspace_and_access_token(
-                "legacy-workspace",
-                "legacy-workspace",
-                "stale-access-token",
-                None,
-            )
-            .await
-            .unwrap();
+        manager.accounts.write().await.insert(
+            "legacy-workspace".to_string(),
+            CodexAccountData {
+                account_id: "legacy-workspace".to_string(),
+                chatgpt_account_id: None,
+                email: Some("legacy@example.com".to_string()),
+                refresh_token: "legacy-refresh-token".to_string(),
+                authenticated_at: 1,
+                id_token: Some("legacy-id-token".to_string()),
+                token_updated_at_ms: 0,
+            },
+        );
 
         for (local_id, workspace_id, user) in [
             ("local-a", "legacy-workspace", "user-a"),


### PR DESCRIPTION
## Summary
- detect legacy Codex OAuth provider bindings that still store a ChatGPT workspace ID
- rewrite only bindings that uniquely map to a ready local managed account
- leave shared or otherwise ambiguous workspaces untouched to avoid cross-account binding

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml legacy_binding_aliases_only_include_unique_ready_accounts`
- `cargo test --manifest-path src-tauri/Cargo.toml repairs_legacy_codex_oauth_binding_once`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`

Closes #6969