### PR TITLE
fix(grokbuild): point session_summary at the selected model profile

### DIFF
--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -486,7 +486,10 @@ fn build_grokbuild_settings(request: &DeepLinkImportRequest) -> serde_json::Valu
 
     json!({
         "config": format!(
-            "[models]\ndefault = {model_value}\n\n[model.{model_value}]\nmodel = {model_value}\nbase_url = {endpoint_value}\nname = {name_value}\napi_key = {api_key_value}\napi_backend = \"{}\"\ncontext_window = {}\n",
+            // session_summary as well as default: Grok Build resolves the
+            // session-title model separately, so an import that set only
+            // `default` left titles going to the client's fallback model.
+            "[models]\ndefault = {model_value}\nsession_summary = {model_value}\n\n[model.{model_value}]\nmodel = {model_value}\nbase_url = {endpoint_value}\nname = {name_value}\napi_key = {api_key_value}\napi_backend = \"{}\"\ncontext_window = {}\n",
             crate::grok_config::DEFAULT_API_BACKEND,
             crate::grok_config::DEFAULT_CONTEXT_WINDOW,
         )
@@ -969,6 +972,36 @@ mod tests {
         }
     }
 
+    /// Grok Build resolves `[models].session_summary` separately from
+    /// `[models].default`. An import that wrote only the default left the
+    /// session-title request going to the client's own fallback model, so a
+    /// custom provider could answer the conversation while titles quietly went
+    /// somewhere else — or failed on their own where that fallback is not
+    /// reachable. (#7003)
+    #[test]
+    fn grokbuild_deeplink_points_session_summary_at_the_imported_model() {
+        let request = DeepLinkImportRequest {
+            resource: "provider".to_string(),
+            app: Some("grokbuild".to_string()),
+            name: Some("Custom".to_string()),
+            model: Some("custom-model".to_string()),
+            endpoint: Some("https://relay.example.invalid/v1".to_string()),
+            api_key: Some("sk-test".to_string()),
+            ..Default::default()
+        };
+
+        let settings = build_grokbuild_settings(&request);
+        let rendered = settings["config"].as_str().expect("config string");
+
+        assert!(
+            rendered.contains("default = \"custom-model\""),
+            "the imported model must be the default profile: {rendered}"
+        );
+        assert!(
+            rendered.contains("session_summary = \"custom-model\""),
+            "session titles must use the imported model too: {rendered}"
+        );
+    }
     /// deeplink 同时声明 `api_key` 与 `env_key` 时，导入结果只保留用户可见的
     /// `api_key`：既不能带上解析后的明文环境变量，也不能把 `env_key` 这个间接
     /// 引用本身写进供应商配置。

--- a/src/utils/grokBuildConfig.test.ts
+++ b/src/utils/grokBuildConfig.test.ts
@@ -140,3 +140,84 @@ context_window = 500000
     expect(parsed.model).not.toHaveProperty("old-profile");
   });
 });
+
+// #7003: Grok Build resolves [models].session_summary separately from
+// [models].default, so a generated custom-provider config that set only the
+// default sent session-title requests to the client's own fallback model.
+describe("session summary profile", () => {
+  it("points a generated config's summary at the selected profile", () => {
+    const config = buildGrokBuildConfig({
+      model: "custom-model",
+      baseUrl: "https://relay.example.invalid/v1",
+      name: "Custom",
+      apiKey: "key",
+      apiBackend: "responses",
+      contextWindow: 320000,
+    });
+    const parsed = parseToml(config) as any;
+
+    expect(parsed.models.default).toBe("custom-model");
+    expect(parsed.models.session_summary).toBe("custom-model");
+  });
+
+  it("leaves a summary profile the user pointed somewhere else alone", () => {
+    const existing = [
+      "[models]",
+      'default = "old-model"',
+      'session_summary = "cheap-model"',
+      "",
+      '[model."old-model"]',
+      'model = "old-model"',
+      'base_url = "https://a.example.invalid/v1"',
+      'name = "Old"',
+      "",
+      '[model."cheap-model"]',
+      'model = "cheap-model"',
+      'base_url = "https://b.example.invalid/v1"',
+      'name = "Cheap"',
+      "",
+    ].join("\n");
+
+    const updated = updateGrokBuildConfig(existing, {
+      model: "new-model",
+      baseUrl: "https://a.example.invalid/v1",
+      name: "New",
+      apiKey: "key",
+      apiBackend: "responses",
+      contextWindow: 320000,
+    });
+    const parsed = parseToml(updated) as any;
+
+    expect(parsed.models.default).toBe("new-model");
+    expect(parsed.models.session_summary).toBe("cheap-model");
+  });
+
+  it("follows the default profile through a rename when it was tracking it", () => {
+    // Otherwise the summary is left pointing at a [model.*] table that the
+    // rename removed, which is worse than not setting it at all.
+    const existing = [
+      "[models]",
+      'default = "old-model"',
+      'session_summary = "old-model"',
+      "",
+      '[model."old-model"]',
+      'model = "old-model"',
+      'base_url = "https://a.example.invalid/v1"',
+      'name = "Old"',
+      "",
+    ].join("\n");
+
+    const updated = updateGrokBuildConfig(existing, {
+      model: "new-model",
+      baseUrl: "https://a.example.invalid/v1",
+      name: "New",
+      apiKey: "key",
+      apiBackend: "responses",
+      contextWindow: 320000,
+    });
+    const parsed = parseToml(updated) as any;
+
+    expect(parsed.models.default).toBe("new-model");
+    expect(parsed.models.session_summary).toBe("new-model");
+  });
+});

