### PR TITLE
fix(codex): proxy image generations endpoint

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1481,8 +1481,9 @@ impl RequestForwarder {
         let codex_anthropic_base_is_full_endpoint =
             codex_responses_to_anthropic && base_url_is_full_endpoint(&base_url, "/v1/messages");
 
-        let is_codex_alpha_search = matches!(app_type, AppType::Codex)
-            && split_endpoint_and_query(&effective_endpoint).0 == "/alpha/search";
+        let codex_standalone_endpoint = matches!(app_type, AppType::Codex)
+            .then(|| CodexStandaloneEndpoint::from_effective_endpoint(&effective_endpoint))
+            .flatten();
 
         let url = if matches!(resolved_claude_api_format.as_deref(), Some("gemini_native")) {
             super::gemini_url::resolve_gemini_native_url(
@@ -1490,12 +1491,17 @@ impl RequestForwarder {
                 &effective_endpoint,
                 is_full_url,
             )
-        } else if is_full_url && is_codex_alpha_search {
-            rewrite_codex_alpha_search_full_url(&base_url, passthrough_query.as_deref())?
-        } else if is_full_url
-            || codex_chat_base_is_full_endpoint
-            || codex_anthropic_base_is_full_endpoint
-        {
+        } else if is_full_url {
+            if let Some(endpoint) = codex_standalone_endpoint {
+                rewrite_codex_standalone_full_url(
+                    &base_url,
+                    passthrough_query.as_deref(),
+                    endpoint,
+                )?
+            } else {
+                append_query_to_full_url(&base_url, passthrough_query.as_deref())
+            }
+        } else if codex_chat_base_is_full_endpoint || codex_anthropic_base_is_full_endpoint {
             append_query_to_full_url(&base_url, passthrough_query.as_deref())
         } else {
             adapter.build_url(&base_url, &effective_endpoint)
@@ -3284,24 +3290,86 @@ fn append_query_to_full_url(base_url: &str, query: Option<&str>) -> String {
     }
 }
 
-/// Derive the standalone Alpha Search endpoint from a Codex provider configured
-/// with a complete Responses URL.
+#[derive(Clone, Copy)]
+enum CodexStandaloneEndpoint {
+    AlphaSearch,
+    ImagesGenerations,
+}
+
+impl CodexStandaloneEndpoint {
+    fn from_effective_endpoint(endpoint: &str) -> Option<Self> {
+        match split_endpoint_and_query(endpoint).0 {
+            "/alpha/search" => Some(Self::AlphaSearch),
+            "/images/generations" => Some(Self::ImagesGenerations),
+            _ => None,
+        }
+    }
+
+    fn path(self) -> &'static str {
+        match self {
+            Self::AlphaSearch => "/alpha/search",
+            Self::ImagesGenerations => "/images/generations",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::AlphaSearch => "Codex Alpha Search",
+            Self::ImagesGenerations => "Codex Images generations",
+        }
+    }
+
+    fn full_url_hint(self) -> &'static str {
+        match self {
+            Self::AlphaSearch => "/responses",
+            Self::ImagesGenerations => "/responses, /chat/completions, or /images/generations",
+        }
+    }
+
+    fn source_suffix(self, parsed_path: &str) -> Option<&'static str> {
+        match self {
+            Self::AlphaSearch => {
+                if parsed_path.ends_with("/responses/compact") {
+                    Some("/responses/compact")
+                } else if parsed_path.ends_with("/responses") {
+                    Some("/responses")
+                } else {
+                    None
+                }
+            }
+            Self::ImagesGenerations => {
+                if parsed_path.ends_with("/images/generations") {
+                    Some("/images/generations")
+                } else if parsed_path.ends_with("/chat/completions") {
+                    Some("/chat/completions")
+                } else if parsed_path.ends_with("/responses/compact") {
+                    Some("/responses/compact")
+                } else if parsed_path.ends_with("/responses") {
+                    Some("/responses")
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+/// Derive Codex standalone sibling endpoints from a provider configured with a
+/// complete Codex-compatible API URL.
 ///
 /// Full-URL mode normally means "use this exact URL". That is correct for the
-/// request type it was configured for, but reusing a `/responses` URL for an
-/// Alpha Search request silently posts the search payload to the wrong API. Only
-/// rewrite URL shapes whose sibling endpoint is unambiguous; opaque full URLs
-/// fail closed with a configuration error instead of leaking the search payload
-/// to an unrelated route.
-fn rewrite_codex_alpha_search_full_url(
+/// request type it was configured for, but standalone Codex protocols cannot be
+/// posted to chat/responses endpoints. Only rewrite URL shapes whose sibling
+/// endpoint is unambiguous; opaque full URLs fail closed instead of leaking the
+/// payload to an unrelated route.
+fn rewrite_codex_standalone_full_url(
     base_url: &str,
     request_query: Option<&str>,
+    endpoint: CodexStandaloneEndpoint,
 ) -> Result<String, ProxyError> {
     let trimmed = base_url.trim();
     let parsed = url::Url::parse(trimmed).map_err(|_| {
-        ProxyError::ConfigError(
-            "Codex Alpha Search requires a valid full Responses URL".to_string(),
-        )
+        ProxyError::ConfigError(format!("{} requires a valid full URL", endpoint.label()))
     })?;
 
     // Fragments are never sent in HTTP requests. Drop one before splitting the
@@ -3317,21 +3385,20 @@ fn rewrite_codex_alpha_search_full_url(
     let url_without_query = url_without_query.trim_end_matches('/');
 
     let parsed_path = parsed.path().trim_end_matches('/').to_string();
-    let suffix = if parsed_path.ends_with("/responses/compact") {
-        "/responses/compact"
-    } else if parsed_path.ends_with("/responses") {
-        "/responses"
-    } else {
-        return Err(ProxyError::ConfigError(
-            "Codex Alpha Search cannot derive /alpha/search from an opaque full URL; use a base URL or a full URL ending in /responses".to_string(),
-        ));
-    };
+    let suffix = endpoint.source_suffix(&parsed_path).ok_or_else(|| {
+        ProxyError::ConfigError(format!(
+            "{} cannot derive {} from an opaque full URL; use a base URL or a full URL ending in {}",
+            endpoint.label(),
+            endpoint.path(),
+            endpoint.full_url_hint()
+        ))
+    })?;
 
     let prefix_len = url_without_query
         .len()
         .checked_sub(suffix.len())
         .ok_or_else(|| ProxyError::ConfigError("Invalid Codex full URL".to_string()))?;
-    let mut rewritten = format!("{}/alpha/search", &url_without_query[..prefix_len]);
+    let mut rewritten = format!("{}{}", &url_without_query[..prefix_len], endpoint.path());
 
     let request_query = request_query.filter(|query| !query.is_empty());
     let base_query = base_query.filter(|query| !query.is_empty());
@@ -4750,18 +4817,88 @@ mod tests {
 
         for (base_url, expected) in cases {
             assert_eq!(
-                rewrite_codex_alpha_search_full_url(base_url, Some("client_version=0.144.6"))
-                    .expect("known Responses full URL should be rewritable"),
+                rewrite_codex_standalone_full_url(
+                    base_url,
+                    Some("client_version=0.144.6"),
+                    CodexStandaloneEndpoint::AlphaSearch,
+                )
+                .expect("known Responses full URL should be rewritable"),
                 expected
             );
         }
     }
 
     #[test]
+    fn images_generations_rewrites_known_full_codex_urls() {
+        let cases = [
+            (
+                "https://relay.example/v1/responses",
+                "https://relay.example/v1/images/generations?client_version=0.145.0",
+            ),
+            (
+                "https://relay.example/backend-api/codex/responses/compact/",
+                "https://relay.example/backend-api/codex/images/generations?client_version=0.145.0",
+            ),
+            (
+                "https://relay.example/custom/%2F/v1/responses?api-version=2026-07",
+                "https://relay.example/custom/%2F/v1/images/generations?api-version=2026-07&client_version=0.145.0",
+            ),
+            (
+                "https://relay.example/v1/chat/completions?api-version=2026-07",
+                "https://relay.example/v1/images/generations?api-version=2026-07&client_version=0.145.0",
+            ),
+        ];
+
+        for (base_url, expected) in cases {
+            assert_eq!(
+                rewrite_codex_standalone_full_url(
+                    base_url,
+                    Some("client_version=0.145.0"),
+                    CodexStandaloneEndpoint::ImagesGenerations,
+                )
+                .expect("known Codex full URL should be rewritable"),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn images_generations_preserves_existing_full_images_url() {
+        let url = rewrite_codex_standalone_full_url(
+            "https://relay.example/v1/images/generations?api-version=2026-07",
+            Some("client_version=0.145.0"),
+            CodexStandaloneEndpoint::ImagesGenerations,
+        )
+        .expect("full Images URL should be preserved");
+
+        assert_eq!(
+            url,
+            "https://relay.example/v1/images/generations?api-version=2026-07&client_version=0.145.0"
+        );
+    }
+
+    #[test]
+    fn images_generations_rejects_opaque_full_url_instead_of_misrouting_payload() {
+        let error = rewrite_codex_standalone_full_url(
+            "https://relay.example/custom/rpc-endpoint",
+            Some("client_version=0.145.0"),
+            CodexStandaloneEndpoint::ImagesGenerations,
+        )
+        .expect_err("opaque endpoint must fail closed");
+
+        assert!(matches!(
+            error,
+            ProxyError::ConfigError(message)
+                if message.contains("cannot derive /images/generations")
+        ));
+    }
+
+    #[test]
     fn alpha_search_rejects_opaque_full_url_instead_of_misrouting_payload() {
-        let error = rewrite_codex_alpha_search_full_url(
+        let error = rewrite_codex_standalone_full_url(
             "https://relay.example/custom/rpc-endpoint",
             Some("client_version=0.144.6"),
+            CodexStandaloneEndpoint::AlphaSearch,
         )
         .expect_err("opaque endpoint must fail closed");
 

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -975,6 +975,22 @@ pub async fn handle_alpha_search(
     State(state): State<ProxyState>,
     request: axum::extract::Request,
 ) -> Result<axum::response::Response, ProxyError> {
+    handle_codex_standalone_passthrough(state, request, "/alpha/search").await
+}
+
+/// Handle Codex's legacy Images API endpoint for built-in ImageGen.
+pub async fn handle_images_generations(
+    State(state): State<ProxyState>,
+    request: axum::extract::Request,
+) -> Result<axum::response::Response, ProxyError> {
+    handle_codex_standalone_passthrough(state, request, "/images/generations").await
+}
+
+async fn handle_codex_standalone_passthrough(
+    state: ProxyState,
+    request: axum::extract::Request,
+    canonical_endpoint: &'static str,
+) -> Result<axum::response::Response, ProxyError> {
     let (parts, req_body) = request.into_parts();
     let method = parts.method.clone();
     let uri = parts.uri;
@@ -991,7 +1007,7 @@ pub async fn handle_alpha_search(
 
     let mut ctx =
         RequestContext::new(&state, &body, &headers, AppType::Codex, "Codex", "codex").await?;
-    let endpoint = endpoint_with_query(&uri, "/alpha/search");
+    let endpoint = endpoint_with_query(&uri, canonical_endpoint);
 
     let forwarder = ctx.create_forwarder(&state);
     let mut result = match forwarder

--- a/src-tauri/src/proxy/server.rs
+++ b/src-tauri/src/proxy/server.rs
@@ -363,6 +363,23 @@ impl ProxyServer {
                 "/codex/v1/alpha/search",
                 post(handlers::handle_alpha_search),
             )
+            // Codex built-in ImageGen still calls the legacy OpenAI Images API.
+            .route(
+                "/images/generations",
+                post(handlers::handle_images_generations),
+            )
+            .route(
+                "/v1/images/generations",
+                post(handlers::handle_images_generations),
+            )
+            .route(
+                "/v1/v1/images/generations",
+                post(handlers::handle_images_generations),
+            )
+            .route(
+                "/codex/v1/images/generations",
+                post(handlers::handle_images_generations),
+            )
             // Gemini API (支持带前缀和不带前缀)
             //
             // 用 `any(..)` 覆盖所有 HTTP 方法：除了 POST `:generateContent` /
@@ -417,6 +434,7 @@ impl ProxyServer {
 mod tests {
     use super::*;
     use crate::provider::{Provider, ProviderMeta};
+    use crate::AppError;
     use axum::http::{header, HeaderMap, StatusCode};
     use serde_json::{json, Value};
     use tokio::sync::Mutex;
@@ -426,6 +444,211 @@ mod tests {
         path_and_query: String,
         authorization: Option<String>,
         body: Value,
+    }
+
+    #[tokio::test]
+    async fn codex_images_generation_aliases_forward_and_record_usage() {
+        let captured = Arc::new(Mutex::new(Vec::<CapturedRequest>::new()));
+        let mock_app = Router::new().route(
+            "/v1/images/generations",
+            post({
+                let captured = captured.clone();
+                move |request: axum::extract::Request| {
+                    let captured = captured.clone();
+                    async move {
+                        let (parts, body) = request.into_parts();
+                        let body = axum::body::to_bytes(body, 1024 * 1024)
+                            .await
+                            .expect("read mock request body");
+                        captured.lock().await.push(CapturedRequest {
+                            path_and_query: parts
+                                .uri
+                                .path_and_query()
+                                .map(|value| value.as_str().to_string())
+                                .unwrap_or_else(|| parts.uri.path().to_string()),
+                            authorization: parts
+                                .headers
+                                .get(header::AUTHORIZATION)
+                                .and_then(|value| value.to_str().ok())
+                                .map(ToString::to_string),
+                            body: serde_json::from_slice(&body).expect("parse mock request body"),
+                        });
+
+                        (
+                            StatusCode::OK,
+                            [(header::CONTENT_TYPE, "application/json")],
+                            r#"{"created":1,"data":[{"b64_json":"aW1hZ2U="}],"usage":{"input_tokens":7,"output_tokens":11,"total_tokens":18}}"#,
+                        )
+                    }
+                }
+            }),
+        );
+        let mock_listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind mock upstream");
+        let mock_addr = mock_listener.local_addr().expect("mock upstream address");
+        let mock_handle = tokio::spawn(async move {
+            axum::serve(mock_listener, mock_app)
+                .await
+                .expect("serve mock upstream");
+        });
+
+        let db = Arc::new(Database::memory().expect("memory database"));
+        let provider = Provider::with_id(
+            "images-api-upstream".to_string(),
+            "Images API Upstream".to_string(),
+            json!({
+                "base_url": format!("http://{mock_addr}/v1"),
+                "auth": {"OPENAI_API_KEY": "upstream-secret"}
+            }),
+            None,
+        );
+        db.save_provider("codex", &provider)
+            .expect("save test provider");
+        db.set_current_provider("codex", &provider.id)
+            .expect("select test provider");
+
+        let proxy = ProxyServer::new(
+            ProxyConfig {
+                listen_port: 0,
+                enable_logging: true,
+                non_streaming_timeout: 10,
+                ..ProxyConfig::default()
+            },
+            db.clone(),
+            None,
+        );
+        let proxy_info = proxy.start().await.expect("start test proxy");
+        let client = reqwest::Client::new();
+        let aliases = [
+            "/images/generations",
+            "/v1/images/generations",
+            "/v1/v1/images/generations",
+            "/codex/v1/images/generations",
+        ];
+
+        for (index, path) in aliases.iter().enumerate() {
+            let response = client
+                .post(format!(
+                    "http://127.0.0.1:{}{}?client_version=0.145.0",
+                    proxy_info.port, path
+                ))
+                .header(header::AUTHORIZATION, "Bearer client-secret")
+                .json(&json!({
+                    "model": "gpt-image-1",
+                    "prompt": format!("image generation alias {index}")
+                }))
+                .send()
+                .await
+                .expect("send images request");
+
+            assert_eq!(response.status(), StatusCode::OK, "alias {path}");
+            assert_eq!(
+                response.text().await.expect("read proxy response"),
+                r#"{"created":1,"data":[{"b64_json":"aW1hZ2U="}],"usage":{"input_tokens":7,"output_tokens":11,"total_tokens":18}}"#,
+                "alias {path}"
+            );
+        }
+
+        let (log_count, input_tokens, output_tokens): (i64, i64, i64) =
+            tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                loop {
+                    let totals = {
+                        let conn = crate::database::lock_conn!(db.conn);
+                        match conn.query_row(
+                            "SELECT COUNT(*), COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0)
+                             FROM proxy_request_logs WHERE provider_id = ?1",
+                            ["images-api-upstream"],
+                            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+                        ) {
+                            Ok(totals) => totals,
+                            Err(error) => panic!("query images usage logs: {error}"),
+                        }
+                    };
+
+                    if totals.0 == aliases.len() as i64 {
+                        break Ok::<_, AppError>(totals);
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("images usage logs were not recorded")
+            .expect("read images usage logs");
+        assert_eq!(log_count, aliases.len() as i64);
+        assert_eq!(input_tokens, 7 * aliases.len() as i64);
+        assert_eq!(output_tokens, 11 * aliases.len() as i64);
+
+        let mut full_url_provider = Provider::with_id(
+            "images-api-full-url".to_string(),
+            "Images API Full URL".to_string(),
+            json!({
+                "base_url": format!("http://{mock_addr}/v1/responses?api-version=test"),
+                "auth": {"OPENAI_API_KEY": "full-url-secret"}
+            }),
+            None,
+        );
+        full_url_provider.meta = Some(ProviderMeta {
+            is_full_url: Some(true),
+            ..ProviderMeta::default()
+        });
+        db.save_provider("codex", &full_url_provider)
+            .expect("save full URL images provider");
+        db.set_current_provider("codex", &full_url_provider.id)
+            .expect("select full URL images provider");
+
+        let response = client
+            .post(format!(
+                "http://127.0.0.1:{}/v1/images/generations?client_version=0.145.0",
+                proxy_info.port
+            ))
+            .header(header::AUTHORIZATION, "Bearer client-secret")
+            .json(&json!({
+                "model": "gpt-image-1",
+                "prompt": "image generation full URL"
+            }))
+            .send()
+            .await
+            .expect("send full URL images request");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.text().await.expect("read full URL image response"),
+            r#"{"created":1,"data":[{"b64_json":"aW1hZ2U="}],"usage":{"input_tokens":7,"output_tokens":11,"total_tokens":18}}"#
+        );
+
+        let captured = captured.lock().await;
+        assert_eq!(captured.len(), aliases.len() + 1);
+        for (index, request) in captured.iter().take(aliases.len()).enumerate() {
+            assert_eq!(
+                request.path_and_query,
+                "/v1/images/generations?client_version=0.145.0"
+            );
+            assert_eq!(
+                request.authorization.as_deref(),
+                Some("Bearer upstream-secret")
+            );
+            assert_eq!(request.body["model"], "gpt-image-1");
+            assert_eq!(
+                request.body["prompt"],
+                format!("image generation alias {index}")
+            );
+        }
+
+        let full_url_request = captured.last().expect("full URL image request captured");
+        assert_eq!(
+            full_url_request.path_and_query,
+            "/v1/images/generations?api-version=test&client_version=0.145.0"
+        );
+        assert_eq!(
+            full_url_request.authorization.as_deref(),
+            Some("Bearer full-url-secret")
+        );
+        assert_eq!(full_url_request.body["model"], "gpt-image-1");
+        assert_eq!(full_url_request.body["prompt"], "image generation full URL");
+
+        proxy.stop().await.expect("stop test proxy");
+        mock_handle.abort();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary / 概述

修复 Codex 本地路由模式下内置 ImageGen 调用 legacy OpenAI Images API 时返回 404，或在 `is_full_url = true` provider 下被误转发到 Responses / Chat Completions URL 的问题。

Codex 的图片生成会请求 `/v1/images/generations`。此前本地 proxy 只注册了 Chat Completions、Responses、Responses Compact 和 Alpha Search 等 Codex 端点，Images generations 请求会在路由层直接 404，无法转发到当前选中的 Codex provider。

同时，如果当前 Codex provider 配置为 full URL（例如完整的 `/v1/responses`、`/responses/compact` 或 `/v1/chat/completions` 地址），普通 full-URL 分支会复用配置 URL，导致 ImageGen payload 被发送到聊天/Responses 端点，而不是 sibling `/v1/images/generations`。本 PR 将 Codex standalone endpoint 的 full URL 改写收敛到同一 helper：仅对可明确推导 sibling endpoint 的 URL 进行改写，已指向 `/images/generations` 的 full URL 会保留原路径并合并 query，无法安全推导的 opaque full URL 会 fail closed，避免把图片请求误发到无关端点。

请求仍走当前 Codex provider 的鉴权、模型映射、重试和响应透传；返回中的 `usage.input_tokens` / `usage.output_tokens` 也会通过 Codex usage parser 正确记录。

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| Codex ImageGen 请求 `/v1/images/generations` | 本地 proxy 未注册该端点，路由层返回 404 | 请求转发到上游 canonical `/v1/images/generations` |
| Codex 本地路径兼容 | `/images/generations`、`/v1/v1/images/generations`、`/codex/v1/images/generations` 不可用 | 4 个本地 alias 都归一到同一个上游 Images generations endpoint |
| full URL Codex provider | 完整 `/v1/responses`、`/responses/compact` 或 `/v1/chat/completions` provider 会把 ImageGen payload 继续发送到原聊天/Responses URL | 可明确推导时改写到 sibling `/v1/images/generations`；已有 Images full URL 保持路径并合并 query |
| 用量统计 | Images API 返回的 `input_tokens` / `output_tokens` 无法通过 Chat Completions parser 正确记录 | 使用 Codex parser 自动解析 Images usage，并写入 proxy request logs |
| 既有 Alpha Search | 维持独立 handler 中重复的 passthrough 流程 | 与 Images generations 共享 Codex standalone passthrough/full URL rewrite helper，行为由原有 Alpha Search 测试继续覆盖 |

## Related Issue / 关联 Issue

Fixes #5429
Fixes #6745

## Screenshots / 截图

| 场景 | Before / 修改前 | After / 修改后 |
| --- | --- | --- |
| Codex ImageGen 本地路由 | ![修改前：ImageGen 返回 404](https://raw.githubusercontent.com/thisTom/cc-switch/pr-assets-7036/.github/pr-assets/7036/before-imagegen-404.png) | ![修改后：ImageGen 成功生成图片](https://raw.githubusercontent.com/thisTom/cc-switch/pr-assets-7036/.github/pr-assets/7036/after-imagegen-success.png) |

- 修改前：Codex 通过本地路由调用 `imagegen` 技能时，`/v1/images/generations` 在 proxy 路由层返回 `404 Not Found`，无法生成图片。
- 修改后：同样的 ImageGen 调用可正常转发并返回有效图片，Codex 会话中展示生成结果。

## Testing / 测试

| 检查项 | 结果 |
| --- | --- |
| `cargo test --manifest-path src-tauri/Cargo.toml proxy::server::tests::codex_images_generation_aliases_forward_and_record_usage -- --exact` | 通过；覆盖 4 个 Images generations alias、上游转发、鉴权替换、query 保留、usage 记录，以及 full URL `/v1/responses` 改写到 `/v1/images/generations` |
| `cargo test --manifest-path src-tauri/Cargo.toml proxy::forwarder::tests::images_generations_rewrites_known_full_codex_urls -- --exact` | 通过；覆盖 Responses、Responses Compact、Chat Completions full URL 改写到 Images generations |
| `cargo test --manifest-path src-tauri/Cargo.toml proxy::forwarder::tests:: -- --nocapture` | 通过，75 个测试通过；覆盖 full URL rewrite、已有 Images full URL 保留、opaque full URL fail closed，以及既有 Alpha Search 行为 |
| `cargo fmt --check --manifest-path src-tauri/Cargo.toml` | 通过 |
| `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` | 通过 |
| `cargo test --manifest-path src-tauri/Cargo.toml -- --skip services::provider::tests::update_current_claude_desktop_provider_syncs_profile_when_proxy_takeover_is_active` | 通过，2765 passed，0 failed，5 ignored，1 filtered out |
| `cargo test --manifest-path src-tauri/Cargo.toml` | 本机未完整通过：当前正在运行的 `ai-manage` 占用 `127.0.0.1:15721`，导致一个固定默认端口的既有测试 `update_current_claude_desktop_provider_syncs_profile_when_proxy_takeover_is_active` 绑定失败；该失败与本 PR 修改路径无关 |
| 手动验证（macOS ChatGPT/Codex 环境） | 通过，在 macOS ChatGPT 环境下使用第三方模型供应商 `sol` + `qwen` 生图模型完成 ImageGen 调用，图片可正常生成并展示 |
| `git diff --check` | 通过 |
| `pnpm typecheck` / `pnpm format:check` | 未运行，本 PR 未修改前端或 TypeScript 文件 |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（N/A：未修改前端或 TypeScript 文件）
- [x] `pnpm format:check` passes / 通过代码格式检查（N/A：未修改前端或 TypeScript 文件）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（N/A：无用户可见文案变更）
