### PR TITLE
fix(proxy): normalize null required in Codex tool schemas

### DIFF
--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -1265,24 +1265,94 @@ fn serialize_tool_definition_for_description(tool: &Value) -> String {
     canonical_json_string(tool)
 }
 
-/// Normalize a function's `parameters` JSON Schema so `type` is always `"object"`.
+/// Normalize a function's `parameters` JSON Schema for strict Chat Completions
+/// providers while preserving the schema's validation semantics.
 ///
-/// Some Responses tools carry `parameters: null` or `parameters: {"type": null}`,
-/// but OpenAI Chat Completions strictly requires `{"type": "object", "properties": {...}}`.
+/// Some Responses tools carry `parameters: null`, `parameters: {"type": null}`
+/// or `required: null`. A few strict OpenAI-compatible gateways also require
+/// `required` to be an array whenever `additionalProperties` is `false`.
 fn normalize_function_parameters(params: Option<&Value>) -> Value {
     let mut params = match params {
         Some(Value::Object(obj)) => Value::Object(obj.clone()),
         _ => json!({"type": "object", "properties": {}}),
     };
-    if let Some(obj) = params.as_object_mut() {
-        match obj.get("type").and_then(|v| v.as_str()) {
-            Some("object") => {}
-            _ => {
-                obj.insert("type".to_string(), json!("object"));
+    sanitize_parameter_schema(&mut params, true);
+    params
+}
+
+fn sanitize_parameter_schema(schema: &mut Value, is_root: bool) {
+    let Value::Object(obj) = schema else {
+        return;
+    };
+
+    if is_root && obj.get("type").and_then(Value::as_str) != Some("object") {
+        obj.insert("type".to_string(), json!("object"));
+    }
+
+    let invalid_required = obj
+        .get("required")
+        .is_some_and(|required| !required.is_array());
+    let strict_object_without_required = obj.get("required").is_none()
+        && obj.get("additionalProperties") == Some(&Value::Bool(false));
+    if invalid_required || strict_object_without_required {
+        obj.insert("required".to_string(), json!([]));
+    }
+
+    // Recurse only through keywords whose values are themselves schemas. This
+    // avoids rewriting arbitrary JSON objects in `default` or `examples`.
+    for key in [
+        "properties",
+        "patternProperties",
+        "$defs",
+        "definitions",
+        "dependentSchemas",
+        "dependencies",
+    ] {
+        if let Some(children) = obj.get_mut(key).and_then(Value::as_object_mut) {
+            for child in children.values_mut() {
+                sanitize_parameter_schema_value(child, false);
             }
         }
     }
-    params
+
+    for key in [
+        "items",
+        "additionalItems",
+        "contains",
+        "propertyNames",
+        "additionalProperties",
+        "unevaluatedItems",
+        "unevaluatedProperties",
+        "contentSchema",
+        "not",
+        "if",
+        "then",
+        "else",
+    ] {
+        if let Some(child) = obj.get_mut(key) {
+            sanitize_parameter_schema_value(child, false);
+        }
+    }
+
+    for key in ["prefixItems", "allOf", "anyOf", "oneOf"] {
+        if let Some(children) = obj.get_mut(key).and_then(Value::as_array_mut) {
+            for child in children {
+                sanitize_parameter_schema_value(child, false);
+            }
+        }
+    }
+}
+
+fn sanitize_parameter_schema_value(value: &mut Value, is_root: bool) {
+    match value {
+        Value::Object(_) => sanitize_parameter_schema(value, is_root),
+        Value::Array(children) => {
+            for child in children {
+                sanitize_parameter_schema_value(child, false);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option<Value> {
@@ -1299,7 +1369,7 @@ fn responses_function_tool_to_chat_tool(tool: &Value, chat_name: &str) -> Option
             .get_mut("function")
             .and_then(|value| value.as_object_mut())
         {
-            // Ensure parameters.type is "object" for strict OpenAI-compatible providers
+            // Normalize parameters for strict OpenAI-compatible providers.
             let parameters = normalize_function_parameters(obj.get("parameters"));
             obj.insert("parameters".to_string(), parameters);
 
@@ -2400,6 +2470,171 @@ mod tests {
         assert_eq!(parameters["type"], "object");
         assert_eq!(parameters["properties"]["query"]["type"], "string");
         assert_eq!(parameters["required"], json!(["query"]));
+    }
+
+    #[test]
+    fn responses_request_to_chat_normalizes_null_required_and_preserves_closed_schema() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "search",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": null,
+                    "additionalProperties": false
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let parameters = &result["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["required"], json!([]));
+        assert_eq!(parameters["additionalProperties"], json!(false));
+        assert_eq!(parameters["properties"]["query"]["type"], json!("string"));
+    }
+
+    #[test]
+    fn responses_request_to_chat_adds_required_for_closed_nested_schemas() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "inspect",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "options": {
+                            "type": "object",
+                            "properties": {"verbose": {"type": "boolean"}},
+                            "additionalProperties": false
+                        },
+                        "entries": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {"id": {"type": "string"}},
+                                "required": null,
+                                "additionalProperties": false
+                            }
+                        }
+                    },
+                    "required": ["options", "entries"]
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let parameters = &result["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["properties"]["options"]["required"], json!([]));
+        assert_eq!(
+            parameters["properties"]["options"]["additionalProperties"],
+            json!(false)
+        );
+        assert_eq!(
+            parameters["properties"]["entries"]["items"]["required"],
+            json!([])
+        );
+        assert_eq!(
+            parameters["properties"]["entries"]["items"]["additionalProperties"],
+            json!(false)
+        );
+    }
+
+    #[test]
+    fn responses_request_to_chat_sanitizes_schema_combinators_and_defs() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "choose",
+                "parameters": {
+                    "type": "object",
+                    "oneOf": [{
+                        "type": "object",
+                        "required": null,
+                        "additionalProperties": false
+                    }],
+                    "$defs": {
+                        "payload": {
+                            "type": "object",
+                            "required": null,
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        let parameters = &result["tools"][0]["function"]["parameters"];
+
+        assert_eq!(parameters["oneOf"][0]["required"], json!([]));
+        assert_eq!(parameters["oneOf"][0]["additionalProperties"], json!(false));
+        assert_eq!(parameters["$defs"]["payload"]["required"], json!([]));
+        assert_eq!(
+            parameters["$defs"]["payload"]["additionalProperties"],
+            json!(false)
+        );
+    }
+
+    #[test]
+    fn responses_request_to_chat_preserves_valid_and_unconstrained_schemas() {
+        let input = json!({
+            "model": "gpt-5.4",
+            "tools": [{
+                "type": "function",
+                "name": "lookup",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "default": {"required": null}
+                        }
+                    },
+                    "required": ["query"],
+                    "additionalProperties": false
+                }
+            }, {
+                "type": "function",
+                "name": "open_lookup",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}}
+                }
+            }],
+            "input": "hi"
+        });
+
+        let result = responses_to_chat_completions(input).unwrap();
+        assert_eq!(
+            result["tools"][0]["function"]["parameters"],
+            json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "default": {"required": null}
+                    }
+                },
+                "required": ["query"],
+                "additionalProperties": false
+            })
+        );
+        assert_eq!(
+            result["tools"][1]["function"]["parameters"],
+            json!({
+                "type": "object",
+                "properties": {"query": {"type": "string"}}
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

Fix Codex built-in MCP resource tools failing on strict OpenAI-compatible upstreams.

修复 Codex 内置 MCP 资源工具在严格 OpenAI 兼容上游中请求失败的问题。

Codex CLI 0.150.0-alpha.8 may emit `required: null` in tool schemas. The Responses-to-Chat-Completions bridge now recursively normalizes invalid or missing `required` values to an empty array, while preserving `additionalProperties: false` and leaving valid schemas unchanged.

Codex CLI 0.150.0-alpha.8 可能在工具 Schema 中生成 `required: null`。本修改在 Responses 到 Chat Completions 的转换过程中递归修正非法或缺失的 `required` 字段，同时保留 `additionalProperties: false`，不修改原本合法的 Schema。

No frontend or user-facing text was changed.
未修改前端和用户可见文本。

## Related Issue / 关联 Issue

Fixes #7019

## Screenshots / 截图

Not applicable. This is a backend proxy/schema transformation fix.
不适用。本 PR 仅修改后端代理中的 Schema 转换逻辑。

## Validation / 验证

- Related conversion tests: 62 passed
- Full Rust library tests: 2749 passed, 0 failed, 5 ignored
- `cargo fmt --check`: passed
- `cargo clippy --all-targets -- -D warnings`: passed
- `git diff --check`: passed

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查（未运行，本次仅修改 Rust 后端）
- [ ] `pnpm format:check` passes / 通过代码格式检查（未运行，本次仅修改 Rust 后端）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查
- [x] Updated i18n files if user-facing text changed / 未修改用户可见文本，国际化不适用