--- a/src/utils/grokBuildConfig.ts
+++ b/src/utils/grokBuildConfig.ts
@@ -72,6 +72,29 @@ export function parseGrokBuildConfig(
   }
 }
 
+/**
+ * Which profile generates session titles.
+ *
+ * Grok Build resolves `[models].session_summary` separately from
+ * `[models].default`, so leaving it unset sent the title request to the
+ * client's own fallback model — a custom provider could answer the
+ * conversation while titles quietly went somewhere else, or failed on their
+ * own where that fallback is unavailable.
+ *
+ * A summary profile the user pointed somewhere else is left alone. One that
+ * was tracking the default profile keeps tracking it through a rename,
+ * rather than being stranded on a table that no longer exists.
+ */
+export function resolveSessionSummaryProfile(
+  existingSummary: string,
+  previousProfile: string,
+  profile: string,
+): string {
+  const current = existingSummary.trim();
+  if (!current || current === previousProfile) return profile;
+  return current;
+}
+
 export function buildGrokBuildConfig(values: GrokBuildConfigValues): string {
   return updateGrokBuildConfig(undefined, values);
 }
@@ -92,7 +115,15 @@ export function updateGrokBuildConfig(
 
   const existingModels = asRecord(config.models) ?? {};
   const previousProfile = asString(existingModels.default, profile);
-  config.models = { ...existingModels, default: profile };
+  config.models = {
+    ...existingModels,
+    default: profile,
+    session_summary: resolveSessionSummaryProfile(
+      asString(existingModels.session_summary),
+      previousProfile,
+      profile,
+    ),
+  };
 
   const modelTables = asRecord(config.model) ?? {};
   const existingSelected =


### PR DESCRIPTION
Fixes #7003.

Grok Build resolves `[models].session_summary` separately from `[models].default`. Neither generator wrote it, so a configured custom provider answered the conversation while the session-title request went to the client's own fallback model — observed as `grok-4.6` on CLI 1.0.13. Where that fallback model or provider is not reachable, *only* title generation fails, which is hard to connect back to the provider that was just set up.

Both builders now set it:

- `build_grokbuild_settings` (deep-link import, `src-tauri/src/deeplink/provider.rs`) — a fresh config, so it simply emits the line
- `buildGrokBuildConfig` / `updateGrokBuildConfig` (form, `src/utils/grokBuildConfig.ts`) — has to respect what is already there

## The editing case

Two rules, both in `resolveSessionSummaryProfile`:

- **A summary profile the user pointed somewhere else is left alone.** Someone who deliberately routes titles to a cheaper model should keep that through an edit.
- **One that was tracking the default profile follows it through a rename.** Otherwise the rename strands `session_summary` on a `[model.*]` table that no longer exists, which is worse than never having set it.

## Tests

**Frontend** — `npx vitest run src/utils/grokBuildConfig.test.ts` → **8 passed** (5 existing, 3 new):

- a generated config points its summary at the selected profile
- an explicitly different summary profile survives an edit
- a summary that tracked the default follows a rename

Mutation-checked: dropping the `current === previousProfile` branch fails `follows the default profile through a rename when it was tracking it`, 7 passed / 1 failed.

**Rust** — a test asserting the deep-link import emits both `default` and `session_summary`, placed next to the existing `grokbuild_deeplink_never_carries_env_key_or_resolved_secret`.

One disclosure: I could type-check it but not run it here. `cargo check --lib --profile test` is clean, so the test compiles; linking the test binary on this machine needs a GNU toolchain workaround (`aws-lc-sys` wants a `nanosleep64` shim, and `build.rs` emits MSVC manifest flags that GNU `ld` rejects) that I did not want to carry anywhere near a commit. The `build.rs` I patched locally to get that far is restored and not in this diff. CI runs it properly.
