### PR TITLE
fix(proxy): restore standalone route on startup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1908,10 +1908,10 @@ pub async fn cleanup_before_exit(app_handle: &tauri::AppHandle) {
         // 非接管模式：代理在运行则仅停止代理
         if proxy_service.is_running().await {
             log::info!("检测到代理服务器正在运行，开始停止...");
-            if let Err(e) = proxy_service.stop().await {
+            if let Err(e) = proxy_service.stop_keep_enabled_state().await {
                 log::error!("退出时停止代理失败: {e}");
             }
-            log::info!("代理服务器清理完成");
+            log::info!("代理服务器清理完成（保留启用状态，下次启动将自动恢复）");
         }
     }
 }
@@ -1963,9 +1963,24 @@ async fn enabled_proxy_apps_on_startup(db: &database::Database) -> Vec<&'static 
 async fn restore_proxy_state_on_startup(state: &store::AppState) {
     // 收集需要恢复接管的应用列表（从 proxy_config.enabled 读取）
     let apps_to_restore = enabled_proxy_apps_on_startup(&state.db).await;
+    let restore_standalone_proxy = match state.db.get_global_proxy_config().await {
+        Ok(config) => config.proxy_enabled,
+        Err(error) => {
+            log::warn!("启动时读取代理总开关失败: {error}");
+            false
+        }
+    };
+
+    if apps_to_restore.is_empty() && !restore_standalone_proxy {
+        log::debug!("启动时无需恢复代理状态");
+        return;
+    }
 
     if apps_to_restore.is_empty() {
-        log::debug!("启动时无需恢复代理状态");
+        match state.proxy_service.start().await {
+            Ok(info) => log::info!("✓ 已恢复本地代理服务: {}:{}", info.address, info.port),
+            Err(error) => log::error!("✗ 恢复本地代理服务失败: {error}"),
+        }
         return;
     }
 
@@ -2282,10 +2297,12 @@ pub fn restart_process(app_handle: &tauri::AppHandle) -> ! {
 mod tests {
     use super::{
         classify_exit_request, enabled_proxy_apps_on_startup, redact_url_for_log,
-        redact_url_for_log_with_secrets, redact_url_origin_for_log, runtime_log_level_allows,
-        ExitRequestAction,
+        redact_url_for_log_with_secrets, redact_url_origin_for_log, restore_proxy_state_on_startup,
+        runtime_log_level_allows, ExitRequestAction,
     };
     use crate::database::Database;
+    use crate::store::AppState;
+    use std::sync::Arc;
 
     #[test]
     fn log_url_redaction_strips_credentials_and_query_keeps_path() {
@@ -2408,5 +2425,39 @@ mod tests {
         let apps = enabled_proxy_apps_on_startup(&db).await;
 
         assert_eq!(apps, vec!["grokbuild"]);
+    }
+
+    #[tokio::test]
+    async fn startup_restores_standalone_proxy_enabled_at_shutdown() {
+        let db = Arc::new(Database::memory().expect("initialize database"));
+        let mut config = db
+            .get_global_proxy_config()
+            .await
+            .expect("read global proxy config");
+        config.proxy_enabled = true;
+        config.listen_port = 0;
+        db.update_global_proxy_config(config)
+            .await
+            .expect("enable standalone proxy");
+        let state = AppState::new(db.clone());
+
+        restore_proxy_state_on_startup(&state).await;
+        assert!(state.proxy_service.is_running().await);
+
+        state
+            .proxy_service
+            .stop_keep_enabled_state()
+            .await
+            .expect("stop for shutdown");
+        assert!(
+            db.get_global_proxy_config()
+                .await
+                .expect("read preserved state")
+                .proxy_enabled
+        );
+
+        restore_proxy_state_on_startup(&state).await;
+        assert!(state.proxy_service.is_running().await);
+        state.proxy_service.stop().await.expect("final cleanup");
     }
 }

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -1715,33 +1715,47 @@ impl ProxyService {
         Ok(())
     }
 
-    /// 停止代理服务器
-    pub async fn stop(&self) -> Result<(), String> {
+    async fn stop_server(&self) -> Result<(), String> {
         if let Some(server) = self.server.write().await.take() {
             server
                 .stop()
                 .await
                 .map_err(|e| format!("停止代理服务器失败: {e}"))?;
 
-            // 停止时设置 proxy_enabled = false
-            let mut global_config = self
-                .db
-                .get_global_proxy_config()
-                .await
-                .map_err(|e| format!("获取全局代理配置失败: {e}"))?;
-
-            if global_config.proxy_enabled {
-                global_config.proxy_enabled = false;
-                if let Err(e) = self.db.update_global_proxy_config(global_config).await {
-                    log::warn!("更新代理总开关失败: {e}");
-                }
-            }
-
-            log::info!("代理服务器已停止");
             Ok(())
         } else {
             Err("代理服务器未运行".to_string())
         }
+    }
+
+    /// 停止代理服务器
+    pub async fn stop(&self) -> Result<(), String> {
+        self.stop_server().await?;
+
+        // 停止时设置 proxy_enabled = false
+        let mut global_config = self
+            .db
+            .get_global_proxy_config()
+            .await
+            .map_err(|e| format!("获取全局代理配置失败: {e}"))?;
+
+        if global_config.proxy_enabled {
+            global_config.proxy_enabled = false;
+            if let Err(e) = self.db.update_global_proxy_config(global_config).await {
+                log::warn!("更新代理总开关失败: {e}");
+            }
+        }
+
+        log::info!("代理服务器已停止");
+        Ok(())
+    }
+
+    /// Stop the listener during app shutdown while preserving the user's
+    /// enabled state so a standalone route can be restored on next launch.
+    pub(crate) async fn stop_keep_enabled_state(&self) -> Result<(), String> {
+        self.stop_server().await?;
+        log::info!("代理服务器已停止（保留启用状态）");
+        Ok(())
     }
 
     /// 停止代理服务器（恢复 Live 配置，用户手动关闭时使用）
@@ -1796,7 +1810,7 @@ impl ProxyService {
     /// 用于程序正常退出时，保留代理状态以便下次启动时自动恢复
     pub async fn stop_with_restore_keep_state(&self) -> Result<(), String> {
         // 1. 停止代理服务器（即使未运行也继续执行恢复逻辑）
-        if let Err(e) = self.stop().await {
+        if let Err(e) = self.stop_keep_enabled_state().await {
             log::warn!("停止代理服务器失败（将继续恢复 Live 配置）: {e}");
         }
 


### PR DESCRIPTION
## Summary
- preserve the global proxy enabled state when CC Switch exits normally
- restore a standalone local proxy on startup even when no CLI takeover is enabled
- keep manual stop behavior unchanged so explicitly disabling the route still persists

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml startup_restores_standalone_proxy_enabled_at_shutdown`
- `cargo test --manifest-path src-tauri/Cargo.toml startup_restore_includes_enabled_grokbuild_route`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`

Closes #6961