### PR TITLE
fix: integrate Responses API route conversions and Claude Desktop fixes

### DIFF
--- a/.github/workflows/test-proxy-fix.yml
+++ b/.github/workflows/test-proxy-fix.yml
@@ -1,0 +1,47 @@
+name: Test Proxy Truncation Fix
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Run Proxy Tests
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            src-tauri/target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      
+      - name: Build
+        run: cd src-tauri && cargo build --release
+      
+      - name: Run streaming_responses tests
+        run: cd src-tauri && cargo test --lib proxy::providers::streaming_responses
+      
+      - name: Run handlers tests
+        run: cd src-tauri && cargo test --lib proxy::handlers
+      
+      - name: Run transform_codex_anthropic tests
+        run: cd src-tauri && cargo test --lib proxy::providers::transform_codex_anthropic
+      
+      - name: Run all proxy tests
+        run: cd src-tauri && cargo test --lib proxy::

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1621,6 +1621,18 @@ impl RequestForwarder {
             mapped_body
         };
 
+        // Claude Desktop：对原生 Anthropic 格式的请求体注入 cache_control 断点。
+        // Bedrock 路径已在上方 provider_body 阶段处理，此处覆盖非 Bedrock 的上游
+        // （直连 anthropic.com / 第三方中转），保证 proxy 模式下也能开启 Prompt Caching。
+        // openai_chat / openai_responses / gemini_native 路径由 transform 层自行处理，不在此注入。
+        if matches!(app_type, AppType::ClaudeDesktop)
+            && self.optimizer_config.enabled
+            && self.optimizer_config.cache_injection
+            && super::providers::get_claude_api_format(provider) == "anthropic"
+        {
+            super::cache_injector::inject(&mut request_body, &self.optimizer_config);
+        }
+
         // Native Responses passthrough to a strict third-party gateway (xAI).
         // One gate so rebase conflicts stay here plus the isolate file, not
         // scattered across sanitizers. Flatten namespaces first; then apply

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -53,6 +53,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use http_body_util::BodyExt;
 use serde_json::{json, Value};
+use std::collections::HashSet;
 
 // ============================================================================
 // 健康检查和状态查询（简单端点）

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -53,6 +53,7 @@ use bytes::Bytes;
 use futures::StreamExt;
 use http_body_util::BodyExt;
 use serde_json::{json, Value};
+use std::collections::HashSet;
 
 // ============================================================================
 // 健康检查和状态查询（简单端点）
@@ -2261,9 +2262,44 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
         ProxyError::TransformError("No response.completed event in upstream SSE".to_string())
     })?;
 
