### PR TITLE
fix(tools): allow npm 12 postinstall in anchored npm commands, self-heal broken claude

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2692,15 +2692,24 @@ fn sibling_bin(bin_path: &str, exe: &str) -> Option<String> {
 /// commonly inherit only the system PATH, while nvm/fnm/mise keep Node in a
 /// user directory. Prefixing npm's sibling directory makes both npm and its
 /// transitive Node interpreter resolve to the installation we selected.
+///
+/// `pkg` 同时作为 `npm_config_allow_scripts` 的值注入：npm 12 起默认拦截未加白
+/// 名单包的 install 脚本（只 warning、exit 0），而 claude-code / grok /
+/// opencode / openclaw 的可执行入口全靠 postinstall 安置——被拦即得到"安装
+/// 成功"toast + tarball 原样 500 字节占位入口的假成功损坏（`claude --version`
+/// 报 "native binary not installed"，实测复现）。走环境变量而非 CLI 旗标
+/// `--allow-scripts=`：未知 npm_config_* 在 npm <12 会被静默忽略，旗标则会
+/// EUNKNOWNCONFIG 硬失败。按命令注入单一包名而非改写用户全局 allow-scripts
+/// 配置，权限最小化；平台二进制 optional 依赖本身不带脚本，不受影响。
 #[cfg(not(target_os = "windows"))]
-fn anchored_npm_command(bin_path: &str, args: &str) -> Option<String> {
+fn anchored_npm_command(bin_path: &str, pkg: &str, args: &str) -> Option<String> {
     let dir = parent_dir(bin_path);
     if dir.is_empty() {
         return None;
     }
     let npm = sibling_bin(bin_path, "npm")?;
     Some(format!(
-        "PATH={}:\"$PATH\" {} {args}",
+        "npm_config_allow_scripts={pkg} PATH={}:\"$PATH\" {} {args}",
         shell_single_quote(&dir),
         quote_path_if_spaced(&npm)
     ))
@@ -2841,8 +2850,8 @@ fn codex_repair_command(bin_path: &str, real: &str) -> Option<String> {
         return None;
     }
     let pkg = "@openai/codex";
-    let uninstall = anchored_npm_command(bin_path, &format!("uninstall -g {pkg}"))?;
-    let install = anchored_npm_command(bin_path, &format!("i -g {pkg}@latest"))?;
+    let uninstall = anchored_npm_command(bin_path, pkg, &format!("uninstall -g {pkg}"))?;
+    let install = anchored_npm_command(bin_path, pkg, &format!("i -g {pkg}@latest"))?;
     Some(format!("{uninstall} || true; {install}"))
 }
 
@@ -2851,6 +2860,39 @@ fn codex_repair_command(bin_path: &str, real: &str) -> Option<String> {
 /// 需要单独设计；先在本问题实际发生的 POSIX 平台落地。返回 None → 上游走正常锚定命令。
 #[cfg(target_os = "windows")]
 fn codex_repair_command(_bin_path: &str, _real: &str) -> Option<String> {
+    None
+}
+
+/// Claude Code 平台分发包损坏的自愈命令，与 `codex_repair_command` 同构。Claude Code 2.x
+/// 的 npm 包同为「纯 JS 壳 + 平台二进制 optional 依赖」，且比 codex 多一步：postinstall
+/// （`install.cjs`）负责把平台二进制安置成 `bin/claude.exe`。npm 12 起默认拦截未白名单包
+/// 的 install 脚本（只 warning、exit 0），被拦后主包"装好"但入口仍是 tarball 里的 500 字节
+/// 占位脚本——`claude --version` 报 "native binary not installed" 退出非 0，enumerate 标记
+/// runnable=false。此状态下 primary 的 `claude update`（占位脚本本体）必然失败白跑，
+/// 带 `npm_config_allow_scripts` 的 `npm i -g @latest` 实测可自愈（npm 12 对全局同版本
+/// 重装非 no-op，实测 `changed 2 packages`），但 uninstall+install 直达重装还顺带覆盖
+/// optional 依赖漏装的另一种损坏，与 codex 保持同一形态。白名单来源收窄理由见
+/// `codex_repair_command` 的 doc（brew formula 归 brew、volta/bun/system 无可靠 sibling npm）。
+#[cfg(not(target_os = "windows"))]
+fn claude_repair_command(bin_path: &str, real: &str) -> Option<String> {
+    if brew_formula_from_path(real).is_some() {
+        return None;
+    }
+    if !matches!(
+        infer_install_source(Path::new(bin_path)),
+        "nvm" | "fnm" | "mise" | "homebrew"
+    ) {
+        return None;
+    }
+    let pkg = "@anthropic-ai/claude-code";
+    let uninstall = anchored_npm_command(bin_path, pkg, &format!("uninstall -g {pkg}"))?;
+    let install = anchored_npm_command(bin_path, pkg, &format!("i -g {pkg}@latest"))?;
+    Some(format!("{uninstall} || true; {install}"))
+}
+
+/// Windows 暂不做 claude 分发自愈，理由同 `codex_repair_command` 的 Windows 版。
+#[cfg(target_os = "windows")]
+fn claude_repair_command(_bin_path: &str, _real: &str) -> Option<String> {
     None
 }
 
@@ -2883,7 +2925,7 @@ fn package_manager_anchored_command_from_paths(
         // self-update，上层会直接锚到 CLI 自身；否则返回 None 走静态兜底。
         _ => return None,
     }
-    anchored_npm_command(bin_path, &format!("i -g {pkg}@latest"))
+    anchored_npm_command(bin_path, pkg, &format!("i -g {pkg}@latest"))
 }
 
 /// 给定工具、原始 bin 路径（命令行命中的入口）、canonicalize 后的真身路径，
@@ -3535,6 +3577,14 @@ fn installs_anchored_command(tool: &str, installs: &[ToolInstallation]) -> Optio
     // 路径（且因 codex 不在 prefers_official_update，不会再跑会假成功掩盖损坏的 `codex update`）。
     if tool == "codex" && !inst.runnable {
         if let Some(cmd) = codex_repair_command(&inst.path, &real) {
+            return Some(cmd);
+        }
+    }
+    // Claude 平台分发包损坏自愈（npm 12 默认拦截 postinstall → 500 字节占位入口，
+    // 见 `claude_repair_command` doc）。runnable=true 的正常升级仍走下方
+    // `claude update || npm` 锚定链。
+    if tool == "claude" && !inst.runnable {
+        if let Some(cmd) = claude_repair_command(&inst.path, &real) {
             return Some(cmd);
         }
     }
@@ -5909,7 +5959,7 @@ mod tests {
             assert_eq!(
                 cmd.as_deref(),
                 Some(
-                    "PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @google/gemini-cli@latest"
+                    "npm_config_allow_scripts=@google/gemini-cli PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @google/gemini-cli@latest"
                 )
             );
         }
@@ -5924,7 +5974,7 @@ mod tests {
             assert_eq!(
                 cmd.as_deref(),
                 Some(
-                    "PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @xai-official/grok@latest"
+                    "npm_config_allow_scripts=@xai-official/grok PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @xai-official/grok@latest"
                 )
             );
         }
@@ -5941,7 +5991,7 @@ mod tests {
             );
             assert_eq!(
                 cmd.as_deref(),
-                Some("PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @openai/codex@latest")
+                Some("npm_config_allow_scripts=@openai/codex PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @openai/codex@latest")
             );
         }
 
@@ -5956,7 +6006,7 @@ mod tests {
             );
             assert_eq!(
                 cmd.as_deref(),
-                Some("/opt/homebrew/bin/openclaw update --yes || PATH='/opt/homebrew/bin':\"$PATH\" /opt/homebrew/bin/npm i -g openclaw@latest")
+                Some("/opt/homebrew/bin/openclaw update --yes || npm_config_allow_scripts=openclaw PATH='/opt/homebrew/bin':\"$PATH\" /opt/homebrew/bin/npm i -g openclaw@latest")
             );
         }
 
