### PR TITLE
fix(proxy): refresh HTTP client when macOS system proxy configuration changes

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -801,6 +801,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "sys-locale",
+ "system-configuration",
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -106,6 +106,8 @@ rquickjs = { version = "0.8", features = ["bindgen"] }
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5"
 objc2-app-kit = { version = "0.2", features = ["NSColor"] }
+# 读取 macOS 系统代理（SCDynamicStore），用于全局 HTTP 客户端跟随系统代理变化
+system-configuration = "0.7"
 
 # Optimize release binary size to help reduce AppImage footprint
 [profile.release]

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -142,6 +142,7 @@ pub fn apply_proxy(proxy_url: Option<&str>) -> Result<(), String> {
         })?;
         *url = effective_url.map(|s| s.to_string());
     }
+    record_baked_system_proxy(effective_url);
 
     log::info!(
         "[GlobalProxy] Applied: {}",
@@ -247,7 +248,13 @@ fn record_baked_system_proxy(explicit_url: Option<&str>) {
 /// 节流地检查"跟随系统代理"的解析结果是否变化，变化则重建全局客户端
 ///
 /// 仅在未配置显式代理时生效；显式代理由用户管理，不参与自动刷新。
+/// 平台边界：变化检测只服务 macOS 的死本机代理旁路（见 [`build_client`]），
+/// 其余平台维持原有行为，不做周期性解析。
 fn refresh_system_proxy_if_changed() {
+    if !cfg!(target_os = "macos") {
+        return;
+    }
+
     // 显式用户代理生效时，跳过自动刷新
     if get_current_proxy_url().is_some() {
         return;
@@ -296,12 +303,12 @@ fn refresh_system_proxy_if_changed() {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "macos"))]
 fn system_proxy_rebuild_count() -> u64 {
     SYSTEM_PROXY_REBUILD_COUNT.load(Ordering::Relaxed)
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "macos"))]
 fn reset_system_proxy_check_throttle() {
     LAST_SYSTEM_PROXY_CHECK_MS.store(0, Ordering::Relaxed);
 }
