### PR TITLE
feat(settings): add provider-only management scope

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -972,6 +972,15 @@ pub fn delete_codex_provider_config(
     Ok(())
 }
 
+fn preserve_live_mcp_when_unmanaged(incoming: &str) -> Result<String, AppError> {
+    if crate::settings::mcp_management_enabled() {
+        return Ok(incoming.to_string());
+    }
+
+    let current = read_codex_config_text()?;
+    crate::mcp::replace_toml_mcp_sections(&current, incoming)
+}
+
 /// 原子写 Codex 的 `auth.json` 与 `config.toml`，在第二步失败时回滚第一步
 pub fn write_codex_live_atomic(
     auth: &Value,
@@ -1001,6 +1010,7 @@ pub fn write_codex_live_atomic(
         Some(s) => s.to_string(),
         None => String::new(),
     };
+    let cfg_text = preserve_live_mcp_when_unmanaged(&cfg_text)?;
     if !cfg_text.trim().is_empty() {
         toml::from_str::<toml::Table>(&cfg_text).map_err(|e| AppError::toml(&config_path, e))?;
     }
@@ -1077,6 +1087,7 @@ pub fn write_codex_live_config_atomic(config_text_opt: Option<&str>) -> Result<(
         Some(config_text) => config_text.to_string(),
         None => String::new(),
     };
+    let cfg_text = preserve_live_mcp_when_unmanaged(&cfg_text)?;
 
     if !cfg_text.trim().is_empty() {
         toml::from_str::<toml::Table>(&cfg_text).map_err(|e| AppError::toml(&config_path, e))?;
@@ -4189,6 +4200,68 @@ mod tests {
             catalog_bytes,
             marker_bytes,
         }
+    }
+
+    #[test]
+    fn unmanaged_mcp_sections_are_preserved_across_provider_config_rewrites() {
+        let current = r#"model = "before"
+
+[mcp_servers.crg]
+command = "crg"
+
+[mcp.servers.legacy]
+command = "legacy"
+"#;
+        let incoming = r#"model = "after"
+
+[mcp_servers.provider_owned]
+command = "replace-me"
+
+[mcp.servers.provider_legacy]
+command = "replace-me-too"
+"#;
+
+        let merged =
+            crate::mcp::replace_toml_mcp_sections(current, incoming).expect("preserve MCP");
+        let parsed: toml::Value = toml::from_str(&merged).expect("valid merged TOML");
+
+        assert_eq!(
+            parsed.get("model").and_then(toml::Value::as_str),
+            Some("after")
+        );
+        assert!(parsed
+            .get("mcp_servers")
+            .and_then(|value| value.get("crg"))
+            .is_some());
+        assert!(parsed
+            .get("mcp_servers")
+            .and_then(|value| value.get("provider_owned"))
+            .is_none());
+        assert!(parsed
+            .get("mcp")
+            .and_then(|value| value.get("servers"))
+            .and_then(|value| value.get("legacy"))
+            .is_some());
+        assert!(parsed
+            .get("mcp")
+            .and_then(|value| value.get("servers"))
+            .and_then(|value| value.get("provider_legacy"))
+            .is_none());
+    }
+
+    #[test]
+    fn unmanaged_mcp_sections_are_removed_when_live_config_has_none() {
+        let incoming = r#"model = "after"
+
+[mcp_servers.provider_owned]
+command = "replace-me"
+"#;
+
+        let merged =
+            crate::mcp::replace_toml_mcp_sections("", incoming).expect("preserve empty MCP state");
+        let parsed: toml::Value = toml::from_str(&merged).expect("valid merged TOML");
+
+        assert!(parsed.get("mcp_servers").is_none());
     }
 
     fn seed_rotated_managed_codex_live_state() -> CodexLiveTestState {

--- a/src-tauri/src/commands/import_export.rs
+++ b/src-tauri/src/commands/import_export.rs
@@ -54,6 +54,7 @@ pub async fn import_config_from_file(
     #[allow(non_snake_case)] filePath: String,
     state: State<'_, AppState>,
 ) -> Result<Value, String> {
+    crate::settings::ensure_all_resource_management_enabled().map_err(|e| e.to_string())?;
     let app_state_for_sync = state.inner().clone();
     let db = app_state_for_sync.db.clone();
     run_with_database_restore_lock(move || {
@@ -172,6 +173,7 @@ pub async fn restore_db_backup(
     state: State<'_, AppState>,
     filename: String,
 ) -> Result<String, String> {
+    crate::settings::ensure_all_resource_management_enabled().map_err(|e| e.to_string())?;
     let app_state_for_sync = state.inner().clone();
     let db = app_state_for_sync.db.clone();
     run_with_database_restore_lock(move || {

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -26,12 +26,14 @@ pub async fn read_claude_mcp_config() -> Result<Option<String>, String> {
 /// 新增或更新一个 MCP 服务器条目
 #[tauri::command]
 pub async fn upsert_claude_mcp_server(id: String, spec: serde_json::Value) -> Result<bool, String> {
+    crate::settings::ensure_mcp_management_enabled().map_err(|e| e.to_string())?;
     claude_mcp::upsert_mcp_server(&id, spec).map_err(|e| e.to_string())
 }
 
 /// 删除一个 MCP 服务器条目
 #[tauri::command]
 pub async fn delete_claude_mcp_server(id: String) -> Result<bool, String> {
+    crate::settings::ensure_mcp_management_enabled().map_err(|e| e.to_string())?;
     claude_mcp::delete_mcp_server(&id).map_err(|e| e.to_string())
 }
 

--- a/src-tauri/src/commands/pi.rs
+++ b/src-tauri/src/commands/pi.rs
@@ -21,6 +21,7 @@ pub(crate) fn update_pi_provider_usage_script(
 }
 
 #[tauri::command]
-pub(crate) fn get_pi_session_discovery() -> PiSessionDiscovery {
-    crate::session_manager::providers::pi::session_discovery()
+pub(crate) fn get_pi_session_discovery() -> Result<PiSessionDiscovery, String> {
+    crate::settings::ensure_sessions_management_enabled().map_err(|error| error.to_string())?;
+    Ok(crate::session_manager::providers::pi::session_discovery())
 }

--- a/src-tauri/src/commands/session_manager.rs
+++ b/src-tauri/src/commands/session_manager.rs
@@ -2,8 +2,13 @@
 
 use crate::session_manager;
 
+fn ensure_session_management_enabled() -> Result<(), String> {
+    crate::settings::ensure_sessions_management_enabled().map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 pub async fn list_sessions() -> Result<Vec<session_manager::SessionMeta>, String> {
+    ensure_session_management_enabled()?;
     let sessions = tauri::async_runtime::spawn_blocking(session_manager::scan_sessions)
         .await
         .map_err(|e| format!("Failed to scan sessions: {e}"))?;
@@ -15,6 +20,7 @@ pub async fn get_session_messages(
     providerId: String,
     sourcePath: String,
 ) -> Result<Vec<session_manager::SessionMessage>, String> {
+    ensure_session_management_enabled()?;
     let provider_id = providerId.clone();
     let source_path = sourcePath.clone();
     tauri::async_runtime::spawn_blocking(move || {
@@ -64,6 +70,7 @@ pub async fn launch_session_terminal(
     cwd: Option<String>,
     custom_config: Option<String>,
 ) -> Result<bool, String> {
+    ensure_session_management_enabled()?;
     let command = command.clone();
     let cwd = cwd.clone();
     let custom_config = custom_config.clone();
@@ -98,6 +105,7 @@ pub async fn delete_session(
     sessionId: String,
     sourcePath: String,
 ) -> Result<bool, String> {
+    ensure_session_management_enabled()?;
     let provider_id = providerId.clone();
     let session_id = sessionId.clone();
     let source_path = sourcePath.clone();
@@ -113,6 +121,7 @@ pub async fn delete_session(
 pub async fn delete_sessions(
     items: Vec<session_manager::DeleteSessionRequest>,
 ) -> Result<Vec<session_manager::DeleteSessionOutcome>, String> {
+    ensure_session_management_enabled()?;
     tauri::async_runtime::spawn_blocking(move || session_manager::delete_sessions(&items))
         .await
         .map_err(|e| format!("Failed to delete sessions: {e}"))

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -65,9 +65,21 @@ pub async fn save_settings(
 ) -> Result<bool, String> {
     let existing = crate::settings::get_settings();
     let merged = merge_settings_for_save(settings, &existing);
-    let unify_codex_changed =
+    let stored_unify_codex_changed =
         merged.unify_codex_session_history != existing.unify_codex_session_history;
-    let unify_codex_enabled = merged.unify_codex_session_history;
+    if stored_unify_codex_changed && !merged.management_scope.sessions {
+        return Err(crate::error::AppError::localized(
+            "management.sessions.unify_history_disabled",
+            "CC Switch 的会话管理已关闭，无法修改统一会话历史设置",
+            "Session management is disabled in CC Switch, so unified session history cannot be changed",
+        )
+        .to_string());
+    }
+    let existing_unify_codex_enabled =
+        existing.management_scope.sessions && existing.unify_codex_session_history;
+    let unify_codex_enabled =
+        merged.management_scope.sessions && merged.unify_codex_session_history;
+    let unify_codex_changed = unify_codex_enabled != existing_unify_codex_enabled;
     crate::settings::update_settings(merged).map_err(|e| e.to_string())?;
 
     // 统一会话开关变更时立即重写当前官方 Codex 供应商的 live 配置，
@@ -139,6 +151,7 @@ pub struct CodexUnifyHistoryRestoreResult {
 /// 是否存在统一会话开关的迁移备份（决定关闭弹窗里是否显示"恢复备份"勾选）。
 #[tauri::command]
 pub async fn has_codex_unify_history_backup() -> Result<bool, String> {
+    crate::settings::ensure_sessions_management_enabled().map_err(|e| e.to_string())?;
     Ok(crate::codex_history_migration::has_codex_official_history_unify_backup())
 }
 
@@ -146,6 +159,7 @@ pub async fn has_codex_unify_history_backup() -> Result<bool, String> {
 /// 由关闭统一会话开关的确认弹窗触发；幂等，可安全重试。
 #[tauri::command]
 pub async fn restore_codex_unified_history() -> Result<CodexUnifyHistoryRestoreResult, String> {
+    crate::settings::ensure_sessions_management_enabled().map_err(|e| e.to_string())?;
     let outcome = tauri::async_runtime::spawn_blocking(|| {
         crate::codex_history_migration::restore_codex_official_history_from_backups()
     })

--- a/src-tauri/src/commands/skill.rs
+++ b/src-tauri/src/commands/skill.rs
@@ -24,21 +24,28 @@ fn parse_app_type(app: &str) -> Result<AppType, String> {
     AppType::from_str(app).map_err(|e| e.to_string())
 }
 
+fn ensure_skills_management_enabled() -> Result<(), String> {
+    crate::settings::ensure_skills_management_enabled().map_err(|e| e.to_string())
+}
+
 // ========== 统一管理命令 ==========
 
 /// 获取所有已安装的 Skills
 #[tauri::command]
 pub fn get_installed_skills(app_state: State<'_, AppState>) -> Result<Vec<InstalledSkill>, String> {
+    ensure_skills_management_enabled()?;
     SkillService::get_all_installed(&app_state.db).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 pub fn get_skill_backups() -> Result<Vec<SkillBackupEntry>, String> {
+    ensure_skills_management_enabled()?;
     SkillService::list_backups().map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 pub fn delete_skill_backup(backup_id: String) -> Result<bool, String> {
+    ensure_skills_management_enabled()?;
     SkillService::delete_backup(&backup_id).map_err(|e| e.to_string())?;
     Ok(true)
 }
@@ -55,6 +62,7 @@ pub async fn install_skill_unified(
     service: State<'_, SkillServiceState>,
     app_state: State<'_, AppState>,
 ) -> Result<InstalledSkill, String> {
+    ensure_skills_management_enabled()?;
     let app_type = parse_app_type(&current_app)?;
 
     service
@@ -70,6 +78,7 @@ pub fn uninstall_skill_unified(
     id: String,
     app_state: State<'_, AppState>,
 ) -> Result<SkillUninstallResult, String> {
+    ensure_skills_management_enabled()?;
     SkillService::uninstall(&app_state.db, &id).map_err(|e| e.to_string())
 }
 
@@ -79,6 +88,7 @@ pub fn restore_skill_backup(
     current_app: String,
     app_state: State<'_, AppState>,
 ) -> Result<InstalledSkill, String> {
+    ensure_skills_management_enabled()?;
     let app_type = parse_app_type(&current_app)?;
     SkillService::restore_from_backup(&app_state.db, &backup_id, &app_type)
         .map_err(|e| e.to_string())
@@ -92,6 +102,7 @@ pub fn toggle_skill_app(
     enabled: bool,
     app_state: State<'_, AppState>,
 ) -> Result<bool, String> {
+    ensure_skills_management_enabled()?;
     let app_type = parse_app_type(&app)?;
     SkillService::toggle_app(&app_state.db, &id, &app_type, enabled).map_err(|e| e.to_string())?;
     Ok(true)
@@ -102,6 +113,7 @@ pub fn toggle_skill_app(
 pub fn scan_unmanaged_skills(
     app_state: State<'_, AppState>,
 ) -> Result<Vec<UnmanagedSkill>, String> {
+    ensure_skills_management_enabled()?;
     SkillService::scan_unmanaged(&app_state.db).map_err(|e| e.to_string())
 }
 
@@ -111,6 +123,7 @@ pub fn import_skills_from_apps(
     imports: Vec<ImportSkillSelection>,
     app_state: State<'_, AppState>,
 ) -> Result<Vec<InstalledSkill>, String> {
+    ensure_skills_management_enabled()?;
     SkillService::import_from_apps(&app_state.db, imports).map_err(|e| e.to_string())
 }
 
@@ -122,6 +135,7 @@ pub async fn discover_available_skills(
     service: State<'_, SkillServiceState>,
     app_state: State<'_, AppState>,
 ) -> Result<Vec<DiscoverableSkill>, String> {
+    ensure_skills_management_enabled()?;
     let repos = app_state.db.get_skill_repos().map_err(|e| e.to_string())?;
     service
         .0
@@ -136,6 +150,7 @@ pub async fn check_skill_updates(
     service: State<'_, SkillServiceState>,
     app_state: State<'_, AppState>,
 ) -> Result<Vec<SkillUpdateInfo>, String> {
+    ensure_skills_management_enabled()?;
     service
         .0
         .check_updates(&app_state.db)
@@ -150,6 +165,7 @@ pub async fn update_skill(
     service: State<'_, SkillServiceState>,
     app_state: State<'_, AppState>,
 ) -> Result<InstalledSkill, String> {
+    ensure_skills_management_enabled()?;
     service
         .0
         .update_skill(&app_state.db, &id)
@@ -163,6 +179,7 @@ pub async fn migrate_skill_storage(
     target: SkillStorageLocation,
     app_state: State<'_, AppState>,
 ) -> Result<MigrationResult, String> {
+    ensure_skills_management_enabled()?;
     SkillService::migrate_storage(&app_state.db, target).map_err(|e| e.to_string())
 }
 
@@ -173,6 +190,7 @@ pub async fn search_skills_sh(
     limit: usize,
     offset: usize,
 ) -> Result<SkillsShSearchResult, String> {
+    ensure_skills_management_enabled()?;
     SkillService::search_skills_sh(&query, limit, offset)
         .await
         .map_err(|e| e.to_string())
@@ -186,6 +204,7 @@ pub async fn get_skills(
     service: State<'_, SkillServiceState>,
     app_state: State<'_, AppState>,
 ) -> Result<Vec<Skill>, String> {
+    ensure_skills_management_enabled()?;
     let repos = app_state.db.get_skill_repos().map_err(|e| e.to_string())?;
     service
         .0
@@ -201,6 +220,7 @@ pub async fn get_skills_for_app(
     service: State<'_, SkillServiceState>,
     app_state: State<'_, AppState>,
 ) -> Result<Vec<Skill>, String> {
+    ensure_skills_management_enabled()?;
     // 新版本不再区分应用，统一返回所有技能
     let _ = parse_app_type(&app)?; // 验证 app 参数有效
     get_skills(service, app_state).await
@@ -213,6 +233,7 @@ pub async fn install_skill(
     service: State<'_, SkillServiceState>,
     app_state: State<'_, AppState>,
 ) -> Result<bool, String> {
+    ensure_skills_management_enabled()?;
     install_skill_for_app("claude".to_string(), directory, service, app_state).await
 }
 
@@ -224,6 +245,7 @@ pub async fn install_skill_for_app(
     service: State<'_, SkillServiceState>,
     app_state: State<'_, AppState>,
 ) -> Result<bool, String> {
+    ensure_skills_management_enabled()?;
     let app_type = parse_app_type(&app)?;
 
     // 先获取技能信息
@@ -267,6 +289,7 @@ pub fn uninstall_skill(
     directory: String,
     app_state: State<'_, AppState>,
 ) -> Result<SkillUninstallResult, String> {
+    ensure_skills_management_enabled()?;
     uninstall_skill_for_app("claude".to_string(), directory, app_state)
 }
 
@@ -277,6 +300,7 @@ pub fn uninstall_skill_for_app(
     directory: String,
     app_state: State<'_, AppState>,
 ) -> Result<SkillUninstallResult, String> {
+    ensure_skills_management_enabled()?;
     let _ = parse_app_type(&app)?; // 验证参数
 
     // 通过 directory 找到对应的 skill id
@@ -295,12 +319,14 @@ pub fn uninstall_skill_for_app(
 /// 获取技能仓库列表
 #[tauri::command]
 pub fn get_skill_repos(app_state: State<'_, AppState>) -> Result<Vec<SkillRepo>, String> {
+    ensure_skills_management_enabled()?;
     app_state.db.get_skill_repos().map_err(|e| e.to_string())
 }
 
 /// 添加技能仓库
 #[tauri::command]
 pub fn add_skill_repo(repo: SkillRepo, app_state: State<'_, AppState>) -> Result<bool, String> {
+    ensure_skills_management_enabled()?;
     // 整个结构体由前端反序列化而来，owner/name/branch 会被拼进归档下载 URL。
     // 主防线在 download_repo，这里让非法值当场报错而不是沉淀进表。
     SkillService::validate_repo_ref(&repo.owner, &repo.name, &repo.branch)
@@ -319,6 +345,7 @@ pub fn remove_skill_repo(
     name: String,
     app_state: State<'_, AppState>,
 ) -> Result<bool, String> {
+    ensure_skills_management_enabled()?;
     app_state
         .db
         .delete_skill_repo(&owner, &name)
@@ -333,6 +360,7 @@ pub fn install_skills_from_zip(
     current_app: String,
     app_state: State<'_, AppState>,
 ) -> Result<Vec<InstalledSkill>, String> {
+    ensure_skills_management_enabled()?;
     let app_type = parse_app_type(&current_app)?;
     let path = std::path::Path::new(&file_path);
 

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -251,6 +251,7 @@ pub fn delete_model_pricing(state: State<'_, AppState>, model_id: String) -> Res
 pub async fn sync_session_usage(
     state: State<'_, AppState>,
 ) -> Result<crate::services::session_usage::SessionSyncResult, AppError> {
+    crate::settings::ensure_sessions_management_enabled()?;
     let db = state.db.clone();
     let _guard = crate::services::session_usage::session_sync_mutex()
         .lock()
@@ -277,6 +278,7 @@ fn finish_codex_rebuild(
 pub async fn rebuild_codex_usage(
     state: State<'_, AppState>,
 ) -> Result<crate::services::session_usage::SessionSyncResult, AppError> {
+    crate::settings::ensure_sessions_management_enabled()?;
     let db = state.db.clone();
     let _guard = crate::services::session_usage::session_sync_mutex()
         .lock()

--- a/src-tauri/src/deeplink/mcp.rs
+++ b/src-tauri/src/deeplink/mcp.rs
@@ -41,6 +41,8 @@ pub fn import_mcp_from_deeplink(
     state: &AppState,
     request: DeepLinkImportRequest,
 ) -> Result<McpImportResult, AppError> {
+    crate::settings::ensure_mcp_management_enabled()?;
+
     // Verify this is an MCP request
     if request.resource != "mcp" {
         return Err(AppError::InvalidInput(format!(

--- a/src-tauri/src/deeplink/skill.rs
+++ b/src-tauri/src/deeplink/skill.rs
@@ -12,6 +12,8 @@ pub fn import_skill_from_deeplink(
     state: &AppState,
     request: DeepLinkImportRequest,
 ) -> Result<String, AppError> {
+    crate::settings::ensure_skills_management_enabled()?;
+
     // Verify this is a skill request
     if request.resource != "skill" {
         return Err(AppError::InvalidInput(format!(

--- a/src-tauri/src/grok_config.rs
+++ b/src-tauri/src/grok_config.rs
@@ -408,7 +408,18 @@ pub fn write_grok_live_settings(settings: &Value) -> Result<(), AppError> {
             )
         })?;
     validate_config_toml_syntax(config)?;
-    write_text_file(&get_grok_config_path(), config)
+    let config = if crate::settings::mcp_management_enabled() {
+        config.to_string()
+    } else {
+        let path = get_grok_config_path();
+        let current = if path.exists() {
+            fs::read_to_string(&path).map_err(|error| AppError::io(&path, error))?
+        } else {
+            String::new()
+        };
+        crate::mcp::replace_toml_mcp_sections(&current, config)?
+    };
+    write_text_file(&get_grok_config_path(), &config)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -658,18 +658,19 @@ pub fn run() {
             // 按表独立判断的导入逻辑（各类数据独立检查，互不影响）
             // ============================================================
 
-            // 1. 初始化默认 Skills 仓库（已有内置检查：表非空则跳过）
-            match app_state.db.init_default_skill_repos() {
-                Ok(count) if count > 0 => {
-                    log::info!("✓ Initialized {count} default skill repositories");
+            if crate::settings::skills_management_enabled() {
+                // 1. 初始化默认 Skills 仓库（已有内置检查：表非空则跳过）
+                match app_state.db.init_default_skill_repos() {
+                    Ok(count) if count > 0 => {
+                        log::info!("✓ Initialized {count} default skill repositories");
+                    }
+                    Ok(_) => {} // 表非空，静默跳过
+                    Err(e) => log::warn!("✗ Failed to initialize default skill repos: {e}"),
                 }
-                Ok(_) => {} // 表非空，静默跳过
-                Err(e) => log::warn!("✗ Failed to initialize default skill repos: {e}"),
-            }
 
-            // 1.1. Skills 统一管理迁移：当数据库迁移到 v3 结构后，自动从各应用目录导入到 SSOT
-            // 触发条件由 schema 迁移设置 settings.skills_ssot_migration_pending = true 控制。
-            match app_state.db.get_setting("skills_ssot_migration_pending") {
+                // 1.1. Skills 统一管理迁移：当数据库迁移到 v3 结构后，自动从各应用目录导入到 SSOT
+                // 触发条件由 schema 迁移设置 settings.skills_ssot_migration_pending = true 控制。
+                match app_state.db.get_setting("skills_ssot_migration_pending") {
                 Ok(Some(flag)) if flag == "true" || flag == "1" => {
                     // 安全保护：如果用户已经有 v3 结构的 Skills 数据，就不要自动清空重建。
                     let has_existing = app_state
@@ -705,7 +706,10 @@ pub fn run() {
                     }
                 }
                 Ok(_) => {} // 未开启迁移标志，静默跳过
-                Err(e) => log::warn!("✗ Failed to read skills migration flag: {e}"),
+                    Err(e) => log::warn!("✗ Failed to read skills migration flag: {e}"),
+                }
+            } else {
+                log::info!("Skills management disabled; startup repository initialization and migration skipped");
             }
 
             // 1.5. 自动导入 live 配置 + seed 官方预设供应商（Claude / Codex / Gemini）
@@ -765,7 +769,7 @@ pub fn run() {
                 Err(e) => log::warn!("✗ Failed to seed official providers: {e}"),
             }
 
-            {
+            if crate::settings::sessions_management_enabled() {
                 let db_for_codex_history_migration = app_state.db.clone();
                 tauri::async_runtime::spawn_blocking(move || {
                     match crate::codex_history_migration::maybe_migrate_codex_third_party_history_provider_bucket(
@@ -825,6 +829,8 @@ pub fn run() {
                         }
                     }
                 });
+            } else {
+                log::info!("Session management disabled; Codex history migrations skipped");
             }
 
             // 老用户 / 已确认的路径由 `fresh_install_at_startup` 自行拦截，这里不做写入。
@@ -924,7 +930,9 @@ pub fn run() {
             }
 
             // 3. 导入 MCP 服务器配置（表空时触发）
-            if app_state.db.is_mcp_table_empty().unwrap_or(false) {
+            if crate::settings::mcp_management_enabled()
+                && app_state.db.is_mcp_table_empty().unwrap_or(false)
+            {
                 log::info!("MCP table empty, importing from live configurations...");
 
                 match crate::services::mcp::McpService::import_from_claude(&app_state) {
@@ -1301,7 +1309,9 @@ pub fn run() {
                     }
 
                     // 首次同步（含费用回填）
-                    run_session_sync(db_for_session_sync.clone(), true).await;
+                    if crate::settings::sessions_management_enabled() {
+                        run_session_sync(db_for_session_sync.clone(), true).await;
+                    }
 
                     // 定期同步
                     let mut interval = tokio::time::interval(std::time::Duration::from_secs(
@@ -1311,7 +1321,9 @@ pub fn run() {
                     interval.tick().await; // skip immediate first tick
                     loop {
                         interval.tick().await;
-                        run_session_sync(db_for_session_sync.clone(), false).await;
+                        if crate::settings::sessions_management_enabled() {
+                            run_session_sync(db_for_session_sync.clone(), false).await;
+                        }
                     }
                 });
             });

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -19,6 +19,71 @@ mod hermes;
 mod opencode;
 mod validation;
 
+pub(crate) fn replace_toml_mcp_sections(
+    current: &str,
+    incoming: &str,
+) -> Result<String, crate::error::AppError> {
+    use toml_edit::{DocumentMut, Item};
+
+    let current_doc = if current.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        current.parse::<DocumentMut>().map_err(|e| {
+            crate::error::AppError::Message(format!("Invalid current TOML configuration: {e}"))
+        })?
+    };
+    let mut incoming_doc = if incoming.trim().is_empty() {
+        DocumentMut::new()
+    } else {
+        incoming.parse::<DocumentMut>().map_err(|e| {
+            crate::error::AppError::Message(format!("Invalid incoming TOML configuration: {e}"))
+        })?
+    };
+
+    let current_standard = current_doc.as_table().get("mcp_servers").cloned();
+    incoming_doc.as_table_mut().remove("mcp_servers");
+    if let Some(item) = current_standard {
+        incoming_doc.as_table_mut().insert("mcp_servers", item);
+    }
+
+    let current_legacy = current_doc
+        .as_table()
+        .get("mcp")
+        .and_then(Item::as_table_like)
+        .and_then(|table| table.get("servers"))
+        .cloned();
+
+    let remove_empty_mcp = incoming_doc
+        .as_table_mut()
+        .get_mut("mcp")
+        .and_then(Item::as_table_like_mut)
+        .map(|table| {
+            table.remove("servers");
+            table.is_empty()
+        })
+        .unwrap_or(false);
+    if remove_empty_mcp {
+        incoming_doc.as_table_mut().remove("mcp");
+    }
+    if let Some(servers) = current_legacy {
+        if !incoming_doc.as_table().contains_key("mcp") {
+            incoming_doc["mcp"] = Item::Table(toml_edit::Table::new());
+        }
+        let mcp = incoming_doc
+            .as_table_mut()
+            .get_mut("mcp")
+            .and_then(Item::as_table_like_mut)
+            .ok_or_else(|| {
+                crate::error::AppError::Message(
+                    "TOML configuration has a non-table 'mcp' value".to_string(),
+                )
+            })?;
+        mcp.insert("servers", servers);
+    }
+
+    Ok(incoming_doc.to_string())
+}
+
 // 重新导出公共 API
 pub use claude::{
     import_from_claude, remove_server_from_claude, sync_enabled_to_claude,

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -17,6 +17,8 @@ impl McpService {
 
     /// 添加或更新 MCP 服务器
     pub fn upsert_server(state: &AppState, server: McpServer) -> Result<(), AppError> {
+        crate::settings::ensure_mcp_management_enabled()?;
+
         // 读取旧状态：用于处理“编辑时取消勾选某个应用”的场景（需要从对应 live 配置中移除）
         let prev_apps = state
             .db
@@ -55,6 +57,8 @@ impl McpService {
 
     /// 删除 MCP 服务器
     pub fn delete_server(state: &AppState, id: &str) -> Result<bool, AppError> {
+        crate::settings::ensure_mcp_management_enabled()?;
+
         let server = state.db.get_all_mcp_servers()?.shift_remove(id);
 
         if let Some(server) = server {
@@ -75,6 +79,8 @@ impl McpService {
         app: AppType,
         enabled: bool,
     ) -> Result<(), AppError> {
+        crate::settings::ensure_mcp_management_enabled()?;
+
         if let Some(server) = state
             .db
             .update_mcp_server_app_enabled(server_id, &app, enabled)?
@@ -194,6 +200,10 @@ impl McpService {
     /// 应用的 MCP 状态陈旧。全部跑完后若有失败，聚合成一个错误上报，
     /// 保留调用方的可见性。
     pub fn sync_all_enabled(state: &AppState) -> Result<(), AppError> {
+        if !crate::settings::mcp_management_enabled() {
+            return Ok(());
+        }
+
         let servers = Self::get_all_servers(state)?;
 
         let mut failures: Vec<String> = Vec::new();
@@ -218,6 +228,10 @@ impl McpService {
     /// 定向重投影，避免把无关应用的失败面（如 ~/.claude.json 坏 JSON）
     /// 牵连进目标应用的关键路径。
     pub fn sync_enabled_for_app(state: &AppState, app: &AppType) -> Result<(), AppError> {
+        if !crate::settings::mcp_management_enabled() {
+            return Ok(());
+        }
+
         let servers = Self::get_all_servers(state)?;
         Self::project_servers_to_app(state, &servers, app)
     }
@@ -282,6 +296,10 @@ impl McpService {
     /// [已废弃] 同步启用的 MCP 到指定应用（兼容旧 API）
     #[deprecated(since = "3.7.0", note = "Use sync_all_enabled instead")]
     pub fn sync_enabled(state: &AppState, app: AppType) -> Result<(), AppError> {
+        if !crate::settings::mcp_management_enabled() {
+            return Ok(());
+        }
+
         let servers = Self::get_all_servers(state)?;
 
         for server in servers.values() {
@@ -295,6 +313,8 @@ impl McpService {
 
     /// 从 Claude 导入 MCP（v3.7.0 已更新为统一结构）
     pub fn import_from_claude(state: &AppState) -> Result<usize, AppError> {
+        crate::settings::ensure_mcp_management_enabled()?;
+
         // 创建临时 MultiAppConfig 用于导入
         let mut temp_config = crate::app_config::MultiAppConfig::default();
 
@@ -333,6 +353,8 @@ impl McpService {
 
     /// 从 Codex 导入 MCP（v3.7.0 已更新为统一结构）
     pub fn import_from_codex(state: &AppState) -> Result<usize, AppError> {
+        crate::settings::ensure_mcp_management_enabled()?;
+
         // 创建临时 MultiAppConfig 用于导入
         let mut temp_config = crate::app_config::MultiAppConfig::default();
 
@@ -371,6 +393,8 @@ impl McpService {
 
     /// 从 Gemini 导入 MCP（v3.7.0 已更新为统一结构）
     pub fn import_from_gemini(state: &AppState) -> Result<usize, AppError> {
+        crate::settings::ensure_mcp_management_enabled()?;
+
         // 创建临时 MultiAppConfig 用于导入
         let mut temp_config = crate::app_config::MultiAppConfig::default();
 
@@ -409,6 +433,8 @@ impl McpService {
 
     /// 从 Grok Build 的 `[mcp_servers]` 导入 MCP。
     pub fn import_from_grokbuild(state: &AppState) -> Result<usize, AppError> {
+        crate::settings::ensure_mcp_management_enabled()?;
+
         let mut temp_config = crate::app_config::MultiAppConfig::default();
         let count = crate::mcp::import_from_grokbuild(&mut temp_config)?;
         let mut new_count = 0;
@@ -435,6 +461,8 @@ impl McpService {
 
     /// 从 OpenCode 导入 MCP（v3.9.2+ 新增）
     pub fn import_from_opencode(state: &AppState) -> Result<usize, AppError> {
+        crate::settings::ensure_mcp_management_enabled()?;
+
         // 创建临时 MultiAppConfig 用于导入
         let mut temp_config = crate::app_config::MultiAppConfig::default();
 
@@ -473,6 +501,8 @@ impl McpService {
 
     /// 从 Hermes 导入 MCP
     pub fn import_from_hermes(state: &AppState) -> Result<usize, AppError> {
+        crate::settings::ensure_mcp_management_enabled()?;
+
         // 创建临时 MultiAppConfig 用于导入
         let mut temp_config = crate::app_config::MultiAppConfig::default();
 
@@ -516,6 +546,8 @@ impl McpService {
     /// `unwrap_or(0)` 吞错，坏文件只会表现为"导入成功 0 个"，用户
     /// 无从得知哪个应用出了问题。
     pub fn import_from_all_apps(state: &AppState) -> Result<usize, AppError> {
+        crate::settings::ensure_mcp_management_enabled()?;
+
         let mut total = 0;
         let mut failures: Vec<String> = Vec::new();
 

--- a/src-tauri/src/services/profile.rs
+++ b/src-tauri/src/services/profile.rs
@@ -21,6 +21,7 @@ use crate::app_config::AppType;
 use crate::database::Profile;
 use crate::error::AppError;
 use crate::services::{McpService, PromptService, ProviderService, SkillService};
+use crate::settings::ManagementScope;
 use crate::store::AppState;
 
 /// Profile 操作的应用分组：项目实体全应用共享，但快照/应用/当前指针按组进行。
@@ -136,17 +137,26 @@ impl ProfilePayload {
     /// 用另一份快照覆盖本载荷中某分组的槽位，其余分组原样保留
     /// （"以当前状态更新"只更新发起页所属分组，避免把别的应用
     /// 正处于其他项目的状态串进来）
-    pub fn merge_scope_from(&mut self, other: &ProfilePayload, scope: ProfileScope) {
+    pub fn merge_scope_from(
+        &mut self,
+        other: &ProfilePayload,
+        scope: ProfileScope,
+        management_scope: ManagementScope,
+    ) {
         for app in scope.apps() {
             if let (Some(dst), Some(src)) = (self.providers.get_mut(app), other.providers.get(app))
             {
                 *dst = src.clone();
             }
-            if let (Some(dst), Some(src)) = (self.mcp.get_mut(app), other.mcp.get(app)) {
-                *dst = src.clone();
+            if management_scope.mcp {
+                if let (Some(dst), Some(src)) = (self.mcp.get_mut(app), other.mcp.get(app)) {
+                    *dst = src.clone();
+                }
             }
-            if let (Some(dst), Some(src)) = (self.skills.get_mut(app), other.skills.get(app)) {
-                *dst = src.clone();
+            if management_scope.skills {
+                if let (Some(dst), Some(src)) = (self.skills.get_mut(app), other.skills.get(app)) {
+                    *dst = src.clone();
+                }
             }
             if let (Some(dst), Some(src)) = (self.prompts.get_mut(app), other.prompts.get(app)) {
                 *dst = src.clone();
@@ -198,15 +208,35 @@ impl ProfileService {
         state: &AppState,
         scope: ProfileScope,
     ) -> Result<ProfilePayload, AppError> {
+        Self::snapshot_current_with_management_scope(
+            state,
+            scope,
+            crate::settings::get_settings().management_scope,
+        )
+    }
+
+    fn snapshot_current_with_management_scope(
+        state: &AppState,
+        scope: ProfileScope,
+        management_scope: ManagementScope,
+    ) -> Result<ProfilePayload, AppError> {
         let mut payload = ProfilePayload::default();
-        let mcp_servers = state.db.get_all_mcp_servers()?;
-        let skills = state.db.get_all_installed_skills()?;
+        let mcp_servers = if management_scope.mcp {
+            Some(state.db.get_all_mcp_servers()?)
+        } else {
+            None
+        };
+        let skills = if management_scope.skills {
+            Some(state.db.get_all_installed_skills()?)
+        } else {
+            None
+        };
 
         for app in scope.apps().iter() {
             if let Some(slot) = payload.providers.get_mut(app) {
                 *slot = crate::settings::get_effective_current_provider(&state.db, app)?;
             }
-            if let Some(slot) = payload.mcp.get_mut(app) {
+            if let (Some(slot), Some(mcp_servers)) = (payload.mcp.get_mut(app), &mcp_servers) {
                 *slot = Some(
                     mcp_servers
                         .values()
@@ -215,7 +245,7 @@ impl ProfileService {
                         .collect(),
                 );
             }
-            if let Some(slot) = payload.skills.get_mut(app) {
+            if let (Some(slot), Some(skills)) = (payload.skills.get_mut(app), &skills) {
                 *slot = Some(
                     skills
                         .values()
@@ -291,7 +321,10 @@ impl ProfileService {
             })?;
             let mut payload: ProfilePayload = serde_json::from_str(&profile.payload)
                 .map_err(|e| AppError::Config(format!("解析 profile payload 失败: {e}")))?;
-            payload.merge_scope_from(&Self::snapshot_current(state, scope)?, scope);
+            let management_scope = crate::settings::get_settings().management_scope;
+            let fresh =
+                Self::snapshot_current_with_management_scope(state, scope, management_scope)?;
+            payload.merge_scope_from(&fresh, scope, management_scope);
             profile.payload = serde_json::to_string(&payload)
                 .map_err(|e| AppError::Config(format!("序列化 profile payload 失败: {e}")))?;
         }
@@ -392,43 +425,47 @@ impl ProfileService {
             }
 
             // 3. MCP diff（最小 toggle：仅动目标态≠当前态的条目；None = 该侧未拍过，不动）
-            if let Some(Some(target_ids)) = payload.mcp.get(app) {
-                let servers = state.db.get_all_mcp_servers()?;
-                let current: Vec<(String, bool)> = servers
-                    .values()
-                    .map(|s| (s.id.clone(), s.apps.is_enabled_for(app)))
-                    .collect();
-                let (toggles, dangling) = plan_toggles(&current, target_ids);
-                for id in dangling {
-                    warnings.push(format!("[{app_str}] MCP '{id}' no longer exists, skipped"));
-                }
-                for (id, enabled) in toggles {
-                    if let Err(e) = McpService::toggle_app(state, &id, app.clone(), enabled) {
-                        warnings.push(format!(
-                            "[{app_str}] toggle MCP '{id}' -> {enabled} failed: {e}"
-                        ));
+            if crate::settings::mcp_management_enabled() {
+                if let Some(Some(target_ids)) = payload.mcp.get(app) {
+                    let servers = state.db.get_all_mcp_servers()?;
+                    let current: Vec<(String, bool)> = servers
+                        .values()
+                        .map(|s| (s.id.clone(), s.apps.is_enabled_for(app)))
+                        .collect();
+                    let (toggles, dangling) = plan_toggles(&current, target_ids);
+                    for id in dangling {
+                        warnings.push(format!("[{app_str}] MCP '{id}' no longer exists, skipped"));
+                    }
+                    for (id, enabled) in toggles {
+                        if let Err(e) = McpService::toggle_app(state, &id, app.clone(), enabled) {
+                            warnings.push(format!(
+                                "[{app_str}] toggle MCP '{id}' -> {enabled} failed: {e}"
+                            ));
+                        }
                     }
                 }
             }
 
             // 4. Skills diff（SkillService 返回 anyhow::Result，收进 warning）
-            if let Some(Some(target_ids)) = payload.skills.get(app) {
-                let skills = state.db.get_all_installed_skills()?;
-                let current: Vec<(String, bool)> = skills
-                    .values()
-                    .map(|s| (s.id.clone(), s.apps.is_enabled_for(app)))
-                    .collect();
-                let (toggles, dangling) = plan_toggles(&current, target_ids);
-                for id in dangling {
-                    warnings.push(format!(
-                        "[{app_str}] skill '{id}' no longer exists, skipped"
-                    ));
-                }
-                for (id, enabled) in toggles {
-                    if let Err(e) = SkillService::toggle_app(&state.db, &id, app, enabled) {
+            if crate::settings::skills_management_enabled() {
+                if let Some(Some(target_ids)) = payload.skills.get(app) {
+                    let skills = state.db.get_all_installed_skills()?;
+                    let current: Vec<(String, bool)> = skills
+                        .values()
+                        .map(|s| (s.id.clone(), s.apps.is_enabled_for(app)))
+                        .collect();
+                    let (toggles, dangling) = plan_toggles(&current, target_ids);
+                    for id in dangling {
                         warnings.push(format!(
-                            "[{app_str}] toggle skill '{id}' -> {enabled} failed: {e}"
+                            "[{app_str}] skill '{id}' no longer exists, skipped"
                         ));
+                    }
+                    for (id, enabled) in toggles {
+                        if let Err(e) = SkillService::toggle_app(&state.db, &id, app, enabled) {
+                            warnings.push(format!(
+                                "[{app_str}] toggle skill '{id}' -> {enabled} failed: {e}"
+                            ));
+                        }
                     }
                 }
             }
@@ -555,7 +592,7 @@ mod tests {
             },
             ..Default::default()
         };
-        payload.merge_scope_from(&fresh, ProfileScope::Claude);
+        payload.merge_scope_from(&fresh, ProfileScope::Claude, ManagementScope::default());
 
         assert_eq!(payload.providers.claude, Some("p2".to_string()));
         assert_eq!(
@@ -587,6 +624,70 @@ mod tests {
         desktop_only.providers.claude_desktop = Some("d1".into());
         assert!(desktop_only.scope_captured(ProfileScope::ClaudeDesktop));
         assert!(!desktop_only.scope_captured(ProfileScope::Claude));
+    }
+
+    #[test]
+    fn test_merge_scope_preserves_unmanaged_resource_slots() {
+        let mut payload = ProfilePayload {
+            mcp: PerApp {
+                claude: Some(ids(&["m1"])),
+                ..Default::default()
+            },
+            skills: PerApp {
+                claude: Some(ids(&["s1"])),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let fresh = ProfilePayload {
+            providers: PerApp {
+                claude: Some("p2".into()),
+                ..Default::default()
+            },
+            mcp: PerApp {
+                claude: Some(ids(&["m2"])),
+                ..Default::default()
+            },
+            skills: PerApp {
+                claude: Some(ids(&["s2"])),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        payload.merge_scope_from(
+            &fresh,
+            ProfileScope::Claude,
+            ManagementScope {
+                mcp: false,
+                skills: false,
+                sessions: true,
+            },
+        );
+
+        assert_eq!(payload.providers.claude, Some("p2".to_string()));
+        assert_eq!(payload.mcp.claude, Some(ids(&["m1"])));
+        assert_eq!(payload.skills.claude, Some(ids(&["s1"])));
+    }
+
+    #[test]
+    fn test_snapshot_omits_unmanaged_resource_slots() {
+        let db = std::sync::Arc::new(crate::database::Database::memory().expect("memory db"));
+        let state = AppState::new(db);
+
+        let payload = ProfileService::snapshot_current_with_management_scope(
+            &state,
+            ProfileScope::Claude,
+            ManagementScope {
+                mcp: false,
+                skills: false,
+                sessions: true,
+            },
+        )
+        .expect("snapshot providers only");
+
+        assert_eq!(payload.mcp.claude, None);
+        assert_eq!(payload.skills.claude, None);
     }
 
     #[test]

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -1686,10 +1686,13 @@ pub fn sync_current_to_live(state: &AppState) -> Result<(), AppError> {
     }
 
     // Skill sync
-    for app_type in AppType::all() {
-        if let Err(e) = crate::services::skill::SkillService::sync_to_app(&state.db, &app_type) {
-            log::warn!("同步 Skill 到 {app_type:?} 失败: {e}");
-            failures.push(format!("skill/{}: {e}", app_type.as_str()));
+    if crate::settings::skills_management_enabled() {
+        for app_type in AppType::all() {
+            if let Err(e) = crate::services::skill::SkillService::sync_to_app(&state.db, &app_type)
+            {
+                log::warn!("同步 Skill 到 {app_type:?} 失败: {e}");
+                failures.push(format!("skill/{}: {e}", app_type.as_str()));
+            }
         }
     }
 
@@ -2036,8 +2039,19 @@ pub(crate) fn write_gemini_live(provider: &Provider) -> Result<(), AppError> {
             if let (Some(merged_obj), Some(config_obj)) =
                 (merged.as_object_mut(), config_value.as_object())
             {
+                let live_mcp_servers = merged_obj.get("mcpServers").cloned();
                 for (k, v) in config_obj {
                     merged_obj.insert(k.clone(), v.clone());
+                }
+                if !crate::settings::mcp_management_enabled() {
+                    match live_mcp_servers {
+                        Some(servers) => {
+                            merged_obj.insert("mcpServers".to_string(), servers);
+                        }
+                        None => {
+                            merged_obj.remove("mcpServers");
+                        }
+                    }
                 }
             }
             config_to_write = Some(merged);

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -3782,7 +3782,7 @@ impl ProxyService {
                         // Unguarded provider writes preserve an existing login;
                         // only restore transactions interpret empty auth as an
                         // exact-generation deletion.
-                        crate::config::write_text_file(&get_codex_config_path(), cfg)
+                        crate::codex_config::write_codex_live_config_atomic(Some(cfg))
                             .map_err(|e| format!("写入 Codex config 失败: {e}"))
                     } else {
                         crate::codex_config::write_codex_live_atomic(auth, Some(cfg))

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -768,6 +768,7 @@ impl SkillService {
         skill: &DiscoverableSkill,
         current_app: &AppType,
     ) -> Result<InstalledSkill> {
+        crate::settings::ensure_skills_management_enabled()?;
         let ssot_dir = Self::get_ssot_dir()?;
 
         // 允许多级目录（如 a/b/c），但必须是安全的相对路径。
@@ -954,6 +955,7 @@ impl SkillService {
     /// 2. 从 SSOT 删除
     /// 3. 从数据库删除
     pub fn uninstall(db: &Arc<Database>, id: &str) -> Result<SkillUninstallResult> {
+        crate::settings::ensure_skills_management_enabled()?;
         let _state_guard = skill_state_write_guard();
 
         // 获取 skill 信息
@@ -1574,6 +1576,7 @@ impl SkillService {
         db: &Arc<Database>,
         target: SkillStorageLocation,
     ) -> Result<MigrationResult> {
+        crate::settings::ensure_skills_management_enabled()?;
         let _state_guard = skill_state_write_guard();
         let current = crate::settings::get_skill_storage_location();
         if current == target {
@@ -1836,6 +1839,7 @@ impl SkillService {
     /// 启用：复制到应用目录
     /// 禁用：从应用目录删除
     pub fn toggle_app(db: &Arc<Database>, id: &str, app: &AppType, enabled: bool) -> Result<()> {
+        crate::settings::ensure_skills_management_enabled()?;
         let _state_guard = skill_state_write_guard();
         // 获取当前 skill
         let mut skill = db
@@ -1867,6 +1871,7 @@ impl SkillService {
     ///
     /// 扫描各应用目录，找出未被 CC Switch 管理的 Skills
     pub fn scan_unmanaged(db: &Arc<Database>) -> Result<Vec<UnmanagedSkill>> {
+        crate::settings::ensure_skills_management_enabled()?;
         let _state_guard = skill_state_read_guard();
         let managed_skills = db.get_all_installed_skills()?;
         let managed_dirs: HashSet<String> = managed_skills
@@ -1934,6 +1939,7 @@ impl SkillService {
         db: &Arc<Database>,
         imports: Vec<ImportSkillSelection>,
     ) -> Result<Vec<InstalledSkill>> {
+        crate::settings::ensure_skills_management_enabled()?;
         let _state_guard = skill_state_write_guard();
         let ssot_dir = Self::get_ssot_dir()?;
         let agents_lock = parse_agents_lock();
@@ -2457,6 +2463,9 @@ impl SkillService {
 
     /// 同步所有已启用的 Skills 到指定应用
     pub fn sync_to_app(db: &Arc<Database>, app: &AppType) -> Result<()> {
+        if !crate::settings::skills_management_enabled() {
+            return Ok(());
+        }
         let _state_guard = skill_state_read_guard();
         Self::sync_to_app_unlocked(db, app)
     }
@@ -3642,6 +3651,7 @@ impl SkillService {
         zip_path: &Path,
         current_app: &AppType,
     ) -> Result<Vec<InstalledSkill>> {
+        crate::settings::ensure_skills_management_enabled()?;
         // 解压到临时目录
         let temp_guard = Self::extract_local_zip(zip_path)?;
         let temp_dir = temp_guard.path();

--- a/src-tauri/src/services/sync_protocol.rs
+++ b/src-tauri/src/services/sync_protocol.rs
@@ -149,6 +149,8 @@ impl RemoteLayout {
 pub(crate) fn build_local_snapshot(
     db: &crate::database::Database,
 ) -> Result<LocalSnapshot, AppError> {
+    crate::settings::ensure_all_resource_management_enabled()?;
+
     // Keep the DB's skill rows and the filesystem SSOT at one logical point in
     // time. Skill writers take the matching write guard around both mutations.
     let _skill_state_guard = skill_state_read_guard();
@@ -359,6 +361,8 @@ pub(crate) fn apply_snapshot(
     db_sql: &[u8],
     skills_zip: &[u8],
 ) -> Result<(), AppError> {
+    crate::settings::ensure_all_resource_management_enabled()?;
+
     let sql_str = std::str::from_utf8(db_sql).map_err(|e| {
         localized(
             "sync.sql_not_utf8",

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -21,6 +21,37 @@ fn default_true() -> bool {
     true
 }
 
+/// Controls which non-provider resources CC Switch is allowed to manage.
+///
+/// All fields default to `true` for backward compatibility with settings files
+/// written before this scope existed.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagementScope {
+    #[serde(default = "default_true")]
+    pub mcp: bool,
+    #[serde(default = "default_true")]
+    pub skills: bool,
+    #[serde(default = "default_true")]
+    pub sessions: bool,
+}
+
+impl Default for ManagementScope {
+    fn default() -> Self {
+        Self {
+            mcp: true,
+            skills: true,
+            sessions: true,
+        }
+    }
+}
+
+impl ManagementScope {
+    pub fn manages_all_resources(self) -> bool {
+        self.mcp && self.skills && self.sessions
+    }
+}
+
 /// 主页面显示的应用配置
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -345,6 +376,11 @@ pub struct CodexOfficialHistoryUnifyMigration {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppSettings {
+    // ===== 管理范围 =====
+    /// CC Switch 可管理的非供应商资源。关闭后不得扫描、导入、同步或改写对应 live 数据。
+    #[serde(default)]
+    pub management_scope: ManagementScope,
+
     // ===== 设备级 UI 设置 =====
     #[serde(default = "default_show_in_tray")]
     pub show_in_tray: bool,
@@ -520,6 +556,7 @@ fn default_session_auto_sync_enabled() -> bool {
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
+            management_scope: ManagementScope::default(),
             show_in_tray: true,
             minimize_to_tray_on_close: true,
             use_app_window_controls: false,
@@ -776,6 +813,66 @@ pub fn get_settings_for_frontend() -> AppSettings {
     settings
 }
 
+pub fn mcp_management_enabled() -> bool {
+    get_settings().management_scope.mcp
+}
+
+pub fn skills_management_enabled() -> bool {
+    get_settings().management_scope.skills
+}
+
+pub fn sessions_management_enabled() -> bool {
+    get_settings().management_scope.sessions
+}
+
+pub fn ensure_mcp_management_enabled() -> Result<(), AppError> {
+    if mcp_management_enabled() {
+        Ok(())
+    } else {
+        Err(AppError::localized(
+            "management.mcp.disabled",
+            "CC Switch 的 MCP 管理已关闭",
+            "MCP management is disabled in CC Switch",
+        ))
+    }
+}
+
+pub fn ensure_skills_management_enabled() -> Result<(), AppError> {
+    if skills_management_enabled() {
+        Ok(())
+    } else {
+        Err(AppError::localized(
+            "management.skills.disabled",
+            "CC Switch 的 Skills 管理已关闭",
+            "Skills management is disabled in CC Switch",
+        ))
+    }
+}
+
+pub fn ensure_sessions_management_enabled() -> Result<(), AppError> {
+    if sessions_management_enabled() {
+        Ok(())
+    } else {
+        Err(AppError::localized(
+            "management.sessions.disabled",
+            "CC Switch 的会话管理已关闭",
+            "Session management is disabled in CC Switch",
+        ))
+    }
+}
+
+pub fn ensure_all_resource_management_enabled() -> Result<(), AppError> {
+    if get_settings().management_scope.manages_all_resources() {
+        Ok(())
+    } else {
+        Err(AppError::localized(
+            "management.full_data.disabled",
+            "完整数据同步或恢复需要启用 MCP、Skills 和会话管理",
+            "Full data sync or restore requires MCP, Skills, and Session management to be enabled",
+        ))
+    }
+}
+
 pub fn update_settings(mut new_settings: AppSettings) -> Result<(), AppError> {
     new_settings.normalize_paths();
     save_settings_file(&new_settings)?;
@@ -865,7 +962,8 @@ pub fn mark_codex_official_history_unify_migrated_if_enabled(
 ) -> Result<bool, AppError> {
     let mut written = false;
     mutate_settings(|settings| {
-        if settings.unify_codex_session_history
+        if settings.management_scope.sessions
+            && settings.unify_codex_session_history
             && settings.unify_codex_migrate_existing.unwrap_or(false)
         {
             settings
@@ -983,13 +1081,11 @@ pub fn preserve_codex_official_auth_on_switch() -> bool {
 }
 
 pub fn unify_codex_session_history() -> bool {
-    settings_store()
-        .read()
-        .unwrap_or_else(|e| {
-            log::warn!("设置锁已毒化，使用恢复值: {e}");
-            e.into_inner()
-        })
-        .unify_codex_session_history
+    let settings = settings_store().read().unwrap_or_else(|e| {
+        log::warn!("设置锁已毒化，使用恢复值: {e}");
+        e.into_inner()
+    });
+    settings.management_scope.sessions && settings.unify_codex_session_history
 }
 
 // ===== 当前供应商管理函数 =====
@@ -1218,6 +1314,46 @@ mod tests {
         .expect("visible apps");
 
         assert!(!visible.is_visible(&AppType::ClaudeDesktop));
+    }
+
+    #[test]
+    fn old_settings_default_to_managing_all_resource_types() {
+        let settings: AppSettings =
+            serde_json::from_value(serde_json::json!({})).expect("deserialize old settings");
+
+        assert_eq!(settings.management_scope, ManagementScope::default());
+    }
+
+    #[test]
+    fn management_scope_accepts_independent_disabled_values() {
+        let settings: AppSettings = serde_json::from_value(serde_json::json!({
+            "managementScope": {
+                "mcp": false,
+                "skills": true,
+                "sessions": false
+            }
+        }))
+        .expect("deserialize management scope");
+
+        assert_eq!(
+            settings.management_scope,
+            ManagementScope {
+                mcp: false,
+                skills: true,
+                sessions: false,
+            }
+        );
+    }
+
+    #[test]
+    fn full_resource_management_requires_every_scope() {
+        assert!(ManagementScope::default().manages_all_resources());
+        assert!(!ManagementScope {
+            mcp: true,
+            skills: false,
+            sessions: true,
+        }
+        .manages_all_resources());
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -202,6 +202,9 @@ function App() {
   }, [currentView]);
 
   const { data: settingsData } = useSettingsQuery();
+  const managesMcp = settingsData?.managementScope?.mcp ?? true;
+  const managesSkills = settingsData?.managementScope?.skills ?? true;
+  const managesSessions = settingsData?.managementScope?.sessions ?? true;
   const useAppWindowControls =
     isLinux() && (settingsData?.useAppWindowControls ?? false);
   const dragBarHeight = useAppWindowControls ? 32 : DEFAULT_DRAG_BAR_HEIGHT;
@@ -226,6 +229,15 @@ function App() {
 
   // Fallback from sessions view when switching to an app without session support
   useEffect(() => {
+    if (
+      (!managesMcp && currentView === "mcp") ||
+      (!managesSkills &&
+        (currentView === "skills" || currentView === "skillsDiscovery")) ||
+      (!managesSessions && currentView === "sessions")
+    ) {
+      setCurrentView("providers");
+      return;
+    }
     if (currentView === "mcp" && sharedFeatureApp === "pi") {
       setCurrentView("providers");
       return;
@@ -243,7 +255,13 @@ function App() {
     ) {
       setCurrentView("providers");
     }
-  }, [sharedFeatureApp, currentView]);
+  }, [
+    sharedFeatureApp,
+    currentView,
+    managesMcp,
+    managesSessions,
+    managesSkills,
+  ]);
 
   const [editingProvider, setEditingProvider] = useState<Provider | null>(null);
   const [usageProvider, setUsageProvider] = useState<Provider | null>(null);
@@ -307,17 +325,18 @@ function App() {
       currentView === "openclawAgents");
   const { data: openclawHealthWarnings = [] } =
     useOpenClawHealth(isOpenClawView);
-  const hasSkillsSupport = sharedFeatureApp !== "openclaw";
+  const hasSkillsSupport = managesSkills && sharedFeatureApp !== "openclaw";
   const hasSessionSupport =
-    sharedFeatureApp === "claude" ||
-    sharedFeatureApp === "codex" ||
-    sharedFeatureApp === "grokbuild" ||
-    sharedFeatureApp === "opencode" ||
-    sharedFeatureApp === "openclaw" ||
-    sharedFeatureApp === "gemini" ||
-    sharedFeatureApp === "hermes" ||
-    sharedFeatureApp === "pi";
-  const hasMcpSupport = sharedFeatureApp !== "pi";
+    managesSessions &&
+    (sharedFeatureApp === "claude" ||
+      sharedFeatureApp === "codex" ||
+      sharedFeatureApp === "grokbuild" ||
+      sharedFeatureApp === "opencode" ||
+      sharedFeatureApp === "openclaw" ||
+      sharedFeatureApp === "gemini" ||
+      sharedFeatureApp === "hermes" ||
+      sharedFeatureApp === "pi");
+  const hasMcpSupport = managesMcp && sharedFeatureApp !== "pi";
 
   const {
     addProvider,
@@ -1031,6 +1050,7 @@ function App() {
         case "hermesMemory":
           return <HermesMemoryPanel />;
         case "skills":
+          if (!managesSkills) return null;
           return (
             <UnifiedSkillsPanel
               ref={unifiedSkillsPanelRef}
@@ -1044,6 +1064,7 @@ function App() {
             />
           );
         case "skillsDiscovery":
+          if (!managesSkills) return null;
           return (
             <SkillsPage
               ref={skillsPageRef}
@@ -1054,6 +1075,7 @@ function App() {
             />
           );
         case "mcp":
+          if (!managesMcp) return null;
           return (
             <UnifiedMcpPanel
               ref={mcpPanelRef}
@@ -1073,6 +1095,7 @@ function App() {
           );
 
         case "sessions":
+          if (!managesSessions) return null;
           return (
             <SessionManagerPage
               key={sharedFeatureApp}
@@ -1583,15 +1606,17 @@ function App() {
                         >
                           {activeApp === "hermes" ? (
                             <>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setCurrentView("skills")}
-                                className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
-                                title={t("skills.manage")}
-                              >
-                                <Wrench className="w-4 h-4" />
-                              </Button>
+                              {managesSkills && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setCurrentView("skills")}
+                                  className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
+                                  title={t("skills.manage")}
+                                >
+                                  <Wrench className="w-4 h-4" />
+                                </Button>
+                              )}
                               <Button
                                 variant="ghost"
                                 size="sm"
@@ -1660,15 +1685,17 @@ function App() {
                               >
                                 <Cpu className="w-4 h-4" />
                               </Button>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                onClick={() => setCurrentView("sessions")}
-                                className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
-                                title={t("sessionManager.title")}
-                              >
-                                <History className="w-4 h-4" />
-                              </Button>
+                              {managesSessions && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => setCurrentView("sessions")}
+                                  className="text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/5 w-8 px-2"
+                                  title={t("sessionManager.title")}
+                                >
+                                  <History className="w-4 h-4" />
+                                </Button>
+                              )}
                             </>
                           ) : (
                             <>

--- a/src/components/settings/CodexAuthSettings.tsx
+++ b/src/components/settings/CodexAuthSettings.tsx
@@ -105,13 +105,15 @@ export function CodexAuthSettings({
         }
       />
 
-      <ToggleRow
-        icon={<History className="h-4 w-4 text-sky-500" />}
-        title={t("settings.unifyCodexSessionHistory")}
-        description={t("settings.unifyCodexSessionHistoryDescription")}
-        checked={settings.unifyCodexSessionHistory ?? false}
-        onCheckedChange={handleUnifyHistoryChange}
-      />
+      {(settings.managementScope?.sessions ?? true) && (
+        <ToggleRow
+          icon={<History className="h-4 w-4 text-sky-500" />}
+          title={t("settings.unifyCodexSessionHistory")}
+          description={t("settings.unifyCodexSessionHistoryDescription")}
+          checked={settings.unifyCodexSessionHistory ?? false}
+          onCheckedChange={handleUnifyHistoryChange}
+        />
+      )}
 
       <ConfirmDialog
         isOpen={showEnableConfirm}

--- a/src/components/settings/ManagementScopeSettings.tsx
+++ b/src/components/settings/ManagementScopeSettings.tsx
@@ -1,0 +1,77 @@
+import { History, Server, Settings2, Wrench } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { ToggleRow } from "@/components/ui/toggle-row";
+import type { SettingsFormState } from "@/hooks/useSettings";
+import type { ManagementScope } from "@/types";
+
+interface ManagementScopeSettingsProps {
+  settings: SettingsFormState;
+  onChange: (updates: Partial<SettingsFormState>) => void | Promise<unknown>;
+}
+
+const DEFAULT_SCOPE: ManagementScope = {
+  mcp: true,
+  skills: true,
+  sessions: true,
+};
+
+export function ManagementScopeSettings({
+  settings,
+  onChange,
+}: ManagementScopeSettingsProps) {
+  const { t } = useTranslation();
+  const scope = settings.managementScope ?? DEFAULT_SCOPE;
+  const providersOnly = !scope.mcp && !scope.skills && !scope.sessions;
+
+  const updateScope = (updates: Partial<ManagementScope>) =>
+    onChange({ managementScope: { ...scope, ...updates } });
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center gap-2 pb-2 border-b border-border/40">
+        <Settings2 className="h-4 w-4 text-primary" />
+        <h3 className="text-sm font-medium">
+          {t("settings.managementScope.title")}
+        </h3>
+      </div>
+
+      <ToggleRow
+        icon={<Settings2 className="h-4 w-4 text-orange-500" />}
+        title={t("settings.managementScope.providersOnly")}
+        description={t("settings.managementScope.providersOnlyDescription")}
+        checked={providersOnly}
+        onCheckedChange={(checked) =>
+          onChange({
+            managementScope: checked
+              ? { mcp: false, skills: false, sessions: false }
+              : { ...DEFAULT_SCOPE },
+          })
+        }
+      />
+
+      <div className="space-y-3 pl-2 border-l border-border/50">
+        <ToggleRow
+          icon={<Server className="h-4 w-4 text-cyan-500" />}
+          title={t("settings.managementScope.mcp")}
+          description={t("settings.managementScope.mcpDescription")}
+          checked={scope.mcp}
+          onCheckedChange={(checked) => updateScope({ mcp: checked })}
+        />
+        <ToggleRow
+          icon={<Wrench className="h-4 w-4 text-emerald-500" />}
+          title={t("settings.managementScope.skills")}
+          description={t("settings.managementScope.skillsDescription")}
+          checked={scope.skills}
+          onCheckedChange={(checked) => updateScope({ skills: checked })}
+        />
+        <ToggleRow
+          icon={<History className="h-4 w-4 text-sky-500" />}
+          title={t("settings.managementScope.sessions")}
+          description={t("settings.managementScope.sessionsDescription")}
+          checked={scope.sessions}
+          onCheckedChange={(checked) => updateScope({ sessions: checked })}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -38,6 +38,7 @@ import { LanguageSettings } from "@/components/settings/LanguageSettings";
 import { ThemeSettings } from "@/components/settings/ThemeSettings";
 import { WindowSettings } from "@/components/settings/WindowSettings";
 import { AppVisibilitySettings } from "@/components/settings/AppVisibilitySettings";
+import { ManagementScopeSettings } from "@/components/settings/ManagementScopeSettings";
 import { SkillStorageLocationSettings } from "@/components/settings/SkillStorageLocationSettings";
 import { SkillSyncMethodSettings } from "@/components/settings/SkillSyncMethodSettings";
 import { TerminalSettings } from "@/components/settings/TerminalSettings";
@@ -105,7 +106,9 @@ export function SettingsPage({
     resetStatus,
   } = useImportExport({ onImportSuccess });
 
-  const { data: installedSkills } = useInstalledSkills();
+  const { data: installedSkills } = useInstalledSkills(
+    settings?.managementScope?.skills ?? true,
+  );
 
   const [activeTab, setActiveTab] = useState<string>("general");
   const [showRestartPrompt, setShowRestartPrompt] = useState(false);
@@ -257,23 +260,31 @@ export function SettingsPage({
                       onChange={(lang) => handleAutoSave({ language: lang })}
                     />
                     <ThemeSettings />
+                    <ManagementScopeSettings
+                      settings={settings}
+                      onChange={handleAutoSave}
+                    />
                     <AppVisibilitySettings
                       settings={settings}
                       onChange={handleAutoSave}
                     />
-                    <SkillStorageLocationSettings
-                      value={settings.skillStorageLocation ?? "cc_switch"}
-                      installedCount={installedSkills?.length ?? 0}
-                      onMigrated={(location) =>
-                        updateSettings({ skillStorageLocation: location })
-                      }
-                    />
-                    <SkillSyncMethodSettings
-                      value={settings.skillSyncMethod ?? "auto"}
-                      onChange={(method) =>
-                        handleAutoSave({ skillSyncMethod: method })
-                      }
-                    />
+                    {(settings.managementScope?.skills ?? true) && (
+                      <>
+                        <SkillStorageLocationSettings
+                          value={settings.skillStorageLocation ?? "cc_switch"}
+                          installedCount={installedSkills?.length ?? 0}
+                          onMigrated={(location) =>
+                            updateSettings({ skillStorageLocation: location })
+                          }
+                        />
+                        <SkillSyncMethodSettings
+                          value={settings.skillSyncMethod ?? "auto"}
+                          onChange={(method) =>
+                            handleAutoSave({ skillSyncMethod: method })
+                          }
+                        />
+                      </>
+                    )}
                     <CodexAuthSettings
                       settings={settings}
                       onChange={handleAutoSave}
@@ -522,6 +533,7 @@ export function SettingsPage({
                   onSessionAutoSyncEnabledChange={(sessionAutoSyncEnabled) =>
                     handleAutoSave({ sessionAutoSyncEnabled })
                   }
+                  managesSessions={settings?.managementScope?.sessions ?? true}
                 />
               </TabsContent>
             </div>

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -90,6 +90,7 @@ interface UsageDashboardProps {
   onSessionAutoSyncEnabledChange?: (
     next: boolean,
   ) => Promise<boolean> | boolean | void;
+  managesSessions?: boolean;
 }
 
 export function UsageDashboard({
@@ -97,6 +98,7 @@ export function UsageDashboard({
   onRefreshIntervalChange,
   sessionAutoSyncEnabled = true,
   onSessionAutoSyncEnabledChange,
+  managesSessions = true,
 }: UsageDashboardProps = {}) {
   const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
@@ -482,43 +484,45 @@ export function UsageDashboard({
       </div>
 
       <div className="space-y-4">
-        <div className="rounded-xl glass-card px-6 py-4 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <ScanSearch className="h-5 w-5 text-sky-500" />
-            <div>
-              <h3 className="text-base font-semibold">
-                {t("usage.sessionSync.title")}
-              </h3>
-              <p className="text-sm text-muted-foreground">
-                {t("usage.sessionSync.description")}
-              </p>
+        {managesSessions && (
+          <div className="rounded-xl glass-card px-6 py-4 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <ScanSearch className="h-5 w-5 text-sky-500" />
+              <div>
+                <h3 className="text-base font-semibold">
+                  {t("usage.sessionSync.title")}
+                </h3>
+                <p className="text-sm text-muted-foreground">
+                  {t("usage.sessionSync.description")}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-3 shrink-0">
+              {!sessionAutoSyncEnabled && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={syncingSession}
+                  onClick={() => void runManualSessionSync()}
+                >
+                  {syncingSession ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <RefreshCw className="mr-2 h-4 w-4" />
+                  )}
+                  {t("usage.sessionSync.syncNow")}
+                </Button>
+              )}
+              <Switch
+                checked={sessionAutoSyncEnabled}
+                onCheckedChange={(value) =>
+                  void onSessionAutoSyncEnabledChange?.(value)
+                }
+                aria-label={t("usage.sessionSync.title")}
+              />
             </div>
           </div>
-          <div className="flex items-center gap-3 shrink-0">
-            {!sessionAutoSyncEnabled && (
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={syncingSession}
-                onClick={() => void runManualSessionSync()}
-              >
-                {syncingSession ? (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                ) : (
-                  <RefreshCw className="mr-2 h-4 w-4" />
-                )}
-                {t("usage.sessionSync.syncNow")}
-              </Button>
-            )}
-            <Switch
-              checked={sessionAutoSyncEnabled}
-              onCheckedChange={(value) =>
-                void onSessionAutoSyncEnabledChange?.(value)
-              }
-              aria-label={t("usage.sessionSync.title")}
-            />
-          </div>
-        </div>
+        )}
 
         <Accordion
           type="multiple"
@@ -546,56 +550,60 @@ export function UsageDashboard({
               <PricingConfigPanel />
             </AccordionContent>
           </AccordionItem>
-          <AccordionItem
-            value="maintenance"
-            className="rounded-xl glass-card overflow-hidden"
-          >
-            <AccordionTrigger className="px-6 py-4 hover:no-underline hover:bg-muted/50 data-[state=open]:bg-muted/50">
-              <div className="flex items-center gap-3">
-                <DatabaseBackup className="h-5 w-5 text-orange-500" />
-                <div className="text-left">
-                  <h3 className="text-base font-semibold">
-                    {t("usage.rebuildCodex.title")}
-                  </h3>
-                  <p className="text-sm text-muted-foreground font-normal">
-                    {t("usage.rebuildCodex.description")}
-                  </p>
+          {managesSessions && (
+            <AccordionItem
+              value="maintenance"
+              className="rounded-xl glass-card overflow-hidden"
+            >
+              <AccordionTrigger className="px-6 py-4 hover:no-underline hover:bg-muted/50 data-[state=open]:bg-muted/50">
+                <div className="flex items-center gap-3">
+                  <DatabaseBackup className="h-5 w-5 text-orange-500" />
+                  <div className="text-left">
+                    <h3 className="text-base font-semibold">
+                      {t("usage.rebuildCodex.title")}
+                    </h3>
+                    <p className="text-sm text-muted-foreground font-normal">
+                      {t("usage.rebuildCodex.description")}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            </AccordionTrigger>
-            <AccordionContent className="px-6 pb-6 pt-4 border-t border-border/50">
-              <div className="flex items-center justify-between gap-4 rounded-lg border border-destructive/20 bg-destructive/5 p-4">
-                <p className="text-sm text-muted-foreground">
-                  {t("usage.rebuildCodex.warning")}
-                </p>
-                <Button
-                  variant="destructive"
-                  disabled={rebuildingCodex}
-                  onClick={() => setShowRebuildConfirm(true)}
-                  className="shrink-0"
-                >
-                  {rebuildingCodex ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : (
-                    <DatabaseBackup className="mr-2 h-4 w-4" />
-                  )}
-                  {t("usage.rebuildCodex.action")}
-                </Button>
-              </div>
-            </AccordionContent>
-          </AccordionItem>
+              </AccordionTrigger>
+              <AccordionContent className="px-6 pb-6 pt-4 border-t border-border/50">
+                <div className="flex items-center justify-between gap-4 rounded-lg border border-destructive/20 bg-destructive/5 p-4">
+                  <p className="text-sm text-muted-foreground">
+                    {t("usage.rebuildCodex.warning")}
+                  </p>
+                  <Button
+                    variant="destructive"
+                    disabled={rebuildingCodex}
+                    onClick={() => setShowRebuildConfirm(true)}
+                    className="shrink-0"
+                  >
+                    {rebuildingCodex ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <DatabaseBackup className="mr-2 h-4 w-4" />
+                    )}
+                    {t("usage.rebuildCodex.action")}
+                  </Button>
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          )}
         </Accordion>
       </div>
 
-      <ConfirmDialog
-        isOpen={showRebuildConfirm}
-        title={t("usage.rebuildCodex.confirmTitle")}
-        message={t("usage.rebuildCodex.confirmMessage")}
-        confirmText={t("usage.rebuildCodex.confirmAction")}
-        variant="destructive"
-        onConfirm={() => void rebuildCodexUsage()}
-        onCancel={() => setShowRebuildConfirm(false)}
-      />
+      {managesSessions && (
+        <ConfirmDialog
+          isOpen={showRebuildConfirm}
+          title={t("usage.rebuildCodex.confirmTitle")}
+          message={t("usage.rebuildCodex.confirmMessage")}
+          confirmText={t("usage.rebuildCodex.confirmAction")}
+          variant="destructive"
+          onConfirm={() => void rebuildCodexUsage()}
+          onCancel={() => setShowRebuildConfirm(false)}
+        />
+      )}
     </motion.div>
   );
 }

--- a/src/hooks/useSkills.ts
+++ b/src/hooks/useSkills.ts
@@ -22,12 +22,13 @@ import { runSequentialBulkAction } from "@/lib/utils/sequentialBulkAction";
  * 使用 staleTime: Infinity 和 placeholderData: keepPreviousData
  * 实现首次进入使用缓存，只有刷新时才重新获取
  */
-export function useInstalledSkills() {
+export function useInstalledSkills(enabled = true) {
   return useQuery({
     queryKey: ["skills", "installed"],
     queryFn: () => skillsApi.getInstalled(),
     staleTime: Infinity,
     placeholderData: keepPreviousData,
+    enabled,
   });
 }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -722,6 +722,17 @@
       "showProfileSwitcher": "Show project switcher",
       "showProfileSwitcherDescription": "Show the project switcher in the main page header"
     },
+    "managementScope": {
+      "title": "Management Scope",
+      "providersOnly": "Manage providers only",
+      "providersOnlyDescription": "When enabled, CC Switch will not scan, import, sync, or rewrite MCP, Skills, or session data",
+      "mcp": "Manage MCP",
+      "mcpDescription": "Allow CC Switch to import, enable, disable, and sync MCP configuration",
+      "skills": "Manage Skills",
+      "skillsDescription": "Allow CC Switch to install, migrate, sync, and back up Skills",
+      "sessions": "Manage sessions",
+      "sessionsDescription": "Allow CC Switch to scan, resume, delete sessions, and import session usage"
+    },
     "skillStorage": {
       "title": "Skill Storage Location",
       "description": "Choose where CC Switch stores the master copies of your skills",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -722,6 +722,17 @@
       "showProfileSwitcher": "プロジェクト切り替えを表示",
       "showProfileSwitcherDescription": "メイン画面上部にプロジェクト切り替えを表示します"
     },
+    "managementScope": {
+      "title": "管理範囲",
+      "providersOnly": "プロバイダーのみ管理",
+      "providersOnlyDescription": "有効にすると、CC Switch は MCP、Skills、セッションデータをスキャン、インポート、同期、または書き換えません",
+      "mcp": "MCP を管理",
+      "mcpDescription": "CC Switch による MCP 設定のインポート、有効化、無効化、同期を許可します",
+      "skills": "Skills を管理",
+      "skillsDescription": "CC Switch による Skills のインストール、移行、同期、バックアップを許可します",
+      "sessions": "セッションを管理",
+      "sessionsDescription": "CC Switch によるセッションのスキャン、再開、削除、使用量の取り込みを許可します"
+    },
     "skillStorage": {
       "title": "スキル保存場所",
       "description": "CC Switch がスキルのマスターコピーを保存するディレクトリを選択します",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -722,6 +722,17 @@
       "showProfileSwitcher": "顯示專案切換",
       "showProfileSwitcherDescription": "在主頁面頂部顯示專案切換入口"
     },
+    "managementScope": {
+      "title": "管理範圍",
+      "providersOnly": "僅管理供應商",
+      "providersOnlyDescription": "開啟後 CC Switch 不再掃描、匯入、同步或改寫 MCP、Skills 和會話資料",
+      "mcp": "管理 MCP",
+      "mcpDescription": "允許 CC Switch 匯入、啟停和同步各應用程式的 MCP 設定",
+      "skills": "管理 Skills",
+      "skillsDescription": "允許 CC Switch 安裝、遷移、同步和備份 Skills",
+      "sessions": "管理會話",
+      "sessionsDescription": "允許 CC Switch 掃描、恢復、刪除會話並匯入會話用量"
+    },
     "skillStorage": {
       "title": "Skills 儲存位置",
       "description": "選擇 CC Switch 存放 Skills 主副本的目錄",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -722,6 +722,17 @@
       "showProfileSwitcher": "显示项目切换",
       "showProfileSwitcherDescription": "在主页面顶部显示项目切换入口"
     },
+    "managementScope": {
+      "title": "管理范围",
+      "providersOnly": "仅管理供应商",
+      "providersOnlyDescription": "开启后 CC Switch 不再扫描、导入、同步或改写 MCP、Skills 和会话数据",
+      "mcp": "管理 MCP",
+      "mcpDescription": "允许 CC Switch 导入、启停和同步各应用的 MCP 配置",
+      "skills": "管理 Skills",
+      "skillsDescription": "允许 CC Switch 安装、迁移、同步和备份 Skills",
+      "sessions": "管理会话",
+      "sessionsDescription": "允许 CC Switch 扫描、恢复、删除会话并导入会话用量"
+    },
     "skillStorage": {
       "title": "Skills 存储位置",
       "description": "选择 CC Switch 存放 Skills 主副本的目录",

--- a/src/types.ts
+++ b/src/types.ts
@@ -338,6 +338,12 @@ export interface S3SyncSettings {
 
 export type RemoteSnapshotLayout = "current" | "legacy";
 
+export interface ManagementScope {
+  mcp: boolean;
+  skills: boolean;
+  sessions: boolean;
+}
+
 // 远端快照信息（下载前预览）
 export interface RemoteSnapshotInfo {
   deviceName: string;
@@ -355,6 +361,10 @@ export interface RemoteSnapshotInfo {
 // 应用设置类型（用于设置对话框与 Tauri API）
 // 存储在本地 ~/.cc-switch/settings.json，不随数据库同步
 export interface Settings {
+  // ===== 管理范围 =====
+  // 默认全部开启；关闭后 CCSwitch 不扫描、导入、同步或改写对应资源
+  managementScope?: ManagementScope;
+
   // ===== 设备级 UI 设置 =====
   // 是否在系统托盘（macOS 菜单栏）显示图标
   showInTray: boolean;

--- a/tests/components/ManagementScopeSettings.test.tsx
+++ b/tests/components/ManagementScopeSettings.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ManagementScopeSettings } from "@/components/settings/ManagementScopeSettings";
+import type { SettingsFormState } from "@/hooks/useSettings";
+
+const settingsWithScope = (
+  scope: SettingsFormState["managementScope"],
+): SettingsFormState =>
+  ({
+    managementScope: scope,
+  }) as SettingsFormState;
+
+describe("ManagementScopeSettings", () => {
+  it("turns off every non-provider manager from the providers-only switch", () => {
+    const onChange = vi.fn();
+    render(
+      <ManagementScopeSettings
+        settings={settingsWithScope({
+          mcp: true,
+          skills: true,
+          sessions: true,
+        })}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "settings.managementScope.providersOnly",
+      }),
+    );
+
+    expect(onChange).toHaveBeenCalledWith({
+      managementScope: { mcp: false, skills: false, sessions: false },
+    });
+  });
+
+  it("updates one resource without changing the others", () => {
+    const onChange = vi.fn();
+    render(
+      <ManagementScopeSettings
+        settings={settingsWithScope({
+          mcp: false,
+          skills: false,
+          sessions: false,
+        })}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("switch", {
+        name: "settings.managementScope.skills",
+      }),
+    );
+
+    expect(onChange).toHaveBeenCalledWith({
+      managementScope: { mcp: false, skills: true, sessions: false },
+    });
+  });
+});

--- a/tests/components/UsageDashboard.test.tsx
+++ b/tests/components/UsageDashboard.test.tsx
@@ -179,4 +179,18 @@ describe("UsageDashboard", () => {
       expect(screen.getByTestId("select-30000")).toBeInTheDocument(),
     );
   });
+
+  it("hides session management controls when sessions are unmanaged", () => {
+    renderDashboard({ managesSessions: false });
+
+    expect(
+      screen.queryByText("usage.sessionSync.title"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("usage.rebuildCodex.title"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("settings.advanced.pricing.title"),
+    ).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- Add independent management switches for MCP, Skills, and Sessions, plus a Manage providers only preset.
- Keep all switches enabled by default for backward compatibility.
- Hide disabled resource sections and reject their scans, imports, deep links, background tasks, and mutation commands.
- Preserve unmanaged MCP and Skills data during provider rewrites and profile autosave.
- Require every resource manager to be enabled for atomic full-data sync, import, and restore because protocol v2 stores db.sql and skills.zip as one snapshot.

## Related Issue

Related to #1876, which describes the risk of full-data sync overwriting independently managed Skills. This PR prevents unmanaged resources from participating in the atomic snapshot instead of introducing a partial-sync protocol.

## Screenshots

Not included. The settings control and hidden resource states are covered by component tests.

## Testing

- pnpm typecheck
- pnpm format:check
- pnpm build:renderer
- pnpm exec vitest run tests/components/ManagementScopeSettings.test.tsx tests/components/UsageDashboard.test.tsx (7 passed)
- Full frontend suite: 1074 passed; 2 pre-existing timeouts remain in tests/integration/App.test.tsx
- cargo fmt --check
- cargo clippy --all-targets
- Focused Rust management-scope and profile-preservation tests passed before the final Pi command guard; the post-guard all-target Clippy build passed. A later Cargo test retry was stopped because Cargo linked all Windows integration-test targets despite the name filter.

## Checklist

- [x] pnpm typecheck passes
- [x] pnpm format:check passes
- [x] cargo clippy passes
- [x] Updated i18n files for user-facing text