### PR TITLE
fix(codex): preserve websocket capability in deeplink imports

### DIFF
--- a/docs/user-manual/en/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/en/5-faq/5.3-deeplink.md
@@ -50,6 +50,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `apiKey` | No | API key |
 | `homepage` | No | Provider website |
 | `model` | No | Default model |
+| `supports_websockets` | No | Codex provider capability flag. When `true`, the imported Codex provider enables downstream WebSocket support. |
 | `haikuModel` | No | Haiku model (Claude only) |
 | `sonnetModel` | No | Sonnet model (Claude only) |
 | `opusModel` | No | Opus model (Claude only) |

--- a/docs/user-manual/ja/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/ja/5-faq/5.3-deeplink.md
@@ -50,6 +50,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `apiKey` | いいえ | API キー |
 | `homepage` | いいえ | プロバイダー公式サイト |
 | `model` | いいえ | デフォルトモデル |
+| `supports_websockets` | いいえ | Codex プロバイダーの機能フラグ。`true` の場合、インポートされた Codex プロバイダーで下流 WebSocket サポートを有効にします。 |
 | `haikuModel` | いいえ | Haiku モデル（Claude のみ） |
 | `sonnetModel` | いいえ | Sonnet モデル（Claude のみ） |
 | `opusModel` | いいえ | Opus モデル（Claude のみ） |

--- a/docs/user-manual/zh/5-faq/5.3-deeplink.md
+++ b/docs/user-manual/zh/5-faq/5.3-deeplink.md
@@ -50,6 +50,7 @@ ccswitch://v1/import?resource={type}&app={app}&name={name}&...
 | `apiKey` | 否 | API 密钥 |
 | `homepage` | 否 | 供应商官网 |
 | `model` | 否 | 默认模型 |
+| `supports_websockets` | 否 | Codex 供应商能力标记。设为 `true` 时，导入的 Codex 供应商会启用下游 WebSocket 支持。 |
 | `haikuModel` | 否 | Haiku 模型（仅 Claude） |
 | `sonnetModel` | 否 | Sonnet 模型（仅 Claude） |
 | `opusModel` | 否 | Opus 模型（仅 Claude） |

