### PR TITLE
fix(usage): count cache tokens in provider and model stats

### DIFF
--- a/src-tauri/src/services/sql_helpers.rs
+++ b/src-tauri/src/services/sql_helpers.rs
@@ -66,6 +66,39 @@ pub fn fresh_input_sql(alias: &str) -> String {
     )
 }
 
+/// Build an SQL expression for the **cache-normalized real total tokens** of a
+/// single row in `proxy_request_logs` or `usage_daily_rollups`:
+///
+/// ```text
+/// fresh_input + output + cache_creation + cache_read
+/// ```
+///
+/// 单一口径（SSOT）：这是用量看板「真实消耗 Tokens」的定义，与
+/// `derive_real_total_and_hit_rate()` 的 `real_total` 逐项对应。Hero 摘要走
+/// Rust 侧的四列相加，供应商 / 模型统计走本函数在 SQL 侧相加——两条路径必须
+/// 引用同一定义，否则同一时间范围下 Hero 与明细表会给出差几个数量级的数字
+/// （缓存命中率高时 cache_read 远大于 fresh_input + output）。
+///
+/// `fresh_input` 由 [`fresh_input_sql`] 归一，因此对 cache-inclusive 供应商
+/// （codex / gemini / grokbuild）不会把缓存部分重复计入。
+///
+/// Pass an empty string to reference the columns directly (no alias),
+/// or a table alias such as `"l"` to emit `l.output_tokens` style references.
+pub fn real_total_tokens_sql(alias: &str) -> String {
+    let prefix = if alias.is_empty() {
+        String::new()
+    } else {
+        format!("{alias}.")
+    };
+    let fresh_input = fresh_input_sql(alias);
+    format!(
+        "({fresh_input}) \
+         + {prefix}output_tokens \
+         + {prefix}cache_creation_tokens \
+         + {prefix}cache_read_tokens"
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -193,5 +226,60 @@ mod tests {
         let sql = format!("SELECT {expr} FROM proxy_request_logs l");
         let value: i64 = conn.query_row(&sql, [], |row| row.get(0)).unwrap();
         assert_eq!(value, 500);
+    }
+
+    #[test]
+    fn real_total_with_alias_emits_prefixed_columns() {
+        let sql = real_total_tokens_sql("l");
+        assert!(sql.contains("l.output_tokens"));
+        assert!(sql.contains("l.cache_creation_tokens"));
+        assert!(sql.contains("l.cache_read_tokens"));
+    }
+
+    #[test]
+    fn real_total_without_alias_uses_bare_columns() {
+        let sql = real_total_tokens_sql("");
+        assert!(sql.contains("output_tokens"));
+        assert!(!sql.contains("l."));
+    }
+
+    #[test]
+    fn real_total_sums_all_four_counters_for_claude_semantics() {
+        let conn = setup_conn();
+        // Anthropic semantics: input_tokens already excludes cache.
+        conn.execute(
+            "INSERT INTO proxy_request_logs (
+                request_id, app_type, input_tokens, output_tokens,
+                cache_read_tokens, cache_creation_tokens
+             ) VALUES ('claude-1', 'claude', 200, 50, 9000, 750)",
+            [],
+        )
+        .unwrap();
+        let expr = real_total_tokens_sql("l");
+        let sql = format!("SELECT {expr} FROM proxy_request_logs l");
+        let value: i64 = conn.query_row(&sql, [], |row| row.get(0)).unwrap();
+        // 200 fresh + 50 out + 9000 cache read + 750 cache write
+        assert_eq!(value, 10_000);
+    }
+
+    #[test]
+    fn real_total_does_not_double_count_cache_for_cache_inclusive_providers() {
+        let conn = setup_conn();
+        // OpenAI semantics: the stored 1000 input_tokens already contains the
+        // 300 cache reads and 200 cache writes. Real total must stay 1000+50,
+        // not 1000+50+300+200.
+        conn.execute(
+            "INSERT INTO proxy_request_logs (
+                request_id, app_type, input_tokens, output_tokens,
+                cache_read_tokens, cache_creation_tokens, input_token_semantics
+             ) VALUES ('codex-1', 'codex', 1000, 50, 300, 200, ?1)",
+            [INPUT_TOKEN_SEMANTICS_TOTAL],
+        )
+        .unwrap();
+        let expr = real_total_tokens_sql("l");
+        let sql = format!("SELECT {expr} FROM proxy_request_logs l");
+        let value: i64 = conn.query_row(&sql, [], |row| row.get(0)).unwrap();
+        // fresh = 1000 - 300 - 200 = 500; 500 + 50 + 200 + 300 = 1050
+        assert_eq!(value, 1050);
     }
 }