@@ -6083,7 +6133,7 @@ mod tests {
             assert_eq!(
                 cmd.as_deref(),
                 Some(
-                    "PATH='/Users/me/.local/share/fnm_multishells/12345_abc/bin':\"$PATH\" /Users/me/.local/share/fnm_multishells/12345_abc/bin/npm i -g @openai/codex@latest"
+                    "npm_config_allow_scripts=@openai/codex PATH='/Users/me/.local/share/fnm_multishells/12345_abc/bin':\"$PATH\" /Users/me/.local/share/fnm_multishells/12345_abc/bin/npm i -g @openai/codex@latest"
                 )
             );
         }
@@ -6097,7 +6147,7 @@ mod tests {
             );
             assert_eq!(
                 cmd.as_deref(),
-                Some("PATH='/Users/my name/.nvm/versions/node/v22/bin':\"$PATH\" '/Users/my name/.nvm/versions/node/v22/bin/npm' i -g @openai/codex@latest")
+                Some("npm_config_allow_scripts=@openai/codex PATH='/Users/my name/.nvm/versions/node/v22/bin':\"$PATH\" '/Users/my name/.nvm/versions/node/v22/bin/npm' i -g @openai/codex@latest")
             );
         }
 
@@ -6259,7 +6309,7 @@ mod tests {
             broken.runnable = false;
             assert_eq!(
                 installs_anchored_command("codex", &[broken]).as_deref(),
-                Some("PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm uninstall -g @openai/codex || true; PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @openai/codex@latest")
+                Some("npm_config_allow_scripts=@openai/codex PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm uninstall -g @openai/codex || true; npm_config_allow_scripts=@openai/codex PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @openai/codex@latest")
             );
         }
 