--- a/src-tauri/src/deeplink/mod.rs
+++ b/src-tauri/src/deeplink/mod.rs
@@ -66,6 +66,9 @@ pub struct DeepLinkImportRequest {
     /// Optional model name
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// Whether the imported Codex provider supports downstream WebSocket transport
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supports_websockets: Option<bool>,
     /// Optional notes/description
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,

--- a/src-tauri/src/deeplink/parser.rs
+++ b/src-tauri/src/deeplink/parser.rs
@@ -116,6 +116,9 @@ fn parse_provider_deeplink(
 
     // Extract optional fields
     let model = params.get("model").cloned();
+    let supports_websockets = params
+        .get("supports_websockets")
+        .and_then(|value| value.parse::<bool>().ok());
     let notes = params.get("notes").cloned();
     let haiku_model = params.get("haikuModel").cloned();
     let sonnet_model = params.get("sonnetModel").cloned();
@@ -153,6 +156,7 @@ fn parse_provider_deeplink(
         api_key,
         icon,
         model,
+        supports_websockets,
         notes,
         haiku_model,
         sonnet_model,

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -422,6 +422,10 @@ fn build_codex_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
     let provider_display_name = toml_edit::Value::from(provider_display_name.as_str()).to_string();
     let model_name = toml_edit::Value::from(model_name.as_str()).to_string();
     let endpoint = toml_edit::Value::from(endpoint.as_str()).to_string();
+    let websocket_capability = request
+        .supports_websockets
+        .map(|enabled| format!("supports_websockets = {enabled}\n"))
+        .unwrap_or_default();
 
     // Build config.toml content
     let config_toml = format!(
@@ -435,6 +439,7 @@ name = {provider_display_name}
 base_url = {endpoint}
 wire_api = "responses"
 requires_openai_auth = true
+{websocket_capability}
 "#
     );
 
@@ -965,6 +970,7 @@ mod tests {
             endpoint: Some("https://api.example.com/v1".to_string()),
             api_key: Some("sk-test".to_string()),
             model: Some("anthropic/claude-opus-4-8".to_string()),
+            supports_websockets: None,
             ..Default::default()
         }
     }
@@ -1114,6 +1120,7 @@ mod tests {
             endpoint: None,
             api_key: None,
             model: None,
+            supports_websockets: None,
             ..Default::default()
         };
         let settings = build_hermes_settings(&request);
@@ -1135,6 +1142,7 @@ mod tests {
             endpoint: Some("https://api.example.com/v1/".to_string()),
             api_key: Some("sk-test".to_string()),
             model: Some("gpt-5-codex".to_string()),
+            supports_websockets: None,
             ..Default::default()
         };
 
@@ -1164,6 +1172,33 @@ mod tests {
                 .get("base_url")
                 .and_then(|value| value.as_str()),
             Some("https://api.example.com/v1")
+        );
+        assert!(custom_provider.get("supports_websockets").is_none());
+    }
+
+    #[test]
+    fn build_codex_settings_preserves_websocket_capability() {
+        let request = DeepLinkImportRequest {
+            resource: "provider".to_string(),
+            app: Some("codex".to_string()),
+            name: Some("WebSocket Relay".to_string()),
+            endpoint: Some("https://api.example.com/v1".to_string()),
+            api_key: Some("sk-test".to_string()),
+            model: Some("gpt-5-codex".to_string()),
+            supports_websockets: Some(true),
+            ..Default::default()
+        };
+
+        let settings = build_codex_settings(&request);
+        let config_text = settings
+            .get("config")
+            .and_then(|value| value.as_str())
+            .expect("config text");
+        let parsed: toml::Value = toml::from_str(config_text).expect("valid Codex config");
+
+        assert_eq!(
+            parsed["model_providers"]["custom"]["supports_websockets"].as_bool(),
+            Some(true)
         );
     }
 

--- a/src-tauri/src/deeplink/tests.rs
+++ b/src-tauri/src/deeplink/tests.rs
@@ -88,6 +88,15 @@ fn test_parse_deeplink_with_notes() {
 }
 
 #[test]
+fn test_parse_codex_deeplink_with_websocket_capability() {
+    let url = "ccswitch://v1/import?resource=provider&app=codex&name=Codex&endpoint=https%3A%2F%2Fapi.example.com%2Fv1&apiKey=key123&supports_websockets=true";
+
+    let request = parse_deeplink_url(url).unwrap();
+
+    assert_eq!(request.supports_websockets, Some(true));
+}
+
+#[test]
 fn pi_provider_deeplink_is_not_a_second_add_provider_entry() {
     let url = "ccswitch://v1/import?resource=provider&app=pi&name=Pi";
     assert!(parse_deeplink_url(url).is_err());
@@ -214,6 +223,7 @@ fn test_build_gemini_provider_with_model() {
         api_key: Some("test-api-key".to_string()),
         icon: None,
         model: Some("gemini-2.0-flash".to_string()),
+        supports_websockets: None,
         notes: None,
         haiku_model: None,
         sonnet_model: None,
@@ -267,6 +277,7 @@ fn test_build_gemini_provider_without_model() {
         api_key: Some("test-api-key".to_string()),
         icon: None,
         model: None,
+        supports_websockets: None,
         notes: None,
         haiku_model: None,
         sonnet_model: None,
@@ -313,6 +324,7 @@ fn test_deeplink_usage_script_does_not_copy_provider_credentials() {
         api_key: Some("sk-main".to_string()),
         icon: None,
         model: None,
+        supports_websockets: None,
         notes: None,
         haiku_model: None,
         sonnet_model: None,
@@ -360,6 +372,7 @@ fn usage_script_request(code: &str, usage_enabled: Option<bool>) -> DeepLinkImpo
         api_key: Some("sk-main".to_string()),
         icon: None,
         model: None,
+        supports_websockets: None,
         notes: None,
         haiku_model: None,
         sonnet_model: None,
@@ -443,6 +456,7 @@ fn test_deeplink_usage_script_omits_explicit_credentials_that_match_provider() {
         api_key: Some("sk-main".to_string()),
         icon: None,
         model: None,
+        supports_websockets: None,
         notes: None,
         haiku_model: None,
         sonnet_model: None,
@@ -491,6 +505,7 @@ fn test_deeplink_usage_script_preserves_distinct_usage_credentials() {
         api_key: Some("sk-main".to_string()),
         icon: None,
         model: None,
+        supports_websockets: None,
         notes: None,
         haiku_model: None,
         sonnet_model: None,
@@ -544,6 +559,7 @@ fn test_parse_and_merge_config_claude() {
         api_key: None,
         icon: None,
         model: None,
+        supports_websockets: None,
         notes: None,
         haiku_model: None,
         sonnet_model: None,
@@ -667,6 +683,7 @@ fn test_parse_and_merge_config_url_override() {
         api_key: Some("sk-new".to_string()), // URL param should override
         icon: None,
         model: None,
+        supports_websockets: None,
         notes: None,
         haiku_model: None,
         sonnet_model: None,
@@ -730,6 +747,7 @@ fn test_build_claude_provider_preserves_custom_env_fields() {
         icon: None,
         // URL param: must win over the same key in config (haiku-from-config)
         model: Some("main-model".to_string()),
+        supports_websockets: None,
         notes: None,
         haiku_model: Some("haiku-from-url".to_string()),
         sonnet_model: None,
@@ -785,6 +803,7 @@ fn test_build_claude_provider_without_config_unchanged() {
         api_key: Some("sk".to_string()),
         icon: None,
         model: None,
+        supports_websockets: None,
         notes: None,
         haiku_model: None,
         sonnet_model: None,

--- a/src-tauri/tests/deeplink_import.rs
+++ b/src-tauri/tests/deeplink_import.rs
@@ -48,7 +48,7 @@ fn deeplink_import_codex_provider_builds_auth_and_config() {
     reset_test_fs();
     let _home = ensure_test_home();
 
-    let url = "ccswitch://v1/import?resource=provider&app=codex&name=DeepLink%20Codex&homepage=https%3A%2F%2Fopenai.example&endpoint=https%3A%2F%2Fapi.openai.example%2Fv1&apiKey=sk-test-codex-key&model=gpt-4o&icon=openai";
+    let url = "ccswitch://v1/import?resource=provider&app=codex&name=DeepLink%20Codex&homepage=https%3A%2F%2Fopenai.example&endpoint=https%3A%2F%2Fapi.openai.example%2Fv1&apiKey=sk-test-codex-key&model=gpt-4o&icon=openai&supports_websockets=true";
     let request = parse_deeplink_url(url).expect("parse deeplink url");
 
     let db = Arc::new(Database::memory().expect("create memory db"));
@@ -82,5 +82,9 @@ fn deeplink_import_codex_provider_builds_auth_and_config() {
     assert!(
         config_text.contains("model = \"gpt-4o\""),
         "config.toml content should contain model setting"
+    );
+    assert!(
+        config_text.contains("supports_websockets = true"),
+        "config.toml content should preserve the WebSocket capability"
     );
 }

--- a/src/lib/api/deeplink.ts
+++ b/src/lib/api/deeplink.ts
@@ -25,6 +25,7 @@ export interface DeepLinkImportRequest {
   apiKey?: string;
   icon?: string;
   model?: string;
+  supportsWebsockets?: boolean;
   notes?: string;
   haikuModel?: string;
   sonnetModel?: string;


### PR DESCRIPTION
## Summary / 概述

Preserve the `supports_websockets` capability supplied by a Codex provider deep link. The parser now carries the optional boolean through the import request, and Codex provider generation writes it into `[model_providers.custom]`. Links that omit the parameter keep the previous output unchanged.

AI-assisted implementation.

## Related Issue / 关联 Issue

No existing issue found; this fixes a verified integration gap with NewAPI-generated CC Switch links.

## Screenshots / 截图

Not applicable. The change affects generated Codex TOML, not visible layout.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码） — local Rust toolchain unavailable; awaiting repository CI
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — no UI text changed; EN/ZH/JA protocol docs updated

Additional verification:

- Frontend unit suite: 1,070/1,073 tests passed; three pre-existing `tests/integration/App.test.tsx` failures (two timeouts, one duplicate `switch-openclaw` element) are unrelated to the deep-link change.
- Added Rust parser, builder, and end-to-end import regression coverage for `supports_websockets=true`.
- `git diff --check` passes.