### PR TITLE
fix(usage): 优化用量趋势 Token 轴标签展示

### DIFF
--- a/src/components/usage/UsageTrendChart.tsx
+++ b/src/components/usage/UsageTrendChart.tsx
@@ -135,6 +135,26 @@ export function formatUsageTrendTickLabel(
   return point?.label ?? xKey;
 }
 
+export function createUsageTrendTokenTickFormatter(
+  locale: string,
+): Intl.NumberFormat {
+  return new Intl.NumberFormat(locale, {
+    notation: "compact",
+    compactDisplay: "short",
+    maximumFractionDigits: 1,
+  });
+}
+
+export function formatUsageTrendTokenTickLabel(
+  value: unknown,
+  formatter: Intl.NumberFormat,
+): string {
+  const num = parseFiniteNumber(value);
+  if (num == null) return "--";
+
+  return formatter.format(num);
+}
+
 export function UsageTrendChart({
   range,
   rangeLabel,
@@ -157,6 +177,10 @@ export function UsageTrendChart({
   const isHourly = durationSeconds <= 24 * 60 * 60;
   const language = i18n.resolvedLanguage || i18n.language || "en";
   const dateLocale = getLocaleFromLanguage(language);
+  const tokenTickFormatter = useMemo(
+    () => createUsageTrendTokenTickFormatter(dateLocale),
+    [dateLocale],
+  );
 
   const chartData = useMemo(
     () =>
@@ -266,16 +290,22 @@ export function UsageTrendChart({
             />
             <YAxis
               yAxisId="tokens"
+              width={72}
               axisLine={false}
               tickLine={false}
+              tickMargin={8}
               tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
-              tickFormatter={(value) => `${(value / 1000).toFixed(0)}k`}
+              tickFormatter={(value) =>
+                formatUsageTrendTokenTickLabel(value, tokenTickFormatter)
+              }
             />
             <YAxis
               yAxisId="cost"
               orientation="right"
+              width={56}
               axisLine={false}
               tickLine={false}
+              tickMargin={8}
               tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
               tickFormatter={(value) => `$${value}`}
             />

--- a/tests/components/UsageTrendChart.test.ts
+++ b/tests/components/UsageTrendChart.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   buildUsageTrendChartData,
+  createUsageTrendTokenTickFormatter,
+  formatUsageTrendTokenTickLabel,
   formatUsageTrendTickLabel,
 } from "@/components/usage/UsageTrendChart";
 
@@ -113,5 +115,41 @@ describe("formatUsageTrendTickLabel", () => {
     expect(formatUsageTrendTickLabel(last.xKey, points)).not.toBe(
       points[0].label,
     );
+  });
+});
+
+describe("formatUsageTrendTokenTickLabel", () => {
+  it("uses localized compact units for large token axis ticks", () => {
+    const zhFormatter = createUsageTrendTokenTickFormatter("zh-CN");
+    const zhTwFormatter = createUsageTrendTokenTickFormatter("zh-TW");
+    const enFormatter = createUsageTrendTokenTickFormatter("en-US");
+
+    expect(formatUsageTrendTokenTickLabel(600_000_000, zhFormatter)).toBe(
+      "6亿",
+    );
+    expect(formatUsageTrendTokenTickLabel(1_950_000_000, zhFormatter)).toBe(
+      "19.5亿",
+    );
+    expect(formatUsageTrendTokenTickLabel(65_000_000, zhTwFormatter)).toBe(
+      "6500萬",
+    );
+    expect(formatUsageTrendTokenTickLabel(600_000_000, enFormatter)).toBe(
+      "600M",
+    );
+  });
+
+  it("keeps zero and small-thousand token ticks readable", () => {
+    expect(
+      formatUsageTrendTokenTickLabel(
+        0,
+        createUsageTrendTokenTickFormatter("zh-CN"),
+      ),
+    ).toBe("0");
+    expect(
+      formatUsageTrendTokenTickLabel(
+        1500,
+        createUsageTrendTokenTickFormatter("en-US"),
+      ),
+    ).toBe("1.5K");
   });
 });


### PR DESCRIPTION
## Summary / 概述

本 PR 修复用量统计页「使用趋势」在 token 数值较大时，左侧纵轴仍固定使用 `k` 单位导致标签过长、裁切或读数不直观的问题。

| 场景 | 修改前 | Root cause | 修改后 |
| --- | --- | --- | --- |
| 中文界面 / 当天 | 左侧纵轴显示 `100000k`、`75000k` 等长标签，读数不直观，靠近图表边缘时容易被裁切。 | `UsageTrendChart` 的 token 轴固定使用 `(value / 1000).toFixed(0) + "k"`，数值到千万、亿级后仍继续堆叠 `k` 单位。 | 改为基于当前 locale 的 compact unit，中文下显示 `1亿`、`7500万` 等更短且更符合语境的单位。 |
| 中文界面 / 30d | 左侧纵轴可出现 `2600000k`、`1950000k` 等超长标签，部分窗口宽度下展示不完整。 | 固定 `k` 单位让 30d 大数趋势标签继续膨胀，且左右 `YAxis` 没有显式预留 tick 宽度和间距。 | 30d 大数压缩为 `26亿`、`19.5亿` 等；同时给左右纵轴设置稳定 `width` 和 `tickMargin`，避免刻度被裁切。 |
| 英文界面 | 同一格式化逻辑在英文 locale 下也会遇到大数 `k` 标签过长的问题。 | formatter 未区分 locale，也未使用浏览器内建的大数单位格式化能力。 | 英文下显示 `2.6B`、`650M` 等 compact label，保持跨语言一致的可读性。 |

实现上新增了趋势图专用的 token 轴 compact formatter，并在组件内按 locale memoize `Intl.NumberFormat`，避免每个 tick 重复创建 formatter。该改动只影响趋势图坐标轴标签，不改变统计数据、tooltip 明细和顶部统计卡片的计算口径。

## Related Issue / 关联 Issue

N/A

已检索现有 issues，关键词包括 `usage trend axis label`、`使用趋势 纵轴`、`tokens k axis`、`用量 趋势`，未发现与本 PR 修复问题完全匹配的 bug issue。已关闭的 #6302 是跨年份趋势图 tooltip / active dots 对齐问题，复现路径和修复范围不同，因此不关联自动关闭。

## Screenshots / 截图

| 场景 | Before / 修改前 | After / 修改后 |
| --- | --- | --- |
| 中文 / 当天 | <img src="https://raw.githubusercontent.com/thisTom/cc-switch/refs/heads/pr-assets/usage-stats-axis-labels/pr-screenshots/usage-stats-axis-labels/usage-trend-token-axis-zh-day-before.png" alt="Before: Chinese today usage trend axis uses long k labels" width="420"> | <img src="https://raw.githubusercontent.com/thisTom/cc-switch/refs/heads/pr-assets/usage-stats-axis-labels/pr-screenshots/usage-stats-axis-labels/usage-trend-token-axis-zh-day-after.png" alt="After: Chinese today usage trend axis uses compact labels" width="420"> |
| 中文 / 30d | <img src="https://raw.githubusercontent.com/thisTom/cc-switch/refs/heads/pr-assets/usage-stats-axis-labels/pr-screenshots/usage-stats-axis-labels/usage-trend-token-axis-zh-30d-before.png" alt="Before: Chinese 30d usage trend axis uses long k labels" width="420"> | <img src="https://raw.githubusercontent.com/thisTom/cc-switch/refs/heads/pr-assets/usage-stats-axis-labels/pr-screenshots/usage-stats-axis-labels/usage-trend-token-axis-zh-30d-after.png" alt="After: Chinese 30d usage trend axis uses compact labels" width="420"> |
| English / 30d locale check | N/A | <img src="https://raw.githubusercontent.com/thisTom/cc-switch/refs/heads/pr-assets/usage-stats-axis-labels/pr-screenshots/usage-stats-axis-labels/usage-trend-token-axis-en-30d-after.png" alt="After: English 30d usage trend axis uses compact labels" width="420"> |

## Testing / 测试

| 检查项 | 结果 |
| --- | --- |
| `pnpm exec vitest run tests/components/UsageTrendChart.test.ts` | 通过，1 个测试文件，6 个测试 |
| `pnpm typecheck` | 通过 |
| `pnpm format:check` | 通过 |
| `pnpm build:renderer` | 通过 |
| `git diff --check` | 通过 |
| macOS Tauri dev 手动验证 | 通过。使用真实 CC Switch dev app 验证中文当天、中文 30d、英文 30d 三个场景，趋势图左侧 token 纵轴单位可读且不再裁切。 |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] Rust code not changed; `cargo clippy` not applicable / 未修改 Rust 代码，Clippy 不适用
- [x] No user-facing text changed; i18n not required / 未修改用户可见文案，无需更新国际化文件