--- a/src-tauri/src/services/usage_stats.rs
+++ b/src-tauri/src/services/usage_stats.rs
@@ -6,7 +6,8 @@ use crate::database::{lock_conn, Database};
 use crate::error::AppError;
 use crate::proxy::usage::calculator::ModelPricing;
 use crate::services::sql_helpers::{
-    fresh_input_sql, INPUT_TOKEN_SEMANTICS_FRESH, INPUT_TOKEN_SEMANTICS_TOTAL,
+    fresh_input_sql, real_total_tokens_sql, INPUT_TOKEN_SEMANTICS_FRESH,
+    INPUT_TOKEN_SEMANTICS_TOTAL,
 };
 use chrono::{Local, NaiveDate, TimeZone, Timelike};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -1328,10 +1329,15 @@ impl Database {
         };
 
         // UNION detail logs + rollup data, then aggregate
+        //
+        // total_tokens 用「真实消耗」口径（fresh_input + output + cache_creation
+        // + cache_read），与 Hero 摘要的 real_total 一致。历史实现只算
+        // fresh_input + output，在高缓存命中场景下明细表会比 Hero 低一到两个
+        // 数量级（上游 #3323）。
         let detail_pname = provider_name_coalesce("l", "p");
         let rollup_pname = provider_name_coalesce("r", "p2");
