### PR TITLE
fix(proxy): enable parallel tool calls for Codex OAuth

### DIFF
--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -1937,6 +1937,13 @@ pub fn anthropic_to_responses(
     if let Some(v) = body.get("tool_choice") {
         result["tool_choice"] =
             map_tool_choice_to_responses(v, &hosted_web_search_names, is_codex_oauth);
+        if is_codex_oauth {
+            if let Some(disable_parallel) =
+                v.get("disable_parallel_tool_use").and_then(Value::as_bool)
+            {
+                result["parallel_tool_calls"] = json!(!disable_parallel);
+            }
+        }
     }
 
     const WEB_SEARCH_SOURCES_MARKER: &str = "web_search_call.action.sources";
@@ -2007,8 +2014,10 @@ pub fn anthropic_to_responses(
             // —— 兜底必填字段（or_insert：客户端送了什么就保留，否则注入默认值）——
             obj.entry("instructions".to_string()).or_insert(json!(""));
             obj.entry("tools".to_string()).or_insert(json!([]));
+            // Anthropic 默认允许并行工具调用。优先保留上方已转换的显式设置，
+            // 否则允许支持该能力的 Codex 模型在同一响应中批量调用独立工具。
             obj.entry("parallel_tool_calls".to_string())
-                .or_insert(json!(false));
+                .or_insert(json!(true));
 
             // —— 强制覆盖 stream = true ——
             // 即便客户端误传 stream:false 也要覆盖，因为 codex-rs 永远 true，
@@ -5065,10 +5074,53 @@ mod tests {
         assert_eq!(result["tools"], json!([]), "tools 缺失时应兜底为空数组");
         assert_eq!(
             result["parallel_tool_calls"],
-            json!(false),
-            "parallel_tool_calls 应兜底为 false"
+            json!(true),
+            "parallel_tool_calls 应默认允许并行工具调用"
         );
         assert_eq!(result["stream"], json!(true), "stream 应被强制设为 true");
+    }
+
+    #[test]
+    fn test_codex_oauth_maps_anthropic_parallel_tool_choice() {
+        let enabled = anthropic_to_responses(
+            json!({
+                "model": "gpt-5.6-sol",
+                "tools": [{
+                    "name": "read_file",
+                    "input_schema": {"type": "object"}
+                }],
+                "tool_choice": {
+                    "type": "auto",
+                    "disable_parallel_tool_use": false
+                },
+                "messages": [{"role": "user", "content": "Read both files"}]
+            }),
+            None,
+            true,
+            true,
+        )
+        .unwrap();
+        assert_eq!(enabled["parallel_tool_calls"], json!(true));
+
+        let disabled = anthropic_to_responses(
+            json!({
+                "model": "gpt-5.6-sol",
+                "tools": [{
+                    "name": "read_file",
+                    "input_schema": {"type": "object"}
+                }],
+                "tool_choice": {
+                    "type": "auto",
+                    "disable_parallel_tool_use": true
+                },
+                "messages": [{"role": "user", "content": "Read one file"}]
+            }),
+            None,
+            true,
+            true,
+        )
+        .unwrap();
+        assert_eq!(disabled["parallel_tool_calls"], json!(false));
     }
 
     #[test]
@@ -5147,6 +5199,10 @@ mod tests {
         let input = json!({
             "model": "gpt-5-codex",
             "max_tokens": 1024,
+            "tool_choice": {
+                "type": "auto",
+                "disable_parallel_tool_use": false
+            },
             "messages": [{"role": "user", "content": "Hello"}]
         });
 


### PR DESCRIPTION
## Summary

Enable parallel tool calls for Claude Code requests routed through the Codex OAuth Responses backend.

Codex OAuth requests currently default `parallel_tool_calls` to `false` when the incoming Anthropic request does not contain an OpenAI-specific value. This forces independent Claude Code tools into separate model turns, increasing request round trips, latency, and repeated context processing.

This PR:

- changes the Codex OAuth default to `parallel_tool_calls: true`;
- maps Anthropic `tool_choice.disable_parallel_tool_use` to the inverse Responses API value;
- preserves explicit serial execution when `disable_parallel_tool_use: true`;
- updates the existing required-fields regression test;
- adds coverage for explicit parallel enable/disable mapping.

The change is limited to the Codex OAuth request conversion path. Non-Codex Responses providers retain their existing behavior.

This carries #5722 forward on top of the latest `main` and resolves its merge conflict. Credit for the original implementation is preserved through the commit's `Co-authored-by` trailer.

## Related Issue

Fixes #5719

Related PR: #5722

## Scope

Modified file:

- `src-tauri/src/proxy/providers/transform_responses.rs`

No changes were made to:

- frontend or i18n;
- provider configuration or database schema;
- authentication;
- model mapping;
- non-Codex Responses providers;
- Responses-to-Anthropic streaming conversion.

The current `main` branch already contains `test_streaming_conversion_interleaved_tool_deltas_by_item_id`, which verifies that interleaved parallel function-call deltas retain independent call IDs, arguments, and content-block indexes.

## Validation

Passed:

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit`
  - 135 test files passed
  - 1,071 tests passed
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml test_codex_oauth_maps_anthropic_parallel_tool_choice --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml test_codex_oauth_defaults_required_fields_when_absent --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml test_streaming_conversion_interleaved_tool_deltas_by_item_id --lib`
- `cargo test --manifest-path src-tauri/Cargo.toml 'proxy::providers::transform_responses::tests' --lib`
  - 116 tests passed
  - 0 tests failed
- `git diff --check`

A live Codex OAuth proxy A/B test was intentionally not run to avoid disrupting an active local CC Switch instance.

## Screenshots

Not applicable. This PR has no UI changes.

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `cargo clippy` passes
- [x] Updated i18n files if user-facing text changed
  - Not applicable: no user-facing text changed
