### PR TITLE
fix(codex): reject duplicate managed accounts

### DIFF
--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -81,6 +81,9 @@ pub enum CodexOAuthError {
     #[error("OAuth Token 获取失败: {0}")]
     TokenFetchFailed(String),
 
+    #[error("codex_oauth_duplicate_account")]
+    DuplicateAccount,
+
     #[error("Refresh Token 失效或已过期")]
     RefreshTokenInvalid,
 
@@ -1619,8 +1622,15 @@ impl CodexOAuthManager {
             .map(str::to_string);
         let replacing_existing = target_account_id.is_some();
         let account_id = target_account_id.unwrap_or_else(|| Uuid::new_v4().to_string());
-        let refresh_lock = self.get_refresh_lock(&account_id).await;
-        let _refresh_guard = refresh_lock.lock().await;
+        let refresh_lock = if replacing_existing {
+            Some(self.get_refresh_lock(&account_id).await)
+        } else {
+            None
+        };
+        let _refresh_guard = match refresh_lock.as_ref() {
+            Some(lock) => Some(lock.lock().await),
+            None => None,
+        };
         let now = chrono::Utc::now().timestamp();
         let now_ms = chrono::Utc::now().timestamp_millis();
 
@@ -1730,6 +1740,34 @@ impl CodexOAuthManager {
         // and its access-token cache untouched.
         let _persist = self.storage_lock.lock().await;
         let mut persisted_accounts = self.accounts.read().await.clone();
+        let new_identity = data
+            .id_token
+            .as_deref()
+            .and_then(crate::codex_config::extract_codex_id_token_user_identity);
+        let duplicate_exists = new_identity.as_deref().is_some_and(|new_identity| {
+            persisted_accounts
+                .iter()
+                .filter(|(existing_id, _)| existing_id.as_str() != account_id.as_str())
+                .any(|(_, existing)| {
+                    existing
+                        .chatgpt_account_id
+                        .as_deref()
+                        .unwrap_or(existing.account_id.as_str())
+                        == data
+                            .chatgpt_account_id
+                            .as_deref()
+                            .unwrap_or(data.account_id.as_str())
+                        && existing
+                            .id_token
+                            .as_deref()
+                            .and_then(crate::codex_config::extract_codex_id_token_user_identity)
+                            .as_deref()
+                            == Some(new_identity)
+                })
+        });
+        if duplicate_exists {
+            return Err(CodexOAuthError::DuplicateAccount);
+        }
         persisted_accounts.insert(account_id.clone(), data.clone());
         let persisted_default = self
             .resolve_default_account_id()
@@ -2167,7 +2205,7 @@ mod tests {
                 "shared-workspace".to_string(),
                 "rt-first".to_string(),
                 Some("first@example.com".to_string()),
-                None,
+                Some(crate::codex_config::test_codex_id_token("user-a")),
                 None,
                 AccountLoginContext::default(),
             )
@@ -2178,7 +2216,7 @@ mod tests {
                 "shared-workspace".to_string(),
                 "rt-second".to_string(),
                 Some("second@example.com".to_string()),
-                None,
+                Some(crate::codex_config::test_codex_id_token("user-b")),
                 None,
                 AccountLoginContext::default(),
             )
@@ -2213,6 +2251,149 @@ mod tests {
         let accounts = manager.accounts.read().await;
         assert_eq!(accounts.get(&first.id).unwrap().refresh_token, "rt-first");
         assert_eq!(accounts.get(&second.id).unwrap().refresh_token, "rt-second");
+    }
+
+    #[tokio::test]
+    async fn concurrent_duplicate_workspace_and_user_identity_is_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().to_path_buf();
+        let manager = CodexOAuthManager::new(path.clone());
+        let first_token = crate::codex_config::test_codex_id_token("same-user");
+        let second_token = first_token.clone();
+
+        let first = manager.add_account_internal(
+            "shared-workspace".to_string(),
+            "rt-first".to_string(),
+            Some("first@example.com".to_string()),
+            Some(first_token),
+            None,
+            AccountLoginContext::default(),
+        );
+        let second = manager.add_account_internal(
+            "shared-workspace".to_string(),
+            "rt-second".to_string(),
+            Some("second@example.com".to_string()),
+            Some(second_token),
+            None,
+            AccountLoginContext::default(),
+        );
+        let (first_result, second_result) = tokio::join!(first, second);
+
+        assert_eq!(
+            [first_result.is_ok(), second_result.is_ok()]
+                .into_iter()
+                .filter(|success| *success)
+                .count(),
+            1
+        );
+        assert!(
+            matches!(first_result, Err(CodexOAuthError::DuplicateAccount))
+                || matches!(second_result, Err(CodexOAuthError::DuplicateAccount))
+        );
+        assert_eq!(manager.list_accounts().await.len(), 1);
+        assert!(manager.refresh_locks.read().await.is_empty());
+        drop(manager);
+
+        let reloaded = CodexOAuthManager::new(path);
+        assert_eq!(reloaded.list_accounts().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn duplicate_legacy_workspace_and_user_identity_is_rejected() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().to_path_buf();
+        let manager = CodexOAuthManager::new(path.clone());
+        let id_token = crate::codex_config::test_codex_id_token("same-user");
+        let legacy = serde_json::json!({
+            "version": 1,
+            "accounts": {
+                "shared-workspace": {
+                    "account_id": "shared-workspace",
+                    "email": "legacy@example.com",
+                    "refresh_token": "rt-legacy",
+                    "id_token": id_token,
+                    "authenticated_at": 1
+                }
+            },
+            "default_account_id": "shared-workspace"
+        });
+        manager
+            .write_store_atomic(&serde_json::to_string(&legacy).unwrap())
+            .unwrap();
+        drop(manager);
+
+        let manager = CodexOAuthManager::new(path);
+        assert!(matches!(
+            manager
+                .add_account_internal(
+                    "shared-workspace".to_string(),
+                    "rt-duplicate".to_string(),
+                    Some("current@example.com".to_string()),
+                    Some(crate::codex_config::test_codex_id_token("same-user")),
+                    None,
+                    AccountLoginContext::default(),
+                )
+                .await,
+            Err(CodexOAuthError::DuplicateAccount)
+        ));
+        assert_eq!(manager.list_accounts().await.len(), 1);
+        assert!(manager.refresh_locks.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn targeted_reauth_rechecks_duplicates_outside_the_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let manager = CodexOAuthManager::new(temp.path().to_path_buf());
+        let target = manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "rt-legacy".to_string(),
+                Some("legacy@example.com".to_string()),
+                None,
+                None,
+                AccountLoginContext::default(),
+            )
+            .await
+            .unwrap();
+        let id_token = crate::codex_config::test_codex_id_token("same-user");
+        manager
+            .add_account_internal(
+                "shared-workspace".to_string(),
+                "rt-current".to_string(),
+                Some("current@example.com".to_string()),
+                Some(id_token.clone()),
+                None,
+                AccountLoginContext::default(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            manager
+                .add_account_internal(
+                    "shared-workspace".to_string(),
+                    "rt-targeted".to_string(),
+                    Some("legacy@example.com".to_string()),
+                    Some(id_token),
+                    None,
+                    AccountLoginContext {
+                        target_account_id: Some(&target.id),
+                        ..Default::default()
+                    },
+                )
+                .await,
+            Err(CodexOAuthError::DuplicateAccount)
+        ));
+        assert_eq!(
+            manager
+                .accounts
+                .read()
+                .await
+                .get(&target.id)
+                .expect("target account remains")
+                .refresh_token,
+            "rt-legacy"
+        );
     }
 
     #[tokio::test]

--- a/src/components/providers/forms/hooks/useManagedAuth.ts
+++ b/src/components/providers/forms/hooks/useManagedAuth.ts
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import { authApi, settingsApi } from "@/lib/api";
+import { CODEX_OAUTH_DUPLICATE_ACCOUNT_ERROR } from "@/lib/api/auth";
 import { copyText } from "@/lib/clipboard";
 import type {
   ManagedAuthProvider,
@@ -185,7 +186,14 @@ export function useManagedAuth(
             void cancelBackendFlow(response.device_code);
             flowGenerationRef.current += 1;
             setPollingState("error");
-            setError(errorMessage);
+            setError(
+              authProvider === "codex_oauth" &&
+                errorMessage === CODEX_OAUTH_DUPLICATE_ACCOUNT_ERROR
+                ? t("codexOauth.duplicateAccount", {
+                    defaultValue: "该 ChatGPT 账号已添加，请直接使用现有账号。",
+                  })
+                : errorMessage,
+            );
           }
         }
       };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1422,6 +1422,7 @@
     "reauthLogin": "Re-login",
     "reauthSelectHint": "This account needs to sign in again to enable managed binding.",
     "reauthNow": "Re-login now",
+    "duplicateAccount": "This ChatGPT account has already been added. Use the existing account.",
     "loggedInAccounts": "Logged in accounts",
     "defaultAccount": "Default",
     "selected": "Selected",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1422,6 +1422,7 @@
     "reauthLogin": "再ログイン",
     "reauthSelectHint": "このアカウントは管理バインドを有効にするため再ログインが必要です。",
     "reauthNow": "今すぐ再ログイン",
+    "duplicateAccount": "この ChatGPT アカウントは追加済みです。既存のアカウントを使用してください。",
     "loggedInAccounts": "ログイン済みアカウント",
     "defaultAccount": "デフォルト",
     "selected": "選択中",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1423,6 +1423,7 @@
     "reauthLogin": "重新登入",
     "reauthSelectHint": "該帳號需重新登入以啟用託管綁定。",
     "reauthNow": "立即重新登入",
+    "duplicateAccount": "該 ChatGPT 帳號已新增，請直接使用現有帳號。",
     "loggedInAccounts": "已登入帳號",
     "defaultAccount": "預設",
     "selected": "已選取",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1422,6 +1422,7 @@
     "reauthLogin": "重新登录",
     "reauthSelectHint": "该账号需重新登录以启用托管绑定。",
     "reauthNow": "立即重新登录",
+    "duplicateAccount": "该 ChatGPT 账号已添加，请直接使用现有账号。",
     "loggedInAccounts": "已登录账号",
     "defaultAccount": "默认",
     "selected": "已选中",

--- a/src/lib/api/auth.ts
+++ b/src/lib/api/auth.ts
@@ -5,6 +5,9 @@ export type ManagedAuthProvider =
   | "codex_oauth"
   | "xai_oauth";
 
+export const CODEX_OAUTH_DUPLICATE_ACCOUNT_ERROR =
+  "codex_oauth_duplicate_account";
+
 export interface ManagedAuthAccount {
   id: string;
   provider: ManagedAuthProvider;

--- a/tests/hooks/useManagedAuth.test.tsx
+++ b/tests/hooks/useManagedAuth.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useManagedAuth } from "@/components/providers/forms/hooks/useManagedAuth";
+import { CODEX_OAUTH_DUPLICATE_ACCOUNT_ERROR } from "@/lib/api/auth";
 
 const apiMocks = vi.hoisted(() => ({
   authGetStatus: vi.fn(),
@@ -119,6 +120,30 @@ describe("useManagedAuth", () => {
       "codex_oauth",
       undefined,
       "acct-1",
+    );
+  });
+
+  it("localizes a duplicate Codex account error", async () => {
+    apiMocks.authStartLogin.mockResolvedValue({
+      provider: "codex_oauth",
+      device_code: "device-1",
+      user_code: "ABCD-EFGH",
+      verification_uri: "https://example.com/device",
+      expires_in: 600,
+      interval: 5,
+    });
+    apiMocks.authPollForAccount.mockRejectedValue(
+      new Error(CODEX_OAUTH_DUPLICATE_ACCOUNT_ERROR),
+    );
+    const { result } = renderHook(() => useManagedAuth("codex_oauth"), {
+      wrapper: createWrapper(),
+    });
+
+    act(() => result.current.addAccount());
+
+    await waitFor(() => expect(result.current.pollingState).toBe("error"));
+    expect(result.current.error).toBe(
+      "该 ChatGPT 账号已添加，请直接使用现有账号。",
     );
   });
 


### PR DESCRIPTION
## Summary

- reject a duplicate Codex managed account when both the ChatGPT workspace and stable user identity match an existing account
- serialize the final duplicate check with account persistence so concurrent login completions cannot create duplicate records
- keep distinct users in the same workspace supported and show a localized duplicate-account error

## Scope

Codex managed-account duplicate prevention only. This PR does not change default-account behavior, targeted re-login, provider bindings or switching, proxy behavior, migrations, backup restore, or other authentication providers.

## Verification

- cargo test --lib --locked — 2774 passed, 5 ignored
- cargo clippy --lib --tests --locked -- -D warnings
- cargo fmt --all -- --check
- vitest — 1074 passed
- TypeScript type check
- Prettier check