@@ -819,7 +826,7 @@ mod tests {
         // 环境变量指向存活端口：应保留该代理
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
-        std::env::set_var("HTTPS_PROXY", &format!("http://127.0.0.1:{port}"));
+        std::env::set_var("HTTPS_PROXY", format!("http://127.0.0.1:{port}"));
         assert_eq!(
             current_effective_system_proxy(),
             Some(format!("http://127.0.0.1:{port}"))
@@ -831,6 +838,7 @@ mod tests {
     }
 
     /// 初始化全局客户端并强制刷新系统代理快照（消除 init 路径差异）
+    #[cfg(target_os = "macos")]
     fn setup_global_client_with_current_snapshot() {
         if GLOBAL_CLIENT.get().is_none() {
             let _ = init(None);
@@ -838,6 +846,7 @@ mod tests {
         record_baked_system_proxy(None);
     }
 
+    #[cfg(target_os = "macos")]
     fn clear_proxy_env() {
         for key in [
             "HTTP_PROXY",
@@ -851,15 +860,17 @@ mod tests {
         }
     }
 
+    // 变化检测与重建行为是 macOS 专属（其余平台 refresh 为 no-op）
     #[test]
     #[serial_test::serial]
+    #[cfg(target_os = "macos")]
     fn test_no_rebuild_when_system_proxy_unchanged() {
         let _guard = env_lock().lock().unwrap();
         clear_proxy_env();
 
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
-        std::env::set_var("HTTPS_PROXY", &format!("http://127.0.0.1:{port}"));
+        std::env::set_var("HTTPS_PROXY", format!("http://127.0.0.1:{port}"));
 
         setup_global_client_with_current_snapshot();
         let before = system_proxy_rebuild_count();
@@ -881,6 +892,7 @@ mod tests {
 
     #[test]
     #[serial_test::serial]
+    #[cfg(target_os = "macos")]
     fn test_rebuild_once_when_system_proxy_dies() {
         let _guard = env_lock().lock().unwrap();
         clear_proxy_env();
@@ -888,7 +900,7 @@ mod tests {
         // 代理存活时初始化快照，随后关掉监听模拟代理工具退出
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
-        std::env::set_var("HTTPS_PROXY", &format!("http://127.0.0.1:{port}"));
+        std::env::set_var("HTTPS_PROXY", format!("http://127.0.0.1:{port}"));
 
         setup_global_client_with_current_snapshot();
         let before = system_proxy_rebuild_count();

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -285,32 +285,23 @@ fn refresh_system_proxy_if_changed() {
     }
 }
 
-/// 解析当前"跟随系统代理"应使用的代理 URL（已过滤失效的本机代理）
-///
-/// 优先级：环境变量（HTTPS_PROXY > HTTP_PROXY > ALL_PROXY）→ macOS 系统代理
-/// （SCDynamicStore，HTTPS 优先于 HTTP）。解析结果若指向本机 loopback 且端口
-/// 无进程监听（代理工具已退出/切换为 TUN 模式），视为无代理（直连），避免
-/// 客户端把请求持续发往失效代理导致所有查询瞬间失败。
-fn current_effective_system_proxy() -> Option<String> {
-    let candidate = env_system_proxy_url()
+/// 原始解析"跟随系统代理"的目标：环境变量 → macOS 系统代理（不做存活判定）
+fn raw_system_proxy_url() -> Option<String> {
+    env_system_proxy_url()
         .or_else(macos_system_proxy_url)
         .map(|url| url.trim().to_string())
-        .filter(|url| !url.is_empty());
+        .filter(|url| !url.is_empty())
+}
 
-    match candidate {
-        Some(url) => {
-            if proxy_url_is_loopback(&url) && !loopback_proxy_listening(&url) {
-                log::warn!(
-                    "[GlobalProxy] System proxy {} points to a local port with no listener, bypassing to direct connection",
-                    mask_url(&url)
-                );
-                None
-            } else {
-                Some(url)
-            }
-        }
-        None => None,
-    }
+/// 解析当前"跟随系统代理"的有效结果（已过滤失效的本机代理）
+///
+/// 在 [`raw_system_proxy_url`] 基础上做存活判定：解析结果若指向本机 loopback
+/// 且端口无进程监听（代理工具已退出/切换为 TUN 模式），视为无代理（直连），
+/// 避免客户端把请求持续发往失效代理导致所有查询瞬间失败。该结果同时用作
+/// 变化检测的签名（见 [`refresh_system_proxy_if_changed`]）。
+fn current_effective_system_proxy() -> Option<String> {
+    raw_system_proxy_url()
+        .filter(|url| !proxy_url_is_loopback(url) || loopback_proxy_listening(url))
 }
 
 /// 从环境变量解析代理 URL（与 hyper-util 的优先级对齐：HTTPS > HTTP > ALL）
@@ -501,32 +492,25 @@ fn build_client(proxy_url: Option<&str>) -> Result<Client, String> {
         // 未设置全局代理时，跟随系统代理。reqwest 内建的自动跟随只在客户端
         // 构建时读取一次系统状态：应用启动后系统代理关闭/切换（代理工具退出、
         // 转为 TUN 模式）会让客户端永远把请求发往失效代理，所有用量查询瞬间
-        // 失败且只能靠重启恢复。因此 macOS 上改为显式解析 + 死本机代理旁路 +
-        // 运行时跟随变化（见 get()），不再交给 reqwest 自动烘焙。
+        // 失败且只能靠重启恢复。因此 macOS 上额外做两件事（其余平台行为不变）：
+        //   1) 构建时若解析出的系统代理指向本机已无监听的端口，旁路为直连；
+        //   2) get() 中节流地检测解析结果变化并按需重建（见 refresh_system_proxy_if_changed）。
+        // 代理存活时仍完全交给 reqwest 自动跟随（语义忠实：分协议、NO_PROXY 等）。
         if system_proxy_points_to_loopback() {
             builder = builder.no_proxy();
             log::warn!(
                 "[GlobalProxy] System proxy points to localhost, bypassing to avoid recursion"
             );
         } else if cfg!(target_os = "macos") {
-            // 禁用 reqwest 的自动系统代理，改用我们自己解析的结果
-            builder = builder.no_proxy();
-            if let Some(proxy_url) = current_effective_system_proxy() {
-                match reqwest::Proxy::all(&proxy_url) {
-                    Ok(proxy) => {
-                        builder = builder.proxy(proxy);
-                        log::debug!(
-                            "[GlobalProxy] Following system proxy: {}",
-                            mask_url(&proxy_url)
-                        );
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "[GlobalProxy] Invalid system proxy {}: {e}, using direct connection",
-                            mask_url(&proxy_url)
-                        );
-                    }
-                }
+            let raw = raw_system_proxy_url();
+            if let Some(dead_url) =
+                raw.filter(|url| proxy_url_is_loopback(url) && !loopback_proxy_listening(url))
+            {
+                builder = builder.no_proxy();
+                log::warn!(
+                    "[GlobalProxy] System proxy {} points to a local port with no listener, bypassing to direct connection",
+                    mask_url(&dead_url)
+                );
             }
         } else {
             log::debug!("[GlobalProxy] Following system proxy (no explicit proxy configured)");

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -383,6 +383,8 @@ fn commit_system_refresh(
 
 /// 读取"跟随系统代理"的结构化解析结果（环境变量优先，系统配置填空）
 fn read_system_proxy_snapshot() -> SystemProxySnapshot {
+    // mut 仅在下方 macOS cfg 块中使用，其他平台不触发 unused_mut
+    #[allow(unused_mut)]
     let mut snapshot = env_system_proxy_snapshot();
 
     // macOS 系统配置只填补环境变量仍为空的协议槽（与 hyper-util 的

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -24,6 +24,9 @@ static CC_SWITCH_PROXY_PORT: OnceCell<RwLock<u16>> = OnceCell::new();
 /// 显式用户代理生效时该值无意义（刷新逻辑会让位于用户设置）。
 static BAKED_SYSTEM_PROXY: OnceCell<RwLock<Option<String>>> = OnceCell::new();
 
+/// 客户端因系统代理变化而重建的次数（诊断与回归测试用）
+static SYSTEM_PROXY_REBUILD_COUNT: AtomicU64 = AtomicU64::new(0);
+
 /// 上次检查系统代理变化的时间戳（毫秒），用于节流
 static LAST_SYSTEM_PROXY_CHECK_MS: AtomicU64 = AtomicU64::new(0);
 
@@ -201,16 +204,32 @@ pub fn update_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 /// 未配置显式代理时（macOS），会节流地检测系统代理变化并按需重建客户端，
 /// 避免应用启动后系统代理关闭/切换导致请求持续打到失效代理上。
 pub fn get() -> Client {
-    if let Some(client) = GLOBAL_CLIENT
+    // 先做节流的变化检测再取客户端：若系统代理已变化，本次调用就直接拿到
+    // 重建后的客户端，而不是把旧客户端（可能仍指向失效代理）多返回一次。
+    refresh_system_proxy_if_changed();
+
+    GLOBAL_CLIENT
         .get()
         .and_then(|lock| lock.read().ok())
         .map(|c| c.clone())
-    {
-        refresh_system_proxy_if_changed();
-        return client;
+        .unwrap_or_else(|| {
+            log::warn!("[GlobalProxy] [GP-004] Client not initialized, using fallback");
+            build_client(None).unwrap_or_default()
+        })
+}
+
+/// 写入"当前客户端所采用的系统代理解析结果"快照（未初始化则初始化）
+fn store_baked_system_proxy(baked: Option<String>) {
+    match BAKED_SYSTEM_PROXY.get() {
+        Some(lock) => {
+            if let Ok(mut baked_lock) = lock.write() {
+                *baked_lock = baked;
+            }
+        }
+        None => {
+            let _ = BAKED_SYSTEM_PROXY.set(RwLock::new(baked));
+        }
     }
-    log::warn!("[GlobalProxy] [GP-004] Client not initialized, using fallback");
-    build_client(None).unwrap_or_default()
 }
 
 /// 记录当前全局客户端所采用的系统代理解析结果
@@ -222,11 +241,7 @@ fn record_baked_system_proxy(explicit_url: Option<&str>) {
     } else {
         current_effective_system_proxy()
     };
-    if let Some(lock) = BAKED_SYSTEM_PROXY.get() {
-        if let Ok(mut baked_lock) = lock.write() {
-            *baked_lock = baked;
-        }
-    }
+    store_baked_system_proxy(baked);
 }
 
 /// 节流地检查"跟随系统代理"的解析结果是否变化，变化则重建全局客户端
@@ -252,8 +267,7 @@ fn refresh_system_proxy_if_changed() {
     let baked = BAKED_SYSTEM_PROXY
         .get()
         .and_then(|lock| lock.read().ok())
-        .map(|b| b.clone())
-        .unwrap_or_default();
+        .and_then(|b| b.clone());
     if current == baked {
         return;
     }
@@ -264,11 +278,8 @@ fn refresh_system_proxy_if_changed() {
             if let Some(lock) = GLOBAL_CLIENT.get() {
                 if let Ok(mut client) = lock.write() {
                     *client = new_client;
-                    if let Some(baked_lock) = BAKED_SYSTEM_PROXY.get() {
-                        if let Ok(mut baked) = baked_lock.write() {
-                            *baked = current.clone();
-                        }
-                    }
+                    store_baked_system_proxy(current.clone());
+                    SYSTEM_PROXY_REBUILD_COUNT.fetch_add(1, Ordering::Relaxed);
                     log::info!(
                         "[GlobalProxy] System proxy changed, rebuilt client: {}",
                         current
@@ -283,6 +294,16 @@ fn refresh_system_proxy_if_changed() {
             log::warn!("[GlobalProxy] Failed to rebuild client after system proxy change: {e}")
         }
     }
+}
+
+#[cfg(test)]
+fn system_proxy_rebuild_count() -> u64 {
+    SYSTEM_PROXY_REBUILD_COUNT.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+fn reset_system_proxy_check_throttle() {
+    LAST_SYSTEM_PROXY_CHECK_MS.store(0, Ordering::Relaxed);
 }
 
 /// 原始解析"跟随系统代理"的目标：环境变量 → macOS 系统代理（不做存活判定）
@@ -807,5 +828,90 @@ mod tests {
         for key in &keys {
             std::env::remove_var(key);
         }
+    }
+
+    /// 初始化全局客户端并强制刷新系统代理快照（消除 init 路径差异）
+    fn setup_global_client_with_current_snapshot() {
+        if GLOBAL_CLIENT.get().is_none() {
+            let _ = init(None);
+        }
+        record_baked_system_proxy(None);
+    }
+
+    fn clear_proxy_env() {
+        for key in [
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+        ] {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_no_rebuild_when_system_proxy_unchanged() {
+        let _guard = env_lock().lock().unwrap();
+        clear_proxy_env();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::env::set_var("HTTPS_PROXY", &format!("http://127.0.0.1:{port}"));
+
+        setup_global_client_with_current_snapshot();
+        let before = system_proxy_rebuild_count();
+
+        // 代理解析结果未变化：多次触发检测都不应重建客户端
+        // （回归防护：若快照未正确写入/读取，这里每次都会误判为变化）
+        for _ in 0..3 {
+            reset_system_proxy_check_throttle();
+            refresh_system_proxy_if_changed();
+            assert_eq!(
+                system_proxy_rebuild_count(),
+                before,
+                "unchanged system proxy must not trigger client rebuild"
+            );
+        }
+
+        clear_proxy_env();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_rebuild_once_when_system_proxy_dies() {
+        let _guard = env_lock().lock().unwrap();
+        clear_proxy_env();
+
+        // 代理存活时初始化快照，随后关掉监听模拟代理工具退出
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::env::set_var("HTTPS_PROXY", &format!("http://127.0.0.1:{port}"));
+
+        setup_global_client_with_current_snapshot();
+        let before = system_proxy_rebuild_count();
+
+        drop(listener);
+        reset_system_proxy_check_throttle();
+        refresh_system_proxy_if_changed();
+        let after_death = system_proxy_rebuild_count();
+        assert_eq!(
+            after_death,
+            before + 1,
+            "system proxy dying must trigger exactly one rebuild"
+        );
+
+        // 代理保持死亡：后续检测不应再次重建
+        reset_system_proxy_check_throttle();
+        refresh_system_proxy_if_changed();
+        assert_eq!(
+            system_proxy_rebuild_count(),
+            after_death,
+            "keep-direct state must not rebuild repeatedly"
+        );
+
+        clear_proxy_env();
     }
 }

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -26,12 +26,18 @@ static CC_SWITCH_PROXY_PORT: OnceCell<RwLock<u16>> = OnceCell::new();
 /// 单个 `Option<String>` 无法表达这些语义：HTTPS 不变、仅 HTTP 变化，或仅
 /// NO_PROXY 变化时，单 URL 签名都看不见。快照按 hyper-util 的规则构造
 /// （环境变量优先，macOS 系统配置只填补仍为空的协议槽），用作变化检测签名。
+///
+/// macOS 上 reqwest 还把系统代理的 bypass 规则（ExceptionsList 与
+/// ExcludeSimpleHostnames）烘焙进客户端，因此快照以 `system_bypass` 记录
+/// 其规范化签名；仅改 bypass 列表时端点槽不变，没有这个字段就检测不到。
+/// 非 macOS 恒为 `None`。
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 struct SystemProxySnapshot {
     http: Option<String>,
     https: Option<String>,
     all: Option<String>,
     no_proxy: Option<String>,
+    system_bypass: Option<String>,
 }
 
 /// 当前全局客户端烘焙时的系统代理快照；`None` 表示显式代理生效
@@ -331,11 +337,12 @@ fn refresh_system_proxy_if_changed() {
         }
     };
     log::info!(
-        "[GlobalProxy] System proxy configuration changed, rebuilt client (http={:?}, https={:?}, all={:?}, no_proxy={:?})",
+        "[GlobalProxy] System proxy configuration changed, rebuilt client (http={:?}, https={:?}, all={:?}, no_proxy={:?}, bypass={:?})",
         current.http.as_deref().map(mask_url),
         current.https.as_deref().map(mask_url),
         current.all.as_deref().map(mask_url),
-        current.no_proxy.is_some()
+        current.no_proxy.is_some(),
+        current.system_bypass
     );
     if commit_system_refresh(new_client, seen_generation, previous, current) {
         SYSTEM_PROXY_REBUILD_COUNT.fetch_add(1, Ordering::Relaxed);
@@ -391,13 +398,17 @@ fn read_system_proxy_snapshot() -> SystemProxySnapshot {
     // "环境变量优先、系统配置补缺"顺序一致）
     #[cfg(target_os = "macos")]
     {
-        let (system_http, system_https) = macos_system_proxy_entries();
+        let (system_http, system_https, system_bypass) = macos_system_proxy_state();
         if snapshot.https.is_none() {
             snapshot.https = system_https;
         }
         if snapshot.http.is_none() {
             snapshot.http = system_http;
         }
+        // bypass 规则恒记录：它与 NO_PROXY 环境变量在 reqwest 里是独立的
+        // 匹配层，没有"环境变量存在则系统 bypass 无效"的可靠结论。多记的
+        // 代价最多是一次幂等的重建，漏记的代价是旧 bypass 规则驻留。
+        snapshot.system_bypass = system_bypass;
     }
 
     snapshot
@@ -419,19 +430,21 @@ fn env_system_proxy_snapshot() -> SystemProxySnapshot {
         https: env_group(&["HTTPS_PROXY", "https_proxy"]),
         all: env_group(&["ALL_PROXY", "all_proxy"]),
         no_proxy: env_group(&["NO_PROXY", "no_proxy"]),
+        system_bypass: None,
     }
 }
 
 /// macOS 系统代理的分协议条目（SCDynamicStore，与 reqwest/hyper-util 的
-/// 数据源一致），返回 (http, https)
+/// 数据源一致），返回 (http, https, bypass 签名)
 #[cfg(target_os = "macos")]
-fn macos_system_proxy_entries() -> (Option<String>, Option<String>) {
+fn macos_system_proxy_state() -> (Option<String>, Option<String>, Option<String>) {
     use system_configuration::core_foundation::base::CFType;
     use system_configuration::core_foundation::dictionary::CFDictionary;
     use system_configuration::core_foundation::number::CFNumber;
     use system_configuration::core_foundation::string::{CFString, CFStringRef};
     use system_configuration::dynamic_store::SCDynamicStoreBuilder;
     use system_configuration::sys::schema_definitions::{
+        kSCPropNetProxiesExceptionsList, kSCPropNetProxiesExcludeSimpleHostnames,
         kSCPropNetProxiesHTTPEnable, kSCPropNetProxiesHTTPPort, kSCPropNetProxiesHTTPProxy,
         kSCPropNetProxiesHTTPSEnable, kSCPropNetProxiesHTTPSPort, kSCPropNetProxiesHTTPSProxy,
     };
@@ -462,7 +475,34 @@ fn macos_system_proxy_entries() -> (Option<String>, Option<String>) {
         Some(format_proxy_entry(&host, port))
     }
 
-    fn read_entries() -> Option<(Option<String>, Option<String>)> {
+    /// ExceptionsList（CFArray<CFString>）+ ExcludeSimpleHostnames 的规范化
+    /// 签名。crate 的 `CFType::downcast` 只支持 `CFArray<*const c_void>`，
+    /// 元素再按 CFStringRef 逐个还原。
+    fn read_bypass(proxies_map: &CFDictionary<CFString, CFType>) -> Option<String> {
+        use system_configuration::core_foundation::array::CFArray;
+        use system_configuration::core_foundation::base::TCFType;
+        let exceptions: Vec<String> = proxies_map
+            .find(unsafe { kSCPropNetProxiesExceptionsList })
+            .and_then(|value| value.downcast::<CFArray<*const std::ffi::c_void>>())
+            .map(|array| {
+                array
+                    .iter()
+                    .map(|entry| unsafe {
+                        CFString::wrap_under_get_rule(*entry as CFStringRef).to_string()
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let exclude_simple_hostnames = proxies_map
+            .find(unsafe { kSCPropNetProxiesExcludeSimpleHostnames })
+            .and_then(|flag| flag.downcast::<CFNumber>())
+            .and_then(|flag| flag.to_i32())
+            .unwrap_or(0)
+            == 1;
+        canonical_macos_bypass(exceptions, exclude_simple_hostnames)
+    }
+
+    fn read_entries() -> Option<(Option<String>, Option<String>, Option<String>)> {
         let store = SCDynamicStoreBuilder::new("cc-switch").build()?;
         let proxies_map = store.get_proxies()?;
         Some((
@@ -478,11 +518,37 @@ fn macos_system_proxy_entries() -> (Option<String>, Option<String>) {
                 unsafe { kSCPropNetProxiesHTTPSProxy },
                 unsafe { kSCPropNetProxiesHTTPSPort },
             ),
+            read_bypass(&proxies_map),
         ))
     }
 
     // SCDynamicStore 读取失败时按"无系统代理"处理，交给环境变量与直连语义
-    read_entries().unwrap_or((None, None))
+    read_entries().unwrap_or((None, None, None))
+}
+
+/// bypass 配置的规范化签名：主机名比较不区分大小写，列表顺序无语义，
+/// 统一小写 + 排序去重，避免无语义变化（大小写调整、条目重排）触发重建。
+/// 两者都为空时返回 `None`（与"没有 bypass 规则"同义）。
+#[cfg(target_os = "macos")]
+fn canonical_macos_bypass(
+    exceptions: Vec<String>,
+    exclude_simple_hostnames: bool,
+) -> Option<String> {
+    let mut entries: Vec<String> = exceptions
+        .into_iter()
+        .map(|entry| entry.trim().to_lowercase())
+        .filter(|entry| !entry.is_empty())
+        .collect();
+    entries.sort();
+    entries.dedup();
+    if entries.is_empty() && !exclude_simple_hostnames {
+        return None;
+    }
+    Some(format!(
+        "exclude_simple_hostnames={};list={}",
+        u8::from(exclude_simple_hostnames),
+        entries.join(",")
+    ))
 }
 
 /// 把系统代理条目的 host:port 组装成 URL（裸 IPv6 地址补方括号）
@@ -780,6 +846,7 @@ mod tests {
                 https: Some("http://127.0.0.1:8899".to_string()),
                 all: Some("socks5://127.0.0.1:7801".to_string()),
                 no_proxy: Some("localhost,127.0.0.1".to_string()),
+                system_bypass: None,
             }
         );
 
@@ -829,6 +896,71 @@ mod tests {
         assert_ne!(read_system_proxy_snapshot(), before);
 
         clear_proxy_env();
+    }
+
+    #[test]
+    fn test_snapshot_detects_system_bypass_only_change() {
+        // macOS 用户只改 bypass/exception 列表、HTTP/HTTPS 端点不变时，
+        // reqwest 烘焙进客户端的匹配器已变；快照必须能看见（这是
+        // refresh_system_proxy_if_changed 里 `current == previous` 的判定
+        // 输入），否则客户端会一直沿用旧的 bypass 规则。
+        let endpoints = SystemProxySnapshot {
+            http: Some("http://127.0.0.1:7890".to_string()),
+            https: Some("http://127.0.0.1:7890".to_string()),
+            ..Default::default()
+        };
+        let with_exceptions = SystemProxySnapshot {
+            system_bypass: Some(
+                "exclude_simple_hostnames=0;list=*.internal,10.0.0.0/8".to_string(),
+            ),
+            ..endpoints.clone()
+        };
+        assert_ne!(endpoints, with_exceptions);
+
+        let changed_exceptions = SystemProxySnapshot {
+            system_bypass: Some("exclude_simple_hostnames=0;list=*.internal".to_string()),
+            ..endpoints.clone()
+        };
+        assert_ne!(with_exceptions, changed_exceptions);
+
+        // ExcludeSimpleHostnames 翻转同样是有效变化，即使列表为空。
+        let exclude_only = SystemProxySnapshot {
+            system_bypass: Some("exclude_simple_hostnames=1;list=".to_string()),
+            ..endpoints
+        };
+        assert_ne!(exclude_only, SystemProxySnapshot::default());
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_canonical_macos_bypass_normalizes_semantically_equal_lists() {
+        // 大小写、空白、顺序、重复项都不构成语义变化。
+        let normalized = canonical_macos_bypass(
+            vec![
+                "  *.Internal ".to_string(),
+                "10.0.0.0/8".to_string(),
+                "*.internal".to_string(),
+            ],
+            false,
+        );
+        assert_eq!(
+            normalized,
+            Some("exclude_simple_hostnames=0;list=*.internal,10.0.0.0/8".to_string())
+        );
+
+        // 无任何规则时为 None（与"没有 bypass"同义）。
+        assert_eq!(canonical_macos_bypass(vec![], false), None);
+        assert_eq!(
+            canonical_macos_bypass(vec!["  ".to_string()], false),
+            None,
+            "空白条目不构成规则"
+        );
+
+        // ExcludeSimpleHostnames 单独开启也是有效签名。
+        assert_eq!(
+            canonical_macos_bypass(vec![], true),
+            Some("exclude_simple_hostnames=1;list=".to_string())
+        );
     }
 
     /// 初始化全局客户端并烘焙当前快照（消除 init 路径差异）

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -84,10 +84,17 @@ fn get_proxy_port() -> u16 {
 ///   传入 None 或空字符串表示直连
 pub fn init(proxy_url: Option<&str>) -> Result<(), String> {
     let effective_url = proxy_url.filter(|s| !s.trim().is_empty());
+    // 与 apply_proxy 相同：先捕获快照再构建，构建期间的变化留待下一轮
+    // 刷新检测，不会把旧配置的 Client 标记成新配置。
+    let baked = if effective_url.is_some() {
+        None
+    } else {
+        Some(read_system_proxy_snapshot())
+    };
     let client = build_client(effective_url)?;
 
     // 尝试初始化全局客户端，如果已存在则记录警告并使用 apply_proxy 更新
-    if GLOBAL_CLIENT.set(RwLock::new(client.clone())).is_err() {
+    if GLOBAL_CLIENT.set(RwLock::new(client)).is_err() {
         log::warn!(
             "[GlobalProxy] [GP-003] Already initialized, updating instead: {}",
             effective_url
@@ -98,14 +105,10 @@ pub fn init(proxy_url: Option<&str>) -> Result<(), String> {
         return apply_proxy(proxy_url);
     }
 
-    // 初始化代理 URL 记录
+    // 初始化代理 URL 记录（OnceCell 首次写入，无并发切换窗口）
     let _ = CURRENT_PROXY_URL.set(RwLock::new(effective_url.map(|s| s.to_string())));
     STATE_GENERATION.fetch_add(1, Ordering::AcqRel);
-    store_baked_system_snapshot(if effective_url.is_some() {
-        None
-    } else {
-        Some(read_system_proxy_snapshot())
-    });
+    store_baked_system_snapshot(baked);
 
     log::info!(
         "[GlobalProxy] Initialized: {}",
@@ -143,36 +146,38 @@ pub fn validate_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 /// * `proxy_url` - 代理 URL，None 或空字符串表示直连
 pub fn apply_proxy(proxy_url: Option<&str>) -> Result<(), String> {
     let effective_url = proxy_url.filter(|s| !s.trim().is_empty());
+    // 先捕获快照再构建：若构建期间系统代理恰好变化，最多造成一次可检测的
+    // snapshot mismatch，下一轮刷新自动修正；反过来（先构建后读快照）会把
+    // 旧配置的 Client 标记成新配置，之后永远检测不到差异。
+    let baked = if effective_url.is_some() {
+        None
+    } else {
+        Some(read_system_proxy_snapshot())
+    };
     let new_client = build_client(effective_url)?;
 
-    // 更新客户端
+    // Client、CURRENT_PROXY_URL、snapshot 三份状态在同一个 GLOBAL_CLIENT
+    // 写锁临界区内切换（锁序与 commit_system_refresh 一致：
+    // GLOBAL_CLIENT → CURRENT_PROXY_URL → snapshot）。自动刷新的提交同样
+    // 需要先取得该写锁，无法插入到切换中间造成"记录为显式、Client 却跟随
+    // 系统"的错位；代数递增也放在临界区内，供已过期的刷新提交复核。
     if let Some(lock) = GLOBAL_CLIENT.get() {
-        // 先递增代数再写入：自动刷新若在此期间提交，会因代数不匹配而放弃，
-        // 不会覆盖刚应用的显式代理。
-        STATE_GENERATION.fetch_add(1, Ordering::AcqRel);
         let mut client = lock.write().map_err(|e| {
             log::error!("[GlobalProxy] [GP-001] Failed to acquire write lock: {e}");
             "Failed to update proxy: lock poisoned".to_string()
         })?;
+        STATE_GENERATION.fetch_add(1, Ordering::AcqRel);
         *client = new_client;
+        if let Some(url_lock) = CURRENT_PROXY_URL.get() {
+            if let Ok(mut url) = url_lock.write() {
+                *url = effective_url.map(|s| s.to_string());
+            }
+        }
+        store_baked_system_snapshot(baked);
     } else {
         // 如果还没初始化，则初始化
         return init(proxy_url);
     }
-
-    // 更新代理 URL 记录
-    if let Some(lock) = CURRENT_PROXY_URL.get() {
-        let mut url = lock.write().map_err(|e| {
-            log::error!("[GlobalProxy] [GP-002] Failed to acquire URL write lock: {e}");
-            "Failed to update proxy URL record: lock poisoned".to_string()
-        })?;
-        *url = effective_url.map(|s| s.to_string());
-    }
-    store_baked_system_snapshot(if effective_url.is_some() {
-        None
-    } else {
-        Some(read_system_proxy_snapshot())
-    });
 
     log::info!(
         "[GlobalProxy] Applied: {}",
@@ -195,34 +200,32 @@ pub fn apply_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 #[allow(dead_code)]
 pub fn update_proxy(proxy_url: Option<&str>) -> Result<(), String> {
     let effective_url = proxy_url.filter(|s| !s.trim().is_empty());
+    let baked = if effective_url.is_some() {
+        None
+    } else {
+        Some(read_system_proxy_snapshot())
+    };
     let new_client = build_client(effective_url)?;
 
-    // 更新客户端
+    // 与 apply_proxy 相同：三份状态在同一个 GLOBAL_CLIENT 写锁临界区内
+    // 切换，锁序与 commit_system_refresh 一致，刷新无法插入切换中间。
     if let Some(lock) = GLOBAL_CLIENT.get() {
-        STATE_GENERATION.fetch_add(1, Ordering::AcqRel);
         let mut client = lock.write().map_err(|e| {
             log::error!("[GlobalProxy] [GP-001] Failed to acquire write lock: {e}");
             "Failed to update proxy: lock poisoned".to_string()
         })?;
+        STATE_GENERATION.fetch_add(1, Ordering::AcqRel);
         *client = new_client;
+        if let Some(url_lock) = CURRENT_PROXY_URL.get() {
+            if let Ok(mut url) = url_lock.write() {
+                *url = effective_url.map(|s| s.to_string());
+            }
+        }
+        store_baked_system_snapshot(baked);
     } else {
         // 如果还没初始化，则初始化
         return init(proxy_url);
     }
-
-    // 更新代理 URL 记录
-    if let Some(lock) = CURRENT_PROXY_URL.get() {
-        let mut url = lock.write().map_err(|e| {
-            log::error!("[GlobalProxy] [GP-002] Failed to acquire URL write lock: {e}");
-            "Failed to update proxy URL record: lock poisoned".to_string()
-        })?;
-        *url = effective_url.map(|s| s.to_string());
-    }
-    store_baked_system_snapshot(if effective_url.is_some() {
-        None
-    } else {
-        Some(read_system_proxy_snapshot())
-    });
 
     log::info!(
         "[GlobalProxy] Updated: {}",
@@ -344,6 +347,11 @@ fn refresh_system_proxy_if_changed() {
 /// 提交前在写锁内校验：显式代理仍为空、状态代数未变、烘焙快照仍是检测时
 /// 的那份。任一不满足即放弃（例如用户在检测期间应用了显式代理，或另一路
 /// 刷新已经提交过），防止自动刷新覆盖用户设置或造成新旧状态错位。
+///
+/// 锁序契约：所有同时触碰 GLOBAL_CLIENT 与其余状态的路径（本函数与
+/// init/apply_proxy/update_proxy）都必须按 GLOBAL_CLIENT → CURRENT_PROXY_URL
+/// → BAKED_SYSTEM_SNAPSHOT 的顺序嵌套加锁，保证三份状态在同一个
+/// GLOBAL_CLIENT 写锁临界区内切换，刷新无法观察到"半切换"状态。
 fn commit_system_refresh(
     candidate: Client,
     seen_generation: u64,

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -7,6 +7,7 @@ use once_cell::sync::OnceCell;
 use reqwest::Client;
 use std::env;
 use std::net::IpAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 use std::time::Duration;
 
@@ -18,6 +19,16 @@ static CURRENT_PROXY_URL: OnceCell<RwLock<Option<String>>> = OnceCell::new();
 
 /// CC Switch 代理服务器当前监听的端口
 static CC_SWITCH_PROXY_PORT: OnceCell<RwLock<u16>> = OnceCell::new();
+
+/// 当前全局客户端所采用的"跟随系统代理"结果（None = 直连）。
+/// 显式用户代理生效时该值无意义（刷新逻辑会让位于用户设置）。
+static BAKED_SYSTEM_PROXY: OnceCell<RwLock<Option<String>>> = OnceCell::new();
+
+/// 上次检查系统代理变化的时间戳（毫秒），用于节流
+static LAST_SYSTEM_PROXY_CHECK_MS: AtomicU64 = AtomicU64::new(0);
+
+/// 跟随系统代理的变化检查间隔（毫秒）
+const SYSTEM_PROXY_RECHECK_INTERVAL_MS: u64 = 5000;
 
 /// 设置 CC Switch 代理服务器的监听端口
 ///
@@ -68,6 +79,7 @@ pub fn init(proxy_url: Option<&str>) -> Result<(), String> {
 
     // 初始化代理 URL 记录
     let _ = CURRENT_PROXY_URL.set(RwLock::new(effective_url.map(|s| s.to_string())));
+    record_baked_system_proxy(effective_url);
 
     log::info!(
         "[GlobalProxy] Initialized: {}",
@@ -171,6 +183,7 @@ pub fn update_proxy(proxy_url: Option<&str>) -> Result<(), String> {
         })?;
         *url = effective_url.map(|s| s.to_string());
     }
+    record_baked_system_proxy(effective_url);
 
     log::info!(
         "[GlobalProxy] Updated: {}",
@@ -185,15 +198,254 @@ pub fn update_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 /// 获取全局 HTTP 客户端
 ///
 /// 返回配置了代理的客户端（如果已配置代理），否则返回跟随系统代理的客户端。
+/// 未配置显式代理时（macOS），会节流地检测系统代理变化并按需重建客户端，
+/// 避免应用启动后系统代理关闭/切换导致请求持续打到失效代理上。
 pub fn get() -> Client {
-    GLOBAL_CLIENT
+    if let Some(client) = GLOBAL_CLIENT
         .get()
         .and_then(|lock| lock.read().ok())
         .map(|c| c.clone())
-        .unwrap_or_else(|| {
-            log::warn!("[GlobalProxy] [GP-004] Client not initialized, using fallback");
-            build_client(None).unwrap_or_default()
+    {
+        refresh_system_proxy_if_changed();
+        return client;
+    }
+    log::warn!("[GlobalProxy] [GP-004] Client not initialized, using fallback");
+    build_client(None).unwrap_or_default()
+}
+
+/// 记录当前全局客户端所采用的系统代理解析结果
+///
+/// 显式用户代理时无需记录（刷新逻辑让位于用户设置），传 `Some(_)` 即可。
+fn record_baked_system_proxy(explicit_url: Option<&str>) {
+    let baked = if explicit_url.is_some() {
+        None
+    } else {
+        current_effective_system_proxy()
+    };
+    if let Some(lock) = BAKED_SYSTEM_PROXY.get() {
+        if let Ok(mut baked_lock) = lock.write() {
+            *baked_lock = baked;
+        }
+    }
+}
+
+/// 节流地检查"跟随系统代理"的解析结果是否变化，变化则重建全局客户端
+///
+/// 仅在未配置显式代理时生效；显式代理由用户管理，不参与自动刷新。
+fn refresh_system_proxy_if_changed() {
+    // 显式用户代理生效时，跳过自动刷新
+    if get_current_proxy_url().is_some() {
+        return;
+    }
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let last = LAST_SYSTEM_PROXY_CHECK_MS.load(Ordering::Relaxed);
+    if now_ms.saturating_sub(last) < SYSTEM_PROXY_RECHECK_INTERVAL_MS {
+        return;
+    }
+    LAST_SYSTEM_PROXY_CHECK_MS.store(now_ms, Ordering::Relaxed);
+
+    let current = current_effective_system_proxy();
+    let baked = BAKED_SYSTEM_PROXY
+        .get()
+        .and_then(|lock| lock.read().ok())
+        .map(|b| b.clone())
+        .unwrap_or_default();
+    if current == baked {
+        return;
+    }
+
+    // 系统代理状态发生变化（开启/关闭/换端口/存活状态翻转），重建客户端
+    match build_client(None) {
+        Ok(new_client) => {
+            if let Some(lock) = GLOBAL_CLIENT.get() {
+                if let Ok(mut client) = lock.write() {
+                    *client = new_client;
+                    if let Some(baked_lock) = BAKED_SYSTEM_PROXY.get() {
+                        if let Ok(mut baked) = baked_lock.write() {
+                            *baked = current.clone();
+                        }
+                    }
+                    log::info!(
+                        "[GlobalProxy] System proxy changed, rebuilt client: {}",
+                        current
+                            .as_deref()
+                            .map(mask_url)
+                            .unwrap_or_else(|| "direct connection".to_string())
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            log::warn!("[GlobalProxy] Failed to rebuild client after system proxy change: {e}")
+        }
+    }
+}
+
+/// 解析当前"跟随系统代理"应使用的代理 URL（已过滤失效的本机代理）
+///
+/// 优先级：环境变量（HTTPS_PROXY > HTTP_PROXY > ALL_PROXY）→ macOS 系统代理
+/// （SCDynamicStore，HTTPS 优先于 HTTP）。解析结果若指向本机 loopback 且端口
+/// 无进程监听（代理工具已退出/切换为 TUN 模式），视为无代理（直连），避免
+/// 客户端把请求持续发往失效代理导致所有查询瞬间失败。
+fn current_effective_system_proxy() -> Option<String> {
+    let candidate = env_system_proxy_url()
+        .or_else(macos_system_proxy_url)
+        .map(|url| url.trim().to_string())
+        .filter(|url| !url.is_empty());
+
+    match candidate {
+        Some(url) => {
+            if proxy_url_is_loopback(&url) && !loopback_proxy_listening(&url) {
+                log::warn!(
+                    "[GlobalProxy] System proxy {} points to a local port with no listener, bypassing to direct connection",
+                    mask_url(&url)
+                );
+                None
+            } else {
+                Some(url)
+            }
+        }
+        None => None,
+    }
+}
+
+/// 从环境变量解析代理 URL（与 hyper-util 的优先级对齐：HTTPS > HTTP > ALL）
+fn env_system_proxy_url() -> Option<String> {
+    const KEY_GROUPS: [&[&str]; 3] = [
+        &["HTTPS_PROXY", "https_proxy"],
+        &["HTTP_PROXY", "http_proxy"],
+        &["ALL_PROXY", "all_proxy"],
+    ];
+    KEY_GROUPS.iter().find_map(|keys| {
+        keys.iter().find_map(|key| {
+            env::var(key)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
         })
+    })
+}
+
+/// 读取 macOS 系统代理（SCDynamicStore，与 reqwest/hyper-util 的数据源一致）
+#[cfg(target_os = "macos")]
+fn macos_system_proxy_url() -> Option<String> {
+    use system_configuration::core_foundation::base::CFType;
+    use system_configuration::core_foundation::dictionary::CFDictionary;
+    use system_configuration::core_foundation::number::CFNumber;
+    use system_configuration::core_foundation::string::{CFString, CFStringRef};
+    use system_configuration::dynamic_store::SCDynamicStoreBuilder;
+    use system_configuration::sys::schema_definitions::{
+        kSCPropNetProxiesHTTPEnable, kSCPropNetProxiesHTTPPort, kSCPropNetProxiesHTTPProxy,
+        kSCPropNetProxiesHTTPSEnable, kSCPropNetProxiesHTTPSPort, kSCPropNetProxiesHTTPSProxy,
+    };
+
+    fn read_entry(
+        proxies_map: &CFDictionary<CFString, CFType>,
+        enabled_key: CFStringRef,
+        host_key: CFStringRef,
+        port_key: CFStringRef,
+    ) -> Option<String> {
+        let enabled = proxies_map
+            .find(enabled_key)
+            .and_then(|flag| flag.downcast::<CFNumber>())
+            .and_then(|flag| flag.to_i32())
+            .unwrap_or(0)
+            == 1;
+        if !enabled {
+            return None;
+        }
+        let host = proxies_map
+            .find(host_key)
+            .and_then(|v| v.downcast::<CFString>())
+            .map(|v| v.to_string())?;
+        let port = proxies_map
+            .find(port_key)
+            .and_then(|v| v.downcast::<CFNumber>())
+            .and_then(|v| v.to_i32())?;
+        Some(format!("http://{host}:{port}"))
+    }
+
+    let store = SCDynamicStoreBuilder::new("cc-switch").build()?;
+    let proxies_map = store.get_proxies()?;
+    // HTTPS 代理优先：用量查询目标几乎全是 https 端点
+    read_entry(
+        &proxies_map,
+        unsafe { kSCPropNetProxiesHTTPSEnable },
+        unsafe { kSCPropNetProxiesHTTPSProxy },
+        unsafe { kSCPropNetProxiesHTTPSPort },
+    )
+    .or_else(|| {
+        read_entry(
+            &proxies_map,
+            unsafe { kSCPropNetProxiesHTTPEnable },
+            unsafe { kSCPropNetProxiesHTTPProxy },
+            unsafe { kSCPropNetProxiesHTTPPort },
+        )
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+fn macos_system_proxy_url() -> Option<String> {
+    None
+}
+
+/// 判断代理 URL 是否指向本机 loopback 地址
+fn proxy_url_is_loopback(url: &str) -> bool {
+    let parsed = url::Url::parse(url)
+        .ok()
+        .or_else(|| url::Url::parse(&format!("http://{url}")).ok());
+    parsed
+        .as_ref()
+        .and_then(|parsed| parsed.host_str())
+        .map(host_is_loopback)
+        .unwrap_or(false)
+}
+
+/// 探测 loopback 代理端口是否有进程监听
+///
+/// 仅对 loopback 地址做探测（连接为微秒级）；非 loopback 地址一律视为可用。
+fn loopback_proxy_listening(url: &str) -> bool {
+    use std::net::TcpStream;
+
+    let parsed = url::Url::parse(url)
+        .ok()
+        .or_else(|| url::Url::parse(&format!("http://{url}")).ok());
+    let Some(parsed) = parsed else {
+        return false;
+    };
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    if !host_is_loopback(host) {
+        return true;
+    }
+    let Some(port) = parsed.port_or_known_default() else {
+        return false;
+    };
+
+    use std::net::ToSocketAddrs;
+    let addrs = match (host, port).to_socket_addrs() {
+        Ok(addrs) => addrs.collect::<Vec<_>>(),
+        Err(_) => return false,
+    };
+    addrs
+        .iter()
+        .any(|addr| TcpStream::connect_timeout(addr, Duration::from_millis(300)).is_ok())
+}
+
+fn host_is_loopback(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    // url crate 对 IPv6 host 保留方括号（如 "[::1]"），解析前需剥掉
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    host.parse::<IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
 }
 
 /// 获取当前代理 URL
@@ -246,13 +498,36 @@ fn build_client(proxy_url: Option<&str>) -> Result<Client, String> {
         builder = builder.proxy(proxy);
         log::debug!("[GlobalProxy] Proxy configured: {}", mask_url(url));
     } else {
-        // 未设置全局代理时，让 reqwest 自动检测系统代理（环境变量）
-        // 若系统代理指向本机，禁用系统代理避免自环
+        // 未设置全局代理时，跟随系统代理。reqwest 内建的自动跟随只在客户端
+        // 构建时读取一次系统状态：应用启动后系统代理关闭/切换（代理工具退出、
+        // 转为 TUN 模式）会让客户端永远把请求发往失效代理，所有用量查询瞬间
+        // 失败且只能靠重启恢复。因此 macOS 上改为显式解析 + 死本机代理旁路 +
+        // 运行时跟随变化（见 get()），不再交给 reqwest 自动烘焙。
         if system_proxy_points_to_loopback() {
             builder = builder.no_proxy();
             log::warn!(
                 "[GlobalProxy] System proxy points to localhost, bypassing to avoid recursion"
             );
+        } else if cfg!(target_os = "macos") {
+            // 禁用 reqwest 的自动系统代理，改用我们自己解析的结果
+            builder = builder.no_proxy();
+            if let Some(proxy_url) = current_effective_system_proxy() {
+                match reqwest::Proxy::all(&proxy_url) {
+                    Ok(proxy) => {
+                        builder = builder.proxy(proxy);
+                        log::debug!(
+                            "[GlobalProxy] Following system proxy: {}",
+                            mask_url(&proxy_url)
+                        );
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "[GlobalProxy] Invalid system proxy {}: {e}, using direct connection",
+                            mask_url(&proxy_url)
+                        );
+                    }
+                }
+            }
         } else {
             log::debug!("[GlobalProxy] Following system proxy (no explicit proxy configured)");
         }
@@ -281,15 +556,6 @@ fn system_proxy_points_to_loopback() -> bool {
 }
 
 fn proxy_points_to_loopback(value: &str) -> bool {
-    fn host_is_loopback(host: &str) -> bool {
-        if host.eq_ignore_ascii_case("localhost") {
-            return true;
-        }
-        host.parse::<IpAddr>()
-            .map(|ip| ip.is_loopback())
-            .unwrap_or(false)
-    }
-
     // 检查是否指向 CC Switch 自己的代理端口
     // 只有指向自己的代理才需要跳过，避免递归
     fn is_cc_switch_proxy_port(port: Option<u16>) -> bool {
@@ -442,6 +708,117 @@ mod tests {
         // 非 loopback 地址不应该被跳过
         std::env::set_var("HTTP_PROXY", "http://10.0.0.2:7890");
         assert!(!system_proxy_points_to_loopback());
+
+        for key in &keys {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[test]
+    fn test_proxy_url_is_loopback() {
+        assert!(proxy_url_is_loopback("http://127.0.0.1:7892"));
+        assert!(proxy_url_is_loopback("http://localhost:7892"));
+        assert!(proxy_url_is_loopback("socks5://127.0.0.1:1080"));
+        // [::1] 带 scheme 与裸 host:port 两种写法
+        assert!(proxy_url_is_loopback("http://[::1]:7892"));
+        assert!(!proxy_url_is_loopback("http://192.168.1.10:7890"));
+        assert!(!proxy_url_is_loopback("http://proxy.example.com:8080"));
+    }
+
+    #[test]
+    fn test_loopback_proxy_listening() {
+        // 未监听的 loopback 端口：探测应返回 false
+        assert!(!loopback_proxy_listening("http://127.0.0.1:9"));
+
+        // 实际监听中的端口：探测应返回 true
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        assert!(loopback_proxy_listening(&format!(
+            "http://127.0.0.1:{port}"
+        )));
+
+        // 非 loopback 地址不探测，直接视为可用
+        assert!(loopback_proxy_listening("http://192.168.1.10:7890"));
+    }
+
+    #[test]
+    fn test_env_system_proxy_url_priority() {
+        let _guard = env_lock().lock().unwrap();
+
+        let keys = [
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+        ];
+        for key in &keys {
+            std::env::remove_var(key);
+        }
+
+        // 无环境变量时返回 None
+        assert_eq!(env_system_proxy_url(), None);
+
+        // HTTPS_PROXY 优先于 HTTP_PROXY 与 ALL_PROXY
+        std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:8899");
+        std::env::set_var("HTTP_PROXY", "http://127.0.0.1:7800");
+        std::env::set_var("ALL_PROXY", "socks5://127.0.0.1:7801");
+        assert_eq!(
+            env_system_proxy_url(),
+            Some("http://127.0.0.1:8899".to_string())
+        );
+
+        // 无 HTTPS 时回退到 HTTP_PROXY
+        std::env::remove_var("HTTPS_PROXY");
+        assert_eq!(
+            env_system_proxy_url(),
+            Some("http://127.0.0.1:7800".to_string())
+        );
+
+        // 小写变量同样生效
+        for key in &keys {
+            std::env::remove_var(key);
+        }
+        std::env::set_var("https_proxy", "http://127.0.0.1:8899");
+        assert_eq!(
+            env_system_proxy_url(),
+            Some("http://127.0.0.1:8899".to_string())
+        );
+
+        for key in &keys {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[test]
+    fn test_effective_system_proxy_bypasses_dead_loopback() {
+        let _guard = env_lock().lock().unwrap();
+
+        let keys = [
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+        ];
+        for key in &keys {
+            std::env::remove_var(key);
+        }
+
+        // 环境变量指向无监听的 loopback 端口：应旁路为直连（None）
+        std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:9");
+        assert_eq!(current_effective_system_proxy(), None);
+
+        // 环境变量指向存活端口：应保留该代理
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        std::env::set_var("HTTPS_PROXY", &format!("http://127.0.0.1:{port}"));
+        assert_eq!(
+            current_effective_system_proxy(),
+            Some(format!("http://127.0.0.1:{port}"))
+        );
 
         for key in &keys {
             std::env::remove_var(key);

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -8,8 +8,8 @@ use reqwest::Client;
 use std::env;
 use std::net::IpAddr;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::RwLock;
-use std::time::Duration;
+use std::sync::{Mutex, RwLock};
+use std::time::{Duration, Instant};
 
 /// 全局 HTTP 客户端实例
 static GLOBAL_CLIENT: OnceCell<RwLock<Client>> = OnceCell::new();
@@ -20,18 +20,36 @@ static CURRENT_PROXY_URL: OnceCell<RwLock<Option<String>>> = OnceCell::new();
 /// CC Switch 代理服务器当前监听的端口
 static CC_SWITCH_PROXY_PORT: OnceCell<RwLock<u16>> = OnceCell::new();
 
-/// 当前全局客户端所采用的"跟随系统代理"结果（None = 直连）。
-/// 显式用户代理生效时该值无意义（刷新逻辑会让位于用户设置）。
-static BAKED_SYSTEM_PROXY: OnceCell<RwLock<Option<String>>> = OnceCell::new();
+/// "跟随系统代理"的结构化解析快照（分协议 + NO_PROXY）。
+///
+/// reqwest/hyper-util 内部按 http/https/all 三类代理外加 NO_PROXY 分别生效，
+/// 单个 `Option<String>` 无法表达这些语义：HTTPS 不变、仅 HTTP 变化，或仅
+/// NO_PROXY 变化时，单 URL 签名都看不见。快照按 hyper-util 的规则构造
+/// （环境变量优先，macOS 系统配置只填补仍为空的协议槽），用作变化检测签名。
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct SystemProxySnapshot {
+    http: Option<String>,
+    https: Option<String>,
+    all: Option<String>,
+    no_proxy: Option<String>,
+}
+
+/// 当前全局客户端烘焙时的系统代理快照；`None` 表示显式代理生效
+/// （刷新逻辑让位于用户设置）或尚未初始化。
+static BAKED_SYSTEM_SNAPSHOT: OnceCell<RwLock<Option<SystemProxySnapshot>>> = OnceCell::new();
+
+/// 状态代数：每次 init/apply/update 显式修改全局客户端前递增。
+/// 自动刷新提交重建结果时会校验代数，避免覆盖并发发生的显式配置。
+static STATE_GENERATION: AtomicU64 = AtomicU64::new(0);
 
 /// 客户端因系统代理变化而重建的次数（诊断与回归测试用）
 static SYSTEM_PROXY_REBUILD_COUNT: AtomicU64 = AtomicU64::new(0);
 
-/// 上次检查系统代理变化的时间戳（毫秒），用于节流
-static LAST_SYSTEM_PROXY_CHECK_MS: AtomicU64 = AtomicU64::new(0);
+/// 上次检查系统代理变化的时间（单调时钟，系统时间回拨不影响节流）
+static LAST_SYSTEM_PROXY_CHECK: Mutex<Option<Instant>> = Mutex::new(None);
 
-/// 跟随系统代理的变化检查间隔（毫秒）
-const SYSTEM_PROXY_RECHECK_INTERVAL_MS: u64 = 5000;
+/// 跟随系统代理的变化检查间隔
+const SYSTEM_PROXY_RECHECK_INTERVAL: Duration = Duration::from_secs(5);
 
 /// 设置 CC Switch 代理服务器的监听端口
 ///
@@ -82,7 +100,12 @@ pub fn init(proxy_url: Option<&str>) -> Result<(), String> {
 
     // 初始化代理 URL 记录
     let _ = CURRENT_PROXY_URL.set(RwLock::new(effective_url.map(|s| s.to_string())));
-    record_baked_system_proxy(effective_url);
+    STATE_GENERATION.fetch_add(1, Ordering::AcqRel);
+    store_baked_system_snapshot(if effective_url.is_some() {
+        None
+    } else {
+        Some(read_system_proxy_snapshot())
+    });
 
     log::info!(
         "[GlobalProxy] Initialized: {}",
@@ -124,6 +147,9 @@ pub fn apply_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 
     // 更新客户端
     if let Some(lock) = GLOBAL_CLIENT.get() {
+        // 先递增代数再写入：自动刷新若在此期间提交，会因代数不匹配而放弃，
+        // 不会覆盖刚应用的显式代理。
+        STATE_GENERATION.fetch_add(1, Ordering::AcqRel);
         let mut client = lock.write().map_err(|e| {
             log::error!("[GlobalProxy] [GP-001] Failed to acquire write lock: {e}");
             "Failed to update proxy: lock poisoned".to_string()
@@ -142,7 +168,11 @@ pub fn apply_proxy(proxy_url: Option<&str>) -> Result<(), String> {
         })?;
         *url = effective_url.map(|s| s.to_string());
     }
-    record_baked_system_proxy(effective_url);
+    store_baked_system_snapshot(if effective_url.is_some() {
+        None
+    } else {
+        Some(read_system_proxy_snapshot())
+    });
 
     log::info!(
         "[GlobalProxy] Applied: {}",
@@ -169,6 +199,7 @@ pub fn update_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 
     // 更新客户端
     if let Some(lock) = GLOBAL_CLIENT.get() {
+        STATE_GENERATION.fetch_add(1, Ordering::AcqRel);
         let mut client = lock.write().map_err(|e| {
             log::error!("[GlobalProxy] [GP-001] Failed to acquire write lock: {e}");
             "Failed to update proxy: lock poisoned".to_string()
@@ -187,7 +218,11 @@ pub fn update_proxy(proxy_url: Option<&str>) -> Result<(), String> {
         })?;
         *url = effective_url.map(|s| s.to_string());
     }
-    record_baked_system_proxy(effective_url);
+    store_baked_system_snapshot(if effective_url.is_some() {
+        None
+    } else {
+        Some(read_system_proxy_snapshot())
+    });
 
     log::info!(
         "[GlobalProxy] Updated: {}",
@@ -202,11 +237,15 @@ pub fn update_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 /// 获取全局 HTTP 客户端
 ///
 /// 返回配置了代理的客户端（如果已配置代理），否则返回跟随系统代理的客户端。
-/// 未配置显式代理时（macOS），会节流地检测系统代理变化并按需重建客户端，
-/// 避免应用启动后系统代理关闭/切换导致请求持续打到失效代理上。
+/// 未配置显式代理时（macOS），会节流地检测系统代理配置变化并按需重建客户端，
+/// 避免应用启动后系统代理关闭/切换导致请求持续打到已移除的代理上。
+///
+/// 注意：这里只跟随"配置"变化，不做代理性存活性探测——系统仍配置代理但
+/// 代理进程未监听时保持 fail-closed（请求按 reqwest 语义正常报错），不静默
+/// 直连，避免绕过用户依赖代理实现的流量隔离/审计策略。
 pub fn get() -> Client {
-    // 先做节流的变化检测再取客户端：若系统代理已变化，本次调用就直接拿到
-    // 重建后的客户端，而不是把旧客户端（可能仍指向失效代理）多返回一次。
+    // 先做节流的变化检测再取客户端：若系统代理配置已变化，本次调用就直接
+    // 拿到重建后的客户端，而不是把旧客户端多返回一次。
     refresh_system_proxy_if_changed();
 
     GLOBAL_CLIENT
@@ -219,37 +258,34 @@ pub fn get() -> Client {
         })
 }
 
-/// 写入"当前客户端所采用的系统代理解析结果"快照（未初始化则初始化）
-fn store_baked_system_proxy(baked: Option<String>) {
-    match BAKED_SYSTEM_PROXY.get() {
+/// 写入当前全局客户端烘焙时的系统代理快照（未初始化则初始化）
+fn store_baked_system_snapshot(baked: Option<SystemProxySnapshot>) {
+    match BAKED_SYSTEM_SNAPSHOT.get() {
         Some(lock) => {
             if let Ok(mut baked_lock) = lock.write() {
                 *baked_lock = baked;
             }
         }
         None => {
-            let _ = BAKED_SYSTEM_PROXY.set(RwLock::new(baked));
+            let _ = BAKED_SYSTEM_SNAPSHOT.set(RwLock::new(baked));
         }
     }
 }
 
-/// 记录当前全局客户端所采用的系统代理解析结果
-///
-/// 显式用户代理时无需记录（刷新逻辑让位于用户设置），传 `Some(_)` 即可。
-fn record_baked_system_proxy(explicit_url: Option<&str>) {
-    let baked = if explicit_url.is_some() {
-        None
-    } else {
-        current_effective_system_proxy()
-    };
-    store_baked_system_proxy(baked);
+/// 读取当前烘焙快照的克隆
+fn baked_system_snapshot() -> Option<SystemProxySnapshot> {
+    BAKED_SYSTEM_SNAPSHOT
+        .get()
+        .and_then(|lock| lock.read().ok())
+        .and_then(|snapshot| snapshot.clone())
 }
 
-/// 节流地检查"跟随系统代理"的解析结果是否变化，变化则重建全局客户端
+/// 节流地检查"跟随系统代理"的配置是否变化，变化则重建全局客户端
 ///
 /// 仅在未配置显式代理时生效；显式代理由用户管理，不参与自动刷新。
-/// 平台边界：变化检测只服务 macOS 的死本机代理旁路（见 [`build_client`]），
-/// 其余平台维持原有行为，不做周期性解析。
+/// 平台边界：reqwest 只在构建时读取一次系统代理，长驻进程里配置关闭/
+/// 切换后旧客户端会一直指向失效目标，这个检测只服务该场景的 macOS 桌面
+/// 应用；其余平台维持原有行为，不做周期性解析。
 fn refresh_system_proxy_if_changed() {
     if !cfg!(target_os = "macos") {
         return;
@@ -260,98 +296,126 @@ fn refresh_system_proxy_if_changed() {
         return;
     }
 
-    let now_ms = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0);
-    let last = LAST_SYSTEM_PROXY_CHECK_MS.load(Ordering::Relaxed);
-    if now_ms.saturating_sub(last) < SYSTEM_PROXY_RECHECK_INTERVAL_MS {
+    // 单调时钟节流。try_lock 失败说明已有并发检测在进行，直接让位，
+    // 避免多个线程同时通过间隔检查并各自重建一次。
+    let Ok(mut last_check) = LAST_SYSTEM_PROXY_CHECK.try_lock() else {
+        return;
+    };
+    if last_check.is_some_and(|last| last.elapsed() < SYSTEM_PROXY_RECHECK_INTERVAL) {
         return;
     }
-    LAST_SYSTEM_PROXY_CHECK_MS.store(now_ms, Ordering::Relaxed);
+    *last_check = Some(Instant::now());
+    drop(last_check);
 
-    let current = current_effective_system_proxy();
-    let baked = BAKED_SYSTEM_PROXY
-        .get()
-        .and_then(|lock| lock.read().ok())
-        .and_then(|b| b.clone());
-    if current == baked {
+    let seen_generation = STATE_GENERATION.load(Ordering::Acquire);
+    let baked = baked_system_snapshot();
+    // 快照为 None 说明显式代理刚被应用（或未初始化），让位
+    let Some(previous) = baked else {
+        return;
+    };
+
+    let current = read_system_proxy_snapshot();
+    if current == previous {
         return;
     }
 
-    // 系统代理状态发生变化（开启/关闭/换端口/存活状态翻转），重建客户端
-    match build_client(None) {
-        Ok(new_client) => {
-            if let Some(lock) = GLOBAL_CLIENT.get() {
-                if let Ok(mut client) = lock.write() {
-                    *client = new_client;
-                    store_baked_system_proxy(current.clone());
-                    SYSTEM_PROXY_REBUILD_COUNT.fetch_add(1, Ordering::Relaxed);
-                    log::info!(
-                        "[GlobalProxy] System proxy changed, rebuilt client: {}",
-                        current
-                            .as_deref()
-                            .map(mask_url)
-                            .unwrap_or_else(|| "direct connection".to_string())
-                    );
-                }
-            }
-        }
+    // 系统代理配置发生变化（开启/关闭/换地址/换端口/NO_PROXY 调整），重建
+    let new_client = match build_client(None) {
+        Ok(client) => client,
         Err(e) => {
-            log::warn!("[GlobalProxy] Failed to rebuild client after system proxy change: {e}")
+            log::warn!("[GlobalProxy] Failed to rebuild client after system proxy change: {e}");
+            return;
         }
+    };
+    log::info!(
+        "[GlobalProxy] System proxy configuration changed, rebuilt client (http={:?}, https={:?}, all={:?}, no_proxy={:?})",
+        current.http.as_deref().map(mask_url),
+        current.https.as_deref().map(mask_url),
+        current.all.as_deref().map(mask_url),
+        current.no_proxy.is_some()
+    );
+    if commit_system_refresh(new_client, seen_generation, previous, current) {
+        SYSTEM_PROXY_REBUILD_COUNT.fetch_add(1, Ordering::Relaxed);
     }
 }
 
-#[cfg(all(test, target_os = "macos"))]
-fn system_proxy_rebuild_count() -> u64 {
-    SYSTEM_PROXY_REBUILD_COUNT.load(Ordering::Relaxed)
-}
-
-#[cfg(all(test, target_os = "macos"))]
-fn reset_system_proxy_check_throttle() {
-    LAST_SYSTEM_PROXY_CHECK_MS.store(0, Ordering::Relaxed);
-}
-
-/// 原始解析"跟随系统代理"的目标：环境变量 → macOS 系统代理（不做存活判定）
-fn raw_system_proxy_url() -> Option<String> {
-    env_system_proxy_url()
-        .or_else(macos_system_proxy_url)
-        .map(|url| url.trim().to_string())
-        .filter(|url| !url.is_empty())
-}
-
-/// 解析当前"跟随系统代理"的有效结果（已过滤失效的本机代理）
+/// 提交一次系统代理刷新的重建结果
 ///
-/// 在 [`raw_system_proxy_url`] 基础上做存活判定：解析结果若指向本机 loopback
-/// 且端口无进程监听（代理工具已退出/切换为 TUN 模式），视为无代理（直连），
-/// 避免客户端把请求持续发往失效代理导致所有查询瞬间失败。该结果同时用作
-/// 变化检测的签名（见 [`refresh_system_proxy_if_changed`]）。
-fn current_effective_system_proxy() -> Option<String> {
-    raw_system_proxy_url()
-        .filter(|url| !proxy_url_is_loopback(url) || loopback_proxy_listening(url))
+/// 提交前在写锁内校验：显式代理仍为空、状态代数未变、烘焙快照仍是检测时
+/// 的那份。任一不满足即放弃（例如用户在检测期间应用了显式代理，或另一路
+/// 刷新已经提交过），防止自动刷新覆盖用户设置或造成新旧状态错位。
+fn commit_system_refresh(
+    candidate: Client,
+    seen_generation: u64,
+    previous: SystemProxySnapshot,
+    updated: SystemProxySnapshot,
+) -> bool {
+    let Some(client_lock) = GLOBAL_CLIENT.get() else {
+        return false;
+    };
+    let mut client = match client_lock.write() {
+        Ok(client) => client,
+        Err(_) => return false,
+    };
+
+    if STATE_GENERATION.load(Ordering::Acquire) != seen_generation {
+        return false;
+    }
+    if get_current_proxy_url().is_some() {
+        return false;
+    }
+    if baked_system_snapshot().as_ref() != Some(&previous) {
+        return false;
+    }
+
+    *client = candidate;
+    store_baked_system_snapshot(Some(updated));
+    true
 }
 
-/// 从环境变量解析代理 URL（与 hyper-util 的优先级对齐：HTTPS > HTTP > ALL）
-fn env_system_proxy_url() -> Option<String> {
-    const KEY_GROUPS: [&[&str]; 3] = [
-        &["HTTPS_PROXY", "https_proxy"],
-        &["HTTP_PROXY", "http_proxy"],
-        &["ALL_PROXY", "all_proxy"],
-    ];
-    KEY_GROUPS.iter().find_map(|keys| {
+/// 读取"跟随系统代理"的结构化解析结果（环境变量优先，系统配置填空）
+fn read_system_proxy_snapshot() -> SystemProxySnapshot {
+    let mut snapshot = env_system_proxy_snapshot();
+
+    // macOS 系统配置只填补环境变量仍为空的协议槽（与 hyper-util 的
+    // "环境变量优先、系统配置补缺"顺序一致）
+    #[cfg(target_os = "macos")]
+    {
+        let (system_http, system_https) = macos_system_proxy_entries();
+        if snapshot.https.is_none() {
+            snapshot.https = system_https;
+        }
+        if snapshot.http.is_none() {
+            snapshot.http = system_http;
+        }
+    }
+
+    snapshot
+}
+
+/// 从环境变量解析分协议代理 URL（优先级：大写与小写同组同权，组间
+/// 按协议独立，不再折叠成单个 URL）
+fn env_system_proxy_snapshot() -> SystemProxySnapshot {
+    let env_group = |keys: &[&str]| {
         keys.iter().find_map(|key| {
             env::var(key)
                 .ok()
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty())
         })
-    })
+    };
+    SystemProxySnapshot {
+        http: env_group(&["HTTP_PROXY", "http_proxy"]),
+        https: env_group(&["HTTPS_PROXY", "https_proxy"]),
+        all: env_group(&["ALL_PROXY", "all_proxy"]),
+        no_proxy: env_group(&["NO_PROXY", "no_proxy"]),
+    }
 }
 
-/// 读取 macOS 系统代理（SCDynamicStore，与 reqwest/hyper-util 的数据源一致）
+/// macOS 系统代理的分协议条目（SCDynamicStore，与 reqwest/hyper-util 的
+/// 数据源一致），返回 (http, https)
 #[cfg(target_os = "macos")]
-fn macos_system_proxy_url() -> Option<String> {
+fn macos_system_proxy_entries() -> (Option<String>, Option<String>) {
     use system_configuration::core_foundation::base::CFType;
     use system_configuration::core_foundation::dictionary::CFDictionary;
     use system_configuration::core_foundation::number::CFNumber;
@@ -385,86 +449,44 @@ fn macos_system_proxy_url() -> Option<String> {
             .find(port_key)
             .and_then(|v| v.downcast::<CFNumber>())
             .and_then(|v| v.to_i32())?;
-        Some(format!("http://{host}:{port}"))
+        Some(format_proxy_entry(&host, port))
     }
 
-    let store = SCDynamicStoreBuilder::new("cc-switch").build()?;
-    let proxies_map = store.get_proxies()?;
-    // HTTPS 代理优先：用量查询目标几乎全是 https 端点
-    read_entry(
-        &proxies_map,
-        unsafe { kSCPropNetProxiesHTTPSEnable },
-        unsafe { kSCPropNetProxiesHTTPSProxy },
-        unsafe { kSCPropNetProxiesHTTPSPort },
-    )
-    .or_else(|| {
-        read_entry(
-            &proxies_map,
-            unsafe { kSCPropNetProxiesHTTPEnable },
-            unsafe { kSCPropNetProxiesHTTPProxy },
-            unsafe { kSCPropNetProxiesHTTPPort },
-        )
-    })
-}
-
-#[cfg(not(target_os = "macos"))]
-fn macos_system_proxy_url() -> Option<String> {
-    None
-}
-
-/// 判断代理 URL 是否指向本机 loopback 地址
-fn proxy_url_is_loopback(url: &str) -> bool {
-    let parsed = url::Url::parse(url)
-        .ok()
-        .or_else(|| url::Url::parse(&format!("http://{url}")).ok());
-    parsed
-        .as_ref()
-        .and_then(|parsed| parsed.host_str())
-        .map(host_is_loopback)
-        .unwrap_or(false)
-}
-
-/// 探测 loopback 代理端口是否有进程监听
-///
-/// 仅对 loopback 地址做探测（连接为微秒级）；非 loopback 地址一律视为可用。
-fn loopback_proxy_listening(url: &str) -> bool {
-    use std::net::TcpStream;
-
-    let parsed = url::Url::parse(url)
-        .ok()
-        .or_else(|| url::Url::parse(&format!("http://{url}")).ok());
-    let Some(parsed) = parsed else {
-        return false;
-    };
-    let Some(host) = parsed.host_str() else {
-        return false;
-    };
-    if !host_is_loopback(host) {
-        return true;
+    fn read_entries() -> Option<(Option<String>, Option<String>)> {
+        let store = SCDynamicStoreBuilder::new("cc-switch").build()?;
+        let proxies_map = store.get_proxies()?;
+        Some((
+            read_entry(
+                &proxies_map,
+                unsafe { kSCPropNetProxiesHTTPEnable },
+                unsafe { kSCPropNetProxiesHTTPProxy },
+                unsafe { kSCPropNetProxiesHTTPPort },
+            ),
+            read_entry(
+                &proxies_map,
+                unsafe { kSCPropNetProxiesHTTPSEnable },
+                unsafe { kSCPropNetProxiesHTTPSProxy },
+                unsafe { kSCPropNetProxiesHTTPSPort },
+            ),
+        ))
     }
-    let Some(port) = parsed.port_or_known_default() else {
-        return false;
-    };
 
-    use std::net::ToSocketAddrs;
-    let addrs = match (host, port).to_socket_addrs() {
-        Ok(addrs) => addrs.collect::<Vec<_>>(),
-        Err(_) => return false,
-    };
-    addrs
-        .iter()
-        .any(|addr| TcpStream::connect_timeout(addr, Duration::from_millis(300)).is_ok())
+    // SCDynamicStore 读取失败时按"无系统代理"处理，交给环境变量与直连语义
+    read_entries().unwrap_or((None, None))
 }
 
-fn host_is_loopback(host: &str) -> bool {
-    if host.eq_ignore_ascii_case("localhost") {
-        return true;
+/// 把系统代理条目的 host:port 组装成 URL（裸 IPv6 地址补方括号）
+#[cfg(target_os = "macos")]
+fn format_proxy_entry(host: &str, port: i32) -> String {
+    let is_bare_ipv6 = host
+        .parse::<IpAddr>()
+        .map(|address| address.is_ipv6())
+        .unwrap_or(false);
+    if is_bare_ipv6 {
+        format!("http://[{host}]:{port}")
+    } else {
+        format!("http://{host}:{port}")
     }
-    // url crate 对 IPv6 host 保留方括号（如 "[::1]"），解析前需剥掉
-    let host = host.trim_start_matches('[').trim_end_matches(']');
-    host.parse::<IpAddr>()
-        .map(|ip| ip.is_loopback())
-        .unwrap_or(false)
 }
 
 /// 获取当前代理 URL
@@ -516,33 +538,17 @@ fn build_client(proxy_url: Option<&str>) -> Result<Client, String> {
             .map_err(|e| format!("Invalid proxy URL '{}': {}", mask_url(url), e))?;
         builder = builder.proxy(proxy);
         log::debug!("[GlobalProxy] Proxy configured: {}", mask_url(url));
+    } else if system_proxy_points_to_loopback() {
+        builder = builder.no_proxy();
+        log::warn!("[GlobalProxy] System proxy points to localhost, bypassing to avoid recursion");
     } else {
-        // 未设置全局代理时，跟随系统代理。reqwest 内建的自动跟随只在客户端
-        // 构建时读取一次系统状态：应用启动后系统代理关闭/切换（代理工具退出、
-        // 转为 TUN 模式）会让客户端永远把请求发往失效代理，所有用量查询瞬间
-        // 失败且只能靠重启恢复。因此 macOS 上额外做两件事（其余平台行为不变）：
-        //   1) 构建时若解析出的系统代理指向本机已无监听的端口，旁路为直连；
-        //   2) get() 中节流地检测解析结果变化并按需重建（见 refresh_system_proxy_if_changed）。
-        // 代理存活时仍完全交给 reqwest 自动跟随（语义忠实：分协议、NO_PROXY 等）。
-        if system_proxy_points_to_loopback() {
-            builder = builder.no_proxy();
-            log::warn!(
-                "[GlobalProxy] System proxy points to localhost, bypassing to avoid recursion"
-            );
-        } else if cfg!(target_os = "macos") {
-            let raw = raw_system_proxy_url();
-            if let Some(dead_url) =
-                raw.filter(|url| proxy_url_is_loopback(url) && !loopback_proxy_listening(url))
-            {
-                builder = builder.no_proxy();
-                log::warn!(
-                    "[GlobalProxy] System proxy {} points to a local port with no listener, bypassing to direct connection",
-                    mask_url(&dead_url)
-                );
-            }
-        } else {
-            log::debug!("[GlobalProxy] Following system proxy (no explicit proxy configured)");
-        }
+        // 跟随系统代理。reqwest 内建的自动跟随只在客户端构建时读取一次系统
+        // 状态：长驻进程里系统代理配置关闭/切换（代理工具退出、转为 TUN
+        // 模式）会让客户端继续使用已移除的代理。macOS 上由 get() 节流检测
+        // 配置变化并重建（见 refresh_system_proxy_if_changed）；代理语义
+        // （分协议、NO_PROXY）完全交由 reqwest 处理，不做存活探测，也不在
+        // 配置仍指向代理时静默直连。
+        log::debug!("[GlobalProxy] Following system proxy (no explicit proxy configured)");
     }
 
     builder
@@ -593,6 +599,17 @@ fn proxy_points_to_loopback(value: &str) -> bool {
     false
 }
 
+fn host_is_loopback(host: &str) -> bool {
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    // url crate 对 IPv6 host 保留方括号（如 "[::1]"），解析前需剥掉
+    let host = host.trim_start_matches('[').trim_end_matches(']');
+    host.parse::<IpAddr>()
+        .map(|ip| ip.is_loopback())
+        .unwrap_or(false)
+}
+
 /// 隐藏 URL 中的敏感信息（用于日志）
 pub fn mask_url(url: &str) -> String {
     if let Ok(parsed) = url::Url::parse(url) {
@@ -620,6 +637,23 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    const ENV_KEYS: [&str; 8] = [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ];
+
+    fn clear_proxy_env() {
+        for key in ENV_KEYS {
+            std::env::remove_var(key);
+        }
     }
 
     #[test]
@@ -696,18 +730,7 @@ mod tests {
         // 设置 CC Switch 代理端口
         set_proxy_port(15721);
 
-        let keys = [
-            "HTTP_PROXY",
-            "http_proxy",
-            "HTTPS_PROXY",
-            "https_proxy",
-            "ALL_PROXY",
-            "all_proxy",
-        ];
-
-        for key in &keys {
-            std::env::remove_var(key);
-        }
+        clear_proxy_env();
 
         // 指向 CC Switch 端口的代理应该被跳过
         std::env::set_var("HTTP_PROXY", "http://127.0.0.1:15721");
@@ -721,146 +744,99 @@ mod tests {
         std::env::set_var("HTTP_PROXY", "http://10.0.0.2:7890");
         assert!(!system_proxy_points_to_loopback());
 
-        for key in &keys {
-            std::env::remove_var(key);
-        }
+        clear_proxy_env();
     }
 
     #[test]
-    fn test_proxy_url_is_loopback() {
-        assert!(proxy_url_is_loopback("http://127.0.0.1:7892"));
-        assert!(proxy_url_is_loopback("http://localhost:7892"));
-        assert!(proxy_url_is_loopback("socks5://127.0.0.1:1080"));
-        // [::1] 带 scheme 与裸 host:port 两种写法
-        assert!(proxy_url_is_loopback("http://[::1]:7892"));
-        assert!(!proxy_url_is_loopback("http://192.168.1.10:7890"));
-        assert!(!proxy_url_is_loopback("http://proxy.example.com:8080"));
-    }
-
-    #[test]
-    fn test_loopback_proxy_listening() {
-        // 未监听的 loopback 端口：探测应返回 false
-        assert!(!loopback_proxy_listening("http://127.0.0.1:9"));
-
-        // 实际监听中的端口：探测应返回 true
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        assert!(loopback_proxy_listening(&format!(
-            "http://127.0.0.1:{port}"
-        )));
-
-        // 非 loopback 地址不探测，直接视为可用
-        assert!(loopback_proxy_listening("http://192.168.1.10:7890"));
-    }
-
-    #[test]
-    fn test_env_system_proxy_url_priority() {
+    fn test_env_system_proxy_snapshot_per_protocol() {
         let _guard = env_lock().lock().unwrap();
 
-        let keys = [
-            "HTTP_PROXY",
-            "http_proxy",
-            "HTTPS_PROXY",
-            "https_proxy",
-            "ALL_PROXY",
-            "all_proxy",
-        ];
-        for key in &keys {
-            std::env::remove_var(key);
-        }
+        clear_proxy_env();
+        assert_eq!(
+            env_system_proxy_snapshot(),
+            SystemProxySnapshot::default(),
+            "no env vars must produce an empty snapshot"
+        );
 
-        // 无环境变量时返回 None
-        assert_eq!(env_system_proxy_url(), None);
-
-        // HTTPS_PROXY 优先于 HTTP_PROXY 与 ALL_PROXY
+        // 分协议独立解析，不再折叠成单个 URL
         std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:8899");
         std::env::set_var("HTTP_PROXY", "http://127.0.0.1:7800");
         std::env::set_var("ALL_PROXY", "socks5://127.0.0.1:7801");
+        std::env::set_var("NO_PROXY", "localhost,127.0.0.1");
         assert_eq!(
-            env_system_proxy_url(),
-            Some("http://127.0.0.1:8899".to_string())
-        );
-
-        // 无 HTTPS 时回退到 HTTP_PROXY
-        std::env::remove_var("HTTPS_PROXY");
-        assert_eq!(
-            env_system_proxy_url(),
-            Some("http://127.0.0.1:7800".to_string())
+            env_system_proxy_snapshot(),
+            SystemProxySnapshot {
+                http: Some("http://127.0.0.1:7800".to_string()),
+                https: Some("http://127.0.0.1:8899".to_string()),
+                all: Some("socks5://127.0.0.1:7801".to_string()),
+                no_proxy: Some("localhost,127.0.0.1".to_string()),
+            }
         );
 
         // 小写变量同样生效
-        for key in &keys {
-            std::env::remove_var(key);
-        }
+        clear_proxy_env();
         std::env::set_var("https_proxy", "http://127.0.0.1:8899");
         assert_eq!(
-            env_system_proxy_url(),
-            Some("http://127.0.0.1:8899".to_string())
+            env_system_proxy_snapshot(),
+            SystemProxySnapshot {
+                https: Some("http://127.0.0.1:8899".to_string()),
+                ..Default::default()
+            }
         );
 
-        for key in &keys {
-            std::env::remove_var(key);
-        }
+        clear_proxy_env();
     }
 
     #[test]
-    fn test_effective_system_proxy_bypasses_dead_loopback() {
-        let _guard = env_lock().lock().unwrap();
-
-        let keys = [
-            "HTTP_PROXY",
-            "http_proxy",
-            "HTTPS_PROXY",
-            "https_proxy",
-            "ALL_PROXY",
-            "all_proxy",
-        ];
-        for key in &keys {
-            std::env::remove_var(key);
-        }
-
-        // 环境变量指向无监听的 loopback 端口：应旁路为直连（None）
-        std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:9");
-        assert_eq!(current_effective_system_proxy(), None);
-
-        // 环境变量指向存活端口：应保留该代理
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        std::env::set_var("HTTPS_PROXY", format!("http://127.0.0.1:{port}"));
+    #[cfg(target_os = "macos")]
+    fn test_format_proxy_entry_brackets_bare_ipv6() {
         assert_eq!(
-            current_effective_system_proxy(),
-            Some(format!("http://127.0.0.1:{port}"))
+            format_proxy_entry("127.0.0.1", 7890),
+            "http://127.0.0.1:7890"
         );
-
-        for key in &keys {
-            std::env::remove_var(key);
-        }
+        assert_eq!(format_proxy_entry("::1", 7890), "http://[::1]:7890");
+        assert_eq!(
+            format_proxy_entry("proxy.example.com", 8080),
+            "http://proxy.example.com:8080"
+        );
     }
 
-    /// 初始化全局客户端并强制刷新系统代理快照（消除 init 路径差异）
+    #[test]
+    fn test_snapshot_detects_http_only_and_no_proxy_only_changes() {
+        let _guard = env_lock().lock().unwrap();
+        clear_proxy_env();
+
+        // HTTPS 固定，仅 HTTP 变化：签名必须能看见
+        std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:8899");
+        std::env::set_var("HTTP_PROXY", "http://127.0.0.1:7800");
+        let before = read_system_proxy_snapshot();
+        std::env::set_var("HTTP_PROXY", "http://127.0.0.1:7801");
+        assert_ne!(read_system_proxy_snapshot(), before);
+
+        // 仅 NO_PROXY 变化：签名必须能看见
+        let before = read_system_proxy_snapshot();
+        std::env::set_var("NO_PROXY", "localhost");
+        assert_ne!(read_system_proxy_snapshot(), before);
+
+        clear_proxy_env();
+    }
+
+    /// 初始化全局客户端并烘焙当前快照（消除 init 路径差异）
     #[cfg(target_os = "macos")]
     fn setup_global_client_with_current_snapshot() {
         if GLOBAL_CLIENT.get().is_none() {
             let _ = init(None);
         }
-        record_baked_system_proxy(None);
+        store_baked_system_snapshot(Some(read_system_proxy_snapshot()));
     }
 
     #[cfg(target_os = "macos")]
-    fn clear_proxy_env() {
-        for key in [
-            "HTTP_PROXY",
-            "http_proxy",
-            "HTTPS_PROXY",
-            "https_proxy",
-            "ALL_PROXY",
-            "all_proxy",
-        ] {
-            std::env::remove_var(key);
+    fn reset_system_proxy_check_throttle() {
+        if let Ok(mut last_check) = LAST_SYSTEM_PROXY_CHECK.try_lock() {
+            *last_check = None;
         }
     }
 
-    // 变化检测与重建行为是 macOS 专属（其余平台 refresh 为 no-op）
     #[test]
     #[serial_test::serial]
     #[cfg(target_os = "macos")]
@@ -868,9 +844,7 @@ mod tests {
         let _guard = env_lock().lock().unwrap();
         clear_proxy_env();
 
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        std::env::set_var("HTTPS_PROXY", format!("http://127.0.0.1:{port}"));
+        std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:8899");
 
         setup_global_client_with_current_snapshot();
         let before = system_proxy_rebuild_count();
@@ -893,37 +867,111 @@ mod tests {
     #[test]
     #[serial_test::serial]
     #[cfg(target_os = "macos")]
-    fn test_rebuild_once_when_system_proxy_dies() {
+    fn test_rebuild_once_when_system_proxy_config_removed() {
         let _guard = env_lock().lock().unwrap();
         clear_proxy_env();
 
-        // 代理存活时初始化快照，随后关掉监听模拟代理工具退出
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        std::env::set_var("HTTPS_PROXY", format!("http://127.0.0.1:{port}"));
+        // 代理配置存在时初始化快照，随后移除配置模拟系统代理被关闭
+        std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:8899");
 
         setup_global_client_with_current_snapshot();
         let before = system_proxy_rebuild_count();
 
-        drop(listener);
+        std::env::remove_var("HTTPS_PROXY");
         reset_system_proxy_check_throttle();
         refresh_system_proxy_if_changed();
-        let after_death = system_proxy_rebuild_count();
+        let after_change = system_proxy_rebuild_count();
         assert_eq!(
-            after_death,
+            after_change,
             before + 1,
-            "system proxy dying must trigger exactly one rebuild"
+            "system proxy config removal must trigger exactly one rebuild"
         );
 
-        // 代理保持死亡：后续检测不应再次重建
+        // 配置保持移除：后续检测不应再次重建
         reset_system_proxy_check_throttle();
         refresh_system_proxy_if_changed();
         assert_eq!(
             system_proxy_rebuild_count(),
-            after_death,
-            "keep-direct state must not rebuild repeatedly"
+            after_change,
+            "stable config must not rebuild repeatedly"
         );
 
         clear_proxy_env();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[cfg(target_os = "macos")]
+    fn test_refresh_yields_to_explicit_proxy() {
+        let _guard = env_lock().lock().unwrap();
+        clear_proxy_env();
+
+        setup_global_client_with_current_snapshot();
+
+        // 用户应用显式代理后，配置变化检测必须让位：不重建、不覆盖
+        std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:8899");
+        apply_proxy(Some("http://127.0.0.1:7890")).expect("apply explicit proxy");
+        let before = system_proxy_rebuild_count();
+
+        reset_system_proxy_check_throttle();
+        refresh_system_proxy_if_changed();
+        assert_eq!(
+            system_proxy_rebuild_count(),
+            before,
+            "explicit proxy must suppress automatic refresh"
+        );
+        assert_eq!(
+            get_current_proxy_url().as_deref(),
+            Some("http://127.0.0.1:7890"),
+            "explicit proxy must stay recorded"
+        );
+        assert_eq!(
+            baked_system_snapshot(),
+            None,
+            "snapshot must be cleared while explicit proxy is active"
+        );
+
+        // 恢复直连（跟随系统）以便后续测试
+        apply_proxy(None).expect("restore direct");
+        clear_proxy_env();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    #[cfg(target_os = "macos")]
+    fn test_stale_refresh_cannot_overwrite_explicit_proxy() {
+        let _guard = env_lock().lock().unwrap();
+        clear_proxy_env();
+
+        setup_global_client_with_current_snapshot();
+        let previous = baked_system_snapshot().expect("snapshot after setup");
+
+        // 模拟竞态：刷新流程读到旧代数后，用户应用了显式代理
+        let stale_generation = STATE_GENERATION.load(Ordering::Acquire);
+        std::env::set_var("HTTPS_PROXY", "http://127.0.0.1:8899");
+        apply_proxy(Some("http://127.0.0.1:7890")).expect("apply explicit proxy");
+        let updated = read_system_proxy_snapshot();
+        let candidate = build_client(None).expect("candidate client");
+
+        // 过期代数的提交必须被拒绝：客户端与记录都保持显式代理
+        assert!(!commit_system_refresh(
+            candidate,
+            stale_generation,
+            previous,
+            updated
+        ));
+        assert_eq!(
+            get_current_proxy_url().as_deref(),
+            Some("http://127.0.0.1:7890"),
+            "stale refresh must not clobber the explicit proxy record"
+        );
+
+        apply_proxy(None).expect("restore direct");
+        clear_proxy_env();
+    }
+
+    #[cfg(target_os = "macos")]
+    fn system_proxy_rebuild_count() -> u64 {
+        SYSTEM_PROXY_REBUILD_COUNT.load(Ordering::Relaxed)
     }
 }


### PR DESCRIPTION
Fixes #7029.

## Summary

On macOS, the global HTTP client follows the system proxy via reqwest's built-in auto-detection. reqwest (hyper-util `Matcher::from_system()`) reads the system proxy through SCDynamicStore **once, at client build time** and bakes it into the `Client`. After the proxy tool exits or switches to TUN mode (i.e. the system proxy configuration is removed or changed), every request from the long-lived app keeps going to the removed proxy, so all usage/balance/connectivity queries fail instantly until the app is restarted.

This PR makes the client rebuild itself when the **system proxy configuration** changes, and only then — no liveness probing, no silent direct-connect fallback.

## Diff walkthrough

### `src-tauri/Cargo.toml` (+2)
- `system-configuration = "0.7"` under the existing `[target.'cfg(target_os = "macos")'.dependencies]` section — SCDynamicStore reads for the per-protocol system entries. (`Cargo.lock` +1 matching entry.)

### `src-tauri/src/proxy/http_client.rs`

**New state (replaces the old single-URL snapshot)**
- `struct SystemProxySnapshot { http, https, all, no_proxy }` (PartialEq) — per-protocol proxy targets plus NO_PROXY, because reqwest/hyper-util apply these independently; a single collapsed `Option<String>` cannot see HTTP-only or NO_PROXY-only changes.
- `BAKED_SYSTEM_SNAPSHOT: RwLock<Option<SystemProxySnapshot>>` — the config the current client was built with; `None` while an explicit user proxy is active (refresh yields).
- `STATE_GENERATION: AtomicU64` — bumped inside the switch critical section by `init`/`apply_proxy`/`update_proxy`; refresh commits verify it.
- `SYSTEM_PROXY_REBUILD_COUNT: AtomicU64` — diagnostics + test assertions.
- `LAST_SYSTEM_PROXY_CHECK: Mutex<Option<Instant>>` + `SYSTEM_PROXY_RECHECK_INTERVAL` (5 s) — monotonic-clock throttle; `try_lock` failure means a concurrent check is in flight and this caller skips.

**`apply_proxy()` / `update_proxy()`**
- Snapshot is captured **before** `build_client`, not after: building between a config change and the snapshot read would bake the old config into the client while recording the new config, permanently hiding the stale client from change detection. Capturing first degrades to one detectable snapshot mismatch that the next refresh cycle corrects.
- Explicit proxy → snapshot `None`; direct/follow-system → fresh snapshot.
- Client, `CURRENT_PROXY_URL`, and the snapshot switch inside **one** `GLOBAL_CLIENT` write-lock critical section (generation bumped inside it), in the lock order `GLOBAL_CLIENT → CURRENT_PROXY_URL → BAKED_SYSTEM_SNAPSHOT` — the same order `commit_system_refresh` uses. No observer can see a half-switched state, and a refresh cannot interleave between the client write and the metadata writes.

**`init()`**
- Captures the snapshot before `build_client` like the apply paths, then performs first-time `OnceCell` initializations of `GLOBAL_CLIENT`, `CURRENT_PROXY_URL`, and the snapshot. Its contract is a single call during single-threaded startup (before any `get()` can trigger a refresh), so it does not need — and does not claim — the same lock-guarded atomic visibility as the apply paths.

**`get()`**
- Calls `refresh_system_proxy_if_changed()` before returning the client. Doc comment states the fail-closed stance (see "Deliberate non-goal").

**`refresh_system_proxy_if_changed()`**
1. Returns immediately on non-macOS and when an explicit proxy is active.
2. Throttle: `try_lock` the monotonic clock; skip if last check < 5 s ago or another check holds the lock (no rebuild stampede).
3. Captures `STATE_GENERATION`, reads the baked snapshot (None → yield).
4. Reads `read_system_proxy_snapshot()` outside any lock; returns if equal.
5. Builds `build_client(None)` outside the lock, logs the per-protocol outcome, then commits via `commit_system_refresh`.

**`commit_system_refresh(candidate, seen_generation, previous, updated)`**
- Under the `GLOBAL_CLIENT` write lock, re-verifies all three invariants before swapping: generation still `seen_generation`, no explicit proxy active, baked snapshot still identical to `previous`. Any mismatch (user applied a proxy mid-flight, or another refresh already committed) discards the candidate. The lock-order contract shared with the apply path is documented here.

**Snapshot readers**
- `read_system_proxy_snapshot()` — env-first per slot, then macOS system config fills only still-empty http/https slots (hyper-util's precedence).
- `env_system_proxy_snapshot()` — per-protocol env groups (upper/lowercase), including `NO_PROXY`.
- `macos_system_proxy_entries()` (macOS) — returns `(http, https)` entries from SCDynamicStore; read errors degrade to `(None, None)`.
- `format_proxy_entry(host, port)` (macOS) — assembles `http://host:port`, bracketing bare IPv6 hosts (`::1` → `http://[::1]:port`).

**Removed vs the earlier iterations of this branch**
- `current_effective_system_proxy()` (liveness-filtered signature), `loopback_proxy_listening()` (300 ms synchronous TCP probe on the `get()` path), `proxy_url_is_loopback()`, `raw_system_proxy_url()` / `env_system_proxy_url()` / `macos_system_proxy_url()` (single collapsed URL).
- The `build_client(None)` branch that called `no_proxy()` when a configured loopback proxy had no listener.

**`build_client(None)`** — final shape: keeps only the pre-existing CC Switch own-port recursion guard, otherwise plain reqwest system-follow; comment documents that config changes are handled by rebuild, and that a configured-but-unreachable proxy fails closed per request.

**Unchanged from main**: `host_is_loopback`, `proxy_points_to_loopback`, `system_proxy_points_to_loopback`, `mask_url`, the explicit-proxy branch of `build_client`, all public signatures (`get`/`init`/`apply_proxy`/`update_proxy`/`validate_proxy`/`set_proxy_port`/`get_current_proxy_url`).

**Tests** (14 in module)
- Kept from main: mask_url, build_client variants, recursion guard tests.
- New/rewritten: per-protocol env snapshot parsing; bare-IPv6 bracketing; snapshot detects HTTP-only change under fixed HTTPS and NO_PROXY-only change; no rebuild while unchanged; exactly one rebuild on config removal and none after; refresh yields to an applied explicit proxy (no rebuild, record intact, snapshot cleared); a stale-generation refresh commit is rejected and cannot clobber the explicit proxy record.
- Removed: the dead-port liveness/bypass tests (feature dropped).

## Concurrency summary

- `apply_proxy`/`update_proxy` switch the three states (client / record / snapshot) atomically under one lock; a refresh commit re-verifies generation, explicit-proxy absence, and snapshot identity under the write lock, so neither side can observe or produce a half-switched state. `init` initializes the OnceCells during single-threaded startup.
- The throttle uses a monotonic `Instant` behind `try_lock`: concurrent `get()` calls cannot stampede past the interval check (at most one rebuild), and system clock adjustments no longer stall detection.

## Deliberate non-goal: no fail-open on dead-but-configured proxies

An earlier iteration of this PR also probed loopback proxy ports and silently fell back to direct connection when the proxy was configured but not listening. That is a traffic policy change, not a bug fix: for users relying on the proxy for traffic isolation, egress hiding, or auditing, silent direct-connect after a proxy crash would leak destination hosts and bypass their network policy. This PR intentionally keeps that case **fail-closed** — requests fail with normal per-request connection errors under reqwest semantics. The scenario reported in #7029 (proxy tool exit / TUN switch removes or changes the system configuration) is fully covered by config-following rebuilds; if maintainers want an optional dead-port fallback, it should be a separate, explicitly-configured setting defaulting to fail-closed.

## Verification

`cargo test --lib` full suite passes, `cargo clippy --all-targets -D warnings` and `cargo fmt` clean. macOS-only paths (`SCDynamicStore` reads, bracket formatting) are `cfg`-gated; other platforms keep zero new periodic behavior.
