### PR TITLE
fix(codex): recover from dangling managed account bindings

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -12,6 +12,7 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fs;
+use std::io::Write;
 use std::process::{Command, Stdio};
 use toml_edit::DocumentMut;
 
@@ -289,6 +290,31 @@ impl CodexLiveStateSnapshot {
                 if let Err(error) = state.restore() {
                     failures.push(format!("{label}: {error}"));
                 }
+            }
+        }
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(AppError::Message(format!(
+                "恢复 Codex Live 状态失败: {}",
+                failures.join("; ")
+            )))
+        }
+    }
+
+    /// Roll back cc-switch-owned files without touching the current auth.json.
+    /// The marker belongs to this failed provider write; Codex CLI never writes
+    /// it, so restoring the snapshot cannot clobber a concurrent native login.
+    pub(crate) fn restore_preserving_current_auth(&self) -> Result<(), AppError> {
+        let mut failures = Vec::new();
+        for (label, state) in [
+            ("catalog", &self.catalog),
+            ("config", &self.config),
+            ("managed marker", &self.managed_marker),
+        ] {
+            if let Err(error) = state.restore() {
+                failures.push(format!("{label}: {error}"));
             }
         }
 
@@ -737,6 +763,20 @@ pub fn clear_codex_live_auth_for_managed_account(account_id: &str) -> Result<(),
     clear_codex_live_auth_for_managed_account_if_unchanged(account_id, None)
 }
 