@@ -6271,7 +6321,7 @@ mod tests {
             let cmd = installs_anchored_command("codex", &[healthy]);
             assert_eq!(
                 cmd.as_deref(),
-                Some("PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @openai/codex@latest")
+                Some("npm_config_allow_scripts=@openai/codex PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @openai/codex@latest")
             );
             assert!(!cmd.unwrap().contains("uninstall"));
         }
@@ -6319,6 +6369,55 @@ mod tests {
                 Some("/Users/me/.bun/bin/bun add -g @openai/codex@latest")
             );
             assert!(!cmd.unwrap().contains("npm"));
+        }
+
+        #[test]
+        fn claude_missing_binary_self_heals_via_uninstall_install() {
+            // npm 12 起默认拦截未白名单包的 postinstall（只 warning、exit 0），装出来的
+            // claude-code 入口还是 tarball 里的 500 字节占位脚本——`--version` 退出非 0
+            // → enumerate 标记 runnable=false。此状态下 primary 的 `claude update`
+            // （占位脚本本体）必然失败白跑；与 codex 同理由 uninstall+install 重装自愈，
+            // npm 端带 `npm_config_allow_scripts` 让 postinstall 真正跑起来。
+            let mut broken = inst("/Users/me/.nvm/versions/node/v22.14.0/bin/claude", true);
+            broken.runnable = false;
+            assert_eq!(
+                installs_anchored_command("claude", &[broken]).as_deref(),
+                Some("npm_config_allow_scripts=@anthropic-ai/claude-code PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm uninstall -g @anthropic-ai/claude-code || true; npm_config_allow_scripts=@anthropic-ai/claude-code PATH='/Users/me/.nvm/versions/node/v22.14.0/bin':\"$PATH\" /Users/me/.nvm/versions/node/v22.14.0/bin/npm i -g @anthropic-ai/claude-code@latest")
+            );
+        }
+
+        #[test]
+        fn claude_broken_homebrew_npm_global_self_heals() {
+            // Homebrew node 的 npm 全局包（real 在 lib/node_modules，非 Cellar）同样
+            // 归 sibling npm 自愈管辖——npm 12 拦脚本问题在这类安装上同样致命。
+            let mut broken = inst("/opt/homebrew/bin/claude", true);
+            broken.runnable = false;
+            broken.real = std::path::PathBuf::from(
+                "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe",
+            );
+            assert!(
+                installs_anchored_command("claude", &[broken])
+                    .unwrap()
+                    .contains("uninstall -g @anthropic-ai/claude-code"),
+                "homebrew npm-global broken claude should self-heal via npm reinstall"
+            );
+        }
+
+        #[test]
+        fn claude_runnable_keeps_official_update_chain() {
+            // 正常（runnable=true）的 claude 升级不走重装：仍是官方 self-update 优先、
+            // 带脚本白名单的锚定 npm 兜底。
+            let healthy = inst("/Users/me/.nvm/versions/node/v22.14.0/bin/claude", true);
+            let cmd = installs_anchored_command("claude", &[healthy]).unwrap();
+            assert!(
+                cmd.starts_with("/Users/me/.nvm/versions/node/v22.14.0/bin/claude update || "),
+                "official update should stay primary: {cmd}"
+            );
+            assert!(
+                cmd.contains("npm_config_allow_scripts=@anthropic-ai/claude-code"),
+                "npm fallback should carry allow-scripts env: {cmd}"
+            );
+            assert!(!cmd.contains("uninstall"));
         }
 
         #[test]

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -2979,7 +2979,22 @@ fn anchored_command_from_paths(tool: &str, bin_path: &str, real_target: &str) ->
         return package_command;
     }
     if prefers_official_update(tool, LifecycleCommandShell::Posix) {
-        let update = anchored_official_update_command(tool, bin_path)?;
+        let mut update = anchored_official_update_command(tool, bin_path)?;
+        // npm-installed Claude invokes npm from its own updater. npm 12 can skip
+        // postinstall and still exit 0, so the fallback alone cannot protect it.
+        // Match the sibling-npm sources above; native/formula installs have
+        // already returned, and other package managers keep their own policy.
+        if tool == "claude"
+            && matches!(
+                infer_install_source(Path::new(bin_path)),
+                "nvm" | "fnm" | "mise" | "homebrew"
+            )
+        {
+            update = format!(
+                "npm_config_allow_scripts={} {update}",
+                npm_package_for(tool)?
+            );
+        }
         return Some(match package_command {
             Some(fallback) => chain_update_commands(update, fallback, LifecycleCommandShell::Posix),
             None => update,
@@ -6405,19 +6420,116 @@ mod tests {
 
         #[test]
         fn claude_runnable_keeps_official_update_chain() {
-            // 正常（runnable=true）的 claude 升级不走重装：仍是官方 self-update 优先、
-            // 带脚本白名单的锚定 npm 兜底。
-            let healthy = inst("/Users/me/.nvm/versions/node/v22.14.0/bin/claude", true);
-            let cmd = installs_anchored_command("claude", &[healthy]).unwrap();
-            assert!(
-                cmd.starts_with("/Users/me/.nvm/versions/node/v22.14.0/bin/claude update || "),
-                "official update should stay primary: {cmd}"
-            );
-            assert!(
-                cmd.contains("npm_config_allow_scripts=@anthropic-ai/claude-code"),
-                "npm fallback should carry allow-scripts env: {cmd}"
-            );
-            assert!(!cmd.contains("uninstall"));
+            for path in [
+                "/Users/me/.nvm/versions/node/v22.14.0/bin/claude",
+                "/Users/me/.local/share/fnm_multishells/12345_abc/bin/claude",
+                "/Users/me/.local/share/mise/installs/node/22/bin/claude",
+                "/opt/homebrew/bin/claude",
+            ] {
+                let cmd = installs_anchored_command("claude", &[inst(path, true)]).unwrap();
+                let (primary, fallback) = cmd.split_once(" || ").unwrap();
+                assert_eq!(
+                    primary,
+                    format!("npm_config_allow_scripts=@anthropic-ai/claude-code {path} update")
+                );
+                assert!(fallback.starts_with("npm_config_allow_scripts=@anthropic-ai/claude-code "));
+                assert!(!cmd.contains("uninstall"));
+            }
+        }
+
+        #[test]
+        fn claude_other_install_sources_keep_their_update_policy() {
+            for (path, real, expected) in [
+                (
+                    "/Users/me/.nvm/versions/node/v22/bin/claude",
+                    "/Users/me/.local/share/claude/versions/2.1.146",
+                    "/Users/me/.nvm/versions/node/v22/bin/claude update",
+                ),
+                (
+                    "/opt/homebrew/bin/claude",
+                    "/opt/homebrew/Cellar/claude-code/2.1.146/bin/claude",
+                    "/opt/homebrew/bin/brew upgrade claude-code",
+                ),
+                (
+                    "/Users/me/.volta/bin/claude",
+                    "/Users/me/.volta/bin/claude",
+                    "/Users/me/.volta/bin/claude update || /Users/me/.volta/bin/volta install @anthropic-ai/claude-code",
+                ),
+                (
+                    "/Users/me/.bun/bin/claude",
+                    "/Users/me/.bun/bin/claude",
+                    "/Users/me/.bun/bin/claude update || /Users/me/.bun/bin/bun add -g @anthropic-ai/claude-code@latest",
+                ),
+                (
+                    "/usr/local/bin/claude",
+                    "/usr/local/bin/claude",
+                    "/usr/local/bin/claude update",
+                ),
+            ] {
+                assert_eq!(
+                    anchored_command_from_paths("claude", path, real).as_deref(),
+                    Some(expected)
+                );
+            }
+        }
+
+        #[test]
+        fn claude_updater_child_and_fallback_receive_scoped_script_permission() {
+            use std::os::unix::fs::PermissionsExt;
+            use std::process::Command;
+
+            let temp = tempfile::tempdir().expect("temp dir should be created");
+            let bin = temp.path().join("home dir/.nvm/versions/node/v22/bin");
+            std::fs::create_dir_all(&bin).unwrap();
+            let claude = bin.join("claude");
+            let npm = bin.join("npm");
+            std::fs::write(
+                &claude,
+                "#!/bin/sh\n[ \"$1\" = update ] || exit 99\nnpm install -g @anthropic-ai/claude-code@latest\nexit \"$TEST_CLAUDE_EXIT\"\n",
+            )
+            .unwrap();
+            std::fs::write(
+                &npm,
+                "#!/bin/sh\nprintf '%s|%s\\n' \"${npm_config_allow_scripts-unset}\" \"$*\"\n[ \"$1\" != i ] || exit \"$TEST_FALLBACK_EXIT\"\n",
+            )
+            .unwrap();
+            for executable in [&claude, &npm] {
+                std::fs::set_permissions(executable, std::fs::Permissions::from_mode(0o755))
+                    .unwrap();
+            }
+            let command =
+                installs_anchored_command("claude", &[inst(&claude.to_string_lossy(), true)])
+                    .unwrap();
+            let script =
+                format!("set -e\n{command}\nprintf 'after|%s\\n' \"$npm_config_allow_scripts\"");
+            let primary = "@anthropic-ai/claude-code|install -g @anthropic-ai/claude-code@latest\n";
+            let fallback = "@anthropic-ai/claude-code|i -g @anthropic-ai/claude-code@latest\n";
+            for (primary_exit, fallback_exit, expected_code, expected_output) in [
+                ("0", "0", 0, format!("{primary}after|previous-package\n")),
+                (
+                    "1",
+                    "0",
+                    0,
+                    format!("{primary}{fallback}after|previous-package\n"),
+                ),
+                ("1", "42", 42, format!("{primary}{fallback}")),
+            ] {
+                let output = Command::new("/bin/bash")
+                    .args(["-c", &script])
+                    .env("PATH", format!("{}:/usr/bin:/bin", bin.display()))
+                    .env("npm_config_allow_scripts", "previous-package")
+                    .env("TEST_CLAUDE_EXIT", primary_exit)
+                    .env("TEST_FALLBACK_EXIT", fallback_exit)
+                    .output()
+                    .expect("Claude update chain should start");
+                assert_eq!(
+                    output.status.code(),
+                    Some(expected_code),
+                    "{}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                assert_eq!(String::from_utf8_lossy(&output.stdout), expected_output);
+            }
         }
 
         #[test]


### PR DESCRIPTION
## Summary / 概述

npm 12 会拦截未授权的安装脚本但仍返回成功，导致 CLI 升级显示成功、Claude 入口实际不可运行。本 PR 为锚定 npm 命令传递单包 `npm_config_allow_scripts`，并让 npm 来源的 Claude 主更新命令继承同一许可。

| 场景 | 修复后 |
|---|---|
| 正常 npm 来源 Claude：主 `claude update` 调用 npm | 主命令收到许可；成功则不运行备用安装 |
| 主更新失败 | 保留原有备用 npm 安装和退出码行为 |
| 已损坏的 npm 来源 Claude | 受来源限制的卸载、重装路径恢复入口 |

许可只作用于命令进程，不改写用户全局 npm 配置。Claude 主更新/修复限定于 nvm、fnm、mise、Homebrew npm；原生安装、Homebrew formula、Volta、Bun、未知来源和 Windows 更新策略不扩展。可独立合并。

## Related Issue / 关联 Issue

Fixes the primary-updater gap identified in [the P1 review](https://github.com/farion1231/cc-switch/pull/7099#discussion_r3930370152).

## Verification / 验证

**新增真实安装验证（macOS arm64，2026-09-16）：**Node 26.8.2 + npm 12.0.0 + Claude Code 2.1.273，隔离 npm prefix/cache/config：

| 操作 | 结果 |
|---|---|
| 未设 allow-scripts，安装同一版本 | npm 退出 0，但明确报告 postinstall blocked；`claude --version` 退出 1，提示 native binary not installed |
| 设置 `npm_config_allow_scripts=@anthropic-ai/claude-code`，卸载后重装 | npm 退出 0；`claude --version` 退出 0，输出 `2.1.273 (Claude Code)` |

兼容验证：Node 22.22.3 + npm 11.16.0，带相同单包许可安装同一 Claude 版本也成功，版本命令退出 0。

现有真实 Bash 子进程回归覆盖 Claude→npm 的许可继承、主命令成功短路、备用命令成功/失败、含空格路径和父 shell 环境不泄漏；测试使用模拟 CLI，与上表的真实 npm 安装验证分开。

本轮在 macOS arm64 将四个 PR 与最新 `main` (`06082e18`) 组合验证（本地验证提交 `d7c73d04`）：Cargo **3,034 passed / 0 failed / 9 ignored**，`cargo fmt --check` 与 `cargo clippy --locked --offline -- -D warnings` 通过。三个 `services::coding_plan::tests::transient` 网络测试单独进程运行，其余测试完整运行；它们在未隔离的运行中受到进程全局代理状态影响，曾拿到代理 502。

同一组合工作树的 `pnpm typecheck`、`pnpm format:check` 通过；前端 **138 files / 1,120 tests passed**（`vitest run --maxWorkers=2 --minWorkers=2`）。

<details>
<summary>Existing head validation and limits / 当前提交验证与边界</summary>

生产代码仍是 `f8585b5f`；本轮未修改代码。该提交的 GitHub 后端 CI（Linux、macOS、Windows、Windows + WSL2）已通过；前端检查按后端改动规则跳过。此前本地 Cargo 全量 2,907 通过、5 ignored，前端 1,074 通过，fmt / Clippy / typecheck / format 均通过。

真实安装验证运行固定版本的 npm 安装/修复路径，没有对用户全局安装执行升级，也没有把真实 `claude update` 的网络更新当作已验证。主更新内部调用 npm 的环境继承由子进程回归验证。npm 包使用官方 12.0.0 发布包并校验 integrity；Claude 包经配置的 registry mirror 获取，由 npm 校验包完整性。

</details>

## Checklist / 检查清单

- [x] `pnpm typecheck` / `pnpm format:check`：现有 head 已验证。
- [x] `cargo clippy`：现有 head 已验证。
- [x] 无用户可见文案变化，无需 i18n 更新。
