### PR TITLE
feat(skills): make import cards clickable

### DIFF
--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -1095,12 +1095,14 @@ const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
             {skills.map((skill) => (
               <div
                 key={skill.directory}
-                className="flex items-start gap-3 p-3 rounded-lg border hover:bg-muted"
+                className="flex cursor-pointer items-start gap-3 rounded-lg border p-3 hover:bg-muted"
+                onClick={() => toggleSelect(skill.directory)}
               >
                 <input
                   type="checkbox"
                   checked={selected.has(skill.directory)}
                   onChange={() => toggleSelect(skill.directory)}
+                  onClick={(event) => event.stopPropagation()}
                   aria-label={skill.name}
                   className="mt-1"
                 />
@@ -1111,7 +1113,10 @@ const ImportSkillsDialog: React.FC<ImportSkillsDialogProps> = ({
                       {skill.description}
                     </div>
                   )}
-                  <div className="mt-2">
+                  <div
+                    className="mt-2"
+                    onClick={(event) => event.stopPropagation()}
+                  >
                     <AppToggleGroup
                       apps={
                         selectedApps[skill.directory] ?? {

--- a/tests/components/UnifiedSkillsPanel.test.tsx
+++ b/tests/components/UnifiedSkillsPanel.test.tsx
@@ -228,6 +228,40 @@ describe("UnifiedSkillsPanel", () => {
     });
   });
 
+  it("toggles import selection from the card without interactive child bubbling", async () => {
+    const ref = createRef<UnifiedSkillsPanelHandle>();
+    const user = userEvent.setup();
+
+    render(
+      <UnifiedSkillsPanel
+        ref={ref}
+        onOpenDiscovery={() => {}}
+        currentApp="claude"
+      />,
+    );
+
+    await act(async () => {
+      await ref.current?.openImport();
+    });
+
+    const checkbox = await screen.findByRole("checkbox", {
+      name: "Shared Skill",
+    });
+    const card = checkbox.parentElement!;
+    const importButton = screen.getByText("skills.importSelected");
+
+    await user.click(card);
+    expect(importButton).toBeDisabled();
+
+    await user.click(card);
+    expect(importButton).toBeEnabled();
+
+    await user.click(checkbox);
+    expect(importButton).toBeDisabled();
+
+    await user.click(within(card).getAllByRole("button")[0]);
+    expect(importButton).toBeDisabled();
+  });
   it("passes only the installed Skill ID to uninstall", async () => {
     installedSkillsMock = [
       makeInstalledSkill({


### PR DESCRIPTION
## Summary / 概述

- Allow users to toggle a Skill import selection by clicking anywhere on its card instead of only the checkbox.
- Stop checkbox and per-app toggle clicks from bubbling to the card, preventing double toggles and accidental selection changes.
- Add a regression test covering card clicks, checkbox clicks, and app-toggle clicks.
- 优化用户体验，现在可以直接点击卡片决定是否勾选skill了，不用单独点左上角那个小小的勾选框了
Validation:
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm exec vitest run tests/components/UnifiedSkillsPanel.test.tsx` (30 tests passed)
- Full `pnpm test:unit` encountered two parallel-run timeouts; both affected files passed when rerun individually (`PiProviderForm.test.tsx`: 46 tests, `App.test.tsx`: 7 tests).

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| <img width="902" height="632" alt="9c38372a-a93e-454d-9a6b-46dbe2184676" src="https://github.com/user-attachments/assets/8ad04bb4-9a49-4034-8d6e-0c2742a47ece" /> | <img width="902" height="632" alt="13e9ebbf-07c5-468b-9d3c-1c6ff6277509" src="https://github.com/user-attachments/assets/22590d37-7292-4b8e-a1a9-c0bc36f398ee" /> |

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）— Not applicable; no Rust code changed.
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — Not applicable; no user-facing text changed.