+    // 重要修复：如果流在 output_item.done 事件之前结束（如网络中断），
+    // response.completed 事件本身可能已经包含了 output 数组。
+    // 我们应该合并两者：使用 completed 中的 output（如果存在），
+    // 并添加我们从 output_item.done 事件中单独收集的 items。
+    // 这确保了即使流被截断，已收到的输出项也不会丢失。
+    let existing_output = response.get("output").cloned();
     if !output_items.is_empty() {
+        let mut final_output = if let Some(existing) = existing_output {
+            if let Some(existing_arr) = existing.as_array() {
+                // 避免重复：只添加不在 existing 中的 items
+                let existing_ids: HashSet<&str> = existing_arr
+                    .iter()
+                    .filter_map(|item| item.get("id").and_then(|i| i.as_str()))
+                    .collect();
+                output_items
+                    .into_iter()
+                    .filter(|item| {
+                        item.get("id")
+                            .and_then(|i| i.as_str())
+                            .map(|id| !existing_ids.contains(id))
+                            .unwrap_or(true)
+                    })
+                    .chain(existing_arr.iter().cloned())
+                    .collect()
+            } else {
+                output_items
+            }
+        } else {
+            output_items
+        };
+        // 按 output_index 排序以确保顺序正确
+        final_output.sort_by(|a, b| {
+            let a_idx = a.get("output_index").and_then(|v| v.as_u64()).unwrap_or(0);
+            let b_idx = b.get("output_index").and_then(|v| v.as_u64()).unwrap_or(0);
+            a_idx.cmp(&b_idx)
+        });
         if let Some(obj) = response.as_object_mut() {
-            obj.insert("output".to_string(), Value::Array(output_items));
+            obj.insert("output".to_string(), Value::Array(final_output));
         } else {
             return Err(ProxyError::TransformError(
                 "response.completed payload is not an object".to_string(),
@@ -2279,14 +2315,42 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
 /// 仅在 JSON 解析已失败后调用：合法 JSON 不可能以这些前缀开头，误判面为零。
 /// 覆盖 SSE 规范的全部四种字段行；包含 ":" 是因为 OpenRouter 等会在流前发
 /// `: PROCESSING` 注释行。
+///
+/// 增加额外守卫：匹配 ":" 前缀时要求冒号后至少跟两个非空白字符
+/// （例如 `: PROCESSING` 的 " PROCESSING"）。这防止纯文本错误（如
+/// `": Bad Gateway"`、`": connection refused"`）被误判为 SSE，否则
+/// 聚合器会吃掉原始诊断信息并返回 "No response.completed event" 之类
+/// 误导性的错误。
 fn body_looks_like_sse(body: &str) -> bool {
     let trimmed = body.trim_start_matches('\u{feff}').trim_start();
-    ["data:", "event:", "id:", "retry:", ":"]
-        .iter()
-        .any(|prefix| trimmed.starts_with(prefix))
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Special case for bare ":" prefix used by OpenAI/SSE spec comments:
+    // SSE comments appear as the first line of the body (e.g. ": PROCESSING",
+    // ": OPENROUTER PROCESSING") followed by newline-separated data lines.
+    // Reject error bodies like ": Bad Gateway" which contain lowercase prose.
+    if trimmed.starts_with(':') {
+        // Only the first line matters for SSE comment detection
+        let first_line = trimmed
+            .lines()
+            .next()
+            .unwrap_or(trimmed)
+            .strip_prefix(':')
+            .unwrap_or("")
+            .trim_start();
+        // SSE comment identifiers are all-uppercase; any lowercase means prose.
+        !first_line.is_empty()
+            && first_line
+                .chars()
+                .all(|c| c.is_whitespace() || c.is_ascii_uppercase())
+    } else {
+        // For other SSE field prefixes (data:, event:, id:, retry:), just check presence.
+        ["data:", "event:", "id:", "retry:"]
+            .iter()
+            .any(|prefix| trimmed.starts_with(prefix))
+    }
 }
-
-/// 构造带现场诊断的上游解析错误：只附结构化分类与元数据，
 /// 避免响应正文经错误链间接进入持久化日志。
 fn upstream_body_parse_error(
     prefix: &str,
@@ -2857,6 +2921,10 @@ mod tests {
         assert!(!body_looks_like_sse("<html><body>blocked</body></html>"));
         assert!(!body_looks_like_sse("Bad Gateway"));
         assert!(!body_looks_like_sse(""));
+        // 纯冒号开头的错误体（如上游健康检查返回 ": connection refused"）不应误判
+        assert!(!body_looks_like_sse(": Bad Gateway"));
+        assert!(!body_looks_like_sse(": upstream timeout\n"));
+        assert!(!body_looks_like_sse(": "));
     }
 
     #[test]

--- a/src-tauri/src/proxy/handlers.rs
+++ b/src-tauri/src/proxy/handlers.rs
@@ -2261,9 +2261,44 @@ fn responses_sse_to_response_value(body: &str) -> Result<Value, ProxyError> {
         ProxyError::TransformError("No response.completed event in upstream SSE".to_string())
     })?;
 
+    // 重要修复：如果流在 output_item.done 事件之前结束（如网络中断），
+    // response.completed 事件本身可能已经包含了 output 数组。
+    // 我们应该合并两者：使用 completed 中的 output（如果存在），
+    // 并添加我们从 output_item.done 事件中单独收集的 items。
+    // 这确保了即使流被截断，已收到的输出项也不会丢失。
+    let existing_output = response.get("output").cloned();
     if !output_items.is_empty() {
+        let mut final_output = if let Some(existing) = existing_output {
+            if let Some(existing_arr) = existing.as_array() {
+                // 避免重复：只添加不在 existing 中的 items
+                let existing_ids: HashSet<&str> = existing_arr
+                    .iter()
+                    .filter_map(|item| item.get("id").and_then(|i| i.as_str()))
+                    .collect();
+                output_items
+                    .into_iter()
+                    .filter(|item| {
+                        item.get("id")
+                            .and_then(|i| i.as_str())
+                            .map(|id| !existing_ids.contains(id))
+                            .unwrap_or(true)
+                    })
+                    .chain(existing_arr.iter().cloned())
+                    .collect()
+            } else {
+                output_items
+            }
+        } else {
+            output_items
+        };
+        // 按 output_index 排序以确保顺序正确
+        final_output.sort_by(|a, b| {
+            let a_idx = a.get("output_index").and_then(|v| v.as_u64()).unwrap_or(0);
+            let b_idx = b.get("output_index").and_then(|v| v.as_u64()).unwrap_or(0);
+            a_idx.cmp(&b_idx)
+        });
         if let Some(obj) = response.as_object_mut() {
-            obj.insert("output".to_string(), Value::Array(output_items));
+            obj.insert("output".to_string(), Value::Array(final_output));
         } else {
             return Err(ProxyError::TransformError(
                 "response.completed payload is not an object".to_string(),

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -4551,9 +4551,9 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                 if let Some(text) = unkeyed_remaining {
                     if !text.is_empty() {
                         let index = next_content_index;
-                        // Allow unused assignment - index is used in the loop below
-                        #[allow(unused_assignments)]
                         next_content_index = next_content_index.wrapping_add(1);
+                        // Use index to avoid unused variable warning
+                        let _ = index;
                         for event in text_block_events(index, &text) {
                             yield Ok(event);
                         }

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -6220,7 +6220,11 @@ mod tests {
             .and_then(Value::as_u64)
             .unwrap();
 
-        assert!(!events.iter().any(|event| {
+        // The stream is truncated mid-function_call, so no message_delta/message_stop
+        // is emitted — but the dangling function block must still be closed with a
+        // content_block_stop so the downstream client doesn't report
+        // "Content block not found" on the next turn.
+        assert!(events.iter().any(|event| {
             event.get("type").and_then(Value::as_str) == Some("content_block_stop")
                 && event.get("index").and_then(Value::as_u64) == Some(function_index)
         }));

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -4550,10 +4550,13 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                 // 发送未发送的未键文本（流截断时保留的内容）
                 if let Some(text) = unkeyed_remaining {
                     if !text.is_empty() {
-                        let index = next_content_index;
-                        next_content_index += 1;
-                        for event in text_block_events(index, &text) {
-                            yield Ok(event);
+                        #[allow(unused_assignments)]
+                        {
+                            let index = next_content_index;
+                            next_content_index += 1;
+                            for event in text_block_events(index, &text) {
+                                yield Ok(event);
+                            }
                         }
                     }
                 }

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -4551,6 +4551,8 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                 if let Some(text) = unkeyed_remaining {
                     if !text.is_empty() {
                         let index = next_content_index;
+                        // Allow unused assignment - index is used in the loop below
+                        #[allow(unused_assignments)]
                         next_content_index = next_content_index.wrapping_add(1);
                         for event in text_block_events(index, &text) {
                             yield Ok(event);

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -4552,8 +4552,6 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                     if !text.is_empty() {
                         let index = next_content_index;
                         next_content_index = next_content_index.wrapping_add(1);
-                        // Use index to avoid unused variable warning
-                        let _ = index;
                         for event in text_block_events(index, &text) {
                             yield Ok(event);
                         }
@@ -4606,9 +4604,9 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                         }
                         for text in pending_text {
                             let index = reusable_text_index.take().unwrap_or_else(|| {
-                                let index = next_content_index;
-                                next_content_index += 1;
-                                index
+                                let idx = next_content_index;
+                                next_content_index = next_content_index.wrapping_add(1);
+                                idx
                             });
                             for event in text_block_events(index, &text) {
                                 yield Ok(event);

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -4550,8 +4550,11 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                 // 发送未发送的未键文本（流截断时保留的内容）
                 if let Some(text) = unkeyed_remaining {
                     if !text.is_empty() {
-                        let index = next_content_index;
-                        next_content_index = next_content_index.wrapping_add(1);
+                        let index = {
+                            let idx = next_content_index;
+                            next_content_index = next_content_index.wrapping_add(1);
+                            idx
+                        };
                         for event in text_block_events(index, &text) {
                             yield Ok(event);
                         }

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -3041,6 +3041,19 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                                     yield Ok(event);
                                                 }
                                             } else {
+                                                // Close dangling blocks before the error so the
+                                                // downstream client doesn't see a content_block_start
+                                                // without a matching stop ("Content block not found").
+                                                let mut dangling: Vec<u32> =
+                                                    open_indices.iter().copied().collect();
+                                                dangling.sort_unstable();
+                                                for index in dangling {
+                                                    yield Ok(anthropic_sse(
+                                                        "content_block_stop",
+                                                        &json!({"type":"content_block_stop","index":index}),
+                                                    ));
+                                                    open_indices.remove(&index);
+                                                }
                                                 yield Ok(anthropic_error_sse(
                                                     "Responses upstream started a web search beyond max_uses while another content block was incomplete",
                                                     "stream_truncated",
@@ -4266,6 +4279,19 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                                     yield Ok(event);
                                                 }
                                             } else {
+                                                // Close dangling blocks before the error so the
+                                                // downstream client doesn't see a content_block_start
+                                                // without a matching stop ("Content block not found").
+                                                let mut dangling: Vec<u32> =
+                                                    open_indices.iter().copied().collect();
+                                                dangling.sort_unstable();
+                                                for index in dangling {
+                                                    yield Ok(anthropic_sse(
+                                                        "content_block_stop",
+                                                        &json!({"type":"content_block_stop","index":index}),
+                                                    ));
+                                                    open_indices.remove(&index);
+                                                }
                                                 yield Ok(anthropic_error_sse(
                                                     "Responses upstream started a web search beyond max_uses while another content block was incomplete",
                                                     "stream_truncated",
@@ -4555,8 +4581,22 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                 ));
                 yield Ok(anthropic_sse("message_stop", &json!({"type":"message_stop"})));
             } else {
-                // A truncated tool/reasoning block cannot be safely finalized: tool
-                // JSON may be partial and thinking may be missing its signature.
+                // A truncated tool/reasoning block cannot be safely finalized with
+                // message_delta/message_stop: tool JSON may be partial and thinking
+                // may be missing its signature. But content_block_stop itself is
+                // safe — it only signals "this block ended", not "it is complete".
+                // Closing dangling blocks prevents the downstream client from seeing
+                // a content_block_start without a matching stop, which surfaces as
+                // "Content block not found" on the next turn.
+                let mut dangling: Vec<u32> = open_indices.iter().copied().collect();
+                dangling.sort_unstable();
+                for index in dangling {
+                    yield Ok(anthropic_sse(
+                        "content_block_stop",
+                        &json!({"type":"content_block_stop","index":index}),
+                    ));
+                    open_indices.remove(&index);
+                }
                 yield Ok(anthropic_error_sse(
                     "Responses upstream stream ended before a terminal event",
                     "stream_truncated",
@@ -6251,7 +6291,11 @@ mod tests {
             .and_then(Value::as_u64)
             .unwrap();
 
-        assert!(!events.iter().any(|event| {
+        // The stream is truncated mid-reasoning, so no message_delta/message_stop
+        // is emitted — but the dangling reasoning block must still be closed with a
+        // content_block_stop so the downstream client doesn't report
+        // "Content block not found" on the next turn.
+        assert!(events.iter().any(|event| {
             event.get("type").and_then(Value::as_str) == Some("content_block_stop")
                 && event.get("index").and_then(Value::as_u64) == Some(reasoning_index)
         }));

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -4551,7 +4551,7 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                 if let Some(text) = unkeyed_remaining {
                     if !text.is_empty() {
                         let index = next_content_index;
-                        next_content_index += 1;
+                        next_content_index = next_content_index.wrapping_add(1);
                         for event in text_block_events(index, &text) {
                             yield Ok(event);
                         }

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -277,15 +277,11 @@ fn content_part_key(data: &Value) -> Option<String> {
     ) {
         return Some(format!("part:out:{output_index}:{content_index}"));
     }
-    // 兼容网关省略了 content_index 时的 fallback：
-    // 如果提供了 item_id，使用 item_id 作为标识（因为通常只有一个输出文本块）
-    if let Some(item_id) = data.get("item_id").and_then(|v| v.as_str()) {
-        return Some(format!("part:{item_id}:0"));
-    }
-    // 如果提供了 output_index 但没有 content_index
-    if let Some(output_index) = data.get("output_index").and_then(|v| v.as_u64()) {
-        return Some(format!("part:out:{output_index}:0"));
-    }
+    // 注意：不在这里添加 fallback。
+    // 如果缺少 content_index，返回 None 让 resolve_content_index 回退到
+    // fallback_open_index，这样可以避免在流还未建立稳定绑定时就分配一个固定索引。
+    // 第三方网关若省略 content_index，后续的事件（如 output_text.done）通常会携带
+    // 完整键信息，届时可以正确绑定。
     None
 }
 

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -263,17 +263,28 @@ fn responses_json_to_anthropic_sse(
 
 #[inline]
 fn content_part_key(data: &Value) -> Option<String> {
+    // 优先使用 (item_id, content_index) 作为稳定键
     if let (Some(item_id), Some(content_index)) = (
         data.get("item_id").and_then(|v| v.as_str()),
         data.get("content_index").and_then(|v| v.as_u64()),
     ) {
         return Some(format!("part:{item_id}:{content_index}"));
     }
+    // 其次使用 (output_index, content_index)
     if let (Some(output_index), Some(content_index)) = (
         data.get("output_index").and_then(|v| v.as_u64()),
         data.get("content_index").and_then(|v| v.as_u64()),
     ) {
         return Some(format!("part:out:{output_index}:{content_index}"));
+    }
+    // 兼容网关省略了 content_index 时的 fallback：
+    // 如果提供了 item_id，使用 item_id 作为标识（因为通常只有一个输出文本块）
+    if let Some(item_id) = data.get("item_id").and_then(|v| v.as_str()) {
+        return Some(format!("part:{item_id}:0"));
+    }
+    // 如果提供了 output_index 但没有 content_index
+    if let Some(output_index) = data.get("output_index").and_then(|v| v.as_u64()) {
+        return Some(format!("part:out:{output_index}:0"));
     }
     None
 }
@@ -4522,6 +4533,12 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                 }
                 // Text-only partial output is safe to expose as a max-token style
                 // incomplete turn. Close blocks before the terminal events.
+                // 尝试从 streamed_text 中获取未发送的文本内容
+                let unkeyed_remaining = if !streamed_text.unkeyed.is_empty() {
+                    Some(streamed_text.unkeyed.clone())
+                } else {
+                    None
+                };
                 let mut remaining: Vec<u32> = open_indices.iter().copied().collect();
                 remaining.sort_unstable();
                 for index in remaining {
@@ -4529,6 +4546,16 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                         "content_block_stop",
                         &json!({"type":"content_block_stop","index":index}),
                     ));
+                }
+                // 发送未发送的未键文本（流截断时保留的内容）
+                if let Some(text) = unkeyed_remaining {
+                    if !text.is_empty() {
+                        let index = next_content_index;
+                        next_content_index += 1;
+                        for event in text_block_events(index, &text) {
+                            yield Ok(event);
+                        }
+                    }
                 }
                 if !has_sent_message_start {
                     yield Ok(anthropic_sse(
@@ -4557,6 +4584,36 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
             } else {
                 // A truncated tool/reasoning block cannot be safely finalized: tool
                 // JSON may be partial and thinking may be missing its signature.
+                // 文本内容不完整但属于实质性输出的情况：
+                // 关闭未闭合的文本块，并尝试从 buffered_citation_text 提取未发送的文本。
+                // 这避免了 stream_truncated 错误导致的对话截断。
+                if preserve_web_search_citations {
+                    let pending_text = buffered_citation_text.render_pending_parts();
+                    let mut reusable_text_index = None;
+                    if !pending_text.is_empty() {
+                        if let Some(index) = current_text_index.take() {
+                            let was_open = open_indices.remove(&index);
+                            if was_open {
+                                yield Ok(anthropic_sse(
+                                    "content_block_stop",
+                                    &json!({"type":"content_block_stop","index":index}),
+                                ));
+                            } else {
+                                reusable_text_index = Some(index);
+                            }
+                        }
+                        for text in pending_text {
+                            let index = reusable_text_index.take().unwrap_or_else(|| {
+                                let index = next_content_index;
+                                next_content_index += 1;
+                                index
+                            });
+                            for event in text_block_events(index, &text) {
+                                yield Ok(event);
+                            }
+                        }
+                    }
+                }
                 yield Ok(anthropic_error_sse(
                     "Responses upstream stream ended before a terminal event",
                     "stream_truncated",

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -4564,36 +4564,6 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
             } else {
                 // A truncated tool/reasoning block cannot be safely finalized: tool
                 // JSON may be partial and thinking may be missing its signature.
-                // 文本内容不完整但属于实质性输出的情况：
-                // 关闭未闭合的文本块，并尝试从 buffered_citation_text 提取未发送的文本。
-                // 这避免了 stream_truncated 错误导致的对话截断。
-                if preserve_web_search_citations {
-                    let pending_text = buffered_citation_text.render_pending_parts();
-                    let mut reusable_text_index = None;
-                    if !pending_text.is_empty() {
-                        if let Some(index) = current_text_index.take() {
-                            let was_open = open_indices.remove(&index);
-                            if was_open {
-                                yield Ok(anthropic_sse(
-                                    "content_block_stop",
-                                    &json!({"type":"content_block_stop","index":index}),
-                                ));
-                            } else {
-                                reusable_text_index = Some(index);
-                            }
-                        }
-                        for text in pending_text {
-                            let index = reusable_text_index.take().unwrap_or_else(|| {
-                                let idx = next_content_index;
-                                next_content_index = next_content_index.wrapping_add(1);
-                                idx
-                            });
-                            for event in text_block_events(index, &text) {
-                                yield Ok(event);
-                            }
-                        }
-                    }
-                }
                 yield Ok(anthropic_error_sse(
                     "Responses upstream stream ended before a terminal event",
                     "stream_truncated",

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -263,18 +263,25 @@ fn responses_json_to_anthropic_sse(
 
 #[inline]
 fn content_part_key(data: &Value) -> Option<String> {
+    // 优先使用 (item_id, content_index) 作为稳定键
     if let (Some(item_id), Some(content_index)) = (
         data.get("item_id").and_then(|v| v.as_str()),
         data.get("content_index").and_then(|v| v.as_u64()),
     ) {
         return Some(format!("part:{item_id}:{content_index}"));
     }
+    // 其次使用 (output_index, content_index)
     if let (Some(output_index), Some(content_index)) = (
         data.get("output_index").and_then(|v| v.as_u64()),
         data.get("content_index").and_then(|v| v.as_u64()),
     ) {
         return Some(format!("part:out:{output_index}:{content_index}"));
     }
+    // 注意：不在这里添加 fallback。
+    // 如果缺少 content_index，返回 None 让 resolve_content_index 回退到
+    // fallback_open_index，这样可以避免在流还未建立稳定绑定时就分配一个固定索引。
+    // 第三方网关若省略 content_index，后续的事件（如 output_text.done）通常会携带
+    // 完整键信息，届时可以正确绑定。
     None
 }
 
@@ -3041,6 +3048,19 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                                     yield Ok(event);
                                                 }
                                             } else {
+                                                // Close dangling blocks before the error so the
+                                                // downstream client doesn't see a content_block_start
+                                                // without a matching stop ("Content block not found").
+                                                let mut dangling: Vec<u32> =
+                                                    open_indices.iter().copied().collect();
+                                                dangling.sort_unstable();
+                                                for index in dangling {
+                                                    yield Ok(anthropic_sse(
+                                                        "content_block_stop",
+                                                        &json!({"type":"content_block_stop","index":index}),
+                                                    ));
+                                                    open_indices.remove(&index);
+                                                }
                                                 yield Ok(anthropic_error_sse(
                                                     "Responses upstream started a web search beyond max_uses while another content block was incomplete",
                                                     "stream_truncated",
@@ -4266,6 +4286,19 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                                                     yield Ok(event);
                                                 }
                                             } else {
+                                                // Close dangling blocks before the error so the
+                                                // downstream client doesn't see a content_block_start
+                                                // without a matching stop ("Content block not found").
+                                                let mut dangling: Vec<u32> =
+                                                    open_indices.iter().copied().collect();
+                                                dangling.sort_unstable();
+                                                for index in dangling {
+                                                    yield Ok(anthropic_sse(
+                                                        "content_block_stop",
+                                                        &json!({"type":"content_block_stop","index":index}),
+                                                    ));
+                                                    open_indices.remove(&index);
+                                                }
                                                 yield Ok(anthropic_error_sse(
                                                     "Responses upstream started a web search beyond max_uses while another content block was incomplete",
                                                     "stream_truncated",
@@ -4557,6 +4590,18 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
             } else {
                 // A truncated tool/reasoning block cannot be safely finalized: tool
                 // JSON may be partial and thinking may be missing its signature.
+                // Closing dangling blocks prevents the downstream client from seeing
+                // a content_block_start without a matching stop, which surfaces as
+                // "Content block not found" on the next turn.
+                let mut dangling: Vec<u32> = open_indices.iter().copied().collect();
+                dangling.sort_unstable();
+                for index in dangling {
+                    yield Ok(anthropic_sse(
+                        "content_block_stop",
+                        &json!({"type":"content_block_stop","index":index}),
+                    ));
+                    open_indices.remove(&index);
+                }
                 yield Ok(anthropic_error_sse(
                     "Responses upstream stream ended before a terminal event",
                     "stream_truncated",
@@ -6180,7 +6225,11 @@ mod tests {
             .and_then(Value::as_u64)
             .unwrap();
 
-        assert!(!events.iter().any(|event| {
+        // The stream is truncated mid-function_call, so no message_delta/message_stop
+        // is emitted — but the dangling function block must still be closed with a
+        // content_block_stop so the downstream client doesn't report
+        // "Content block not found" on the next turn.
+        assert!(events.iter().any(|event| {
             event.get("type").and_then(Value::as_str) == Some("content_block_stop")
                 && event.get("index").and_then(Value::as_u64) == Some(function_index)
         }));
@@ -6251,7 +6300,11 @@ mod tests {
             .and_then(Value::as_u64)
             .unwrap();
 
-        assert!(!events.iter().any(|event| {
+        // The stream is truncated mid-reasoning, so no message_delta/message_stop
+        // is emitted — but the dangling reasoning block must still be closed with a
+        // content_block_stop so the downstream client doesn't report
+        // "Content block not found" on the next turn.
+        assert!(events.iter().any(|event| {
             event.get("type").and_then(Value::as_str) == Some("content_block_stop")
                 && event.get("index").and_then(Value::as_u64) == Some(reasoning_index)
         }));

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -4550,11 +4550,8 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                 // 发送未发送的未键文本（流截断时保留的内容）
                 if let Some(text) = unkeyed_remaining {
                     if !text.is_empty() {
-                        let index = {
-                            let idx = next_content_index;
-                            next_content_index = next_content_index.wrapping_add(1);
-                            idx
-                        };
+                        let index = next_content_index;
+                        next_content_index += 1;
                         for event in text_block_events(index, &text) {
                             yield Ok(event);
                         }

--- a/src-tauri/src/proxy/providers/streaming_responses.rs
+++ b/src-tauri/src/proxy/providers/streaming_responses.rs
@@ -4533,12 +4533,6 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                 }
                 // Text-only partial output is safe to expose as a max-token style
                 // incomplete turn. Close blocks before the terminal events.
-                // 尝试从 streamed_text 中获取未发送的文本内容
-                let unkeyed_remaining = if !streamed_text.unkeyed.is_empty() {
-                    Some(streamed_text.unkeyed.clone())
-                } else {
-                    None
-                };
                 let mut remaining: Vec<u32> = open_indices.iter().copied().collect();
                 remaining.sort_unstable();
                 for index in remaining {
@@ -4546,19 +4540,6 @@ fn create_anthropic_sse_stream_from_responses_raw<E: std::error::Error + Send + 
                         "content_block_stop",
                         &json!({"type":"content_block_stop","index":index}),
                     ));
-                }
-                // 发送未发送的未键文本（流截断时保留的内容）
-                if let Some(text) = unkeyed_remaining {
-                    if !text.is_empty() {
-                        #[allow(unused_assignments)]
-                        {
-                            let index = next_content_index;
-                            next_content_index += 1;
-                            for event in text_block_events(index, &text) {
-                                yield Ok(event);
-                            }
-                        }
-                    }
                 }
                 if !has_sent_message_start {
                     yield Ok(anthropic_sse(

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -1458,55 +1458,74 @@ pub fn anthropic_sse_to_message_value(body: &str) -> Result<Value, ProxyError> {
                 }
             }
             "content_block_delta" => {
-                if let Some(index) = value.get("index").and_then(|v| v.as_u64()) {
-                    let delta = value.get("delta").cloned().unwrap_or(json!({}));
-                    match delta.get("type").and_then(|t| t.as_str()).unwrap_or("") {
-                        "text_delta" => {
-                            if let Some(text) = delta.get("text").and_then(|t| t.as_str()) {
-                                append_str_field(
-                                    blocks.entry(index).or_insert(json!({})),
-                                    "text",
-                                    text,
-                                );
-                            }
+                // 修复：如果 delta 事件缺少 index，尝试从其他字段推断或使用默认值 0
+                // 某些第三方网关可能在 delta 事件中省略 index 字段
+                let index = value
+                    .get("index")
+                    .and_then(|v| v.as_u64())
+                    .or_else(|| value.get("output_index").and_then(|v| v.as_u64()))
+                    .unwrap_or(0);
+
+                if index == 0 && value.get("index").is_none() && value.get("output_index").is_none()
+                {
+                    // 记录警告但继续处理，避免完全丢失内容
+                    log::debug!(
+                        "[Anthropic SSE] content_block_delta missing index, using default 0"
+                    );
+                }
+
+                let delta = value.get("delta").cloned().unwrap_or(json!({}));
+                match delta.get("type").and_then(|t| t.as_str()).unwrap_or("") {
+                    "text_delta" => {
+                        if let Some(text) = delta.get("text").and_then(|t| t.as_str()) {
+                            append_str_field(
+                                blocks.entry(index).or_insert(json!({})),
+                                "text",
+                                text,
+                            );
                         }
-                        "thinking_delta" => {
-                            if let Some(text) = delta.get("thinking").and_then(|t| t.as_str()) {
-                                append_str_field(
-                                    blocks.entry(index).or_insert(json!({})),
-                                    "thinking",
-                                    text,
-                                );
-                            }
-                        }
-                        "signature_delta" => {
-                            if let Some(sig) = delta.get("signature").and_then(|t| t.as_str()) {
-                                blocks.entry(index).or_insert(json!({}))["signature"] = json!(sig);
-                            }
-                        }
-                        "input_json_delta" => {
-                            if let Some(partial) =
-                                delta.get("partial_json").and_then(|t| t.as_str())
-                            {
-                                json_accum.entry(index).or_default().push_str(partial);
-                            }
-                        }
-                        _ => {}
                     }
+                    "thinking_delta" => {
+                        if let Some(text) = delta.get("thinking").and_then(|t| t.as_str()) {
+                            append_str_field(
+                                blocks.entry(index).or_insert(json!({})),
+                                "thinking",
+                                text,
+                            );
+                        }
+                    }
+                    "signature_delta" => {
+                        if let Some(sig) = delta.get("signature").and_then(|t| t.as_str()) {
+                            blocks.entry(index).or_insert(json!({}))["signature"] = json!(sig);
+                        }
+                    }
+                    "input_json_delta" => {
+                        if let Some(partial) = delta.get("partial_json").and_then(|t| t.as_str()) {
+                            json_accum.entry(index).or_default().push_str(partial);
+                        }
+                    }
+                    _ => {}
                 }
             }
             "content_block_stop" => {
-                if let Some(index) = value.get("index").and_then(|v| v.as_u64()) {
-                    if let Some(accum) = json_accum.get(&index) {
-                        if !accum.trim().is_empty() {
-                            let parsed: Value =
-                                serde_json::from_str(accum).unwrap_or_else(|_| json!({}));
-                            if let Some(block) = blocks.get_mut(&index) {
-                                block["input"] = parsed;
-                            }
+                // 修复：如果 stop 事件缺少 index，尝试从其他字段推断
+                let index = value
+                    .get("index")
+                    .and_then(|v| v.as_u64())
+                    .or_else(|| value.get("output_index").and_then(|v| v.as_u64()))
+                    .unwrap_or(0);
+
+                if let Some(accum) = json_accum.get(&index) {
+                    if !accum.trim().is_empty() {
+                        let parsed: Value =
+                            serde_json::from_str(accum).unwrap_or_else(|_| json!({}));
+                        if let Some(block) = blocks.get_mut(&index) {
+                            block["input"] = parsed;
                         }
                     }
                 }
+                // 清理 accumulator
+                json_accum.remove(&index);
             }
             "message_delta" => {
                 if let Some(reason) = value.pointer("/delta/stop_reason").and_then(|v| v.as_str()) {

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -1502,9 +1502,7 @@ pub fn anthropic_sse_to_message_value(body: &str) -> Result<Value, ProxyError> {
                         }
                     }
                     "input_json_delta" => {
-                        if let Some(partial) =
-                            delta.get("partial_json").and_then(|t| t.as_str())
-                        {
+                        if let Some(partial) = delta.get("partial_json").and_then(|t| t.as_str()) {
                             json_accum.entry(index).or_default().push_str(partial);
                         }
                     }

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -1463,13 +1463,13 @@ pub fn anthropic_sse_to_message_value(body: &str) -> Result<Value, ProxyError> {
                 let index = value
                     .get("index")
                     .and_then(|v| v.as_u64())
-                    .or_else(|| {
-                        // 尝试从 item_id 或 output_index 推断
-                        value.get("output_index").and_then(|v| v.as_u64())
-                    })
+                    .or_else(|| value.get("output_index").and_then(|v| v.as_u64()))
                     .unwrap_or(0);
 
-                if index == 0 && !value.get("index").is_some() && !value.get("output_index").is_some() {
+                if index == 0
+                    && !value.get("index").is_some()
+                    && !value.get("output_index").is_some()
+                {
                     // 记录警告但继续处理，避免完全丢失内容
                     log::debug!(
                         "[Anthropic SSE] content_block_delta missing index, using default 0"
@@ -1516,9 +1516,7 @@ pub fn anthropic_sse_to_message_value(body: &str) -> Result<Value, ProxyError> {
                 let index = value
                     .get("index")
                     .and_then(|v| v.as_u64())
-                    .or_else(|| {
-                        value.get("output_index").and_then(|v| v.as_u64())
-                    })
+                    .or_else(|| value.get("output_index").and_then(|v| v.as_u64()))
                     .unwrap_or(0);
 
                 if let Some(accum) = json_accum.get(&index) {

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -1467,8 +1467,8 @@ pub fn anthropic_sse_to_message_value(body: &str) -> Result<Value, ProxyError> {
                     .unwrap_or(0);
 
                 if index == 0
-                    && !value.get("index").is_some()
-                    && !value.get("output_index").is_some()
+                    && value.get("index").is_none()
+                    && value.get("output_index").is_none()
                 {
                     // 记录警告但继续处理，避免完全丢失内容
                     log::debug!(

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -1477,39 +1477,38 @@ pub fn anthropic_sse_to_message_value(body: &str) -> Result<Value, ProxyError> {
                 }
 
                 let delta = value.get("delta").cloned().unwrap_or(json!({}));
-                    match delta.get("type").and_then(|t| t.as_str()).unwrap_or("") {
-                        "text_delta" => {
-                            if let Some(text) = delta.get("text").and_then(|t| t.as_str()) {
-                                append_str_field(
-                                    blocks.entry(index).or_insert(json!({})),
-                                    "text",
-                                    text,
-                                );
-                            }
+                match delta.get("type").and_then(|t| t.as_str()).unwrap_or("") {
+                    "text_delta" => {
+                        if let Some(text) = delta.get("text").and_then(|t| t.as_str()) {
+                            append_str_field(
+                                blocks.entry(index).or_insert(json!({})),
+                                "text",
+                                text,
+                            );
                         }
-                        "thinking_delta" => {
-                            if let Some(text) = delta.get("thinking").and_then(|t| t.as_str()) {
-                                append_str_field(
-                                    blocks.entry(index).or_insert(json!({})),
-                                    "thinking",
-                                    text,
-                                );
-                            }
-                        }
-                        "signature_delta" => {
-                            if let Some(sig) = delta.get("signature").and_then(|t| t.as_str()) {
-                                blocks.entry(index).or_insert(json!({}))["signature"] = json!(sig);
-                            }
-                        }
-                        "input_json_delta" => {
-                            if let Some(partial) =
-                                delta.get("partial_json").and_then(|t| t.as_str())
-                            {
-                                json_accum.entry(index).or_default().push_str(partial);
-                            }
-                        }
-                        _ => {}
                     }
+                    "thinking_delta" => {
+                        if let Some(text) = delta.get("thinking").and_then(|t| t.as_str()) {
+                            append_str_field(
+                                blocks.entry(index).or_insert(json!({})),
+                                "thinking",
+                                text,
+                            );
+                        }
+                    }
+                    "signature_delta" => {
+                        if let Some(sig) = delta.get("signature").and_then(|t| t.as_str()) {
+                            blocks.entry(index).or_insert(json!({}))["signature"] = json!(sig);
+                        }
+                    }
+                    "input_json_delta" => {
+                        if let Some(partial) =
+                            delta.get("partial_json").and_then(|t| t.as_str())
+                        {
+                            json_accum.entry(index).or_default().push_str(partial);
+                        }
+                    }
+                    _ => {}
                 }
             }
             "content_block_stop" => {

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -1458,8 +1458,25 @@ pub fn anthropic_sse_to_message_value(body: &str) -> Result<Value, ProxyError> {
                 }
             }
             "content_block_delta" => {
-                if let Some(index) = value.get("index").and_then(|v| v.as_u64()) {
-                    let delta = value.get("delta").cloned().unwrap_or(json!({}));
+                // 修复：如果 delta 事件缺少 index，尝试从其他字段推断或使用默认值 0
+                // 某些第三方网关可能在 delta 事件中省略 index 字段
+                let index = value
+                    .get("index")
+                    .and_then(|v| v.as_u64())
+                    .or_else(|| {
+                        // 尝试从 item_id 或 output_index 推断
+                        value.get("output_index").and_then(|v| v.as_u64())
+                    })
+                    .unwrap_or(0);
+
+                if index == 0 && !value.get("index").is_some() && !value.get("output_index").is_some() {
+                    // 记录警告但继续处理，避免完全丢失内容
+                    log::debug!(
+                        "[Anthropic SSE] content_block_delta missing index, using default 0"
+                    );
+                }
+
+                let delta = value.get("delta").cloned().unwrap_or(json!({}));
                     match delta.get("type").and_then(|t| t.as_str()).unwrap_or("") {
                         "text_delta" => {
                             if let Some(text) = delta.get("text").and_then(|t| t.as_str()) {
@@ -1496,17 +1513,26 @@ pub fn anthropic_sse_to_message_value(body: &str) -> Result<Value, ProxyError> {
                 }
             }
             "content_block_stop" => {
-                if let Some(index) = value.get("index").and_then(|v| v.as_u64()) {
-                    if let Some(accum) = json_accum.get(&index) {
-                        if !accum.trim().is_empty() {
-                            let parsed: Value =
-                                serde_json::from_str(accum).unwrap_or_else(|_| json!({}));
-                            if let Some(block) = blocks.get_mut(&index) {
-                                block["input"] = parsed;
-                            }
+                // 修复：如果 stop 事件缺少 index，尝试从其他字段推断
+                let index = value
+                    .get("index")
+                    .and_then(|v| v.as_u64())
+                    .or_else(|| {
+                        value.get("output_index").and_then(|v| v.as_u64())
+                    })
+                    .unwrap_or(0);
+
+                if let Some(accum) = json_accum.get(&index) {
+                    if !accum.trim().is_empty() {
+                        let parsed: Value =
+                            serde_json::from_str(accum).unwrap_or_else(|_| json!({}));
+                        if let Some(block) = blocks.get_mut(&index) {
+                            block["input"] = parsed;
                         }
                     }
                 }
+                // 清理 accumulator
+                json_accum.remove(&index);
             }
             "message_delta" => {
                 if let Some(reason) = value.pointer("/delta/stop_reason").and_then(|v| v.as_str()) {

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -1466,7 +1466,8 @@ pub fn anthropic_sse_to_message_value(body: &str) -> Result<Value, ProxyError> {
                     .or_else(|| value.get("output_index").and_then(|v| v.as_u64()))
                     .unwrap_or(0);
 
-                if index == 0 && value.get("index").is_none() && value.get("output_index").is_none() {
+                if index == 0 && value.get("index").is_none() && value.get("output_index").is_none()
+                {
                     // 记录警告但继续处理，避免完全丢失内容
                     log::debug!(
                         "[Anthropic SSE] content_block_delta missing index, using default 0"

--- a/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_anthropic.rs
@@ -1466,10 +1466,7 @@ pub fn anthropic_sse_to_message_value(body: &str) -> Result<Value, ProxyError> {
                     .or_else(|| value.get("output_index").and_then(|v| v.as_u64()))
                     .unwrap_or(0);
 
-                if index == 0
-                    && value.get("index").is_none()
-                    && value.get("output_index").is_none()
-                {
+                if index == 0 && value.get("index").is_none() && value.get("output_index").is_none() {
                     // 记录警告但继续处理，避免完全丢失内容
                     log::debug!(
                         "[Anthropic SSE] content_block_delta missing index, using default 0"


### PR DESCRIPTION
## Summary

Integrates fixes from three independent fix branches into a single PR:
1. **stream-truncated-content-block-not-found**: Closing dangling `content_block_start` events before `stream_truncated` errors to prevent downstream clients from seeing unclosed blocks and reporting "Content block not found".
2. **claude-desktop-cache-injection**: Injecting `cache_control` breakpoints for Claude Desktop proxy mode when using native Anthropic requests, enabling prompt caching.
3. **resolve-conversation-truncation**: Fixing conversation truncation in the Responses API proxy — merging truncated `output` arrays from `response.completed`, stabilizing `content_part_key`, and tolerating missing `index` fields in `content_block_delta` events.
4. **body_looks_like_sse guard**: Preventing colon-prefixed plain text error bodies (e.g. ": Bad Gateway") from being misclassified as SSE streams.

## Root Cause

### Problem 1: Stream truncation leaves dangling content blocks
Three early-exit paths in `create_anthropic_sse_stream_from_responses_raw` emit `stream_truncated` without closing `open_indices`. Fix: close all dangling blocks before emitting the error.

### Problem 2: Claude Desktop proxy lacks prompt caching
Claude Desktop with `api_format="anthropic"` bypasses the Bedrock check, so `cache_injector::inject()` is never called. Fix: explicitly inject `cache_control` for Claude Desktop + Anthropic.

### Problem 3: Truncated SSE responses lose output items
`responses_sse_to_response_value` only collects `output_item.done` events; the `response.completed` payload's output is ignored. Fix: merge both sources, dedup by `item.id`, sort by `output_index`.

### Problem 4: body_looks_like_sse false positive
Plain text errors like ": Bad Gateway" match the bare ":" prefix and enter the SSE aggregation path, hiding the real error. Fix: require all-uppercase text after ":" (SSE comments are uppercase identifiers like ": PROCESSING").

## Changed Files

| File | Changes |
|---|---|
| `src-tauri/src/proxy/providers/streaming_responses.rs` | Close dangling blocks before truncation; stabilize `content_part_key` |
| `src-tauri/src/proxy/providers/transform_codex_anthropic.rs` | Tolerate missing `index` in delta/stop events |
| `src-tauri/src/proxy/handlers.rs` | Merge truncated output arrays; tighten `body_looks_like_sse`; add tests |
| `src-tauri/src/proxy/forwarder.rs` | Inject `cache_control` for Claude Desktop |
| `.github/workflows/test-proxy-fix.yml` | CI workflow for isolated proxy testing |

## CI Status

All backend checks passed on https://github.com/sugu6/cc-switch/pull/4
