### PR TITLE
fix(claude): hide session URL attribution

### DIFF
--- a/docs/user-manual/en/2-providers/2.1-add.md
+++ b/docs/user-manual/en/2-providers/2.1-add.md
@@ -543,7 +543,7 @@ When editing Claude providers, a set of **quick toggles** is available above the
 
 | Toggle | Effect | Config Change |
 |--------|--------|---------------|
-| **Hide Attribution** | Clears commit/PR attribution metadata | Sets `attribution: {commit: "", pr: ""}` |
+| **Hide Attribution** | Clears commit/PR attribution metadata and session links | Sets `attribution: {commit: "", pr: "", sessionUrl: false}` |
 | **Enable Teammates** | Enables the agent teams feature | Sets `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"` |
 | **Enable Tool Search** | Enables tool search functionality | Sets `env.ENABLE_TOOL_SEARCH = "true"` |
 | **Max Effort** | Sets effort level to max | Sets `env.CLAUDE_CODE_EFFORT_LEVEL = "max"` |

--- a/docs/user-manual/ja/2-providers/2.1-add.md
+++ b/docs/user-manual/ja/2-providers/2.1-add.md
@@ -543,7 +543,7 @@ Claude プロバイダーの編集時、JSON エディタの上部に **クイ�
 
 | トグル | 効果 | 設定変更 |
 |------|------|------|
-| **帰属情報を非表示** | コミット/PR の帰属メタデータをクリア | `attribution: {commit: "", pr: ""}` を設定 |
+| **帰属情報を非表示** | コミット/PR の帰属メタデータとセッションリンクをクリア | `attribution: {commit: "", pr: "", sessionUrl: false}` を設定 |
 | **チームメイトを有効化** | エージェントチーム機能を有効化 | `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"` を設定 |
 | **ツール検索を有効化** | ツール検索機能を有効化 | `env.ENABLE_TOOL_SEARCH = "true"` を設定 |
 | **最大強度思考** | エフォートレベルを max に設定 | `env.CLAUDE_CODE_EFFORT_LEVEL = "max"` を設定 |

--- a/docs/user-manual/zh/2-providers/2.1-add.md
+++ b/docs/user-manual/zh/2-providers/2.1-add.md
@@ -543,7 +543,7 @@ v3.13.0 起新增的高级选项。默认情况下，CC Switch 会把配置的 `
 
 | 开关 | 效果 | 配置变更 |
 |------|------|----------|
-| **隐藏署名** | 清除提交/PR 的署名元数据 | 设置 `attribution: {commit: "", pr: ""}` |
+| **隐藏署名** | 清除提交/PR 的署名元数据和会话链接 | 设置 `attribution: {commit: "", pr: "", sessionUrl: false}` |
 | **启用 Teammates** | 启用 Agent 团队功能 | 设置 `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"` |
 | **启用工具搜索** | 启用工具搜索功能 | 设置 `env.ENABLE_TOOL_SEARCH = "true"` |
 | **最大强度思考** | 将 effort 级别设为 max | 设置 `env.CLAUDE_CODE_EFFORT_LEVEL = "max"` |

--- a/src/components/providers/forms/CommonConfigEditor.tsx
+++ b/src/components/providers/forms/CommonConfigEditor.tsx
@@ -74,7 +74,9 @@ export function CommonConfigEditor({
       const config = JSON.parse(localValue);
       return {
         hideAttribution:
-          config?.attribution?.commit === "" && config?.attribution?.pr === "",
+          config?.attribution?.commit === "" &&
+          config?.attribution?.pr === "" &&
+          config?.attribution?.sessionUrl === false,
         teammates:
           config?.env?.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === "1" ||
           config?.env?.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS === 1,
@@ -105,7 +107,7 @@ export function CommonConfigEditor({
         switch (toggleKey) {
           case "hideAttribution":
             if (checked) {
-              config.attribution = { commit: "", pr: "" };
+              config.attribution = { commit: "", pr: "", sessionUrl: false };
             } else {
               delete config.attribution;
             }

--- a/tests/components/CommonConfigEditor.test.tsx
+++ b/tests/components/CommonConfigEditor.test.tsx
@@ -66,6 +66,34 @@ function renderEditor(value: string, onChange = vi.fn()) {
 const effortCheckbox = () =>
   screen.getByRole("checkbox", { name: "claudeConfig.effortMax" });
 
+const hideAttributionCheckbox = () =>
+  screen.getByRole("checkbox", { name: "claudeConfig.hideAttribution" });
+
+describe("CommonConfigEditor hide attribution toggle", () => {
+  it("requires sessionUrl=false to treat attribution as hidden", () => {
+    renderEditor(
+      JSON.stringify({ attribution: { commit: "", pr: "" } }, null, 2),
+    );
+
+    expect(hideAttributionCheckbox()).not.toBeChecked();
+  });
+
+  it("disables commit, PR, and session URL attribution", () => {
+    const onChange = renderEditor("{}");
+
+    fireEvent.click(hideAttributionCheckbox());
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(onChange.mock.calls[0][0])).toEqual({
+      attribution: {
+        commit: "",
+        pr: "",
+        sessionUrl: false,
+      },
+    });
+  });
+});
+
 describe("CommonConfigEditor max effort toggle", () => {
   it("does not treat legacy top-level effortLevel=max as checked", () => {
     renderEditor(JSON.stringify({ effortLevel: "max" }, null, 2));


### PR DESCRIPTION
## Summary

- include sessionUrl: false when enabling Hide AI Attribution
- require commit, PR, and session URL attribution to all be disabled before showing the toggle as checked
- add regression coverage for legacy and updated attribution configurations

Claude Code 2.1.183 introduced attribution.sessionUrl as a separate setting for suppressing claude.ai links in commits and pull requests created from web and Remote Control sessions. Clearing commit and pr alone no longer hides every attribution surface.

Official changelog: https://code.claude.com/docs/en/changelog

## Verification

- pnpm typecheck
- pnpm test:unit -- tests/components/CommonConfigEditor.test.tsx (5 tests passed)
- Prettier check for changed files
- git diff --check