+pub(crate) fn ensure_codex_live_auth_absent() -> Result<(), AppError> {
+    let auth_path = get_codex_auth_path();
+    if auth_path.try_exists().map_err(|source| AppError::Io {
+        path: auth_path.display().to_string(),
+        source,
+    })? {
+        return Err(AppError::Conflict(
+            "Codex CLI 登录凭据在切换期间出现；为避免覆盖有效凭据，本次操作已取消，请重试"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Verify that the outgoing account's live refresh generation has not changed
 /// since it was adopted into the OAuth manager.
 pub fn ensure_codex_live_auth_unchanged_for_managed_account(
@@ -1020,6 +1060,76 @@ pub fn write_codex_live_atomic(
     }
 
     Ok(())
+}
+
+/// Final step of a guarded live-auth write. All other state is committed
+/// before this value is consumed, so a successful auth publication cannot be
+/// followed by a fallible operation that would need to delete it again.
+pub(crate) enum CodexAbsentAuthCommit {
+    Publish {
+        temporary: tempfile::NamedTempFile,
+        auth_path: PathBuf,
+    },
+    VerifyAbsent,
+    Preserve,
+}
+
+impl CodexAbsentAuthCommit {
+    pub(crate) fn commit(self) -> Result<(), AppError> {
+        match self {
+            Self::Publish {
+                temporary,
+                auth_path,
+            } => temporary.persist_noclobber(&auth_path).map(|_| ()).map_err(|error| {
+                if error.error.kind() == std::io::ErrorKind::AlreadyExists
+                    || auth_path.try_exists().unwrap_or(false)
+                {
+                    AppError::Conflict(
+                        "Codex CLI 登录凭据在切换期间出现；为避免覆盖有效凭据，本次操作已取消，请重试"
+                            .to_string(),
+                    )
+                } else {
+                    AppError::io(&auth_path, error.error)
+                }
+            }),
+            Self::VerifyAbsent => ensure_codex_live_auth_absent(),
+            Self::Preserve => Ok(()),
+        }
+    }
+}
+
+/// Stage config and a managed auth bundle without replacing a concurrent login.
+fn prepare_codex_live_if_auth_absent(
+    auth: &Value,
+    config_text_opt: Option<&str>,
+) -> Result<CodexAbsentAuthCommit, AppError> {
+    let auth_path = get_codex_auth_path();
+    let config_path = get_codex_config_path();
+    let config_text = config_text_opt.unwrap_or_default();
+    if !config_text.trim().is_empty() {
+        toml::from_str::<toml::Table>(config_text)
+            .map_err(|error| AppError::toml(&config_path, error))?;
+    }
+
+    let parent = auth_path
+        .parent()
+        .ok_or_else(|| AppError::Config("无效的 Codex auth 路径".to_string()))?;
+    fs::create_dir_all(parent).map_err(|error| AppError::io(parent, error))?;
+    let json =
+        serde_json::to_vec_pretty(auth).map_err(|source| AppError::JsonSerialize { source })?;
+    let mut temporary =
+        tempfile::NamedTempFile::new_in(parent).map_err(|error| AppError::io(parent, error))?;
+
+    temporary
+        .write_all(&json)
+        .and_then(|_| temporary.flush())
+        .map_err(|error| AppError::io(temporary.path(), error))?;
+
+    write_text_file(&config_path, config_text)?;
+    Ok(CodexAbsentAuthCommit::Publish {
+        temporary,
+        auth_path,
+    })
 }
 
 /// 读取 `~/.codex/config.toml`，若不存在返回空字符串
@@ -2514,6 +2624,20 @@ pub fn write_codex_provider_live_with_catalog(
     write_codex_live_for_provider(category, auth, prepared_config.as_deref())
 }
 
+pub(crate) fn prepare_codex_provider_live_with_catalog_if_auth_absent(
+    settings: &Value,
+    category: Option<&str>,
+    auth: &Value,
+    config_text: Option<&str>,
+    profile: CodexCatalogToolProfile,
+) -> Result<CodexAbsentAuthCommit, AppError> {
+    let prepared_config = config_text
+        .map(|text| prepare_codex_config_text_with_model_catalog(settings, text, profile))
+        .transpose()?;
+
+    prepare_codex_live_for_provider_if_auth_absent(category, auth, prepared_config.as_deref())
+}
+
 /// Extract a provider-scoped `experimental_bearer_token` from Codex `config.toml`.
 ///
 /// Mobile compat: third-party providers may store the API key inside
@@ -3798,6 +3922,29 @@ pub fn write_codex_live_for_provider(
     Ok(())
 }
 
+pub(crate) fn prepare_codex_live_for_provider_if_auth_absent(
+    category: Option<&str>,
+    auth: &Value,
+    config_text: Option<&str>,
+) -> Result<CodexAbsentAuthCommit, AppError> {
+    let plan = plan_codex_live_write(
+        category,
+        auth,
+        config_text,
+        crate::settings::preserve_codex_official_auth_on_switch(),
+    )?;
+    if plan.write_full_auth {
+        return prepare_codex_live_if_auth_absent(auth, plan.config_text.as_deref());
+    }
+
+    write_codex_live_config_atomic(plan.config_text.as_deref())?;
+    if plan.remove_auth_file {
+        Ok(CodexAbsentAuthCommit::VerifyAbsent)
+    } else {
+        Ok(CodexAbsentAuthCommit::Preserve)
+    }
+}
+
 fn remove_codex_live_auth_after_third_party_switch() {
     let auth_path = get_codex_auth_path();
     if !auth_path.exists() {
@@ -4189,6 +4336,53 @@ mod tests {
             catalog_bytes,
             marker_bytes,
         }
+    }
+
+    #[test]
+    #[serial]
+    fn absent_auth_rollback_preserves_a_concurrent_login() {
+        let _home = CodexLiveTestHome::new();
+        crate::config::write_text_file(&get_codex_config_path(), "model = \"before\"\n")
+            .expect("seed config");
+        let snapshot = CodexLiveStateSnapshot::capture().expect("capture absent auth state");
+        let managed_auth = codex_managed_oauth_auth_value(
+            "managed-workspace",
+            "managed-access",
+            Some(&test_codex_id_token("managed-user")),
+            "managed-refresh",
+            "2026-09-02T00:00:00Z",
+        );
+
+        let pending = prepare_codex_live_for_provider_if_auth_absent(
+            Some("official"),
+            &managed_auth,
+            Some("model = \"after\"\n"),
+        )
+        .expect("stage guarded write");
+        let native_auth = json!({
+            "tokens": {
+                "refresh_token": "native-refresh",
+                "account_id": "native-workspace"
+            }
+        });
+        crate::config::write_json_file(&get_codex_auth_path(), &native_auth)
+            .expect("simulate concurrent login");
+        let error = pending
+            .commit()
+            .expect_err("concurrent login must cancel guarded write");
+        assert!(matches!(error, AppError::Conflict(_)));
+        snapshot
+            .restore_preserving_current_auth()
+            .expect("roll back without replacing concurrent auth");
+
+        assert_eq!(
+            crate::config::read_json_file::<Value>(&get_codex_auth_path()).unwrap(),
+            native_auth
+        );
+        assert_eq!(
+            fs::read_to_string(get_codex_config_path()).unwrap(),
+            "model = \"before\"\n"
+        );
     }
 
     fn seed_rotated_managed_codex_live_state() -> CodexLiveTestState {

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -726,7 +726,8 @@ pub(crate) fn codex_live_auth_matches_managed_request(
     Ok(live_access_token == Some(request_access_token.trim()))
 }
 
-fn clear_codex_managed_oauth_live_auth_marker_for_account(
+/// Relinquish only this account's ownership marker, without touching live auth.
+pub(crate) fn clear_codex_managed_oauth_live_auth_marker_for_account(
     account_id: &str,
 ) -> Result<(), AppError> {
     let marker_path = get_codex_managed_oauth_live_auth_marker_path();

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -3933,6 +3933,21 @@ pub(crate) fn prepare_codex_live_for_provider_if_auth_absent(
         config_text,
         crate::settings::preserve_codex_official_auth_on_switch(),
     )?;
+    // A login already on disk requires user action, not a retry. Check only
+    // targets that would replace/remove auth: config-only preservation is the
+    // escape route for a dangling binding and must remain available.
+    if plan.write_full_auth || plan.remove_auth_file {
+        let auth_path = get_codex_auth_path();
+        if auth_path
+            .try_exists()
+            .map_err(|error| AppError::io(&auth_path, error))?
+        {
+            return Err(AppError::Conflict(
+                "Codex auth.json 中已有登录凭据，无法安全完成此次切换。请先在终端运行 codex logout，或先切换到未绑定托管账号且不含登录凭据的官方供应商，再重试"
+                    .to_string(),
+            ));
+        }
+    }
     if plan.write_full_auth {
         return prepare_codex_live_if_auth_absent(auth, plan.config_text.as_deref());
     }
@@ -4336,6 +4351,33 @@ mod tests {
             catalog_bytes,
             marker_bytes,
         }
+    }
+
+    #[test]
+    #[serial]
+    fn preexisting_auth_recovery_error_precedes_config_write() {
+        let _home = CodexLiveTestHome::new();
+        crate::settings::reload_settings().expect("reload settings");
+        let auth = codex_managed_oauth_auth_value(
+            "managed-workspace",
+            "managed-access",
+            Some(&test_codex_id_token("managed-user")),
+            "managed-refresh",
+            "2026-09-02T00:00:00Z",
+        );
+        crate::config::write_json_file(&get_codex_auth_path(), &auth).expect("seed auth");
+        crate::config::write_text_file(&get_codex_config_path(), "model = \"before\"\n")
+            .expect("seed config");
+        let snapshot = CodexLiveStateSnapshot::capture().expect("capture live state");
+        let error = prepare_codex_live_for_provider_if_auth_absent(
+            Some("official"),
+            &auth,
+            Some("model = \"after\"\n"),
+        )
+        .err()
+        .expect("preexisting auth must refuse guarded publication");
+        assert!(error.to_string().contains("codex logout"));
+        assert_eq!(CodexLiveStateSnapshot::capture().unwrap(), snapshot);
     }
 
     #[test]

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -1065,6 +1065,7 @@ pub fn write_codex_live_atomic(
 /// Final step of a guarded live-auth write. All other state is committed
 /// before this value is consumed, so a successful auth publication cannot be
 /// followed by a fallible operation that would need to delete it again.
+#[must_use = "staged Codex auth must be committed after all other fallible state changes"]
 pub(crate) enum CodexAbsentAuthCommit {
     Publish {
         temporary: tempfile::NamedTempFile,

--- a/src-tauri/src/database/dao/providers.rs
+++ b/src-tauri/src/database/dao/providers.rs
@@ -408,6 +408,16 @@ impl Database {
         Ok(())
     }
 
+    pub(crate) fn clear_current_provider(&self, app_type: &str) -> Result<(), AppError> {
+        let conn = lock_conn!(self.conn);
+        conn.execute(
+            "UPDATE providers SET is_current = 0 WHERE app_type = ?1",
+            params![app_type],
+        )
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(())
+    }
+
     pub fn update_provider_settings_config(
         &self,
         app_type: &str,

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -202,6 +202,55 @@ enum RefreshTokenAdoptionOutcome {
     NotManaged,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CodexLiveAuthSwitchGuard {
+    ExistingAccount(Option<String>),
+    MissingAccount,
+}
+
+impl CodexLiveAuthSwitchGuard {
+    pub(crate) fn requires_guarded_commit(&self) -> bool {
+        matches!(self, Self::MissingAccount | Self::ExistingAccount(None))
+    }
+
+    pub(crate) fn account_missing(&self) -> bool {
+        matches!(self, Self::MissingAccount)
+    }
+
+    pub(crate) fn expected_refresh_token(&self) -> Option<&str> {
+        match self {
+            Self::ExistingAccount(token) => token.as_deref(),
+            Self::MissingAccount => None,
+        }
+    }
+
+    pub(crate) fn ensure_unchanged(&self, account_id: &str) -> Result<(), crate::error::AppError> {
+        match self {
+            Self::ExistingAccount(Some(expected)) => {
+                crate::codex_config::ensure_codex_live_auth_unchanged_for_managed_account(
+                    account_id, expected,
+                )
+            }
+            Self::ExistingAccount(None) | Self::MissingAccount => Ok(()),
+        }
+    }
+
+    pub(crate) fn clear_outgoing_if_unchanged(
+        &self,
+        account_id: &str,
+    ) -> Result<(), crate::error::AppError> {
+        match self {
+            Self::ExistingAccount(expected) => {
+                crate::codex_config::clear_codex_live_auth_for_managed_account_if_unchanged(
+                    account_id,
+                    expected.as_deref(),
+                )
+            }
+            Self::MissingAccount => Ok(()),
+        }
+    }
+}
+
 impl RefreshTokenAdoptionOutcome {
     fn state_changed(self) -> bool {
         matches!(
@@ -233,7 +282,7 @@ struct AccountLoginContext<'a> {
 }
 
 /// 持久化的账号数据
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct CodexAccountData {
     /// 本地稳定账号 ID（同时作为 HashMap 的 key）
     pub account_id: String,
@@ -1144,21 +1193,26 @@ impl CodexOAuthManager {
     pub(crate) async fn prepare_live_auth_for_account_switch_away(
         &self,
         account_id: &str,
-    ) -> Result<Option<String>, CodexOAuthError> {
+    ) -> Result<CodexLiveAuthSwitchGuard, CodexOAuthError> {
         let _lifecycle = self.lifecycle_lock.read().await;
         let refresh_lock = self.get_refresh_lock(account_id).await;
         let _guard = refresh_lock.lock().await;
-        {
+        let account_exists = {
             let accounts = self.accounts.read().await;
-            accounts
-                .get(account_id)
-                .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
+            accounts.contains_key(account_id)
+        };
+        if !account_exists {
+            self.ensure_account_absent_from_store(account_id).await?;
+            log::warn!(
+                "[CodexOAuth] outgoing account {account_id} is missing; continuing with a guarded live-auth commit"
+            );
+            return Ok(CodexLiveAuthSwitchGuard::MissingAccount);
         }
         let Some((live_refresh, live_id_token, live_last_refresh_ms)) = self
             .read_managed_live_auth_refresh_for_account(account_id)
             .await?
         else {
-            return Ok(None);
+            return Ok(CodexLiveAuthSwitchGuard::ExistingAccount(None));
         };
 
         let outcome = self
@@ -1174,7 +1228,9 @@ impl CodexOAuthManager {
         match outcome {
             RefreshTokenAdoptionOutcome::Synchronized { .. }
             | RefreshTokenAdoptionOutcome::Adopted
-            | RefreshTokenAdoptionOutcome::ProvablyOlder => Ok(Some(live_refresh)),
+            | RefreshTokenAdoptionOutcome::ProvablyOlder => Ok(
+                CodexLiveAuthSwitchGuard::ExistingAccount(Some(live_refresh)),
+            ),
             RefreshTokenAdoptionOutcome::Ambiguous => {
                 Err(Self::ambiguous_live_refresh_error(account_id))
             }
@@ -1817,6 +1873,56 @@ impl CodexOAuthManager {
         )
     }
 
+    async fn ensure_account_absent_from_store(
+        &self,
+        account_id: &str,
+    ) -> Result<(), CodexOAuthError> {
+        let _persist = self.storage_lock.lock().await;
+        if !self.storage_path.try_exists()? {
+            if self.accounts.read().await.is_empty() {
+                return Ok(());
+            }
+            return Err(CodexOAuthError::TokenFetchFailed(format!(
+                "账号 {account_id} 的内存与磁盘存储不一致；请重启应用后重试"
+            )));
+        }
+
+        let content = fs::read_to_string(&self.storage_path)?;
+        let raw_store: serde_json::Value = serde_json::from_str(&content)
+            .map_err(|error| CodexOAuthError::ParseError(error.to_string()))?;
+        if !raw_store
+            .as_object()
+            .is_some_and(|object| object.contains_key("accounts"))
+        {
+            return Err(CodexOAuthError::ParseError(
+                "Codex 账号存储缺少 accounts 字段".to_string(),
+            ));
+        }
+        let store: CodexOAuthStore = serde_json::from_value(raw_store)
+            .map_err(|error| CodexOAuthError::ParseError(error.to_string()))?;
+        if !matches!(store.version, 1 | 2) {
+            return Err(CodexOAuthError::ParseError(format!(
+                "不支持的 Codex 账号存储版本: {}",
+                store.version
+            )));
+        }
+        if store
+            .accounts
+            .iter()
+            .any(|(key, account)| key.trim().is_empty() || key != &account.account_id)
+        {
+            return Err(CodexOAuthError::ParseError(
+                "Codex 账号存储中的账号 ID 与索引不一致".to_string(),
+            ));
+        }
+        if store.accounts != *self.accounts.read().await {
+            return Err(CodexOAuthError::TokenFetchFailed(format!(
+                "账号 {account_id} 的内存与磁盘存储不一致；请重启应用后重试"
+            )));
+        }
+        Ok(())
+    }
+
     fn write_store_atomic(&self, content: &str) -> Result<(), CodexOAuthError> {
         if let Some(parent) = self.storage_path.parent() {
             fs::create_dir_all(parent)?;
@@ -2016,6 +2122,90 @@ fn extract_account_metadata_from_tokens(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn missing_account_requires_a_readable_store() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("codex_oauth_auth.json"), "{invalid").unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+
+        assert!(matches!(
+            manager
+                .prepare_live_auth_for_account_switch_away("missing-account")
+                .await,
+            Err(CodexOAuthError::ParseError(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn memory_disk_divergence_does_not_look_like_a_deleted_account() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        manager
+            .add_test_account_with_user_identity("account-a", "access", "user-a")
+            .await
+            .unwrap();
+        manager.accounts.write().await.clear();
+
+        assert!(matches!(
+            manager
+                .prepare_live_auth_for_account_switch_away("account-a")
+                .await,
+            Err(CodexOAuthError::TokenFetchFailed(message))
+                if message.contains("内存与磁盘存储不一致")
+        ));
+    }
+
+    #[tokio::test]
+    async fn missing_store_is_not_safe_when_memory_has_accounts() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        manager
+            .add_test_account_with_user_identity("account-b", "access", "user-b")
+            .await
+            .unwrap();
+        std::fs::remove_file(temp.path().join("codex_oauth_auth.json")).unwrap();
+
+        assert!(matches!(
+            manager
+                .prepare_live_auth_for_account_switch_away("missing-account")
+                .await,
+            Err(CodexOAuthError::TokenFetchFailed(message))
+                if message.contains("内存与磁盘存储不一致")
+        ));
+    }
+
+    #[tokio::test]
+    async fn structurally_invalid_store_does_not_look_like_a_deleted_account() {
+        for store in [
+            serde_json::json!({ "version": 2 }),
+            serde_json::json!({
+                "version": 2,
+                "accounts": {
+                    "wrong-key": {
+                        "account_id": "account-a",
+                        "refresh_token": "refresh",
+                        "authenticated_at": 1
+                    }
+                }
+            }),
+        ] {
+            let temp = tempfile::tempdir().unwrap();
+            std::fs::write(
+                temp.path().join("codex_oauth_auth.json"),
+                serde_json::to_vec(&store).unwrap(),
+            )
+            .unwrap();
+            let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+
+            assert!(matches!(
+                manager
+                    .prepare_live_auth_for_account_switch_away("account-a")
+                    .await,
+                Err(CodexOAuthError::ParseError(_))
+            ));
+        }
+    }
 
     #[test]
     fn test_parse_interval_number() {

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -242,9 +242,14 @@ impl CodexLiveAuthSwitchGuard {
                     expected.as_deref(),
                 )
             }
-            // There was no outgoing auth to remove. Anything now present may
-            // be a concurrent native login, even when its identity matches.
-            Self::AbsentAuth | Self::MissingAccount => Ok(()),
+            // Relinquish ownership without removing a concurrent native login,
+            // even when its identity matches the outgoing account. The helper
+            // also leaves a newly staged target account's marker untouched.
+            Self::AbsentAuth | Self::MissingAccount => {
+                crate::codex_config::clear_codex_managed_oauth_live_auth_marker_for_account(
+                    account_id,
+                )
+            }
         }
     }
 }

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -204,13 +204,16 @@ enum RefreshTokenAdoptionOutcome {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum CodexLiveAuthSwitchGuard {
+    /// None means auth existed at preflight but had no adoptable managed refresh token.
     ExistingAccount(Option<String>),
+    /// The manager account exists, but auth was absent at preflight.
+    AbsentAuth,
     MissingAccount,
 }
 
 impl CodexLiveAuthSwitchGuard {
     pub(crate) fn requires_guarded_commit(&self) -> bool {
-        matches!(self, Self::MissingAccount | Self::ExistingAccount(None))
+        matches!(self, Self::MissingAccount | Self::AbsentAuth)
     }
 
     pub(crate) fn account_missing(&self) -> bool {
@@ -220,7 +223,7 @@ impl CodexLiveAuthSwitchGuard {
     pub(crate) fn expected_refresh_token(&self) -> Option<&str> {
         match self {
             Self::ExistingAccount(token) => token.as_deref(),
-            Self::MissingAccount => None,
+            Self::AbsentAuth | Self::MissingAccount => None,
         }
     }
 
@@ -231,7 +234,7 @@ impl CodexLiveAuthSwitchGuard {
                     account_id, expected,
                 )
             }
-            Self::ExistingAccount(None) | Self::MissingAccount => Ok(()),
+            Self::ExistingAccount(None) | Self::AbsentAuth | Self::MissingAccount => Ok(()),
         }
     }
 
@@ -245,6 +248,9 @@ impl CodexLiveAuthSwitchGuard {
                     account_id,
                     expected.as_deref(),
                 )
+            }
+            Self::AbsentAuth => {
+                crate::codex_config::clear_codex_live_auth_for_managed_account(account_id)
             }
             Self::MissingAccount => Ok(()),
         }
@@ -1208,11 +1214,22 @@ impl CodexOAuthManager {
             );
             return Ok(CodexLiveAuthSwitchGuard::MissingAccount);
         }
+        // Capture absence before reading: a native login that appears during
+        // the read must not accidentally opt out of guarded publication.
+        let auth_existed = crate::codex_config::get_codex_auth_path().try_exists()?;
         let Some((live_refresh, live_id_token, live_last_refresh_ms)) = self
             .read_managed_live_auth_refresh_for_account(account_id)
             .await?
         else {
-            return Ok(CodexLiveAuthSwitchGuard::ExistingAccount(None));
+            // No managed refresh token can also mean a preexisting native
+            // login or a missing marker. Explicit switches keep their normal
+            // replacement semantics in that case; only an absent auth file
+            // needs no-clobber publication against a later concurrent login.
+            return Ok(if auth_existed {
+                CodexLiveAuthSwitchGuard::ExistingAccount(None)
+            } else {
+                CodexLiveAuthSwitchGuard::AbsentAuth
+            });
         };
 
         let outcome = self

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -220,13 +220,6 @@ impl CodexLiveAuthSwitchGuard {
         matches!(self, Self::MissingAccount)
     }
 
-    pub(crate) fn expected_refresh_token(&self) -> Option<&str> {
-        match self {
-            Self::ExistingAccount(token) => token.as_deref(),
-            Self::AbsentAuth | Self::MissingAccount => None,
-        }
-    }
-
     pub(crate) fn ensure_unchanged(&self, account_id: &str) -> Result<(), crate::error::AppError> {
         match self {
             Self::ExistingAccount(Some(expected)) => {
@@ -249,10 +242,9 @@ impl CodexLiveAuthSwitchGuard {
                     expected.as_deref(),
                 )
             }
-            Self::AbsentAuth => {
-                crate::codex_config::clear_codex_live_auth_for_managed_account(account_id)
-            }
-            Self::MissingAccount => Ok(()),
+            // There was no outgoing auth to remove. Anything now present may
+            // be a concurrent native login, even when its identity matches.
+            Self::AbsentAuth | Self::MissingAccount => Ok(()),
         }
     }
 }

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -14,7 +14,7 @@ use crate::config::{delete_file, get_claude_settings_path, read_json_file, write
 use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
-use crate::proxy::providers::codex_oauth_auth::CodexOAuthManager;
+use crate::proxy::providers::codex_oauth_auth::{CodexLiveAuthSwitchGuard, CodexOAuthManager};
 use crate::services::mcp::McpService;
 use crate::store::AppState;
 
@@ -714,6 +714,19 @@ pub(crate) fn write_live_with_common_config_for_state(
     )
 }
 
+pub(crate) fn prepare_live_with_common_config_if_codex_auth_absent(
+    state: &AppState,
+    provider: &Provider,
+) -> Result<crate::codex_config::CodexAbsentAuthCommit, AppError> {
+    let effective_provider = build_effective_provider_for_live_with_codex_oauth_manager(
+        state.db.as_ref(),
+        &AppType::Codex,
+        provider,
+        &state.codex_oauth_manager,
+    )?;
+    prepare_live_snapshot_if_codex_auth_absent(&effective_provider)
+}
+
 /// Validate the target provider's Codex live projection without writing:
 /// build the effective settings exactly like the live write would, then run
 /// the write-layer plan (legacy normalization, safety gates, token
@@ -907,7 +920,7 @@ fn get_codex_managed_oauth_live_auth_value(
 pub(crate) fn prepare_codex_managed_oauth_live_auth_switch_away(
     manager: Arc<CodexOAuthManager>,
     account_id: String,
-) -> Result<Option<String>, AppError> {
+) -> Result<CodexLiveAuthSwitchGuard, AppError> {
     std::thread::spawn(move || {
         tauri::async_runtime::block_on(async move {
             manager
@@ -1701,6 +1714,35 @@ pub fn sync_current_to_live(state: &AppState) -> Result<(), AppError> {
             failures.join("; ")
         )))
     }
+}
+
+pub(crate) fn prepare_live_snapshot_if_codex_auth_absent(
+    provider: &Provider,
+) -> Result<crate::codex_config::CodexAbsentAuthCommit, AppError> {
+    let obj = provider
+        .settings_config
+        .as_object()
+        .ok_or_else(|| AppError::Config("Codex 供应商配置必须是 JSON 对象".to_string()))?;
+    let auth = obj
+        .get("auth")
+        .ok_or_else(|| AppError::Config("Codex 供应商配置缺少 'auth' 字段".to_string()))?;
+    let config_str = obj.get("config").and_then(|value| value.as_str());
+    let profile = crate::proxy::providers::resolve_codex_catalog_tool_profile(provider);
+
+    if let Some(account_id) = provider
+        .meta
+        .as_ref()
+        .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
+    {
+        crate::codex_config::record_codex_managed_oauth_live_auth(auth, &account_id)?;
+    }
+    crate::codex_config::prepare_codex_provider_live_with_catalog_if_auth_absent(
+        &provider.settings_config,
+        provider.category.as_deref(),
+        auth,
+        config_str,
+        profile,
+    )
 }
 
 /// Read current live settings for an app type

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -17,6 +17,7 @@ use crate::app_config::AppType;
 use crate::database::{validate_cost_multiplier, validate_pricing_source};
 use crate::error::AppError;
 use crate::provider::{Provider, UsageResult};
+use crate::proxy::providers::codex_oauth_auth::CodexLiveAuthSwitchGuard;
 use crate::services::mcp::McpService;
 use crate::settings::CustomEndpoint;
 use crate::store::AppState;
@@ -3037,6 +3038,129 @@ wire_api = "responses"
 
     #[test]
     #[serial]
+    fn deleted_managed_account_can_be_rebound_or_switched_away_from() {
+        with_test_home(|state, _| {
+            crate::settings::reload_settings().expect("reload settings");
+            tauri::async_runtime::block_on(async {
+                for (id, user) in [("acct-old", "user-old"), ("acct-new", "user-new")] {
+                    state
+                        .codex_oauth_manager
+                        .add_test_account_with_user_identity(id, "test-access", user)
+                        .await
+                        .expect("seed managed account");
+                }
+            });
+
+            let managed = managed_codex_provider("managed-current", "acct-old");
+            let mut fallback = Provider::with_id(
+                "unbound-official".to_string(),
+                "Unbound Official".to_string(),
+                json!({ "auth": {}, "config": "" }),
+                None,
+            );
+            fallback.category = Some("official".to_string());
+            for provider in [&managed, &fallback] {
+                state
+                    .db
+                    .save_provider(AppType::Codex.as_str(), provider)
+                    .expect("save provider");
+            }
+            ProviderService::switch(state, AppType::Codex, &managed.id)
+                .expect("activate managed provider");
+
+            std::fs::remove_file(crate::codex_config::get_codex_auth_path())
+                .expect("simulate absent live auth");
+            let guard =
+                ProviderService::prepare_outgoing_managed_codex_live_auth(state, Some("acct-old"))
+                    .expect("prepare absent live auth")
+                    .expect("managed outgoing guard");
+            assert!(guard.requires_guarded_commit());
+            assert!(!guard.account_missing());
+
+            tauri::async_runtime::block_on(state.codex_oauth_manager.remove_account("acct-old"))
+                .expect("remove old account");
+            let mut rebound = managed.clone();
+            rebound
+                .meta
+                .as_mut()
+                .and_then(|meta| meta.auth_binding.as_mut())
+                .expect("managed binding")
+                .account_id = Some("acct-new".to_string());
+            ProviderService::update(state, AppType::Codex, None, rebound)
+                .expect("rebind after account deletion");
+
+            tauri::async_runtime::block_on(state.codex_oauth_manager.remove_account("acct-new"))
+                .expect("remove rebound account");
+            let native_auth = json!({
+                "tokens": {
+                    "refresh_token": "native-refresh",
+                    "account_id": "native-workspace"
+                }
+            });
+            write_json_file(&crate::codex_config::get_codex_auth_path(), &native_auth)
+                .expect("simulate native login after account deletion");
+            ProviderService::switch(state, AppType::Codex, &fallback.id)
+                .expect("switch away after account deletion");
+            assert_eq!(
+                state
+                    .db
+                    .get_current_provider(AppType::Codex.as_str())
+                    .expect("read current provider")
+                    .as_deref(),
+                Some(fallback.id.as_str())
+            );
+            assert_eq!(
+                read_json_file::<Value>(&crate::codex_config::get_codex_auth_path())
+                    .expect("read preserved native auth"),
+                native_auth
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn guarded_codex_write_validates_marker_before_publishing_auth() {
+        with_test_home(|_, _| {
+            crate::settings::reload_settings().expect("reload settings");
+            let mut provider = Provider::with_id(
+                "managed-invalid-marker".to_string(),
+                "Managed invalid marker".to_string(),
+                json!({
+                    "auth": {
+                        "auth_mode": "chatgpt",
+                        "OPENAI_API_KEY": null,
+                        "tokens": {
+                            "access_token": "managed-access",
+                            "refresh_token": "managed-refresh",
+                            "account_id": "managed-workspace"
+                        },
+                        "last_refresh": "2026-09-02T00:00:00Z"
+                    },
+                    "config": "model = \"gpt-test\"\n"
+                }),
+                None,
+            );
+            provider.category = Some("official".to_string());
+            provider.meta = Some(ProviderMeta {
+                auth_binding: Some(AuthBinding {
+                    source: AuthBindingSource::ManagedAccount,
+                    auth_provider: Some("codex_oauth".to_string()),
+                    account_id: Some("managed-local".to_string()),
+                }),
+                ..Default::default()
+            });
+
+            let error = live::prepare_live_snapshot_if_codex_auth_absent(&provider)
+                .err()
+                .expect("marker validation must fail");
+            assert!(error.to_string().contains("稳定用户身份"));
+            assert!(!crate::codex_config::get_codex_auth_path().exists());
+            assert!(!crate::codex_config::get_codex_config_path().exists());
+        });
+    }
+
+    #[test]
+    #[serial]
     fn codex_auth_center_removal_waits_for_provider_switch_lock() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");
@@ -4157,6 +4281,18 @@ impl ProviderService {
         }
     }
 
+    fn prepare_live_if_codex_auth_absent(
+        state: &AppState,
+        provider: &Provider,
+        preflighted_provider: Option<&Provider>,
+    ) -> Result<crate::codex_config::CodexAbsentAuthCommit, AppError> {
+        if let Some(effective_provider) = preflighted_provider {
+            live::prepare_live_snapshot_if_codex_auth_absent(effective_provider)
+        } else {
+            live::prepare_live_with_common_config_if_codex_auth_absent(state, provider)
+        }
+    }
+
     fn managed_codex_transaction_error(
         operation: &str,
         error: AppError,
@@ -4172,6 +4308,55 @@ impl ProviderService {
             }
         }
         if let Err(rollback_error) = snapshot.restore_preserving_newer_same_account_auth() {
+            rollback_failures.push(rollback_error.to_string());
+        }
+
+        if rollback_failures.is_empty() {
+            error
+        } else {
+            AppError::Message(format!(
+                "{operation}失败: {error}; 回滚同时失败: {}",
+                rollback_failures.join("; ")
+            ))
+        }
+    }
+
+    /// Roll back a guarded live-auth transaction. This is called only when the
+    /// guarded writer failed before publishing auth.json; current auth may
+    /// therefore belong to a concurrent Codex login and must stay untouched.
+    fn guarded_codex_transaction_error(
+        state: &AppState,
+        operation: &str,
+        error: AppError,
+        snapshot: &crate::codex_config::CodexLiveStateSnapshot,
+        previous_provider: Option<&Provider>,
+        restore_current: Option<(&AppType, Option<&str>, Option<&str>)>,
+    ) -> AppError {
+        let mut rollback_failures = Vec::new();
+
+        if let Some(previous_provider) = previous_provider {
+            if let Err(rollback_error) = state
+                .db
+                .save_provider(AppType::Codex.as_str(), previous_provider)
+            {
+                rollback_failures.push(format!("恢复 Provider 数据失败: {rollback_error}"));
+            }
+        }
+        if let Some((app_type, previous_local_current, previous_db_current)) = restore_current {
+            let db_restore = match previous_db_current {
+                Some(id) => state.db.set_current_provider(app_type.as_str(), id),
+                None => state.db.clear_current_provider(app_type.as_str()),
+            };
+            if let Err(rollback_error) = db_restore {
+                rollback_failures.push(format!("恢复数据库 current 失败: {rollback_error}"));
+            }
+            if let Err(rollback_error) =
+                crate::settings::set_current_provider(app_type, previous_local_current)
+            {
+                rollback_failures.push(format!("恢复本地 current 失败: {rollback_error}"));
+            }
+        }
+        if let Err(rollback_error) = snapshot.restore_preserving_current_auth() {
             rollback_failures.push(rollback_error.to_string());
         }
 
@@ -4287,7 +4472,7 @@ impl ProviderService {
     fn prepare_outgoing_managed_codex_live_auth(
         state: &AppState,
         account_id: Option<&str>,
-    ) -> Result<Option<String>, AppError> {
+    ) -> Result<Option<CodexLiveAuthSwitchGuard>, AppError> {
         let Some(account_id) = account_id else {
             return Ok(None);
         };
@@ -4295,38 +4480,27 @@ impl ProviderService {
             state.codex_oauth_manager.clone(),
             account_id.to_string(),
         )
+        .map(Some)
     }
 
     fn ensure_outgoing_managed_codex_live_auth_unchanged(
         account_id: Option<&str>,
-        expected_refresh_token: Option<&str>,
+        guard: Option<&CodexLiveAuthSwitchGuard>,
     ) -> Result<(), AppError> {
-        if let (Some(account_id), Some(expected_refresh_token)) =
-            (account_id, expected_refresh_token)
-        {
-            crate::codex_config::ensure_codex_live_auth_unchanged_for_managed_account(
-                account_id,
-                expected_refresh_token,
-            )?;
+        if let (Some(account_id), Some(guard)) = (account_id, guard) {
+            guard.ensure_unchanged(account_id)?;
         }
         Ok(())
     }
 
     fn clear_outgoing_managed_codex_live_auth(
         account_id: Option<&str>,
-        expected_refresh_token: Option<&str>,
+        guard: Option<&CodexLiveAuthSwitchGuard>,
     ) -> Result<(), AppError> {
-        let Some(account_id) = account_id else {
-            return Ok(());
-        };
-        if let Some(expected_refresh_token) = expected_refresh_token {
-            crate::codex_config::clear_codex_live_auth_for_managed_account_if_unchanged(
-                account_id,
-                Some(expected_refresh_token),
-            )
-        } else {
-            crate::codex_config::clear_codex_live_auth_for_managed_account(account_id)
+        if let (Some(account_id), Some(guard)) = (account_id, guard) {
+            guard.clear_outgoing_if_unchanged(account_id)?;
         }
+        Ok(())
     }
 
     fn normalize_provider_if_claude(app_type: &AppType, provider: &mut Provider) {
@@ -4776,7 +4950,7 @@ impl ProviderService {
                 return Ok(true);
             }
 
-            let outgoing_live_refresh_token = Self::prepare_outgoing_managed_codex_live_auth(
+            let outgoing_live_auth_guard = Self::prepare_outgoing_managed_codex_live_auth(
                 state,
                 outgoing_managed_codex_account_id.as_deref(),
             )?;
@@ -4790,6 +4964,21 @@ impl ProviderService {
             let live_taken_over = state
                 .proxy_service
                 .detect_takeover_in_live_config_for_app(&app_type);
+            if (has_live_backup || live_taken_over)
+                && outgoing_live_auth_guard
+                    .as_ref()
+                    .is_some_and(CodexLiveAuthSwitchGuard::account_missing)
+            {
+                return Err(AppError::Message(
+                    "当前托管账号已删除；请先关闭代理接管，再更新账号绑定".to_string(),
+                ));
+            }
+            let outgoing_live_refresh_token = outgoing_live_auth_guard
+                .as_ref()
+                .and_then(CodexLiveAuthSwitchGuard::expected_refresh_token);
+            let requires_guarded_auth_commit = outgoing_live_auth_guard
+                .as_ref()
+                .is_some_and(CodexLiveAuthSwitchGuard::requires_guarded_commit);
             let preflighted_provider =
                 Self::preflight_managed_codex_live(state, &app_type, &provider)?;
             // Capture after preflight: a legitimate refresh may have advanced
@@ -4797,10 +4986,64 @@ impl ProviderService {
             let snapshot = crate::codex_config::CodexLiveStateSnapshot::capture()?;
 
             if !has_live_backup && !live_taken_over {
+                if requires_guarded_auth_commit {
+                    let pending_auth = (|| {
+                        Self::ensure_outgoing_managed_codex_live_auth_unchanged(
+                            outgoing_managed_codex_account_id.as_deref(),
+                            outgoing_live_auth_guard.as_ref(),
+                        )?;
+                        Self::prepare_live_if_codex_auth_absent(
+                            state,
+                            &provider,
+                            preflighted_provider.as_ref(),
+                        )
+                    })();
+                    let pending_auth = match pending_auth {
+                        Ok(pending) => pending,
+                        Err(error) => {
+                            return Err(Self::guarded_codex_transaction_error(
+                                state,
+                                "准备 Codex Live",
+                                error,
+                                &snapshot,
+                                None,
+                                None,
+                            ));
+                        }
+                    };
+                    if let Err(error) = state.db.save_provider(app_type.as_str(), &provider) {
+                        return Err(Self::guarded_codex_transaction_error(
+                            state,
+                            "更新托管 Codex provider",
+                            error,
+                            &snapshot,
+                            None,
+                            None,
+                        ));
+                    }
+                    if let Err(error) = pending_auth.commit() {
+                        return Err(Self::guarded_codex_transaction_error(
+                            state,
+                            "发布 Codex 认证",
+                            error,
+                            &snapshot,
+                            existing_provider.as_ref(),
+                            None,
+                        ));
+                    }
+
+                    if let Err(err) = McpService::sync_enabled_for_app(state, &app_type) {
+                        log::warn!(
+                            "保存供应商后重投影 {app_type:?} MCP 失败（将在下次同步时自愈）: {err}"
+                        );
+                    }
+                    return Ok(true);
+                }
+
                 let commit_result = (|| {
                     Self::ensure_outgoing_managed_codex_live_auth_unchanged(
                         outgoing_managed_codex_account_id.as_deref(),
-                        outgoing_live_refresh_token.as_deref(),
+                        outgoing_live_auth_guard.as_ref(),
                     )?;
                     Self::write_preflighted_or_current_live(
                         state,
@@ -4810,7 +5053,7 @@ impl ProviderService {
                     )?;
                     Self::clear_outgoing_managed_codex_live_auth(
                         outgoing_managed_codex_account_id.as_deref(),
-                        outgoing_live_refresh_token.as_deref(),
+                        outgoing_live_auth_guard.as_ref(),
                     )?;
                     state.db.save_provider(app_type.as_str(), &provider)?;
                     Ok::<(), AppError>(())
@@ -4835,7 +5078,7 @@ impl ProviderService {
             let commit_result = (|| {
                 Self::ensure_outgoing_managed_codex_live_auth_unchanged(
                     outgoing_managed_codex_account_id.as_deref(),
-                    outgoing_live_refresh_token.as_deref(),
+                    outgoing_live_auth_guard.as_ref(),
                 )?;
                 futures::executor::block_on(
                     state.proxy_service.update_live_backup_from_provider_inner(
@@ -4853,7 +5096,7 @@ impl ProviderService {
                             .sync_codex_live_from_provider_while_proxy_active_guarded(
                                 &provider,
                                 outgoing_managed_codex_account_id.as_deref(),
-                                outgoing_live_refresh_token.as_deref(),
+                                outgoing_live_refresh_token,
                             ),
                     )
                     .map_err(|error| {
@@ -4865,7 +5108,7 @@ impl ProviderService {
                     // with the edited current provider as well as the backup.
                     Self::ensure_outgoing_managed_codex_live_auth_unchanged(
                         outgoing_managed_codex_account_id.as_deref(),
-                        outgoing_live_refresh_token.as_deref(),
+                        outgoing_live_auth_guard.as_ref(),
                     )?;
                     Self::write_preflighted_or_current_live(
                         state,
@@ -4877,7 +5120,7 @@ impl ProviderService {
 
                 Self::clear_outgoing_managed_codex_live_auth(
                     outgoing_managed_codex_account_id.as_deref(),
-                    outgoing_live_refresh_token.as_deref(),
+                    outgoing_live_auth_guard.as_ref(),
                 )?;
 
                 // DB is the final commit. Every fallible side effect above can be
@@ -5256,10 +5499,13 @@ impl ProviderService {
             .as_ref()
             .filter(|account_id| target_managed_codex_account_id.as_ref() != Some(*account_id))
             .cloned();
-        let outgoing_live_refresh_token = Self::prepare_outgoing_managed_codex_live_auth(
+        let outgoing_live_auth_guard = Self::prepare_outgoing_managed_codex_live_auth(
             state,
             outgoing_managed_codex_account_id.as_deref(),
         )?;
+        let requires_guarded_auth_commit = outgoing_live_auth_guard
+            .as_ref()
+            .is_some_and(CodexLiveAuthSwitchGuard::requires_guarded_commit);
 
         // 提交 current 前预检托管 Codex token（见 preflight_managed_codex_live）。
         let preflighted_provider = Self::preflight_managed_codex_live(state, &app_type, provider)?;
@@ -5268,53 +5514,118 @@ impl ProviderService {
                 || target_managed_codex_account_id.is_some());
 
         if use_managed_codex_transaction {
-            // auth/config/catalog/marker form one logical live commit. Write them
-            // before current, then restore the exact four-file snapshot on any
-            // failure so native logins and CLI-rotated tokens are not reconstructed
-            // from a stale provider row.
+            // auth/config/catalog/marker form one logical live commit.
             let snapshot = crate::codex_config::CodexLiveStateSnapshot::capture()?;
-            let live_result = (|| {
-                Self::ensure_outgoing_managed_codex_live_auth_unchanged(
-                    outgoing_managed_codex_account_id.as_deref(),
-                    outgoing_live_refresh_token.as_deref(),
-                )?;
-                Self::write_preflighted_or_current_live(
-                    state,
-                    &app_type,
-                    provider,
-                    preflighted_provider.as_ref(),
-                )?;
-                Self::clear_outgoing_managed_codex_live_auth(
-                    outgoing_managed_codex_account_id.as_deref(),
-                    outgoing_live_refresh_token.as_deref(),
-                )?;
-                Ok::<(), AppError>(())
-            })();
-            if let Err(error) = live_result {
-                return Err(Self::managed_codex_transaction_error(
-                    "写入 Codex Live",
-                    error,
-                    &snapshot,
-                    None,
-                ));
-            }
 
-            let previous_local_current = crate::settings::get_current_provider(&app_type);
-            if let Err(error) = crate::settings::set_current_provider(&app_type, Some(id)) {
-                return Err(Self::managed_codex_transaction_error(
-                    "更新本地 current",
-                    error,
-                    &snapshot,
-                    Some((&app_type, previous_local_current.as_deref())),
-                ));
-            }
-            if let Err(error) = state.db.set_current_provider(app_type.as_str(), id) {
-                return Err(Self::managed_codex_transaction_error(
-                    "更新数据库 current",
-                    error,
-                    &snapshot,
-                    Some((&app_type, previous_local_current.as_deref())),
-                ));
+            if requires_guarded_auth_commit {
+                let previous_local_current = crate::settings::get_current_provider(&app_type);
+                let previous_db_current = state.db.get_current_provider(app_type.as_str())?;
+                let pending_auth = (|| {
+                    Self::ensure_outgoing_managed_codex_live_auth_unchanged(
+                        outgoing_managed_codex_account_id.as_deref(),
+                        outgoing_live_auth_guard.as_ref(),
+                    )?;
+                    Self::prepare_live_if_codex_auth_absent(
+                        state,
+                        provider,
+                        preflighted_provider.as_ref(),
+                    )
+                })();
+                let pending_auth = match pending_auth {
+                    Ok(pending) => pending,
+                    Err(error) => {
+                        return Err(Self::guarded_codex_transaction_error(
+                            state,
+                            "准备 Codex Live",
+                            error,
+                            &snapshot,
+                            None,
+                            None,
+                        ));
+                    }
+                };
+                if let Err(error) = state.db.set_current_provider(app_type.as_str(), id) {
+                    return Err(Self::guarded_codex_transaction_error(
+                        state,
+                        "更新数据库 current",
+                        error,
+                        &snapshot,
+                        None,
+                        None,
+                    ));
+                }
+                if let Err(error) = crate::settings::set_current_provider(&app_type, Some(id)) {
+                    return Err(Self::guarded_codex_transaction_error(
+                        state,
+                        "更新本地 current",
+                        error,
+                        &snapshot,
+                        None,
+                        Some((
+                            &app_type,
+                            previous_local_current.as_deref(),
+                            previous_db_current.as_deref(),
+                        )),
+                    ));
+                }
+                if let Err(error) = pending_auth.commit() {
+                    return Err(Self::guarded_codex_transaction_error(
+                        state,
+                        "发布 Codex 认证",
+                        error,
+                        &snapshot,
+                        None,
+                        Some((
+                            &app_type,
+                            previous_local_current.as_deref(),
+                            previous_db_current.as_deref(),
+                        )),
+                    ));
+                }
+            } else {
+                let live_result = (|| {
+                    Self::ensure_outgoing_managed_codex_live_auth_unchanged(
+                        outgoing_managed_codex_account_id.as_deref(),
+                        outgoing_live_auth_guard.as_ref(),
+                    )?;
+                    Self::write_preflighted_or_current_live(
+                        state,
+                        &app_type,
+                        provider,
+                        preflighted_provider.as_ref(),
+                    )?;
+                    Self::clear_outgoing_managed_codex_live_auth(
+                        outgoing_managed_codex_account_id.as_deref(),
+                        outgoing_live_auth_guard.as_ref(),
+                    )?;
+                    Ok::<(), AppError>(())
+                })();
+                if let Err(error) = live_result {
+                    return Err(Self::managed_codex_transaction_error(
+                        "写入 Codex Live",
+                        error,
+                        &snapshot,
+                        None,
+                    ));
+                }
+
+                let previous_local_current = crate::settings::get_current_provider(&app_type);
+                if let Err(error) = crate::settings::set_current_provider(&app_type, Some(id)) {
+                    return Err(Self::managed_codex_transaction_error(
+                        "更新本地 current",
+                        error,
+                        &snapshot,
+                        Some((&app_type, previous_local_current.as_deref())),
+                    ));
+                }
+                if let Err(error) = state.db.set_current_provider(app_type.as_str(), id) {
+                    return Err(Self::managed_codex_transaction_error(
+                        "更新数据库 current",
+                        error,
+                        &snapshot,
+                        Some((&app_type, previous_local_current.as_deref())),
+                    ));
+                }
             }
         } else {
             // Codex: validate the live projection before committing current —
@@ -5349,6 +5660,7 @@ impl ProviderService {
         // a log entry: config.toml and is_current are already committed, so
         // failing the switch here would report a switch that in fact happened.
         if matches!(app_type, AppType::Codex)
+            && !requires_guarded_auth_commit
             && backfill_completed
             && (provider.category.as_deref() == Some("official")
                 || crate::proxy::providers::is_codex_official_provider(provider))

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -3038,6 +3038,171 @@ wire_api = "responses"
 
     #[test]
     #[serial]
+    fn codex_switch_and_rebind_handle_preexisting_auth() {
+        for auth_state in ["native-login", "missing-marker", "deleted-account"] {
+            for target_kind in [
+                "managed",
+                "third-party",
+                "preserving-third-party",
+                "unbound-official",
+            ] {
+                for update_current in [false, true] {
+                    with_test_home(|state, _| {
+                        crate::settings::reload_settings().expect("reload settings");
+                        let mut settings = crate::settings::get_settings();
+                        settings.preserve_codex_official_auth_on_switch =
+                            target_kind == "preserving-third-party";
+                        crate::settings::update_settings(settings).expect("set auth preservation");
+                        tauri::async_runtime::block_on(async {
+                            for (id, user) in [("acct-old", "user-old"), ("acct-new", "user-new")] {
+                                state
+                                    .codex_oauth_manager
+                                    .add_test_account_with_user_identity(id, "test-access", user)
+                                    .await
+                                    .expect("seed managed account");
+                            }
+                        });
+                        let current = managed_codex_provider("current", "acct-old");
+                        let target_id = if update_current { "current" } else { "target" };
+                        let target = match target_kind {
+                            "managed" => managed_codex_provider(target_id, "acct-new"),
+                            "unbound-official" => {
+                                let mut provider = Provider::with_id(
+                                    target_id.to_string(),
+                                    "Unbound Official".to_string(),
+                                    json!({"auth": {}, "config": ""}),
+                                    None,
+                                );
+                                provider.category = Some("official".to_string());
+                                provider
+                            }
+                            _ => Provider::with_id(
+                                target_id.to_string(),
+                                "Third Party".to_string(),
+                                codex_settings("https://third.example/v1", "sk-third"),
+                                None,
+                            ),
+                        };
+                        state
+                            .db
+                            .save_provider("codex", &current)
+                            .expect("save current");
+                        if !update_current {
+                            state
+                                .db
+                                .save_provider("codex", &target)
+                                .expect("save target");
+                        }
+                        ProviderService::switch(state, AppType::Codex, &current.id)
+                            .expect("activate current");
+                        let auth_path = crate::codex_config::get_codex_auth_path();
+                        if auth_state == "missing-marker" {
+                            fs::remove_file(
+                                crate::config::get_app_config_dir()
+                                    .join("codex_managed_oauth_live_auth.json"),
+                            )
+                            .expect("remove marker");
+                        } else {
+                            if auth_state == "deleted-account" {
+                                tauri::async_runtime::block_on(
+                                    state.codex_oauth_manager.remove_account("acct-old"),
+                                )
+                                .expect("remove outgoing account");
+                            }
+                            let native_auth = crate::codex_config::codex_managed_oauth_auth_value(
+                                "native-workspace",
+                                "native-access",
+                                Some(&crate::codex_config::test_codex_id_token("native-user")),
+                                "native-refresh",
+                                "2026-09-01T00:00:00Z",
+                            );
+                            write_json_file(&auth_path, &native_auth)
+                                .expect("simulate native login");
+                        }
+                        let auth_before: Value =
+                            read_json_file(&auth_path).expect("read auth before switch");
+                        let snapshot = crate::codex_config::CodexLiveStateSnapshot::capture()
+                            .expect("snapshot before switch");
+                        let apply = || {
+                            if update_current {
+                                ProviderService::update(state, AppType::Codex, None, target.clone())
+                                    .map(|_| ())
+                            } else {
+                                ProviderService::switch(state, AppType::Codex, &target.id)
+                                    .map(|_| ())
+                            }
+                        };
+                        let result = apply();
+                        if auth_state == "deleted-account"
+                            && matches!(target_kind, "managed" | "third-party")
+                        {
+                            let error =
+                                result.expect_err("preexisting login needs explicit recovery");
+                            assert!(matches!(error, AppError::Conflict(_)));
+                            let message = error.to_string();
+                            assert!(message.contains("codex logout"), "{message}");
+                            assert!(
+                                message.contains("未绑定托管账号且不含登录凭据"),
+                                "{message}"
+                            );
+                            assert!(!message.contains("切换期间出现"), "{message}");
+                            assert_eq!(
+                                crate::codex_config::CodexLiveStateSnapshot::capture().unwrap(),
+                                snapshot
+                            );
+                            assert_eq!(
+                                state.db.get_current_provider("codex").unwrap().as_deref(),
+                                Some("current")
+                            );
+                            assert_eq!(
+                                crate::settings::get_current_provider(&AppType::Codex).as_deref(),
+                                Some("current")
+                            );
+                            let stored = state
+                                .db
+                                .get_provider_by_id("current", "codex")
+                                .unwrap()
+                                .unwrap();
+                            assert_eq!(
+                                ProviderService::managed_codex_oauth_account_id(&stored).as_deref(),
+                                Some("acct-old")
+                            );
+                            fs::remove_file(&auth_path)
+                                .expect("simulate the suggested codex logout");
+                            apply().expect("recovery succeeds after logout");
+                        } else {
+                            result.unwrap_or_else(|error| {
+                                panic!(
+                                    "{auth_state}/{target_kind}/update={update_current}: {error}"
+                                )
+                            });
+                        }
+                        assert_eq!(
+                            state.db.get_current_provider("codex").unwrap().as_deref(),
+                            Some(target_id)
+                        );
+                        match target_kind {
+                            "managed" => {
+                                let auth: Value = read_json_file(&auth_path).unwrap();
+                                assert_eq!(
+                                    auth.pointer("/tokens/account_id").and_then(Value::as_str),
+                                    Some("acct-new")
+                                );
+                            }
+                            "third-party" => assert!(!auth_path.exists()),
+                            _ => assert_eq!(
+                                read_json_file::<Value>(&auth_path).unwrap(),
+                                auth_before
+                            ),
+                        }
+                    });
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
     fn deleted_managed_account_can_be_rebound_or_switched_away_from() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -39,8 +39,9 @@ pub(crate) use live::sanitize_claude_settings_for_live;
 pub(crate) use live::{
     build_effective_provider_for_live_with_codex_oauth_manager,
     build_effective_settings_with_common_config, normalize_provider_common_config_for_storage,
-    provider_exists_in_live_config, strip_common_config_from_live_settings,
-    sync_current_provider_for_app_to_live, write_live_with_common_config_for_codex_oauth_manager,
+    prepare_live_snapshot_if_codex_auth_absent, provider_exists_in_live_config,
+    strip_common_config_from_live_settings, sync_current_provider_for_app_to_live,
+    write_live_snapshot, write_live_with_common_config_for_codex_oauth_manager,
     write_live_with_common_config_for_state, LiveSyncOutcome,
 };
 
@@ -4578,14 +4579,13 @@ impl ProviderService {
         error: AppError,
         snapshot: &crate::codex_config::CodexLiveStateSnapshot,
         previous_backup: Option<&crate::proxy::types::LiveBackup>,
-        restore_local_current: Option<(&AppType, Option<&str>)>,
+        preserve_current_auth: bool,
+        previous_provider: Option<&Provider>,
     ) -> AppError {
         let mut rollback_failures = Vec::new();
-        if let Some((app_type, previous_local_current)) = restore_local_current {
-            if let Err(rollback_error) =
-                crate::settings::set_current_provider(app_type, previous_local_current)
-            {
-                rollback_failures.push(format!("恢复本地 current 失败: {rollback_error}"));
+        if let Some(provider) = previous_provider {
+            if let Err(rollback_error) = state.db.save_provider(AppType::Codex.as_str(), provider) {
+                rollback_failures.push(format!("恢复 Provider 数据失败: {rollback_error}"));
             }
         }
         let backup_restore = match previous_backup {
@@ -4601,7 +4601,12 @@ impl ProviderService {
         if let Err(rollback_error) = backup_restore {
             rollback_failures.push(format!("恢复 Codex Live 备份失败: {rollback_error}"));
         }
-        if let Err(rollback_error) = snapshot.restore_preserving_newer_same_account_auth() {
+        let restore = if preserve_current_auth {
+            snapshot.restore_preserving_current_auth()
+        } else {
+            snapshot.restore_preserving_newer_same_account_auth()
+        };
+        if let Err(rollback_error) = restore {
             rollback_failures.push(rollback_error.to_string());
         }
 
@@ -5138,9 +5143,6 @@ impl ProviderService {
                     "当前托管账号已删除；请先关闭代理接管，再更新账号绑定".to_string(),
                 ));
             }
-            let outgoing_live_refresh_token = outgoing_live_auth_guard
-                .as_ref()
-                .and_then(CodexLiveAuthSwitchGuard::expected_refresh_token);
             let requires_guarded_auth_commit = outgoing_live_auth_guard
                 .as_ref()
                 .is_some_and(CodexLiveAuthSwitchGuard::requires_guarded_commit);
@@ -5254,19 +5256,19 @@ impl ProviderService {
                 )
                 .map_err(|error| AppError::Message(format!("更新 Live 备份失败: {error}")))?;
 
-                if live_taken_over {
+                let pending_auth = if live_taken_over {
                     futures::executor::block_on(
                         state
                             .proxy_service
-                            .sync_codex_live_from_provider_while_proxy_active_guarded(
+                            .prepare_codex_live_from_provider_while_proxy_active(
                                 &provider,
                                 outgoing_managed_codex_account_id.as_deref(),
-                                outgoing_live_refresh_token,
+                                outgoing_live_auth_guard.as_ref(),
                             ),
                     )
                     .map_err(|error| {
                         AppError::Message(format!("同步 Codex Live 配置失败: {error}"))
-                    })?;
+                    })?
                 } else {
                     // A backup without a takeover marker is a recoverable
                     // half-takeover state. Keep the actual Live bundle aligned
@@ -5275,32 +5277,55 @@ impl ProviderService {
                         outgoing_managed_codex_account_id.as_deref(),
                         outgoing_live_auth_guard.as_ref(),
                     )?;
-                    Self::write_preflighted_or_current_live(
-                        state,
-                        &app_type,
-                        &provider,
-                        preflighted_provider.as_ref(),
-                    )?;
-                }
+                    if requires_guarded_auth_commit {
+                        Self::prepare_live_if_codex_auth_absent(
+                            state,
+                            &provider,
+                            preflighted_provider.as_ref(),
+                        )?
+                    } else {
+                        Self::write_preflighted_or_current_live(
+                            state,
+                            &app_type,
+                            &provider,
+                            preflighted_provider.as_ref(),
+                        )?;
+                        crate::codex_config::CodexAbsentAuthCommit::Preserve
+                    }
+                };
 
                 Self::clear_outgoing_managed_codex_live_auth(
                     outgoing_managed_codex_account_id.as_deref(),
                     outgoing_live_auth_guard.as_ref(),
                 )?;
 
-                // DB is the final commit. Every fallible side effect above can be
-                // restored exactly while the previous provider row is untouched.
+                // Guarded auth is published only after saving the provider row.
                 state.db.save_provider(app_type.as_str(), &provider)?;
-                Ok::<(), AppError>(())
+                Ok::<_, AppError>(pending_auth)
             })();
-            if let Err(error) = commit_result {
+            let pending_auth = match commit_result {
+                Ok(pending) => pending,
+                Err(error) => {
+                    return Err(Self::managed_codex_takeover_transaction_error(
+                        state,
+                        "更新接管中的 Codex provider",
+                        error,
+                        &snapshot,
+                        previous_backup.as_ref(),
+                        requires_guarded_auth_commit,
+                        None,
+                    ));
+                }
+            };
+            if let Err(error) = pending_auth.commit() {
                 return Err(Self::managed_codex_takeover_transaction_error(
                     state,
-                    "更新接管中的 Codex provider",
+                    "发布接管中的 Codex 认证",
                     error,
                     &snapshot,
                     previous_backup.as_ref(),
-                    None,
+                    requires_guarded_auth_commit,
+                    existing_provider.as_ref(),
                 ));
             }
 

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -3039,6 +3039,139 @@ wire_api = "responses"
 
     #[test]
     #[serial]
+    fn codex_absent_auth_direct_switch_leaves_no_stale_ownership() {
+        assert_absent_auth_relinquishes_ownership("direct-switch");
+    }
+
+    #[test]
+    #[serial]
+    fn codex_absent_auth_direct_update_leaves_no_stale_ownership() {
+        assert_absent_auth_relinquishes_ownership("direct-update");
+    }
+
+    #[test]
+    #[serial]
+    fn codex_absent_auth_proxy_switch_leaves_no_stale_ownership() {
+        assert_absent_auth_relinquishes_ownership("proxy-switch");
+    }
+
+    #[test]
+    #[serial]
+    fn codex_absent_auth_proxy_update_leaves_no_stale_ownership() {
+        assert_absent_auth_relinquishes_ownership("proxy-update");
+    }
+
+    fn assert_absent_auth_relinquishes_ownership(operation: &str) {
+        for (third_party, fail_commit) in [(false, false), (true, false), (false, true)] {
+            with_test_home(|state, _| {
+                crate::settings::reload_settings().expect("reload settings");
+                tauri::async_runtime::block_on(
+                    state
+                        .codex_oauth_manager
+                        .add_test_account_with_user_identity("acct-a", "managed-access", "user-a"),
+                )
+                .expect("seed managed account");
+                let current = managed_codex_provider("current", "acct-a");
+                let update = operation.ends_with("update");
+                let mut target = Provider::with_id(
+                    if update { "current" } else { "target" }.to_string(),
+                    "Target".to_string(),
+                    if third_party {
+                        codex_settings("https://third.example/v1", "sk-third")
+                    } else {
+                        json!({"auth": {}, "config": ""})
+                    },
+                    None,
+                );
+                if !third_party {
+                    target.category = Some("official".to_string());
+                }
+                state
+                    .db
+                    .save_provider("codex", &current)
+                    .expect("save current");
+                if !update {
+                    state
+                        .db
+                        .save_provider("codex", &target)
+                        .expect("save target");
+                }
+                ProviderService::switch(state, AppType::Codex, &current.id)
+                    .expect("activate managed account");
+                if operation.starts_with("proxy") {
+                    tauri::async_runtime::block_on(
+                        state
+                            .proxy_service
+                            .sync_codex_live_from_provider_while_proxy_active(&current),
+                    )
+                    .expect("activate takeover");
+                    tauri::async_runtime::block_on(
+                        state
+                            .db
+                            .save_live_backup("codex", &current.settings_config.to_string()),
+                    )
+                    .expect("save takeover backup");
+                }
+                let auth_path = crate::codex_config::get_codex_auth_path();
+                fs::remove_file(&auth_path).expect("remove auth while retaining ownership marker");
+                assert!(crate::codex_config::codex_managed_oauth_live_auth_marker_exists());
+                let snapshot = crate::codex_config::CodexLiveStateSnapshot::capture()
+                    .expect("capture live state before switching");
+                if fail_commit {
+                    state
+                        .db
+                        .conn
+                        .lock()
+                        .expect("lock database")
+                        .execute_batch(
+                            "CREATE TRIGGER reject_provider_commit BEFORE UPDATE ON providers
+                         BEGIN SELECT RAISE(ABORT, 'forced provider commit failure'); END;",
+                        )
+                        .expect("install provider commit failure");
+                }
+                let result = if update {
+                    ProviderService::update(state, AppType::Codex, None, target).map(|_| ())
+                } else {
+                    ProviderService::switch(state, AppType::Codex, &target.id).map(|_| ())
+                };
+                if fail_commit {
+                    let error = result.expect_err("provider commit must fail");
+                    assert!(error.to_string().contains("forced provider commit failure"));
+                    assert_eq!(
+                        crate::codex_config::CodexLiveStateSnapshot::capture().unwrap(),
+                        snapshot,
+                        "{operation}: rollback must restore outgoing ownership and live state"
+                    );
+                    return;
+                }
+                result.expect("switch away from managed account");
+                assert!(
+                    !crate::codex_config::codex_managed_oauth_live_auth_marker_exists(),
+                    "{operation}, third_party={third_party}: outgoing ownership must be relinquished"
+                );
+                // A later native login can have exactly the same user/workspace
+                // identity. Removing the old managed account must leave it alone.
+                let native = crate::codex_config::codex_managed_oauth_auth_value(
+                    "acct-a",
+                    "native-access",
+                    Some(&crate::codex_config::test_codex_id_token("user-a")),
+                    "native-refresh",
+                    "2099-01-01T00:00:00Z",
+                );
+                write_json_file(&auth_path, &native).expect("write later native login");
+                tauri::async_runtime::block_on(state.codex_oauth_manager.remove_account("acct-a"))
+                    .expect("remove former managed account");
+                assert_eq!(
+                    read_json_file::<Value>(&auth_path).expect("native login must survive"),
+                    native,
+                    "{operation}, third_party={third_party}"
+                );
+            });
+        }
+    }
+
+    #[test]
+    #[serial]
     fn codex_switch_and_rebind_handle_preexisting_auth() {
         for auth_state in ["native-login", "missing-marker", "deleted-account"] {
             for target_kind in [
@@ -5159,11 +5292,16 @@ impl ProviderService {
                             outgoing_managed_codex_account_id.as_deref(),
                             outgoing_live_auth_guard.as_ref(),
                         )?;
-                        Self::prepare_live_if_codex_auth_absent(
+                        let pending = Self::prepare_live_if_codex_auth_absent(
                             state,
                             &provider,
                             preflighted_provider.as_ref(),
-                        )
+                        )?;
+                        Self::clear_outgoing_managed_codex_live_auth(
+                            outgoing_managed_codex_account_id.as_deref(),
+                            outgoing_live_auth_guard.as_ref(),
+                        )?;
+                        Ok::<_, AppError>(pending)
                     })();
                     let pending_auth = match pending_auth {
                         Ok(pending) => pending,
@@ -5715,11 +5853,16 @@ impl ProviderService {
                         outgoing_managed_codex_account_id.as_deref(),
                         outgoing_live_auth_guard.as_ref(),
                     )?;
-                    Self::prepare_live_if_codex_auth_absent(
+                    let pending = Self::prepare_live_if_codex_auth_absent(
                         state,
                         provider,
                         preflighted_provider.as_ref(),
-                    )
+                    )?;
+                    Self::clear_outgoing_managed_codex_live_auth(
+                        outgoing_managed_codex_account_id.as_deref(),
+                        outgoing_live_auth_guard.as_ref(),
+                    )?;
+                    Ok::<_, AppError>(pending)
                 })();
                 let pending_auth = match pending_auth {
                     Ok(pending) => pending,

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3019,11 +3019,19 @@ impl ProxyService {
         let outgoing_live_refresh_token =
             if should_sync_backup && matches!(app_type_enum, AppType::Codex) {
                 match outgoing_managed_codex_account_id.as_deref() {
-                    Some(account_id) => self
-                        .codex_oauth_manager
-                        .prepare_live_auth_for_account_switch_away(account_id)
-                        .await
-                        .map_err(|error| error.to_string())?,
+                    Some(account_id) => {
+                        let guard = self
+                            .codex_oauth_manager
+                            .prepare_live_auth_for_account_switch_away(account_id)
+                            .await
+                            .map_err(|error| error.to_string())?;
+                        if guard.account_missing() {
+                            return Err(
+                                "当前托管账号已删除；请先关闭代理接管，再切换供应商".to_string()
+                            );
+                        }
+                        guard.expected_refresh_token().map(str::to_string)
+                    }
                     None => None,
                 }
             } else {

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3,10 +3,11 @@
 //! 提供代理服务器的启动、停止和配置管理
 
 use crate::app_config::AppType;
+use crate::codex_config::CodexAbsentAuthCommit;
 use crate::config::{get_claude_settings_path, read_json_file, write_json_file};
 use crate::database::Database;
 use crate::provider::Provider;
-use crate::proxy::providers::codex_oauth_auth::CodexOAuthManager;
+use crate::proxy::providers::codex_oauth_auth::{CodexLiveAuthSwitchGuard, CodexOAuthManager};
 use crate::proxy::server::ProxyServer;
 use crate::proxy::switch_lock::SwitchLockManager;
 use crate::proxy::types::*;
@@ -712,16 +713,19 @@ impl ProxyService {
         &self,
         provider: &Provider,
     ) -> Result<(), String> {
-        self.sync_codex_live_from_provider_while_proxy_active_guarded(provider, None, None)
-            .await
+        self.prepare_codex_live_from_provider_while_proxy_active(provider, None, None)
+            .await?
+            .commit()
+            .map_err(|error| error.to_string())
     }
 
-    pub(crate) async fn sync_codex_live_from_provider_while_proxy_active_guarded(
+    /// Stage guarded auth until the caller has committed backup/provider state.
+    pub(crate) async fn prepare_codex_live_from_provider_while_proxy_active(
         &self,
         provider: &Provider,
         outgoing_managed_account_id: Option<&str>,
-        expected_outgoing_refresh_token: Option<&str>,
-    ) -> Result<(), String> {
+        outgoing_auth_guard: Option<&CodexLiveAuthSwitchGuard>,
+    ) -> Result<CodexAbsentAuthCommit, String> {
         let existing_live = self.read_codex_live().ok();
         let mut effective_settings = build_effective_provider_for_live_with_codex_oauth_manager(
             self.db.as_ref(),
@@ -745,18 +749,18 @@ impl ProxyService {
             provider,
         )?;
 
-        if let (Some(account_id), Some(expected_refresh_token)) =
-            (outgoing_managed_account_id, expected_outgoing_refresh_token)
+        if let (Some(account_id), Some(guard)) = (outgoing_managed_account_id, outgoing_auth_guard)
         {
-            crate::codex_config::ensure_codex_live_auth_unchanged_for_managed_account(
-                account_id,
-                expected_refresh_token,
-            )
-            .map_err(|error| error.to_string())?;
+            guard
+                .ensure_unchanged(account_id)
+                .map_err(|error| error.to_string())?;
         }
 
-        self.write_codex_takeover_live_for_provider(&effective_settings, Some(provider))?;
-        Ok(())
+        self.prepare_codex_takeover_live_for_provider(
+            &effective_settings,
+            Some(provider),
+            outgoing_auth_guard.is_some_and(CodexLiveAuthSwitchGuard::requires_guarded_commit),
+        )
     }
 
     pub async fn sync_grok_live_from_provider_while_proxy_active(
@@ -851,7 +855,7 @@ impl ProxyService {
         previous_provider_id: Option<&str>,
         should_sync_backup: bool,
         live_taken_over: bool,
-        previous_codex_live_state: Option<&crate::codex_config::CodexLiveStateSnapshot>,
+        previous_codex_live_state: Option<(&crate::codex_config::CodexLiveStateSnapshot, bool)>,
     ) {
         if !should_sync_backup {
             return;
@@ -869,8 +873,13 @@ impl ProxyService {
             log::error!("{} 热切换失败后恢复原备份失败: {error}", app_type.as_str());
         }
 
-        if let Some(previous_live) = previous_codex_live_state {
-            if let Err(error) = previous_live.restore_preserving_newer_same_account_auth() {
+        if let Some((previous_live, preserve_current_auth)) = previous_codex_live_state {
+            let restore = if preserve_current_auth {
+                previous_live.restore_preserving_current_auth()
+            } else {
+                previous_live.restore_preserving_newer_same_account_auth()
+            };
+            if let Err(error) = restore {
                 log::error!(
                     "{} 热切换失败后恢复 Codex Live 状态失败: {error}",
                     app_type.as_str()
@@ -3016,7 +3025,7 @@ impl ProxyService {
             .is_some();
         let live_taken_over = self.detect_takeover_in_live_config_for_app(&app_type_enum);
         let should_sync_backup = has_backup || live_taken_over;
-        let outgoing_live_refresh_token =
+        let outgoing_live_auth_guard =
             if should_sync_backup && matches!(app_type_enum, AppType::Codex) {
                 match outgoing_managed_codex_account_id.as_deref() {
                     Some(account_id) => {
@@ -3030,18 +3039,23 @@ impl ProxyService {
                                 "当前托管账号已删除；请先关闭代理接管，再切换供应商".to_string()
                             );
                         }
-                        guard.expected_refresh_token().map(str::to_string)
+                        Some(guard)
                     }
                     None => None,
                 }
             } else {
                 None
             };
+        let requires_guarded_auth_commit = outgoing_live_auth_guard
+            .as_ref()
+            .is_some_and(CodexLiveAuthSwitchGuard::requires_guarded_commit);
+        let previous_db_provider_id = self
+            .db
+            .get_current_provider(app_type_enum.as_str())
+            .map_err(|error| format!("读取数据库当前供应商失败: {error}"))?;
 
-        // All fallible backup/live writes must finish before committing the logical
-        // current provider. Otherwise a failed hot switch leaves the UI pointing at
-        // the new provider while the proxy still serves the old one (and the next
-        // query may fall back to the first provider).
+        // Stage backup/config before current. Guarded auth is published last,
+        // without clobbering a native login that appears during this transaction.
         let previous_backup = if should_sync_backup {
             self.db
                 .get_live_backup(app_type_enum.as_str())
@@ -3060,7 +3074,11 @@ impl ProxyService {
                 None
             };
 
-        let prepare_result: Result<(), String> = async {
+        let rollback_snapshot = previous_codex_live_state
+            .as_ref()
+            .map(|snapshot| (snapshot, requires_guarded_auth_commit));
+        let prepare_result: Result<CodexAbsentAuthCommit, String> = async {
+            let mut pending_auth = CodexAbsentAuthCommit::Preserve;
             if should_sync_backup {
                 self.update_live_backup_from_provider_inner(
                     app_type,
@@ -3073,12 +3091,13 @@ impl ProxyService {
                     self.sync_claude_live_from_provider_while_proxy_active(&provider)
                         .await?;
                 } else if live_taken_over && matches!(app_type_enum, AppType::Codex) {
-                    self.sync_codex_live_from_provider_while_proxy_active_guarded(
-                        &provider,
-                        outgoing_managed_codex_account_id.as_deref(),
-                        outgoing_live_refresh_token.as_deref(),
-                    )
-                    .await?;
+                    pending_auth = self
+                        .prepare_codex_live_from_provider_while_proxy_active(
+                            &provider,
+                            outgoing_managed_codex_account_id.as_deref(),
+                            outgoing_live_auth_guard.as_ref(),
+                        )
+                        .await?;
                 } else if live_taken_over && matches!(app_type_enum, AppType::GrokBuild) {
                     self.sync_grok_live_from_provider_while_proxy_active(&provider)
                         .await?;
@@ -3094,71 +3113,60 @@ impl ProxyService {
                         &self.codex_oauth_manager,
                     )
                     .map_err(|e| format!("构建 Codex 有效配置失败: {e}"))?;
-                let effective_settings = &effective_provider.settings_config;
-                let auth = effective_settings
-                    .get("auth")
-                    .ok_or_else(|| "Codex 供应商缺少 auth 配置".to_string())?;
-                let config_str = effective_settings.get("config").and_then(|v| v.as_str());
-                let profile = crate::proxy::providers::resolve_codex_catalog_tool_profile(
-                    &effective_provider,
-                );
-
-                if let (Some(account_id), Some(expected_refresh_token)) = (
+                if let (Some(account_id), Some(guard)) = (
                     outgoing_managed_codex_account_id.as_deref(),
-                    outgoing_live_refresh_token.as_deref(),
+                    outgoing_live_auth_guard.as_ref(),
                 ) {
-                    crate::codex_config::ensure_codex_live_auth_unchanged_for_managed_account(
-                        account_id,
-                        expected_refresh_token,
-                    )
-                    .map_err(|error| error.to_string())?;
+                    guard
+                        .ensure_unchanged(account_id)
+                        .map_err(|error| error.to_string())?;
                 }
 
-                crate::codex_config::write_codex_provider_live_with_catalog(
-                    effective_settings,
-                    effective_provider.category.as_deref(),
-                    auth,
-                    config_str,
-                    profile,
-                )
-                .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
-                if let Some(account_id) = target_managed_codex_account_id.as_deref() {
-                    crate::codex_config::record_codex_managed_oauth_live_auth(auth, account_id)
-                        .map_err(|error| format!("记录 Codex 托管认证标记失败: {error}"))?;
+                if requires_guarded_auth_commit {
+                    pending_auth =
+                        crate::services::provider::prepare_live_snapshot_if_codex_auth_absent(
+                            &effective_provider,
+                        )
+                        .map_err(|error| error.to_string())?;
+                } else {
+                    crate::services::provider::write_live_snapshot(
+                        &AppType::Codex,
+                        &effective_provider,
+                    )
+                    .map_err(|error| error.to_string())?;
                 }
             }
 
             if should_sync_backup && matches!(app_type_enum, AppType::Codex) {
-                if let Some(account_id) = outgoing_managed_codex_account_id.as_deref() {
-                    if let Some(expected_refresh_token) = outgoing_live_refresh_token.as_deref() {
-                        crate::codex_config::clear_codex_live_auth_for_managed_account_if_unchanged(
-                            account_id,
-                            Some(expected_refresh_token),
-                        )
+                if let (Some(account_id), Some(guard)) = (
+                    outgoing_managed_codex_account_id.as_deref(),
+                    outgoing_live_auth_guard.as_ref(),
+                ) {
+                    guard
+                        .clear_outgoing_if_unchanged(account_id)
                         .map_err(|error| error.to_string())?;
-                    } else {
-                        crate::codex_config::clear_codex_live_auth_for_managed_account(account_id)
-                            .map_err(|error| error.to_string())?;
-                    }
                 }
             }
 
-            Ok(())
+            Ok(pending_auth)
         }
         .await;
 
-        if let Err(error) = prepare_result {
-            self.rollback_hot_switch_preparation(
-                &app_type_enum,
-                previous_backup.as_ref(),
-                previous_provider_id.as_deref(),
-                should_sync_backup,
-                live_taken_over,
-                previous_codex_live_state.as_ref(),
-            )
-            .await;
-            return Err(error);
-        }
+        let pending_auth = match prepare_result {
+            Ok(pending) => pending,
+            Err(error) => {
+                self.rollback_hot_switch_preparation(
+                    &app_type_enum,
+                    previous_backup.as_ref(),
+                    previous_provider_id.as_deref(),
+                    should_sync_backup,
+                    live_taken_over,
+                    rollback_snapshot,
+                )
+                .await;
+                return Err(error);
+            }
+        };
 
         if let Err(error) = crate::settings::set_current_provider(&app_type_enum, Some(provider_id))
         {
@@ -3168,7 +3176,7 @@ impl ProxyService {
                 previous_provider_id.as_deref(),
                 should_sync_backup,
                 live_taken_over,
-                previous_codex_live_state.as_ref(),
+                rollback_snapshot,
             )
             .await;
             return Err(format!("更新本地当前供应商失败: {error}"));
@@ -3189,10 +3197,36 @@ impl ProxyService {
                 previous_provider_id.as_deref(),
                 should_sync_backup,
                 live_taken_over,
-                previous_codex_live_state.as_ref(),
+                rollback_snapshot,
             )
             .await;
             return Err(format!("更新当前供应商失败: {error}"));
+        }
+
+        if let Err(error) = pending_auth.commit() {
+            let db_restore = match previous_db_provider_id.as_deref() {
+                Some(id) => self.db.set_current_provider(app_type_enum.as_str(), id),
+                None => self.db.clear_current_provider(app_type_enum.as_str()),
+            };
+            if let Err(rollback_error) = db_restore {
+                log::error!("认证发布失败后恢复数据库 current 失败: {rollback_error}");
+            }
+            if let Err(rollback_error) = crate::settings::set_current_provider(
+                &app_type_enum,
+                previous_local_provider_id.as_deref(),
+            ) {
+                log::error!("认证发布失败后恢复本地 current 失败: {rollback_error}");
+            }
+            self.rollback_hot_switch_preparation(
+                &app_type_enum,
+                previous_backup.as_ref(),
+                previous_provider_id.as_deref(),
+                should_sync_backup,
+                live_taken_over,
+                rollback_snapshot,
+            )
+            .await;
+            return Err(format!("发布 Codex 认证失败: {error}"));
         }
 
         if let Some(server) = self.server.read().await.as_ref() {
@@ -3613,11 +3647,12 @@ impl ProxyService {
         auth.get("OPENAI_API_KEY").and_then(|v| v.as_str()) == Some(PROXY_TOKEN_PLACEHOLDER)
     }
 
-    fn write_codex_takeover_live_for_provider(
+    fn prepare_codex_takeover_live_for_provider(
         &self,
         config: &Value,
         provider: Option<&Provider>,
-    ) -> Result<(), String> {
+        require_absent_auth: bool,
+    ) -> Result<CodexAbsentAuthCommit, String> {
         let official_passthrough =
             provider.is_some_and(crate::proxy::providers::is_codex_official_provider);
         let managed_account_id = provider
@@ -3647,6 +3682,23 @@ impl ProxyService {
                 let auth = config
                     .get("auth")
                     .ok_or_else(|| "Codex 托管官方配置缺少 auth 字段".to_string())?;
+                if require_absent_auth {
+                    // Validate/write the marker before publication: no fallible
+                    // writes may follow a successful no-clobber auth commit.
+                    crate::codex_config::record_codex_managed_oauth_live_auth(
+                        auth,
+                        managed_account_id
+                            .as_deref()
+                            .expect("checked managed account"),
+                    )
+                    .map_err(|error| error.to_string())?;
+                    return crate::codex_config::prepare_codex_live_for_provider_if_auth_absent(
+                        Some("official"),
+                        auth,
+                        Some(&prepared_config),
+                    )
+                    .map_err(|error| error.to_string());
+                }
                 // An explicitly managed official account is different from the
                 // unbound native-login passthrough: the selected account owns
                 // auth.json and must replace any previously active account.
@@ -3663,7 +3715,7 @@ impl ProxyService {
                         .expect("managed official account checked"),
                 )
                 .map_err(|e| format!("记录 Codex 托管认证标记失败: {e}"))?;
-                return Ok(());
+                return Ok(CodexAbsentAuthCommit::Preserve);
             }
             let live_config = if official_passthrough {
                 prepared_config
@@ -3676,10 +3728,14 @@ impl ProxyService {
             };
             crate::codex_config::write_codex_live_config_atomic(Some(&live_config))
                 .map_err(|e| format!("写入 Codex 配置失败: {e}"))?;
-            return Ok(());
+            return Ok(CodexAbsentAuthCommit::Preserve);
         }
 
-        self.write_codex_live_for_provider(config, provider)
+        if require_absent_auth {
+            return Err("无法在保留并发登录的前提下写入该 Codex 接管配置".to_string());
+        }
+        self.write_codex_live_for_provider(config, provider)?;
+        Ok(CodexAbsentAuthCommit::Preserve)
     }
 
     fn write_codex_live_verbatim(&self, config: &Value) -> Result<(), String> {
@@ -5280,6 +5336,271 @@ wire_api = "responses"
             Some("rightcode-key"),
             "stripping outgoing managed auth must preserve the target provider key"
         );
+    }
+
+    async fn assert_absent_auth_takeover_transaction(scenario: &str) {
+        for active in [true, false] {
+            for update_current in [false, true] {
+                let _home = TempHome::new();
+                crate::settings::reload_settings().unwrap();
+                crate::settings::update_settings(crate::settings::AppSettings::default()).unwrap();
+                let db = Arc::new(Database::memory().unwrap());
+                let state = crate::store::AppState::new(db.clone());
+                let service = &state.proxy_service;
+                for (id, user) in [("acct-a", "user-a"), ("acct-b", "user-b")] {
+                    service
+                        .codex_oauth_manager
+                        .add_test_account_with_user_identity(id, "access", user)
+                        .await
+                        .unwrap();
+                }
+                let mut current = Provider::with_id(
+                    "current".to_string(),
+                    "Current".to_string(),
+                    json!({"auth": {}, "config": "model = \"gpt-5.4\"\n"}),
+                    None,
+                );
+                current.category = Some("official".to_string());
+                current.meta = Some(ProviderMeta {
+                    auth_binding: Some(AuthBinding {
+                        source: AuthBindingSource::ManagedAccount,
+                        auth_provider: Some("codex_oauth".to_string()),
+                        account_id: Some("acct-a".to_string()),
+                    }),
+                    ..Default::default()
+                });
+                let mut target = current.clone();
+                target.id = if update_current { "current" } else { "target" }.to_string();
+                let managed_target = matches!(scenario, "overwrite" | "late-overwrite" | "publish");
+                if managed_target {
+                    target
+                        .meta
+                        .as_mut()
+                        .unwrap()
+                        .auth_binding
+                        .as_mut()
+                        .unwrap()
+                        .account_id = Some("acct-b".to_string());
+                } else {
+                    target.meta = None;
+                }
+                if scenario == "third-party" {
+                    target.category = None;
+                    target.settings_config = json!({
+                        "auth": {"OPENAI_API_KEY": "sk-third"},
+                        "config": "model_provider = \"third\"\n[model_providers.third]\nname = \"Third\"\nbase_url = \"https://third.example/v1\"\nwire_api = \"responses\"\n"
+                    });
+                }
+                db.save_provider("codex", &current).unwrap();
+                if !update_current {
+                    db.save_provider("codex", &target).unwrap();
+                }
+                db.set_current_provider("codex", &current.id).unwrap();
+                crate::settings::set_current_provider(&AppType::Codex, Some(&current.id)).unwrap();
+                service
+                    .sync_codex_live_from_provider_while_proxy_active(&current)
+                    .await
+                    .unwrap();
+                db.save_live_backup("codex", &current.settings_config.to_string())
+                    .await
+                    .unwrap();
+                if !active {
+                    crate::codex_config::write_codex_live_config_atomic(
+                        current.settings_config["config"].as_str(),
+                    )
+                    .unwrap();
+                }
+                assert_eq!(
+                    service.detect_takeover_in_live_config_for_app(&AppType::Codex),
+                    active
+                );
+                let auth_path = crate::codex_config::get_codex_auth_path();
+                std::fs::remove_file(&auth_path).unwrap();
+                let guard = service
+                    .codex_oauth_manager
+                    .prepare_live_auth_for_account_switch_away("acct-a")
+                    .await
+                    .unwrap();
+                assert!(matches!(guard, CodexLiveAuthSwitchGuard::AbsentAuth));
+                let backup_before = db.get_live_backup("codex").await.unwrap().unwrap();
+                let config_before =
+                    std::fs::read(crate::codex_config::get_codex_config_path()).unwrap();
+                let marker_path =
+                    crate::config::get_app_config_dir().join("codex_managed_oauth_live_auth.json");
+                let marker_before = std::fs::read(&marker_path).unwrap();
+                let (workspace, user) = if matches!(scenario, "cleanup" | "third-party") {
+                    ("acct-a", "user-a")
+                } else {
+                    ("native-c", "user-c")
+                };
+                let native = crate::codex_config::codex_managed_oauth_auth_value(
+                    workspace,
+                    "native-access",
+                    Some(&crate::codex_config::test_codex_id_token(user)),
+                    "native-refresh",
+                    "2099-01-01T00:00:00Z",
+                );
+                let hook_ran = Arc::new(std::sync::atomic::AtomicBool::new(false));
+                {
+                    let conn = db.conn.lock().unwrap();
+                    let hook_ran = hook_ran.clone();
+                    let native = native.clone();
+                    let auth_path = auth_path.clone();
+                    let at_current_commit = matches!(scenario, "late-overwrite" | "publish");
+                    let inject_login = scenario != "publish";
+                    conn.update_hook(Some(
+                        move |_: rusqlite::hooks::Action, _: &str, table: &str, _: i64| {
+                            let watched_table = if at_current_commit {
+                                "providers"
+                            } else {
+                                "proxy_live_backup"
+                            };
+                            if table == watched_table
+                                && !hook_ran.swap(true, std::sync::atomic::Ordering::SeqCst)
+                            {
+                                // Both hooks run after outgoing preflight; provider
+                                // writes additionally prove auth was only staged.
+                                assert!(
+                                    !auth_path.exists(),
+                                    "auth must not be published before current/provider commits"
+                                );
+                                if inject_login {
+                                    crate::config::write_json_file(&auth_path, &native).unwrap();
+                                }
+                            }
+                        },
+                    ));
+                    if scenario == "rollback" {
+                        conn.execute_batch("CREATE TRIGGER reject_current BEFORE UPDATE OF is_current ON providers BEGIN SELECT RAISE(ABORT, 'forced current failure'); END;").unwrap();
+                    }
+                }
+                let result = if update_current {
+                    crate::services::provider::ProviderService::update(
+                        &state,
+                        AppType::Codex,
+                        None,
+                        target.clone(),
+                    )
+                    .map(|_| ())
+                    .map_err(|error| error.to_string())
+                } else {
+                    service
+                        .hot_switch_provider("codex", &target.id)
+                        .await
+                        .map(|_| ())
+                };
+                assert!(hook_ran.load(std::sync::atomic::Ordering::SeqCst));
+                let should_succeed = matches!(scenario, "cleanup" | "publish")
+                    || (scenario == "third-party" && active);
+                assert_eq!(
+                    result.is_ok(),
+                    should_succeed,
+                    "{scenario}/active={active}/update={update_current}: {result:?}"
+                );
+                let observed = crate::config::read_json_file::<Value>(&auth_path).unwrap();
+                if scenario == "publish" {
+                    assert_eq!(
+                        observed
+                            .pointer("/tokens/account_id")
+                            .and_then(Value::as_str),
+                        Some("acct-b")
+                    );
+                    assert!(
+                        crate::codex_config::codex_auth_matches_recorded_managed_oauth(
+                            &observed, "acct-b"
+                        )
+                        .unwrap()
+                    );
+                } else {
+                    assert_eq!(
+                        observed, native,
+                        "{scenario}: concurrent login must survive"
+                    );
+                }
+                let expected_current = if should_succeed {
+                    &target.id
+                } else {
+                    &current.id
+                };
+                assert_eq!(
+                    db.get_current_provider("codex").unwrap().as_ref(),
+                    Some(expected_current)
+                );
+                assert_eq!(
+                    crate::settings::get_current_provider(&AppType::Codex).as_ref(),
+                    Some(expected_current)
+                );
+                let saved = db
+                    .get_provider_by_id(expected_current, "codex")
+                    .unwrap()
+                    .unwrap();
+                let saved_binding = saved
+                    .meta
+                    .as_ref()
+                    .and_then(|meta| meta.managed_account_id_for("codex_oauth"));
+                let expected_binding = if !should_succeed {
+                    Some("acct-a")
+                } else if managed_target {
+                    Some("acct-b")
+                } else {
+                    None
+                };
+                assert_eq!(saved_binding.as_deref(), expected_binding);
+                if !should_succeed {
+                    assert_eq!(
+                        db.get_live_backup("codex")
+                            .await
+                            .unwrap()
+                            .unwrap()
+                            .original_config,
+                        backup_before.original_config
+                    );
+                    assert_eq!(
+                        std::fs::read(crate::codex_config::get_codex_config_path()).unwrap(),
+                        config_before
+                    );
+                    assert_eq!(std::fs::read(&marker_path).unwrap(), marker_before);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_absent_auth_takeover_preserves_login_during_preparation() {
+        assert_absent_auth_takeover_transaction("overwrite").await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_absent_auth_takeover_rejects_login_at_final_publication() {
+        assert_absent_auth_takeover_transaction("late-overwrite").await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_absent_auth_takeover_does_not_clean_concurrent_same_account_login() {
+        assert_absent_auth_takeover_transaction("cleanup").await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_absent_auth_takeover_rollback_preserves_concurrent_login() {
+        assert_absent_auth_takeover_transaction("rollback").await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_absent_auth_takeover_publishes_after_provider_commit() {
+        assert_absent_auth_takeover_transaction("publish").await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn codex_absent_auth_takeover_third_party_preserves_concurrent_login() {
+        // Active takeover preserves login; a backup-only direct projection
+        // with preservation disabled must instead refuse and roll back.
+        assert_absent_auth_takeover_transaction("third-party").await;
     }
 
     #[tokio::test]

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -5546,6 +5546,12 @@ wire_api = "responses"
                     None
                 };
                 assert_eq!(saved_binding.as_deref(), expected_binding);
+                if should_succeed && !managed_target {
+                    assert!(
+                        !marker_path.exists(),
+                        "{scenario}: successful switch must relinquish outgoing ownership"
+                    );
+                }
                 if !should_succeed {
                     assert_eq!(
                         db.get_live_backup("codex")


### PR DESCRIPTION
## Summary

- recover direct Codex provider rebinds and switch-away operations when the outgoing managed account record was deleted
- treat an account as absent only after the persisted store is readable, structurally valid, and consistent with memory
- preserve concurrent native Codex credentials with target-aware guarded auth publication and rollback

## Scope

This PR is limited to the non-takeover dangling-binding recovery path from #7055. It does not change account removal, duplicate-account policy, default-account behavior, re-login UI, device login, general storage retry behavior, or proxy-takeover recovery.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --lib --tests --locked -- -D warnings`
- `cargo test --lib --locked` — 2778 passed, 5 ignored
- two independent blind-review passes after the final fixes
