### PR TITLE
fix(grokbuild): bind session summaries to custom provider profiles

### DIFF
--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -486,7 +486,7 @@ fn build_grokbuild_settings(request: &DeepLinkImportRequest) -> serde_json::Valu
 
     json!({
         "config": format!(
-            "[models]\ndefault = {model_value}\n\n[model.{model_value}]\nmodel = {model_value}\nbase_url = {endpoint_value}\nname = {name_value}\napi_key = {api_key_value}\napi_backend = \"{}\"\ncontext_window = {}\n",
+            "[models]\ndefault = {model_value}\nsession_summary = {model_value}\n\n[model.{model_value}]\nmodel = {model_value}\nbase_url = {endpoint_value}\nname = {name_value}\napi_key = {api_key_value}\napi_backend = \"{}\"\ncontext_window = {}\n",
             crate::grok_config::DEFAULT_API_BACKEND,
             crate::grok_config::DEFAULT_CONTEXT_WINDOW,
         )
@@ -956,6 +956,37 @@ fn extract_codex_base_url(toml_value: &toml::Value) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn grokbuild_deeplink_pins_session_summary_to_selected_model() {
+        for (model, expected) in [
+            (Some("  custom-model  "), "custom-model"),
+            (Some("vendor/model.with-dots"), "vendor/model.with-dots"),
+            (None, crate::grok_config::DEFAULT_MODEL),
+            (Some("  "), crate::grok_config::DEFAULT_MODEL),
+        ] {
+            let request = DeepLinkImportRequest {
+                resource: "provider".to_string(),
+                app: Some("grokbuild".to_string()),
+                name: Some("Relay".to_string()),
+                endpoint: Some("https://relay.example.com/v1".to_string()),
+                api_key: Some("test-key".to_string()),
+                model: model.map(str::to_string),
+                ..Default::default()
+            };
+            let provider = build_provider_from_request(&AppType::GrokBuild, &request)
+                .expect("provider should build");
+            let config: toml::Value = provider.settings_config["config"]
+                .as_str()
+                .expect("config string")
+                .parse()
+                .expect("valid TOML");
+
+            assert_eq!(config["models"]["default"].as_str(), Some(expected));
+            assert_eq!(config["models"]["session_summary"].as_str(), Some(expected));
+            assert_eq!(config["model"][expected]["model"].as_str(), Some(expected));
+        }
+    }
 
     fn hermes_request() -> DeepLinkImportRequest {
         DeepLinkImportRequest {

--- a/src/utils/grokBuildConfig.test.ts
+++ b/src/utils/grokBuildConfig.test.ts
@@ -21,6 +21,7 @@ describe("Grok Build config", () => {
     const parsed = parseToml(config) as any;
 
     expect(parsed.models.default).toBe("grok-4.5");
+    expect(parsed.models.session_summary).toBe("grok-4.5");
     expect(parsed.model["grok-4.5"]).toEqual({
       model: "grok-4.5",
       base_url: "https://relay.example.com/v1",
@@ -55,6 +56,9 @@ describe("Grok Build config", () => {
       contextWindow: 320000,
     });
     expect(extractGrokBuildBaseUrl(config)).toBe("https://api.example.com");
+    expect((parseToml(config) as any).models.session_summary).toBe(
+      "custom-model",
+    );
   });
 
   it("accepts env_key credentials without adding an empty api_key", () => {
@@ -136,7 +140,66 @@ context_window = 500000
     const parsed = parseToml(renamed) as any;
 
     expect(parsed.models.default).toBe("new-profile");
+    expect(parsed.models.session_summary).toBe("new-profile");
     expect(parsed.model["new-profile"].model).toBe("grok-upstream");
+    expect(parsed.model).not.toHaveProperty("old-profile");
+  });
+
+  it("sets the summary profile when editing a legacy config without one", () => {
+    const original = `[models]
+default = "custom-profile"
+
+[model."custom-profile"]
+model = "upstream-model"
+base_url = "https://relay.example.com/v1"
+name = "Relay"
+api_key = "test-key"
+api_backend = "responses"
+context_window = 500000
+`;
+    const updated = updateGrokBuildConfig(original, {
+      ...parseGrokBuildConfig(original),
+      name: "Updated Relay",
+    });
+    const parsed = parseToml(updated) as any;
+
+    expect(parsed.models.session_summary).toBe("custom-profile");
+    expect(parsed.model[parsed.models.session_summary].model).toBe(
+      "upstream-model",
+    );
+  });
+
+  it("preserves a separately configured summary model when renaming the default", () => {
+    const original = `[models]
+default = "old-profile"
+session_summary = "title-profile"
+web_search = "search-profile"
+
+[model."old-profile"]
+model = "upstream-model"
+base_url = "https://relay.example.com/v1"
+name = "Relay"
+api_key = "test-key"
+api_backend = "responses"
+context_window = 500000
+
+[model."title-profile"]
+model = "small-model"
+base_url = "https://title.example.com/v1"
+env_key = "TITLE_API_KEY"
+`;
+    const updated = updateGrokBuildConfig(original, {
+      ...parseGrokBuildConfig(original),
+      model: "new-profile",
+    });
+    const parsed = parseToml(updated) as any;
+
+    expect(parsed.models.default).toBe("new-profile");
+    expect(parsed.models.session_summary).toBe("title-profile");
+    expect(parsed.models.web_search).toBe("search-profile");
+    expect(parsed.model["title-profile"]).toEqual(
+      (parseToml(original) as any).model["title-profile"],
+    );
     expect(parsed.model).not.toHaveProperty("old-profile");
   });
 });

--- a/src/utils/grokBuildConfig.ts
+++ b/src/utils/grokBuildConfig.ts
@@ -92,7 +92,16 @@ export function updateGrokBuildConfig(
 
   const existingModels = asRecord(config.models) ?? {};
   const previousProfile = asString(existingModels.default, profile);
-  config.models = { ...existingModels, default: profile };
+  const sessionSummary = existingModels.session_summary;
+  config.models = {
+    ...existingModels,
+    default: profile,
+    // Title generation selects its model independently of the main session.
+    session_summary:
+      sessionSummary === undefined || sessionSummary === previousProfile
+        ? profile
+        : sessionSummary,
+  };
 
   const modelTables = asRecord(config.model) ?? {};
   const existingSelected =


### PR DESCRIPTION
## Summary / 概述

Grok Build chooses the model for session titles/summaries independently of the main session (`models.session_summary` vs `models.default`). Generated custom-provider configs currently omit the former, so a working custom-model conversation can still issue a title request to the client's fallback model.

This focused fix uses the existing configuration builders:

- Set `models.session_summary` to the selected profile when generating Grok Build deep-link and form configurations.
- Preserve a separately configured summary profile when editing a provider.
- If summaries followed the previous default profile, follow its rename instead of referring to the model table that the editor removes.
- Use the profile name, not the upstream model ID, so aliases resolve through the correct provider table.

No new UI, dependency, model catalog changes, credential-resolution changes, API retries, or provider protocol changes. Existing deep-link `env_key` protections are unchanged and their tests still pass.

Reference: [Grok Build model configuration](https://docs.x.ai/build/settings/reference#models).

## Related Issue / 关联 Issue

Fixes #7003

## Verification / 验证

Run locally on macOS:

- `pnpm typecheck` — PASS.
- `pnpm format:check` — PASS.
- `pnpm exec vitest run src/utils/grokBuildConfig.test.ts tests/components/GrokBuildProviderForm.test.tsx tests/utils/deepLinkConfigPreview.test.ts --reporter=dot` — 21 PASS.
- `cd src-tauri && cargo fmt --check` — PASS.
- `cargo test --locked --lib deeplink::provider::tests::grokbuild --no-fail-fast` — 3 PASS, including both existing credential-import regression tests. The new test covers selected, trimmed, namespaced, absent and blank-model behavior through the configuration builder.
- `cargo clippy --locked --all-targets --all-features` — PASS.
- `git diff --check` — PASS.

The new assertions were first run against the original builders: four TypeScript checks and the Rust summary-field check failed because the field was missing. They pass with this patch.

Full frontend suite: `pnpm test:unit --maxWorkers=2 --minWorkers=1` ran 1,016 tests: 1,014 passed, 2 failed in the unchanged `tests/config/codexReasoningLevelPresets.test.ts` (`xAI (Grok)` and `xAI (Grok) OAuth`, `grok-4.5`: actual reasoning levels include `xhigh`, expected levels do not). Both failures were reproduced in a separate **unmodified** `054673e0b8cca7d8bd8c67658f2c28e63b2855e0` worktree by running that file: 38 passed, the same 2 failed. No reasoning catalog or unrelated test assertions were changed.

This is a config-generation regression fix, not a claim of complete desktop GUI or cross-platform acceptance. The patch was AI-assisted; the code and changes were reviewed and the checks above were actually run locally.

## Screenshots / 截图

Not applicable: no visual changes.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查
- [x] No user-facing text changed; i18n updates are not needed / 未修改用户可见文案，无需更新国际化