-        let fresh_input_detail = fresh_input_sql("l");
-        let fresh_input_rollup = fresh_input_sql("r");
+        let real_total_detail = real_total_tokens_sql("l");
+        let real_total_rollup = real_total_tokens_sql("r");
         let sql = format!(
             "SELECT
                 provider_id, app_type, provider_name,
@@ -1346,7 +1352,7 @@ impl Database {
                 SELECT l.provider_id, l.app_type,
                     {detail_pname} as provider_name,
                     COUNT(*) as request_count,
-                    COALESCE(SUM({fresh_input_detail} + l.output_tokens), 0) as total_tokens,
+                    COALESCE(SUM({real_total_detail}), 0) as total_tokens,
                     COALESCE(SUM(CAST(l.total_cost_usd AS REAL)), 0) as total_cost,
                     COALESCE(SUM(CASE WHEN l.status_code >= 200 AND l.status_code < 300 THEN 1 ELSE 0 END), 0) as success_count,
                     COALESCE(SUM(l.latency_ms), 0) as latency_sum
@@ -1358,7 +1364,7 @@ impl Database {
                 SELECT r.provider_id, r.app_type,
                     {rollup_pname} as provider_name,
                     COALESCE(SUM(r.request_count), 0),
-                    COALESCE(SUM({fresh_input_rollup} + r.output_tokens), 0),
+                    COALESCE(SUM({real_total_rollup}), 0),
                     COALESCE(SUM(CAST(r.total_cost_usd AS REAL)), 0),
                     COALESCE(SUM(r.success_count), 0),
                     COALESCE(SUM(r.avg_latency_ms * r.request_count), 0)
@@ -1487,8 +1493,11 @@ impl Database {
         // 定价算的，金额与定价表自洽），NULL/'' 回落 model。默认 response 计价
         // 模式下两者相同，行为不变；request 模式 + 路由接管下，钱挂在实际计价
         // 基准名下，而不是上游回显/客户端别名名下。
-        let fresh_input_detail = fresh_input_sql("l");
-        let fresh_input_rollup = fresh_input_sql("r");
+        //
+        // total_tokens 同供应商统计，用「真实消耗」口径（含缓存创建 + 缓存
+        // 读取），与 Hero 摘要的 real_total 对齐（上游 #3323）。
+        let real_total_detail = real_total_tokens_sql("l");
+        let real_total_rollup = real_total_tokens_sql("r");
         let detail_model = effective_model_sql("l");
         let rollup_model = effective_model_sql("r");
         let sql = format!(
@@ -1500,7 +1509,7 @@ impl Database {
             FROM (
                 SELECT {detail_model} as model,
                     COUNT(*) as request_count,
-                    COALESCE(SUM({fresh_input_detail} + l.output_tokens), 0) as total_tokens,
+                    COALESCE(SUM({real_total_detail}), 0) as total_tokens,
                     COALESCE(SUM(CAST(l.total_cost_usd AS REAL)), 0) as total_cost
                 FROM proxy_request_logs l
                 {detail_join}
@@ -1509,7 +1518,7 @@ impl Database {
                 UNION ALL
                 SELECT {rollup_model},
                     COALESCE(SUM(r.request_count), 0),
-                    COALESCE(SUM({fresh_input_rollup} + r.output_tokens), 0),
+                    COALESCE(SUM({real_total_rollup}), 0),
                     COALESCE(SUM(CAST(r.total_cost_usd AS REAL)), 0)
                 FROM usage_daily_rollups r
                 {rollup_join}
@@ -3810,6 +3819,168 @@ mod tests {
         assert_eq!(stats.len(), 1);
         assert_eq!(stats[0].model, "claude-3-sonnet");
         assert_eq!(stats[0].request_count, 1);
+
+        Ok(())
+    }
+
+    /// 回归测试：供应商 / 模型统计的 total_tokens 必须与 Hero 的
+    /// real_total_tokens 同口径（含 cache_read + cache_creation）。
+    ///
+    /// 上游 #3323：历史实现只算 fresh_input + output，在真实的高缓存命中场景
+    /// （命中率 95%+）下明细表会比 Hero 低一到两个数量级。这里刻意把缓存列
+    /// 造得远大于 fresh 列，任何回退到 fresh+output 的改动都会立刻失败。
+    #[test]
+    fn test_provider_and_model_stats_include_cache_tokens_like_hero() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        {
+            let conn = lock_conn!(db.conn);
+            // 明细行：Anthropic 语义，200 fresh / 50 out / 9000 缓存读 / 750 缓存写
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model,
+                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                    total_cost_usd, latency_ms, status_code, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    "cache-heavy-1",
+                    "p1",
+                    "claude",
+                    "claude-opus-4-5",
+                    200,
+                    50,
+                    9000,
+                    750,
+                    "0.01",
+                    100,
+                    200,
+                    1000
+                ],
+            )?;
+        }
+
+        let summary = db.get_usage_summary(None, None, None, None, None)?;
+        // 200 + 50 + 750 + 9000
+        assert_eq!(summary.real_total_tokens, 10_000);
+
+        let provider_stats = db.get_provider_stats(None, None, None, None, None)?;
+        assert_eq!(provider_stats.len(), 1);
+        assert_eq!(
+            provider_stats[0].total_tokens, summary.real_total_tokens,
+            "供应商统计的 total_tokens 应与 Hero 的 real_total_tokens 一致"
+        );
+
+        let model_stats = db.get_model_stats(None, None, None, None, None)?;
+        assert_eq!(model_stats.len(), 1);
+        assert_eq!(
+            model_stats[0].total_tokens, summary.real_total_tokens,
+            "模型统计的 total_tokens 应与 Hero 的 real_total_tokens 一致"
+        );
+
+        // 旧口径会得到 250，这个断言用来钉死回归方向
+        assert_ne!(provider_stats[0].total_tokens, 250);
+        assert_ne!(model_stats[0].total_tokens, 250);
+
+        Ok(())
+    }
+
+    /// 明细行 + 日报聚合行混合时，两条 UNION 分支都要用真实消耗口径。
+    #[test]
+    fn test_provider_and_model_stats_include_cache_tokens_in_rollups() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        {
+            let conn = lock_conn!(db.conn);
+            // 日报行：Anthropic 语义，1000 fresh / 500 out / 40000 缓存读 / 2500 缓存写
+            conn.execute(
+                "INSERT INTO usage_daily_rollups (
+                    date, app_type, provider_id, model,
+                    request_count, success_count, input_tokens, output_tokens,
+                    cache_read_tokens, cache_creation_tokens, total_cost_usd, avg_latency_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    "2024-01-02",
+                    "claude",
+                    "p1",
+                    "claude-opus-4-5",
+                    10,
+                    10,
+                    1000,
+                    500,
+                    40000,
+                    2500,
+                    "0.5",
+                    120
+                ],
+            )?;
+        }
+
+        let start = Local
+            .with_ymd_and_hms(2024, 1, 1, 0, 0, 0)
+            .unwrap()
+            .timestamp();
+        let end = Local
+            .with_ymd_and_hms(2024, 1, 3, 23, 59, 59)
+            .unwrap()
+            .timestamp();
+
+        let summary = db.get_usage_summary(Some(start), Some(end), Some("claude"), None, None)?;
+        // 1000 + 500 + 2500 + 40000
+        assert_eq!(summary.real_total_tokens, 44_000);
+
+        let provider_stats =
+            db.get_provider_stats(Some(start), Some(end), Some("claude"), None, None)?;
+        assert_eq!(provider_stats.len(), 1);
+        assert_eq!(provider_stats[0].total_tokens, summary.real_total_tokens);
+
+        let model_stats = db.get_model_stats(Some(start), Some(end), Some("claude"), None, None)?;
+        assert_eq!(model_stats.len(), 1);
+        assert_eq!(model_stats[0].total_tokens, summary.real_total_tokens);
+
+        Ok(())
+    }
+
+    /// cache-inclusive 供应商（codex / gemini / grokbuild）的 input_tokens 已含
+    /// 缓存，明细表不能因为改用真实消耗口径而把缓存重复计入。
+    #[test]
+    fn test_provider_stats_does_not_double_count_cache_inclusive_input() -> Result<(), AppError> {
+        let db = Database::memory()?;
+
+        {
+            let conn = lock_conn!(db.conn);
+            conn.execute(
+                "INSERT INTO proxy_request_logs (
+                    request_id, provider_id, app_type, model,
+                    input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+                    input_token_semantics, total_cost_usd, latency_ms, status_code, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    "codex-total-1",
+                    "p1",
+                    "codex",
+                    "gpt-5.2",
+                    1000,
+                    50,
+                    300,
+                    200,
+                    INPUT_TOKEN_SEMANTICS_TOTAL,
+                    "0.01",
+                    100,
+                    200,
+                    1000
+                ],
+            )?;
+        }
+
+        let summary = db.get_usage_summary(None, None, None, None, None)?;
+        // fresh = 1000 - 300 - 200 = 500；500 + 50 + 200 + 300 = 1050
+        assert_eq!(summary.real_total_tokens, 1050);
+
+        let provider_stats = db.get_provider_stats(None, None, None, None, None)?;
+        assert_eq!(provider_stats[0].total_tokens, 1050);
+
+        let model_stats = db.get_model_stats(None, None, None, None, None)?;
+        assert_eq!(model_stats[0].total_tokens, 1050);
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

用量看板的「供应商统计」「模型统计」两张明细表的 `total_tokens` 此前只算 `fresh_input + output`,而 Hero 摘要的「真实消耗 Tokens」算的是 `fresh_input + output + cache_creation + cache_read`。同一时间范围下两者相差一到两个数量级——Claude 的 prompt cache 命中率常在 99% 以上,被排除的 `cache_read` 远大于被统计的部分。

用户视角:30 天总用量在 Hero 显示 138 亿,但 provider/model 表加总只有 1.4 亿。明细表里缓存命中率高的行,Token 列严重被低估,无法和 Hero 对账。

## Root Cause

| 位置 | 口径 |
|---|---|
| `usage_stats.rs` Hero (L49-54 `derive_real_total_and_hit_rate`) | `fresh + output + cache_create + cache_read` |
| `usage_stats.rs:1349` provider detail | `fresh + output`  ❌ |
| `usage_stats.rs:1361` provider rollup | `fresh + output`  ❌ |
| `usage_stats.rs:1503` model detail | `fresh + output`  ❌ |
| `usage_stats.rs:1512` model rollup | `fresh + output`  ❌ |

v3.15.0 引入 Hero 缓存归一化时,改动这行 SQL 的提交 `edf28b64` 只把 `input_tokens` 换成了 `fresh_input_sql`,**没顺手补 cache 两列**——新口径加在了 Hero,旧口径留在了明细表,一次没做完的重构。

## Fix

新增 `sql_helpers::real_total_tokens_sql()` 作为该口径的 SSOT,与 `derive_real_total_and_hit_rate` 的 `real_total` 逐项对应:

```rust
pub fn real_total_tokens_sql(alias: &str) -> String {
    let prefix = ...; // "l." 或 ""
    let fresh_input = fresh_input_sql(alias);  // 已有 helper,扣 cache inclusive
    format!(
        "({fresh_input}) + {prefix}output_tokens \
         + {prefix}cache_creation_tokens \
         + {prefix}cache_read_tokens"
    )
}
```

四条 UNION 分支统一引用 `real_total_tokens_sql("l")` / `real_total_tokens_sql("r")`。`fresh_input` 仍由 `fresh_input_sql` 归一,所以 `codex` / `gemini` / `grokbuild` 这类 `input_tokens` 已含缓存的供应商不会被双算。

**为什么用 helper 而不是四处内联?** 仓库自己的 v3.19.0 注释已经定下规矩——「缓存含入式供应商集合只定义一处」。这次把同款思路用到「真实消耗」口径,避免下次有人在某条 UNION 分支上再写错。

## Tests

新增 7 个测试:

- `real_total_with_alias_emits_prefixed_columns` / `real_total_without_alias_uses_bare_columns` — SQL 形状
- `real_total_sums_all_four_counters_for_claude_semantics` — Anthropic 行口径正确
- `real_total_does_not_double_count_cache_for_cache_inclusive_providers` — codex total 语义不被双算
- `test_provider_and_model_stats_include_cache_tokens_like_hero` — **核心集成断言**:provider/model 表的 `total_tokens` 必须 == Hero 的 `real_total_tokens`(刻意造 200 fresh vs 9000 cache read 的数据,并 `assert_ne!(total, 250)` 钉死回归)
- `test_provider_and_model_stats_include_cache_tokens_in_rollups` — 同上,验 `usage_daily_rollups` UNION 分支
- `test_provider_stats_does_not_double_count_cache_inclusive_input` — codex 行不被双算

全量 `cargo test --lib`:2768 passed,无回归。

## Backward Compatibility

- **没动 schema**,没改任何持久化字段
- **没动 SQL 历史回填**——历史数据本就存了 cache 两列,只是之前 SUM 漏了。换上后明细表数字直接跳到正确量级,无迁移成本
- **不影响 Hero**——`derive_real_total_and_hit_rate` 一字未动
- **不影响成本计算**——只改展示侧,`total_cost_usd` 仍然按 `fresh_input_sql + output` 在另一处独立算

## Fixes

- farion1231/cc-switch#3323

## Local Verification

本机 30 天数据:明细表加总 1.4 亿 → 138 亿,与 Hero 对齐。

🤖 Generated with [Claude Code](https://claude.com/claude-code)