### PR TITLE
fix(usage): widen pricing model source select to fit localized labels

### DIFF
--- a/src/components/usage/PricingConfigPanel.tsx
+++ b/src/components/usage/PricingConfigPanel.tsx
@@ -295,7 +295,7 @@ export function PricingConfigPanel() {
                         }
                         disabled={isSaving}
                         placeholder="1"
-                        className="h-7 w-24"
+                        className="w-24"
                       />
                     </td>
                     <td className="px-3 py-1.5">
@@ -312,7 +312,7 @@ export function PricingConfigPanel() {
                         }
                         disabled={isSaving}
                       >
-                        <SelectTrigger className="h-7 w-28">
+                        <SelectTrigger className="w-40">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>


### PR DESCRIPTION
## Summary / 概述

修复了“设置--使用统计--成本定价”面板在英语和日语情况下文本溢出选择框容器的问题。

## Related Issue / 关联 Issue

无


## Screenshots / 截图

### Before / 修改前

<img width="1547" height="507" alt="image" src="https://github.com/user-attachments/assets/bf090432-5377-4dc6-a91f-65b072b3e8a9" />         

<img width="1550" height="496" alt="image" src="https://github.com/user-attachments/assets/ef57942d-dd6e-441a-963f-8f78c49981ff" />

 
### After / 修改后
<img width="1542" height="536" alt="image" src="https://github.com/user-attachments/assets/0d20a051-800a-4459-a10d-4de19479dc55" />    


<img width="1564" height="493" alt="image" src="https://github.com/user-attachments/assets/9646c847-6948-4584-97a1-fd29387fbc2a" />   

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
