### PR TITLE
fix(providers): preserve "apply common config" checkbox when editing suppliers

### DIFF
--- a/src/components/providers/EditProviderDialog.tsx
+++ b/src/components/providers/EditProviderDialog.tsx
@@ -17,6 +17,7 @@ import {
   type ManagedAuthProvider,
 } from "@/lib/api";
 import { extractCodexExperimentalBearerToken } from "@/utils/providerConfigUtils";
+import { useInitialDataCommonConfig } from "@/components/providers/forms/hooks/useInitialDataCommonConfig";
 
 interface EditProviderDialogProps {
   open: boolean;
@@ -271,6 +272,16 @@ export function EditProviderDialog({
     return base;
   }, [liveSettings, provider?.settingsConfig, provider?.category, appId]); // 只依赖表单初始化所需字段，不依赖整个 provider
 
+  // 存储快照按设计不含通用配置片段（`meta.commonConfigEnabled` 是单一真相），
+  // 在这里补回，使表单拿到的就是"合并后"的最终配置。
+  const mergedSettingsConfig = useInitialDataCommonConfig({
+    appId,
+    commonConfigEnabled: provider?.meta?.commonConfigEnabled,
+    settingsConfig: initialSettingsConfig,
+    // 等 live 读取有结论后再合并，避免 DB 快照与 live 快照各合并一次
+    enabled: open && hasLoadedLive,
+  });
+
   // 固定 initialData，防止 provider 对象更新时重置表单
   const initialData = useMemo(() => {
     if (!provider) return null;
@@ -278,7 +289,7 @@ export function EditProviderDialog({
       name: provider.name,
       notes: provider.notes,
       websiteUrl: provider.websiteUrl,
-      settingsConfig: initialSettingsConfig,
+      settingsConfig: mergedSettingsConfig,
       category: provider.category,
       meta: provider.meta,
       icon: provider.icon,
@@ -288,7 +299,7 @@ export function EditProviderDialog({
     open, // 修复：编辑保存后再次打开显示旧数据，依赖 open 确保每次打开时重新读取最新 provider 数据
     provider?.id, // 只依赖 ID，provider 对象更新不会触发重新计算
     provider?.meta, // 供应商元数据变化时重新初始化表单
-    initialSettingsConfig,
+    mergedSettingsConfig,
   ]);
 
   const handleSubmit = useCallback(

--- a/src/components/providers/forms/hooks/index.ts
+++ b/src/components/providers/forms/hooks/index.ts
@@ -5,6 +5,7 @@ export { useModelState } from "./useModelState";
 export { useCodexConfigState } from "./useCodexConfigState";
 export { useApiKeyLink } from "./useApiKeyLink";
 export { useTemplateValues } from "./useTemplateValues";
+export { useCommonConfigSyncGuard } from "./useCommonConfigSyncGuard";
 export { useCommonConfigSnippet } from "./useCommonConfigSnippet";
 export { useCodexCommonConfig } from "./useCodexCommonConfig";
 export { useSpeedTestEndpoints } from "./useSpeedTestEndpoints";

--- a/src/components/providers/forms/hooks/index.ts
+++ b/src/components/providers/forms/hooks/index.ts
@@ -6,6 +6,7 @@ export { useCodexConfigState } from "./useCodexConfigState";
 export { useApiKeyLink } from "./useApiKeyLink";
 export { useTemplateValues } from "./useTemplateValues";
 export { useCommonConfigSyncGuard } from "./useCommonConfigSyncGuard";
+export { useInitialDataCommonConfig } from "./useInitialDataCommonConfig";
 export { useCommonConfigSnippet } from "./useCommonConfigSnippet";
 export { useCodexCommonConfig } from "./useCodexCommonConfig";
 export { useSpeedTestEndpoints } from "./useSpeedTestEndpoints";

--- a/src/components/providers/forms/hooks/useCodexCommonConfig.ts
+++ b/src/components/providers/forms/hooks/useCodexCommonConfig.ts
@@ -52,6 +52,11 @@ export function useCodexCommonConfig({
   selectedPresetId,
 }: UseCodexCommonConfigProps) {
   const { t } = useTranslation();
+  // 编辑态下 meta.commonConfigEnabled 是“是否应用通用配置”的权威来源：
+  // 后端保存时会从供应商快照中剥离通用配置片段（runtime overlay），
+  // 因此不能在编辑态用“当前 config.toml 里是否包含片段”来反推勾选状态。
+  const isEditMode = Boolean(initialData);
+  const hasExplicitInitialEnabled = initialEnabled !== undefined;
   const [useCommonConfig, setUseCommonConfig] = useState(false);
   const [commonConfigSnippet, setCommonConfigSnippetState] = useState<string>(
     DEFAULT_CODEX_COMMON_CONFIG_SNIPPET,
@@ -204,6 +209,11 @@ export function useCodexCommonConfig({
     const hasCommon =
       initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
 
+    // 勾选状态先落定，再异步合并片段用于编辑预览。meta.commonConfigEnabled
+    // 是权威来源：即使后端合并失败或被外部改动作废，也不能把勾选翻掉。
+    setCommonConfigError("");
+    setUseCommonConfig(hasCommon);
+
     // 如果应该启用通用配置但配置中还没有，则自动添加
     if (hasCommon && !inferredHasCommon && parsedSnippet.hasContent) {
       let cancelled = false;
@@ -219,12 +229,9 @@ export function useCodexCommonConfig({
         }
         if (error) {
           setCommonConfigError(error);
-          setUseCommonConfig(false);
           return;
         }
 
-        setCommonConfigError("");
-        setUseCommonConfig(true);
         isUpdatingFromCommonConfig.current = true;
         onConfigChange(updatedConfig);
         setTimeout(() => {
@@ -235,9 +242,6 @@ export function useCodexCommonConfig({
         cancelled = true;
       };
     }
-
-    setCommonConfigError("");
-    setUseCommonConfig(hasCommon);
   }, [
     codexConfig,
     commonConfigSnippet,
@@ -482,9 +486,14 @@ export function useCodexCommonConfig({
     ],
   );
 
-  // 当配置变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）
+  // 当配置变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）。
+  // 编辑态且 meta.commonConfigEnabled 有显式值时跳过内容推断，防止打开编辑界面时
+  // 被“快照中暂无片段”的中间态 / 异步初始化竞态覆盖成未勾选。
   useEffect(() => {
     if (isUpdatingFromCommonConfig.current || isLoading) {
+      return;
+    }
+    if (isEditMode && hasExplicitInitialEnabled) {
       return;
     }
     const parsedSnippet = parseCommonConfigSnippet(commonConfigSnippet);
@@ -497,7 +506,14 @@ export function useCodexCommonConfig({
       commonConfigSnippet,
     );
     setUseCommonConfig(hasCommon);
-  }, [codexConfig, commonConfigSnippet, isLoading, parseCommonConfigSnippet]);
+  }, [
+    codexConfig,
+    commonConfigSnippet,
+    isLoading,
+    parseCommonConfigSnippet,
+    isEditMode,
+    hasExplicitInitialEnabled,
+  ]);
 
   // 从编辑器当前内容提取通用配置片段
   const handleExtract = useCallback(async () => {

--- a/src/components/providers/forms/hooks/useCodexCommonConfig.ts
+++ b/src/components/providers/forms/hooks/useCodexCommonConfig.ts
@@ -4,6 +4,7 @@ import { parse as parseToml } from "smol-toml";
 import { hasTomlCommonConfigSnippet } from "@/utils/providerConfigUtils";
 import { configApi } from "@/lib/api";
 import { normalizeTomlText } from "@/utils/textNormalization";
+import { useCommonConfigSyncGuard } from "./useCommonConfigSyncGuard";
 
 /**
  * 合并/剥离通用配置片段（走后端 toml_edit，保注释、保键序）。
@@ -52,11 +53,6 @@ export function useCodexCommonConfig({
   selectedPresetId,
 }: UseCodexCommonConfigProps) {
   const { t } = useTranslation();
-  // 编辑态下 meta.commonConfigEnabled 是“是否应用通用配置”的权威来源：
-  // 后端保存时会从供应商快照中剥离通用配置片段（runtime overlay），
-  // 因此不能在编辑态用“当前 config.toml 里是否包含片段”来反推勾选状态。
-  const isEditMode = Boolean(initialData);
-  const hasExplicitInitialEnabled = initialEnabled !== undefined;
   const [useCommonConfig, setUseCommonConfig] = useState(false);
   const [commonConfigSnippet, setCommonConfigSnippetState] = useState<string>(
     DEFAULT_CODEX_COMMON_CONFIG_SNIPPET,
@@ -65,12 +61,15 @@ export function useCodexCommonConfig({
   const [isLoading, setIsLoading] = useState(true);
   const [isExtracting, setIsExtracting] = useState(false);
 
-  // 用于跟踪是否正在通过通用配置更新
-  const isUpdatingFromCommonConfig = useRef(false);
+  // 程序性配置写入的回显保护（替代 setTimeout 重置标记）
+  const syncGuard = useCommonConfigSyncGuard();
   // 用于跟踪新建模式是否已初始化默认勾选
   const hasInitializedNewMode = useRef(false);
-  // 用于跟踪编辑模式是否已初始化显式开关/预览
-  const hasInitializedEditMode = useRef(false);
+  // 用于识别 initialData 被 live 配置替换后的“codexConfig 重置窗口”
+  const lastInitialDataRef = useRef<typeof initialData | undefined>(undefined);
+  const lastInitialEnabledRef = useRef<boolean | undefined>(undefined);
+  const preResetConfigRef = useRef<string | null>(null);
+  const pendingResetConfigRef = useRef<string | null>(null);
   // 后端 TOML 合并是异步的：连续操作（快速点开关、连点保存）可能乱序
   // 返回。每个写 config 的异步操作在发起时领取递增序号，结果落地前
   // 校验自己仍是最新一次；过期结果直接丢弃，保证最后一次操作胜出。
@@ -95,8 +94,9 @@ export function useCodexCommonConfig({
   // 当预设变化时，重置初始化标记，使新预设能够重新触发初始化逻辑
   useEffect(() => {
     hasInitializedNewMode.current = false;
-    hasInitializedEditMode.current = false;
-  }, [selectedPresetId, initialEnabled]);
+    lastInitialDataRef.current = undefined;
+    lastInitialEnabledRef.current = undefined;
+  }, [selectedPresetId]);
 
   const parseCommonConfigSnippet = useCallback((snippetString: string) => {
     const trimmed = snippetString.trim();
@@ -174,83 +174,41 @@ export function useCodexCommonConfig({
     };
   }, []);
 
-  // 初始化时检查通用配置片段（编辑模式）
+  // 编辑态初始化 / live 配置刷新：勾选状态以 meta.commonConfigEnabled 为准，
+  // 记录 codexConfig 即将重置到的快照值，由下面的同步 effect 等待重置落地后补回预览。
   useEffect(() => {
+    if (!initialData?.settingsConfig || isLoading) return;
     if (
-      !initialData?.settingsConfig ||
-      isLoading ||
-      hasInitializedEditMode.current
+      lastInitialDataRef.current === initialData &&
+      lastInitialEnabledRef.current === initialEnabled
     ) {
       return;
     }
 
-    hasInitializedEditMode.current = true;
+    lastInitialDataRef.current = initialData;
+    lastInitialEnabledRef.current = initialEnabled;
 
-    const parsedSnippet = parseCommonConfigSnippet(commonConfigSnippet);
-    if (parsedSnippet.error) {
-      if (commonConfigSnippet.trim()) {
-        setCommonConfigError(parsedSnippet.error);
-      }
-      setUseCommonConfig(false);
-      return;
-    }
-
-    const config =
+    const expectedConfig =
       typeof initialData.settingsConfig.config === "string"
         ? initialData.settingsConfig.config
         : "";
     const inferredHasCommon = hasTomlCommonConfigSnippet(
-      config,
+      expectedConfig,
       commonConfigSnippet,
     );
-
-    // 优先级：显式设置的 initialEnabled > 从配置推断的值
-    // 如果 initialEnabled 为 undefined，使用推断值
     const hasCommon =
       initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
 
-    // 勾选状态先落定，再异步合并片段用于编辑预览。meta.commonConfigEnabled
-    // 是权威来源：即使后端合并失败或被外部改动作废，也不能把勾选翻掉。
     setCommonConfigError("");
     setUseCommonConfig(hasCommon);
-
-    // 如果应该启用通用配置但配置中还没有，则自动添加
-    if (hasCommon && !inferredHasCommon && parsedSnippet.hasContent) {
-      let cancelled = false;
-      const seq = ++tomlOpSeqRef.current;
-      (async () => {
-        const { updatedConfig, error } = await applyTomlSnippet(
-          codexConfig,
-          commonConfigSnippet,
-          true,
-        );
-        if (cancelled || isTomlOpStale(seq, codexConfig)) {
-          return;
-        }
-        if (error) {
-          setCommonConfigError(error);
-          return;
-        }
-
-        isUpdatingFromCommonConfig.current = true;
-        onConfigChange(updatedConfig);
-        setTimeout(() => {
-          isUpdatingFromCommonConfig.current = false;
-        }, 0);
-      })();
-      return () => {
-        cancelled = true;
-      };
-    }
+    preResetConfigRef.current = codexConfig;
+    pendingResetConfigRef.current = hasCommon ? expectedConfig : null;
   }, [
-    codexConfig,
-    commonConfigSnippet,
     initialData,
     initialEnabled,
+    commonConfigSnippet,
     isLoading,
-    isTomlOpStale,
-    onConfigChange,
-    parseCommonConfigSnippet,
+    codexConfig,
   ]);
 
   // 新建模式：如果通用配置片段存在且有效，默认启用
@@ -275,16 +233,20 @@ export function useCodexCommonConfig({
 
     let cancelled = false;
     const seq = ++tomlOpSeqRef.current;
+    const base = codexConfig;
+    syncGuard.begin(base);
     (async () => {
       const { updatedConfig, error } = await applyTomlSnippet(
-        codexConfig,
+        base,
         commonConfigSnippet,
         true,
       );
-      if (cancelled || isTomlOpStale(seq, codexConfig)) {
+      if (cancelled || isTomlOpStale(seq, base)) {
+        syncGuard.abort();
         return;
       }
       if (error) {
+        syncGuard.abort();
         setCommonConfigError(error);
         setUseCommonConfig(false);
         return;
@@ -292,14 +254,12 @@ export function useCodexCommonConfig({
 
       setCommonConfigError("");
       setUseCommonConfig(true);
-      isUpdatingFromCommonConfig.current = true;
+      syncGuard.schedule(base, updatedConfig);
       onConfigChange(updatedConfig);
-      setTimeout(() => {
-        isUpdatingFromCommonConfig.current = false;
-      }, 0);
     })();
     return () => {
       cancelled = true;
+      syncGuard.abort();
     };
   }, [
     initialData,
@@ -333,16 +293,20 @@ export function useCodexCommonConfig({
         return;
       }
 
+      const base = codexConfig;
+      syncGuard.begin(base);
       const { updatedConfig, error: snippetError } = await applyTomlSnippet(
-        codexConfig,
+        base,
         commonConfigSnippet,
         checked,
       );
-      if (isTomlOpStale(seq, codexConfig)) {
+      if (isTomlOpStale(seq, base)) {
+        syncGuard.abort();
         return;
       }
 
       if (snippetError) {
+        syncGuard.abort();
         setCommonConfigError(snippetError);
         setUseCommonConfig(false);
         return;
@@ -350,13 +314,8 @@ export function useCodexCommonConfig({
 
       setCommonConfigError("");
       setUseCommonConfig(checked);
-      // 标记正在通过通用配置更新
-      isUpdatingFromCommonConfig.current = true;
+      syncGuard.schedule(base, updatedConfig);
       onConfigChange(updatedConfig);
-      // 在下一个事件循环中重置标记
-      setTimeout(() => {
-        isUpdatingFromCommonConfig.current = false;
-      }, 0);
     },
     [
       codexConfig,
@@ -365,6 +324,7 @@ export function useCodexCommonConfig({
       onConfigChange,
       parseCommonConfigSnippet,
       t,
+      syncGuard,
     ],
   );
 
@@ -381,24 +341,29 @@ export function useCodexCommonConfig({
 
         if (useCommonConfig) {
           const previousParsed = parseCommonConfigSnippet(previousSnippet);
-          let updatedConfig = codexConfig;
+          const base = codexConfig;
+          let updatedConfig = base;
+          syncGuard.begin(base);
 
           if (!previousParsed.error && previousParsed.hasContent) {
             const removeResult = await applyTomlSnippet(
-              codexConfig,
+              base,
               previousSnippet,
               false,
             );
-            if (isTomlOpStale(seq, codexConfig)) {
+            if (isTomlOpStale(seq, base)) {
+              syncGuard.abort();
               return false;
             }
             if (removeResult.error) {
+              syncGuard.abort();
               setCommonConfigError(removeResult.error);
               return false;
             }
             updatedConfig = removeResult.updatedConfig;
           }
 
+          syncGuard.schedule(base, updatedConfig);
           onConfigChange(updatedConfig);
           setUseCommonConfig(false);
         }
@@ -423,19 +388,23 @@ export function useCodexCommonConfig({
 
       // 若当前启用通用配置，需要替换为最新片段
       if (useCommonConfig) {
-        let nextConfig = codexConfig;
+        const base = codexConfig;
+        let nextConfig = base;
         const previousParsed = parseCommonConfigSnippet(previousSnippet);
+        syncGuard.begin(base);
 
         if (!previousParsed.error && previousParsed.hasContent) {
           const removeResult = await applyTomlSnippet(
-            codexConfig,
+            base,
             previousSnippet,
             false,
           );
-          if (isTomlOpStale(seq, codexConfig)) {
+          if (isTomlOpStale(seq, base)) {
+            syncGuard.abort();
             return false;
           }
           if (removeResult.error) {
+            syncGuard.abort();
             setCommonConfigError(removeResult.error);
             return false;
           }
@@ -443,23 +412,20 @@ export function useCodexCommonConfig({
         }
 
         const addResult = await applyTomlSnippet(nextConfig, value, true);
-        // nextConfig 派生自发起时的 codexConfig，基线校验仍对 codexConfig 做
-        if (isTomlOpStale(seq, codexConfig)) {
+        // nextConfig 派生自发起时的 base，基线校验仍对 base 做
+        if (isTomlOpStale(seq, base)) {
+          syncGuard.abort();
           return false;
         }
 
         if (addResult.error) {
+          syncGuard.abort();
           setCommonConfigError(addResult.error);
           return false;
         }
 
-        // 标记正在通过通用配置更新，避免触发状态检查
-        isUpdatingFromCommonConfig.current = true;
+        syncGuard.schedule(base, addResult.updatedConfig);
         onConfigChange(addResult.updatedConfig);
-        // 在下一个事件循环中重置标记
-        setTimeout(() => {
-          isUpdatingFromCommonConfig.current = false;
-        }, 0);
       }
 
       setCommonConfigError("");
@@ -483,19 +449,77 @@ export function useCodexCommonConfig({
       parseCommonConfigSnippet,
       t,
       useCommonConfig,
+      syncGuard,
     ],
   );
 
-  // 当配置变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）。
-  // 编辑态且 meta.commonConfigEnabled 有显式值时跳过内容推断，防止打开编辑界面时
-  // 被“快照中暂无片段”的中间态 / 异步初始化竞态覆盖成未勾选。
+  // 配置变化同步 effect：先处理程序性写入回显，再处理 codexConfig 重置窗口，
+  // 最后才进行用户编辑触发的内容推断（兼容没有 commonConfigEnabled 的旧供应商）。
   useEffect(() => {
-    if (isUpdatingFromCommonConfig.current || isLoading) {
-      return;
+    if (isLoading) return;
+    if (syncGuard.skip(codexConfig)) return;
+
+    // initialData 被 live 配置替换后，useCodexConfigState 会把 codexConfig 重置为
+    // DB/live 快照（快照按设计不含片段）。等到重置值落地后把片段补回编辑预览。
+    if (pendingResetConfigRef.current !== null) {
+      const expected = pendingResetConfigRef.current;
+      if (codexConfig === expected) {
+        pendingResetConfigRef.current = null;
+        preResetConfigRef.current = null;
+
+        const parsedSnippet = parseCommonConfigSnippet(commonConfigSnippet);
+        if (parsedSnippet.error) {
+          if (commonConfigSnippet.trim()) {
+            setCommonConfigError(parsedSnippet.error);
+          }
+          setUseCommonConfig(false);
+          return;
+        }
+        const hasCommon =
+          initialEnabled !== undefined
+            ? initialEnabled
+            : hasTomlCommonConfigSnippet(codexConfig, commonConfigSnippet);
+        if (
+          hasCommon &&
+          !hasTomlCommonConfigSnippet(codexConfig, commonConfigSnippet) &&
+          parsedSnippet.hasContent
+        ) {
+          const base = codexConfig;
+          const seq = ++tomlOpSeqRef.current;
+          syncGuard.begin(base);
+          (async () => {
+            const { updatedConfig, error } = await applyTomlSnippet(
+              base,
+              commonConfigSnippet,
+              true,
+            );
+            if (isTomlOpStale(seq, base)) {
+              syncGuard.abort();
+              return;
+            }
+            if (error) {
+              syncGuard.abort();
+              setCommonConfigError(error);
+              return;
+            }
+            syncGuard.schedule(base, updatedConfig);
+            onConfigChange(updatedConfig);
+          })();
+          return;
+        }
+        return;
+      }
+
+      if (codexConfig === preResetConfigRef.current) {
+        // 还没等到 codexConfig 重置
+        return;
+      }
+
+      // 重置没有如期发生（或用户先编辑了），清除窗口并按当前值继续处理
+      pendingResetConfigRef.current = null;
+      preResetConfigRef.current = null;
     }
-    if (isEditMode && hasExplicitInitialEnabled) {
-      return;
-    }
+
     const parsedSnippet = parseCommonConfigSnippet(commonConfigSnippet);
     if (parsedSnippet.error) {
       setUseCommonConfig(false);
@@ -511,8 +535,11 @@ export function useCodexCommonConfig({
     commonConfigSnippet,
     isLoading,
     parseCommonConfigSnippet,
-    isEditMode,
-    hasExplicitInitialEnabled,
+    initialData,
+    initialEnabled,
+    isTomlOpStale,
+    onConfigChange,
+    syncGuard,
   ]);
 
   // 从编辑器当前内容提取通用配置片段

--- a/src/components/providers/forms/hooks/useCodexCommonConfig.ts
+++ b/src/components/providers/forms/hooks/useCodexCommonConfig.ts
@@ -65,11 +65,9 @@ export function useCodexCommonConfig({
   const syncGuard = useCommonConfigSyncGuard();
   // 用于跟踪新建模式是否已初始化默认勾选
   const hasInitializedNewMode = useRef(false);
-  // 用于识别 initialData 被 live 配置替换后的“codexConfig 重置窗口”
+  // 用于识别 initialData 被 live 配置替换后的 codexConfig 重置
   const lastInitialDataRef = useRef<typeof initialData | undefined>(undefined);
   const lastInitialEnabledRef = useRef<boolean | undefined>(undefined);
-  const preResetConfigRef = useRef<string | null>(null);
-  const pendingResetConfigRef = useRef<string | null>(null);
   // 后端 TOML 合并是异步的：连续操作（快速点开关、连点保存）可能乱序
   // 返回。每个写 config 的异步操作在发起时领取递增序号，结果落地前
   // 校验自己仍是最新一次；过期结果直接丢弃，保证最后一次操作胜出。
@@ -174,13 +172,17 @@ export function useCodexCommonConfig({
     };
   }, []);
 
-  // 编辑态初始化 / live 配置刷新：勾选状态以 meta.commonConfigEnabled 为准，
-  // 记录 codexConfig 即将重置到的快照值，由下面的同步 effect 等待重置落地后补回预览。
+  // 编辑态初始化 / live 配置刷新：勾选状态以 meta.commonConfigEnabled 为准。
+  //
+  // 片段已由 useInitialDataCommonConfig 在数据层合并进 initialData，所以这里
+  // 只需同步勾选状态。codexConfig 随后会被重置到 expectedConfig，把这次重置
+  // 登记给 syncGuard，避免同步 effect 在重置落地前用旧值做一次无谓的推断。
   useEffect(() => {
-    if (!initialData?.settingsConfig || isLoading) return;
     if (
-      lastInitialDataRef.current === initialData &&
-      lastInitialEnabledRef.current === initialEnabled
+      !initialData?.settingsConfig ||
+      isLoading ||
+      (lastInitialDataRef.current === initialData &&
+        lastInitialEnabledRef.current === initialEnabled)
     ) {
       return;
     }
@@ -196,19 +198,22 @@ export function useCodexCommonConfig({
       expectedConfig,
       commonConfigSnippet,
     );
+    // 优先级：显式设置的 initialEnabled > 从配置推断的值
+    // 如果 initialEnabled 为 undefined，使用推断值
     const hasCommon =
       initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
 
     setCommonConfigError("");
     setUseCommonConfig(hasCommon);
-    preResetConfigRef.current = codexConfig;
-    pendingResetConfigRef.current = hasCommon ? expectedConfig : null;
+    // 无条件登记：即使 codexConfig 当前已经是 expectedConfig，也要让同步 effect
+    // 跳过这一轮推断，否则片段为空/不匹配时会把刚设好的勾选状态又推断成 false。
+    syncGuard.schedule(codexConfig, expectedConfig);
   }, [
+    codexConfig,
+    commonConfigSnippet,
     initialData,
     initialEnabled,
-    commonConfigSnippet,
     isLoading,
-    codexConfig,
   ]);
 
   // 新建模式：如果通用配置片段存在且有效，默认启用
@@ -233,20 +238,16 @@ export function useCodexCommonConfig({
 
     let cancelled = false;
     const seq = ++tomlOpSeqRef.current;
-    const base = codexConfig;
-    syncGuard.begin(base);
     (async () => {
       const { updatedConfig, error } = await applyTomlSnippet(
-        base,
+        codexConfig,
         commonConfigSnippet,
         true,
       );
-      if (cancelled || isTomlOpStale(seq, base)) {
-        syncGuard.abort();
+      if (cancelled || isTomlOpStale(seq, codexConfig)) {
         return;
       }
       if (error) {
-        syncGuard.abort();
         setCommonConfigError(error);
         setUseCommonConfig(false);
         return;
@@ -254,12 +255,11 @@ export function useCodexCommonConfig({
 
       setCommonConfigError("");
       setUseCommonConfig(true);
-      syncGuard.schedule(base, updatedConfig);
+      syncGuard.schedule(codexConfig, updatedConfig);
       onConfigChange(updatedConfig);
     })();
     return () => {
       cancelled = true;
-      syncGuard.abort();
     };
   }, [
     initialData,
@@ -293,20 +293,16 @@ export function useCodexCommonConfig({
         return;
       }
 
-      const base = codexConfig;
-      syncGuard.begin(base);
       const { updatedConfig, error: snippetError } = await applyTomlSnippet(
-        base,
+        codexConfig,
         commonConfigSnippet,
         checked,
       );
-      if (isTomlOpStale(seq, base)) {
-        syncGuard.abort();
+      if (isTomlOpStale(seq, codexConfig)) {
         return;
       }
 
       if (snippetError) {
-        syncGuard.abort();
         setCommonConfigError(snippetError);
         setUseCommonConfig(false);
         return;
@@ -314,7 +310,7 @@ export function useCodexCommonConfig({
 
       setCommonConfigError("");
       setUseCommonConfig(checked);
-      syncGuard.schedule(base, updatedConfig);
+      syncGuard.schedule(codexConfig, updatedConfig);
       onConfigChange(updatedConfig);
     },
     [
@@ -324,7 +320,6 @@ export function useCodexCommonConfig({
       onConfigChange,
       parseCommonConfigSnippet,
       t,
-      syncGuard,
     ],
   );
 
@@ -341,29 +336,25 @@ export function useCodexCommonConfig({
 
         if (useCommonConfig) {
           const previousParsed = parseCommonConfigSnippet(previousSnippet);
-          const base = codexConfig;
-          let updatedConfig = base;
-          syncGuard.begin(base);
+          let updatedConfig = codexConfig;
 
           if (!previousParsed.error && previousParsed.hasContent) {
             const removeResult = await applyTomlSnippet(
-              base,
+              codexConfig,
               previousSnippet,
               false,
             );
-            if (isTomlOpStale(seq, base)) {
-              syncGuard.abort();
+            if (isTomlOpStale(seq, codexConfig)) {
               return false;
             }
             if (removeResult.error) {
-              syncGuard.abort();
               setCommonConfigError(removeResult.error);
               return false;
             }
             updatedConfig = removeResult.updatedConfig;
           }
 
-          syncGuard.schedule(base, updatedConfig);
+          syncGuard.schedule(codexConfig, updatedConfig);
           onConfigChange(updatedConfig);
           setUseCommonConfig(false);
         }
@@ -388,23 +379,19 @@ export function useCodexCommonConfig({
 
       // 若当前启用通用配置，需要替换为最新片段
       if (useCommonConfig) {
-        const base = codexConfig;
-        let nextConfig = base;
+        let nextConfig = codexConfig;
         const previousParsed = parseCommonConfigSnippet(previousSnippet);
-        syncGuard.begin(base);
 
         if (!previousParsed.error && previousParsed.hasContent) {
           const removeResult = await applyTomlSnippet(
-            base,
+            codexConfig,
             previousSnippet,
             false,
           );
-          if (isTomlOpStale(seq, base)) {
-            syncGuard.abort();
+          if (isTomlOpStale(seq, codexConfig)) {
             return false;
           }
           if (removeResult.error) {
-            syncGuard.abort();
             setCommonConfigError(removeResult.error);
             return false;
           }
@@ -412,19 +399,17 @@ export function useCodexCommonConfig({
         }
 
         const addResult = await applyTomlSnippet(nextConfig, value, true);
-        // nextConfig 派生自发起时的 base，基线校验仍对 base 做
-        if (isTomlOpStale(seq, base)) {
-          syncGuard.abort();
+        // nextConfig 派生自发起时的 codexConfig，基线校验仍对 codexConfig 做
+        if (isTomlOpStale(seq, codexConfig)) {
           return false;
         }
 
         if (addResult.error) {
-          syncGuard.abort();
           setCommonConfigError(addResult.error);
           return false;
         }
 
-        syncGuard.schedule(base, addResult.updatedConfig);
+        syncGuard.schedule(codexConfig, addResult.updatedConfig);
         onConfigChange(addResult.updatedConfig);
       }
 
@@ -449,98 +434,30 @@ export function useCodexCommonConfig({
       parseCommonConfigSnippet,
       t,
       useCommonConfig,
-      syncGuard,
     ],
   );
 
-  // 配置变化同步 effect：先处理程序性写入回显，再处理 codexConfig 重置窗口，
-  // 最后才进行用户编辑触发的内容推断（兼容没有 commonConfigEnabled 的旧供应商）。
+  // 配置变化同步 effect：跳过程序性写入的回显，其余按内容推断勾选状态，
+  // 让用户手动增删片段时勾选框跟着变。
   useEffect(() => {
-    if (isLoading) return;
-    if (syncGuard.skip(codexConfig)) return;
-
-    // initialData 被 live 配置替换后，useCodexConfigState 会把 codexConfig 重置为
-    // DB/live 快照（快照按设计不含片段）。等到重置值落地后把片段补回编辑预览。
-    if (pendingResetConfigRef.current !== null) {
-      const expected = pendingResetConfigRef.current;
-      if (codexConfig === expected) {
-        pendingResetConfigRef.current = null;
-        preResetConfigRef.current = null;
-
-        const parsedSnippet = parseCommonConfigSnippet(commonConfigSnippet);
-        if (parsedSnippet.error) {
-          if (commonConfigSnippet.trim()) {
-            setCommonConfigError(parsedSnippet.error);
-          }
-          setUseCommonConfig(false);
-          return;
-        }
-        const hasCommon =
-          initialEnabled !== undefined
-            ? initialEnabled
-            : hasTomlCommonConfigSnippet(codexConfig, commonConfigSnippet);
-        if (
-          hasCommon &&
-          !hasTomlCommonConfigSnippet(codexConfig, commonConfigSnippet) &&
-          parsedSnippet.hasContent
-        ) {
-          const base = codexConfig;
-          const seq = ++tomlOpSeqRef.current;
-          syncGuard.begin(base);
-          (async () => {
-            const { updatedConfig, error } = await applyTomlSnippet(
-              base,
-              commonConfigSnippet,
-              true,
-            );
-            if (isTomlOpStale(seq, base)) {
-              syncGuard.abort();
-              return;
-            }
-            if (error) {
-              syncGuard.abort();
-              setCommonConfigError(error);
-              return;
-            }
-            syncGuard.schedule(base, updatedConfig);
-            onConfigChange(updatedConfig);
-          })();
-          return;
-        }
-        return;
-      }
-
-      if (codexConfig === preResetConfigRef.current) {
-        // 还没等到 codexConfig 重置
-        return;
-      }
-
-      // 重置没有如期发生（或用户先编辑了），清除窗口并按当前值继续处理
-      pendingResetConfigRef.current = null;
-      preResetConfigRef.current = null;
+    if (isLoading || syncGuard.skip(codexConfig)) {
+      return;
     }
-
     const parsedSnippet = parseCommonConfigSnippet(commonConfigSnippet);
     if (parsedSnippet.error) {
       setUseCommonConfig(false);
       return;
     }
+    // 没有片段可比对时，推断不出任何信息——保持当前勾选状态，
+    // 否则会把 meta.commonConfigEnabled 静默改写成 false。
+    if (!parsedSnippet.hasContent) return;
+
     const hasCommon = hasTomlCommonConfigSnippet(
       codexConfig,
       commonConfigSnippet,
     );
     setUseCommonConfig(hasCommon);
-  }, [
-    codexConfig,
-    commonConfigSnippet,
-    isLoading,
-    parseCommonConfigSnippet,
-    initialData,
-    initialEnabled,
-    isTomlOpStale,
-    onConfigChange,
-    syncGuard,
-  ]);
+  }, [codexConfig, commonConfigSnippet, isLoading, parseCommonConfigSnippet]);
 
   // 从编辑器当前内容提取通用配置片段
   const handleExtract = useCallback(async () => {

--- a/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
+++ b/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
@@ -50,11 +50,9 @@ export function useCommonConfigSnippet({
   const syncGuard = useCommonConfigSyncGuard();
   // 用于跟踪新建模式是否已初始化默认勾选
   const hasInitializedNewMode = useRef(false);
-  // 用于识别 initialData 被 live 配置替换后的“表单重置窗口”
+  // 用于识别 initialData 被 live 配置替换后的表单重置
   const lastInitialDataRef = useRef<typeof initialData | undefined>(undefined);
   const lastInitialEnabledRef = useRef<boolean | undefined>(undefined);
-  const preResetConfigRef = useRef<string | null>(null);
-  const pendingResetConfigRef = useRef<string | null>(null);
 
   // 当预设变化时，重置初始化标记，使新预设能够重新触发初始化逻辑
   useEffect(() => {
@@ -120,13 +118,18 @@ export function useCommonConfigSnippet({
     };
   }, [enabled]);
 
-  // 编辑态初始化 / live 配置刷新：勾选状态以 meta.commonConfigEnabled 为准，
-  // 同时记录表单即将重置到的快照值，由下面的同步 effect 在重置落地后补回预览。
+  // 编辑态初始化 / live 配置刷新：勾选状态以 meta.commonConfigEnabled 为准。
+  //
+  // 片段已由 useInitialDataCommonConfig 在数据层合并进 initialData，所以这里
+  // 只需同步勾选状态。表单随后会被 reset 到 expectedConfig，把这次重置登记给
+  // syncGuard，避免下面的同步 effect 在重置落地前用旧值做一次无谓的推断。
   useEffect(() => {
-    if (!enabled || !initialData || isLoading) return;
+    if (!enabled) return;
     if (
-      lastInitialDataRef.current === initialData &&
-      lastInitialEnabledRef.current === initialEnabled
+      !initialData ||
+      isLoading ||
+      (lastInitialDataRef.current === initialData &&
+        lastInitialEnabledRef.current === initialEnabled)
     ) {
       return;
     }
@@ -139,13 +142,16 @@ export function useCommonConfigSnippet({
       expectedConfig,
       commonConfigSnippet,
     );
+    // 优先级：显式设置的 initialEnabled > 从配置推断的值
+    // 如果 initialEnabled 为 undefined，使用推断值
     const hasCommon =
       initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
 
     setCommonConfigError("");
     setUseCommonConfig(hasCommon);
-    preResetConfigRef.current = settingsConfig;
-    pendingResetConfigRef.current = hasCommon ? expectedConfig : null;
+    // 无条件登记：即使表单当前已经是 expectedConfig，也要让同步 effect 跳过
+    // 这一轮推断，否则片段为空/不匹配时会把刚设好的勾选状态又推断成 false。
+    syncGuard.schedule(settingsConfig, expectedConfig);
   }, [
     enabled,
     initialData,
@@ -212,7 +218,7 @@ export function useCommonConfigSnippet({
       syncGuard.schedule(settingsConfig, updatedConfig);
       onConfigChange(updatedConfig);
     },
-    [settingsConfig, commonConfigSnippet, onConfigChange, syncGuard],
+    [settingsConfig, commonConfigSnippet, onConfigChange],
   );
 
   // 处理通用配置片段变化
@@ -289,75 +295,26 @@ export function useCommonConfigSnippet({
         onConfigChange(addResult.updatedConfig);
       }
     },
-    [
-      commonConfigSnippet,
-      settingsConfig,
-      useCommonConfig,
-      onConfigChange,
-      syncGuard,
-    ],
+    [commonConfigSnippet, settingsConfig, useCommonConfig, onConfigChange],
   );
 
-  // 配置变化同步 effect：先处理程序性写入回显，再处理 initialData 重置窗口，
-  // 最后才进行用户编辑触发的内容推断（兼容没有 commonConfigEnabled 的旧供应商）。
+  // 配置变化同步 effect：跳过程序性写入的回显，其余按内容推断勾选状态，
+  // 让用户手动增删片段时勾选框跟着变。
   useEffect(() => {
-    if (!enabled || isLoading) return;
-    if (syncGuard.skip(settingsConfig)) return;
-
-    // initialData 被 live 配置替换后，表单会重置为 DB/live 快照（快照按设计
-    // 不含片段）。等到重置值落地后把片段补回编辑预览，期间不做内容推断。
-    if (pendingResetConfigRef.current !== null) {
-      const expected = pendingResetConfigRef.current;
-      if (settingsConfig === expected) {
-        pendingResetConfigRef.current = null;
-        preResetConfigRef.current = null;
-        const hasCommon =
-          initialEnabled !== undefined
-            ? initialEnabled
-            : hasCommonConfigSnippet(settingsConfig, commonConfigSnippet);
-        if (hasCommon) {
-          const { updatedConfig, error } = updateCommonConfigSnippet(
-            settingsConfig,
-            commonConfigSnippet,
-            true,
-          );
-          if (error) {
-            setCommonConfigError(error);
-            return;
-          }
-          if (updatedConfig !== settingsConfig) {
-            syncGuard.schedule(settingsConfig, updatedConfig);
-            onConfigChange(updatedConfig);
-          }
-        }
-        return;
-      }
-
-      if (settingsConfig === preResetConfigRef.current) {
-        // 还没等到表单重置
-        return;
-      }
-
-      // 重置没有如期发生（或用户先编辑了），清除窗口并按当前值继续处理
-      pendingResetConfigRef.current = null;
-      preResetConfigRef.current = null;
+    if (!enabled) return;
+    if (isLoading || syncGuard.skip(settingsConfig)) {
+      return;
     }
+    // 没有片段可比对时，推断不出任何信息——保持当前勾选状态，
+    // 否则会把 meta.commonConfigEnabled 静默改写成 false。
+    if (!commonConfigSnippet.trim()) return;
 
     const hasCommon = hasCommonConfigSnippet(
       settingsConfig,
       commonConfigSnippet,
     );
     setUseCommonConfig(hasCommon);
-  }, [
-    enabled,
-    settingsConfig,
-    commonConfigSnippet,
-    isLoading,
-    initialData,
-    initialEnabled,
-    onConfigChange,
-    syncGuard,
-  ]);
+  }, [enabled, settingsConfig, commonConfigSnippet, isLoading]);
 
   // 从编辑器当前内容提取通用配置片段
   const handleExtract = useCallback(async () => {

--- a/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
+++ b/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { useCommonConfigSyncGuard } from "./useCommonConfigSyncGuard";
 import {
   updateCommonConfigSnippet,
   hasCommonConfigSnippet,
@@ -37,11 +38,6 @@ export function useCommonConfigSnippet({
   enabled = true,
 }: UseCommonConfigSnippetProps) {
   const { t } = useTranslation();
-  // 编辑态下 meta.commonConfigEnabled 是“是否应用通用配置”的权威来源：
-  // 后端保存时会从供应商快照中剥离通用配置片段（runtime overlay），
-  // 因此不能在编辑态用“当前配置里是否包含片段”来反推勾选状态。
-  const isEditMode = Boolean(initialData);
-  const hasExplicitInitialEnabled = initialEnabled !== undefined;
   const [useCommonConfig, setUseCommonConfig] = useState(false);
   const [commonConfigSnippet, setCommonConfigSnippetState] = useState<string>(
     DEFAULT_COMMON_CONFIG_SNIPPET,
@@ -50,19 +46,23 @@ export function useCommonConfigSnippet({
   const [isLoading, setIsLoading] = useState(true);
   const [isExtracting, setIsExtracting] = useState(false);
 
-  // 用于跟踪是否正在通过通用配置更新
-  const isUpdatingFromCommonConfig = useRef(false);
+  // 程序性配置写入的回显保护（替代 setTimeout 重置标记）
+  const syncGuard = useCommonConfigSyncGuard();
   // 用于跟踪新建模式是否已初始化默认勾选
   const hasInitializedNewMode = useRef(false);
-  // 用于跟踪编辑模式是否已初始化显式开关/预览
-  const hasInitializedEditMode = useRef(false);
+  // 用于识别 initialData 被 live 配置替换后的“表单重置窗口”
+  const lastInitialDataRef = useRef<typeof initialData | undefined>(undefined);
+  const lastInitialEnabledRef = useRef<boolean | undefined>(undefined);
+  const preResetConfigRef = useRef<string | null>(null);
+  const pendingResetConfigRef = useRef<string | null>(null);
 
   // 当预设变化时，重置初始化标记，使新预设能够重新触发初始化逻辑
   useEffect(() => {
     if (!enabled) return;
     hasInitializedNewMode.current = false;
-    hasInitializedEditMode.current = false;
-  }, [selectedPresetId, enabled, initialEnabled]);
+    lastInitialDataRef.current = undefined;
+    lastInitialEnabledRef.current = undefined;
+  }, [selectedPresetId, enabled]);
 
   // 初始化：从 config.json 加载，支持从 localStorage 迁移
   useEffect(() => {
@@ -120,47 +120,38 @@ export function useCommonConfigSnippet({
     };
   }, [enabled]);
 
-  // 初始化时检查通用配置片段（编辑模式）
+  // 编辑态初始化 / live 配置刷新：勾选状态以 meta.commonConfigEnabled 为准，
+  // 同时记录表单即将重置到的快照值，由下面的同步 effect 在重置落地后补回预览。
   useEffect(() => {
-    if (!enabled) return;
-    if (initialData && !isLoading && !hasInitializedEditMode.current) {
-      hasInitializedEditMode.current = true;
-
-      const configString = JSON.stringify(initialData.settingsConfig, null, 2);
-      const inferredHasCommon = hasCommonConfigSnippet(
-        configString,
-        commonConfigSnippet,
-      );
-
-      // 优先级：显式设置的 initialEnabled > 从配置推断的值
-      // 如果 initialEnabled 为 undefined，使用推断值
-      const hasCommon =
-        initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
-      setUseCommonConfig(hasCommon);
-
-      // 如果应该启用通用配置但配置中还没有，则自动添加
-      if (hasCommon && !inferredHasCommon) {
-        const { updatedConfig, error } = updateCommonConfigSnippet(
-          settingsConfig,
-          commonConfigSnippet,
-          true,
-        );
-        if (!error) {
-          isUpdatingFromCommonConfig.current = true;
-          onConfigChange(updatedConfig);
-          setTimeout(() => {
-            isUpdatingFromCommonConfig.current = false;
-          }, 0);
-        }
-      }
+    if (!enabled || !initialData || isLoading) return;
+    if (
+      lastInitialDataRef.current === initialData &&
+      lastInitialEnabledRef.current === initialEnabled
+    ) {
+      return;
     }
+
+    lastInitialDataRef.current = initialData;
+    lastInitialEnabledRef.current = initialEnabled;
+
+    const expectedConfig = JSON.stringify(initialData.settingsConfig, null, 2);
+    const inferredHasCommon = hasCommonConfigSnippet(
+      expectedConfig,
+      commonConfigSnippet,
+    );
+    const hasCommon =
+      initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
+
+    setCommonConfigError("");
+    setUseCommonConfig(hasCommon);
+    preResetConfigRef.current = settingsConfig;
+    pendingResetConfigRef.current = hasCommon ? expectedConfig : null;
   }, [
     enabled,
     initialData,
     initialEnabled,
     commonConfigSnippet,
     isLoading,
-    onConfigChange,
     settingsConfig,
   ]);
 
@@ -184,11 +175,8 @@ export function useCommonConfigSnippet({
             true,
           );
           if (!error) {
-            isUpdatingFromCommonConfig.current = true;
+            syncGuard.schedule(settingsConfig, updatedConfig);
             onConfigChange(updatedConfig);
-            setTimeout(() => {
-              isUpdatingFromCommonConfig.current = false;
-            }, 0);
           }
         }
       } catch {
@@ -221,15 +209,10 @@ export function useCommonConfigSnippet({
 
       setCommonConfigError("");
       setUseCommonConfig(checked);
-      // 标记正在通过通用配置更新
-      isUpdatingFromCommonConfig.current = true;
+      syncGuard.schedule(settingsConfig, updatedConfig);
       onConfigChange(updatedConfig);
-      // 在下一个事件循环中重置标记
-      setTimeout(() => {
-        isUpdatingFromCommonConfig.current = false;
-      }, 0);
     },
-    [settingsConfig, commonConfigSnippet, onConfigChange],
+    [settingsConfig, commonConfigSnippet, onConfigChange, syncGuard],
   );
 
   // 处理通用配置片段变化
@@ -256,6 +239,7 @@ export function useCommonConfigSnippet({
             previousSnippet,
             false,
           );
+          syncGuard.schedule(settingsConfig, updatedConfig);
           onConfigChange(updatedConfig);
           setUseCommonConfig(false);
         }
@@ -301,29 +285,64 @@ export function useCommonConfigSnippet({
           return;
         }
 
-        // 标记正在通过通用配置更新，避免触发状态检查
-        isUpdatingFromCommonConfig.current = true;
+        syncGuard.schedule(settingsConfig, addResult.updatedConfig);
         onConfigChange(addResult.updatedConfig);
-        // 在下一个事件循环中重置标记
-        setTimeout(() => {
-          isUpdatingFromCommonConfig.current = false;
-        }, 0);
       }
     },
-    [commonConfigSnippet, settingsConfig, useCommonConfig, onConfigChange],
+    [
+      commonConfigSnippet,
+      settingsConfig,
+      useCommonConfig,
+      onConfigChange,
+      syncGuard,
+    ],
   );
 
-  // 当配置变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）。
-  // 编辑态且 meta.commonConfigEnabled 有显式值时跳过内容推断，防止打开编辑界面时
-  // 被“快照中暂无片段”的中间态 / 异步初始化竞态覆盖成未勾选。
+  // 配置变化同步 effect：先处理程序性写入回显，再处理 initialData 重置窗口，
+  // 最后才进行用户编辑触发的内容推断（兼容没有 commonConfigEnabled 的旧供应商）。
   useEffect(() => {
-    if (!enabled) return;
-    if (isUpdatingFromCommonConfig.current || isLoading) {
-      return;
+    if (!enabled || isLoading) return;
+    if (syncGuard.skip(settingsConfig)) return;
+
+    // initialData 被 live 配置替换后，表单会重置为 DB/live 快照（快照按设计
+    // 不含片段）。等到重置值落地后把片段补回编辑预览，期间不做内容推断。
+    if (pendingResetConfigRef.current !== null) {
+      const expected = pendingResetConfigRef.current;
+      if (settingsConfig === expected) {
+        pendingResetConfigRef.current = null;
+        preResetConfigRef.current = null;
+        const hasCommon =
+          initialEnabled !== undefined
+            ? initialEnabled
+            : hasCommonConfigSnippet(settingsConfig, commonConfigSnippet);
+        if (hasCommon) {
+          const { updatedConfig, error } = updateCommonConfigSnippet(
+            settingsConfig,
+            commonConfigSnippet,
+            true,
+          );
+          if (error) {
+            setCommonConfigError(error);
+            return;
+          }
+          if (updatedConfig !== settingsConfig) {
+            syncGuard.schedule(settingsConfig, updatedConfig);
+            onConfigChange(updatedConfig);
+          }
+        }
+        return;
+      }
+
+      if (settingsConfig === preResetConfigRef.current) {
+        // 还没等到表单重置
+        return;
+      }
+
+      // 重置没有如期发生（或用户先编辑了），清除窗口并按当前值继续处理
+      pendingResetConfigRef.current = null;
+      preResetConfigRef.current = null;
     }
-    if (isEditMode && hasExplicitInitialEnabled) {
-      return;
-    }
+
     const hasCommon = hasCommonConfigSnippet(
       settingsConfig,
       commonConfigSnippet,
@@ -334,8 +353,10 @@ export function useCommonConfigSnippet({
     settingsConfig,
     commonConfigSnippet,
     isLoading,
-    isEditMode,
-    hasExplicitInitialEnabled,
+    initialData,
+    initialEnabled,
+    onConfigChange,
+    syncGuard,
   ]);
 
   // 从编辑器当前内容提取通用配置片段

--- a/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
+++ b/src/components/providers/forms/hooks/useCommonConfigSnippet.ts
@@ -37,6 +37,11 @@ export function useCommonConfigSnippet({
   enabled = true,
 }: UseCommonConfigSnippetProps) {
   const { t } = useTranslation();
+  // 编辑态下 meta.commonConfigEnabled 是“是否应用通用配置”的权威来源：
+  // 后端保存时会从供应商快照中剥离通用配置片段（runtime overlay），
+  // 因此不能在编辑态用“当前配置里是否包含片段”来反推勾选状态。
+  const isEditMode = Boolean(initialData);
+  const hasExplicitInitialEnabled = initialEnabled !== undefined;
   const [useCommonConfig, setUseCommonConfig] = useState(false);
   const [commonConfigSnippet, setCommonConfigSnippetState] = useState<string>(
     DEFAULT_COMMON_CONFIG_SNIPPET,
@@ -308,10 +313,15 @@ export function useCommonConfigSnippet({
     [commonConfigSnippet, settingsConfig, useCommonConfig, onConfigChange],
   );
 
-  // 当配置变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）
+  // 当配置变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）。
+  // 编辑态且 meta.commonConfigEnabled 有显式值时跳过内容推断，防止打开编辑界面时
+  // 被“快照中暂无片段”的中间态 / 异步初始化竞态覆盖成未勾选。
   useEffect(() => {
     if (!enabled) return;
     if (isUpdatingFromCommonConfig.current || isLoading) {
+      return;
+    }
+    if (isEditMode && hasExplicitInitialEnabled) {
       return;
     }
     const hasCommon = hasCommonConfigSnippet(
@@ -319,7 +329,14 @@ export function useCommonConfigSnippet({
       commonConfigSnippet,
     );
     setUseCommonConfig(hasCommon);
-  }, [enabled, settingsConfig, commonConfigSnippet, isLoading]);
+  }, [
+    enabled,
+    settingsConfig,
+    commonConfigSnippet,
+    isLoading,
+    isEditMode,
+    hasExplicitInitialEnabled,
+  ]);
 
   // 从编辑器当前内容提取通用配置片段
   const handleExtract = useCallback(async () => {

--- a/src/components/providers/forms/hooks/useCommonConfigSyncGuard.ts
+++ b/src/components/providers/forms/hooks/useCommonConfigSyncGuard.ts
@@ -1,0 +1,82 @@
+import { useCallback, useRef } from "react";
+
+export interface CommonConfigSyncGuard {
+  /** 开始一个尚未拿到结果的异步合并/剥离操作。 */
+  begin: (base: string) => void;
+  /** 记录一个即将写入配置的程序性变更。 */
+  schedule: (base: string, next: string) => void;
+  /** 异步操作过期/失败时清空保护状态。 */
+  abort: () => void;
+  /**
+   * 在“配置变化”同步 effect 中使用。当前值是自己刚写入的旧值/新值回显，
+   * 或仍有异步操作在飞时返回 true，调用方应跳过本次内容推断。
+   */
+  skip: (current: string) => boolean;
+}
+
+/**
+ * 追踪程序性配置写入的回显窗口，避免 setTimeout(0) 重置标记的竞态：
+ * - 写入前 `schedule(base, next)`；
+ * - effect 先看到 base（本次提交的旧 props）→ skip；
+ * - 下一次渲染看到 next → 清除保护并 skip；
+ * - 期间出现其它值（用户编辑/外部重置）→ 清除保护并放行内容推断。
+ */
+export function useCommonConfigSyncGuard(): CommonConfigSyncGuard {
+  const activeRef = useRef(false);
+  const baseRef = useRef<string | null>(null);
+  const pendingRef = useRef<string | null>(null);
+
+  const begin = useCallback((base: string) => {
+    baseRef.current = base;
+    pendingRef.current = null;
+    activeRef.current = true;
+  }, []);
+
+  const schedule = useCallback((base: string, next: string) => {
+    baseRef.current = base;
+    pendingRef.current = next;
+    activeRef.current = true;
+  }, []);
+
+  const abort = useCallback(() => {
+    activeRef.current = false;
+    baseRef.current = null;
+    pendingRef.current = null;
+  }, []);
+
+  const skip = useCallback((current: string): boolean => {
+    if (!activeRef.current) return false;
+
+    const base = baseRef.current;
+    const pending = pendingRef.current;
+
+    if (pending === null) {
+      // 异步操作结果未落地；base 回显继续跳过，其它值说明被外部改写
+      if (current === base) return true;
+      activeRef.current = false;
+      baseRef.current = null;
+      return false;
+    }
+
+    if (current === pending) {
+      // 程序性写入已落地，本次 effect 无需再处理
+      activeRef.current = false;
+      baseRef.current = null;
+      pendingRef.current = null;
+      return true;
+    }
+
+    if (current === base) {
+      // 还没渲染到新值前的旧值回显
+      return true;
+    }
+
+    // 既不是旧值也不是新值：用户编辑/外部重置获胜，恢复内容推断
+    activeRef.current = false;
+    baseRef.current = null;
+    pendingRef.current = null;
+    return false;
+  }, []);
+
+  return { begin, schedule, abort, skip };
+}

--- a/src/components/providers/forms/hooks/useCommonConfigSyncGuard.ts
+++ b/src/components/providers/forms/hooks/useCommonConfigSyncGuard.ts
@@ -1,15 +1,11 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef } from "react";
 
 export interface CommonConfigSyncGuard {
-  /** 开始一个尚未拿到结果的异步合并/剥离操作。 */
-  begin: (base: string) => void;
   /** 记录一个即将写入配置的程序性变更。 */
   schedule: (base: string, next: string) => void;
-  /** 异步操作过期/失败时清空保护状态。 */
-  abort: () => void;
   /**
-   * 在“配置变化”同步 effect 中使用。当前值是自己刚写入的旧值/新值回显，
-   * 或仍有异步操作在飞时返回 true，调用方应跳过本次内容推断。
+   * 在“配置变化”同步 effect 中使用。当前值是自己刚写入的旧值/新值回显时
+   * 返回 true，调用方应跳过本次内容推断。
    */
   skip: (current: string) => boolean;
 }
@@ -20,63 +16,43 @@ export interface CommonConfigSyncGuard {
  * - effect 先看到 base（本次提交的旧 props）→ skip；
  * - 下一次渲染看到 next → 清除保护并 skip；
  * - 期间出现其它值（用户编辑/外部重置）→ 清除保护并放行内容推断。
+ *
+ * 返回值是稳定引用，语义上等同 `useRef` 的容器，调用方不必把它列进依赖数组。
  */
 export function useCommonConfigSyncGuard(): CommonConfigSyncGuard {
-  const activeRef = useRef(false);
   const baseRef = useRef<string | null>(null);
   const pendingRef = useRef<string | null>(null);
 
-  const begin = useCallback((base: string) => {
-    baseRef.current = base;
+  const clear = useCallback(() => {
+    baseRef.current = null;
     pendingRef.current = null;
-    activeRef.current = true;
   }, []);
 
   const schedule = useCallback((base: string, next: string) => {
     baseRef.current = base;
     pendingRef.current = next;
-    activeRef.current = true;
   }, []);
 
-  const abort = useCallback(() => {
-    activeRef.current = false;
-    baseRef.current = null;
-    pendingRef.current = null;
-  }, []);
+  const skip = useCallback(
+    (current: string): boolean => {
+      if (pendingRef.current === null) return false;
 
-  const skip = useCallback((current: string): boolean => {
-    if (!activeRef.current) return false;
+      if (current === pendingRef.current) {
+        // 程序性写入已落地，本次 effect 无需再处理
+        clear();
+        return true;
+      }
+      if (current === baseRef.current) {
+        // 还没渲染到新值前的旧值回显
+        return true;
+      }
 
-    const base = baseRef.current;
-    const pending = pendingRef.current;
-
-    if (pending === null) {
-      // 异步操作结果未落地；base 回显继续跳过，其它值说明被外部改写
-      if (current === base) return true;
-      activeRef.current = false;
-      baseRef.current = null;
+      // 既不是旧值也不是新值：用户编辑/外部重置获胜，恢复内容推断
+      clear();
       return false;
-    }
+    },
+    [clear],
+  );
 
-    if (current === pending) {
-      // 程序性写入已落地，本次 effect 无需再处理
-      activeRef.current = false;
-      baseRef.current = null;
-      pendingRef.current = null;
-      return true;
-    }
-
-    if (current === base) {
-      // 还没渲染到新值前的旧值回显
-      return true;
-    }
-
-    // 既不是旧值也不是新值：用户编辑/外部重置获胜，恢复内容推断
-    activeRef.current = false;
-    baseRef.current = null;
-    pendingRef.current = null;
-    return false;
-  }, []);
-
-  return { begin, schedule, abort, skip };
+  return useMemo(() => ({ schedule, skip }), [schedule, skip]);
 }

--- a/src/components/providers/forms/hooks/useGeminiCommonConfig.ts
+++ b/src/components/providers/forms/hooks/useGeminiCommonConfig.ts
@@ -62,7 +62,7 @@ const SENSITIVE_CONTAINS = [
   "BEARER_TOKEN",
 ];
 
-function isForbiddenCommonEnvKey(name: string): boolean {
+export function isForbiddenCommonEnvKey(name: string): boolean {
   if (
     GEMINI_COMMON_ENV_FORBIDDEN_KEYS.includes(
       name as (typeof GEMINI_COMMON_ENV_FORBIDDEN_KEYS)[number],
@@ -127,11 +127,9 @@ export function useGeminiCommonConfig({
   const syncGuard = useCommonConfigSyncGuard();
   // 用于跟踪新建模式是否已初始化默认勾选
   const hasInitializedNewMode = useRef(false);
-  // 用于识别 initialData 被 live 配置替换后的“env 重置窗口”
+  // 用于识别 initialData 被 live 配置替换后的 env 重置
   const lastInitialDataRef = useRef<typeof initialData | undefined>(undefined);
   const lastInitialEnabledRef = useRef<boolean | undefined>(undefined);
-  const preResetConfigRef = useRef<string | null>(null);
-  const pendingResetConfigRef = useRef<string | null>(null);
 
   // 当预设变化时，重置初始化标记，使新预设能够重新触发初始化逻辑
   useEffect(() => {
@@ -283,13 +281,17 @@ export function useGeminiCommonConfig({
     };
   }, [parseSnippetEnv]);
 
-  // 编辑态初始化 / live 配置刷新：勾选状态以 meta.commonConfigEnabled 为准，
-  // 记录 env 即将重置到的快照值，由下面的同步 effect 等待重置落地后补回预览。
+  // 编辑态初始化 / live 配置刷新：勾选状态以 meta.commonConfigEnabled 为准。
+  //
+  // 片段已由 useInitialDataCommonConfig 在数据层合并进 initialData，所以这里
+  // 只需同步勾选状态。env 随后会被重置到 expectedEnv，把这次重置登记给
+  // syncGuard，避免同步 effect 在重置落地前用旧值做一次无谓的推断。
   useEffect(() => {
-    if (!initialData?.settingsConfig || isLoading) return;
     if (
-      lastInitialDataRef.current === initialData &&
-      lastInitialEnabledRef.current === initialEnabled
+      !initialData?.settingsConfig ||
+      isLoading ||
+      (lastInitialDataRef.current === initialData &&
+        lastInitialEnabledRef.current === initialEnabled)
     ) {
       return;
     }
@@ -297,18 +299,17 @@ export function useGeminiCommonConfig({
     lastInitialDataRef.current = initialData;
     lastInitialEnabledRef.current = initialEnabled;
 
-    const env = isPlainObject(initialData.settingsConfig.env)
-      ? (initialData.settingsConfig.env as Record<string, string>)
-      : {};
-    const expectedEnv = envObjToString(env as Record<string, unknown>);
+    const env =
+      isPlainObject(initialData.settingsConfig.env) &&
+      Object.keys(initialData.settingsConfig.env).length > 0
+        ? (initialData.settingsConfig.env as Record<string, string>)
+        : {};
     const parsed = parseSnippetEnv(commonConfigSnippet);
     if (parsed.error) {
       if (commonConfigSnippet.trim()) {
         setCommonConfigError(parsed.error);
       }
       setUseCommonConfig(false);
-      pendingResetConfigRef.current = null;
-      preResetConfigRef.current = null;
       return;
     }
 
@@ -316,13 +317,17 @@ export function useGeminiCommonConfig({
       env,
       parsed.env as Record<string, string>,
     );
+
+    // 优先级：显式设置的 initialEnabled > 从配置推断的值
+    // 如果 initialEnabled 为 undefined，使用推断值
     const hasCommon =
       initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
 
     setCommonConfigError("");
     setUseCommonConfig(hasCommon);
-    preResetConfigRef.current = envValue;
-    pendingResetConfigRef.current = hasCommon ? expectedEnv : null;
+    // 无条件登记：即使 env 当前已经是 expectedEnv，也要让同步 effect 跳过这一轮
+    // 推断，否则片段为空/不匹配时会把刚设好的勾选状态又推断成 false。
+    syncGuard.schedule(envValue, envObjToString(env));
   }, [
     commonConfigSnippet,
     envObjToString,
@@ -371,7 +376,6 @@ export function useGeminiCommonConfig({
     applySnippetToEnv,
     onEnvChange,
     parseSnippetEnv,
-    syncGuard,
   ]);
 
   // 处理通用配置开关
@@ -411,7 +415,6 @@ export function useGeminiCommonConfig({
       parseSnippetEnv,
       removeSnippetFromEnv,
       t,
-      syncGuard,
     ],
   );
 
@@ -505,69 +508,19 @@ export function useGeminiCommonConfig({
       removeSnippetFromEnv,
       t,
       useCommonConfig,
-      syncGuard,
     ],
   );
 
-  // env 变化同步 effect：先处理程序性写入回显，再处理 env 重置窗口，
-  // 最后才进行用户编辑触发的内容推断（兼容没有 commonConfigEnabled 的旧供应商）。
+  // 当 env 变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）
   useEffect(() => {
-    if (isLoading) return;
-    if (syncGuard.skip(envValue)) return;
-
-    // initialData 被 live 配置替换后，useGeminiConfigState 会把 env 重置为
-    // DB/live 快照（快照按设计不含片段）。等到重置值落地后把片段补回编辑预览。
-    if (pendingResetConfigRef.current !== null) {
-      const expected = pendingResetConfigRef.current;
-      if (envValue === expected) {
-        pendingResetConfigRef.current = null;
-        preResetConfigRef.current = null;
-
-        const parsed = parseSnippetEnv(commonConfigSnippet);
-        if (parsed.error) {
-          if (commonConfigSnippet.trim()) {
-            setCommonConfigError(parsed.error);
-          }
-          return;
-        }
-        const envObj = envStringToObj(envValue);
-        const hasCommon =
-          initialEnabled !== undefined
-            ? initialEnabled
-            : hasEnvCommonConfigSnippet(
-                envObj,
-                parsed.env as Record<string, string>,
-              );
-        if (
-          hasCommon &&
-          !hasEnvCommonConfigSnippet(
-            envObj,
-            parsed.env as Record<string, string>,
-          ) &&
-          Object.keys(parsed.env).length > 0
-        ) {
-          const merged = applySnippetToEnv(envObj, parsed.env);
-          const nextEnvString = envObjToString(merged);
-          if (nextEnvString !== envValue) {
-            syncGuard.schedule(envValue, nextEnvString);
-            onEnvChange(nextEnvString);
-          }
-        }
-        return;
-      }
-
-      if (envValue === preResetConfigRef.current) {
-        // 还没等到 env 重置
-        return;
-      }
-
-      // 重置没有如期发生（或用户先编辑了），清除窗口并按当前值继续处理
-      pendingResetConfigRef.current = null;
-      preResetConfigRef.current = null;
+    if (isLoading || syncGuard.skip(envValue)) {
+      return;
     }
-
     const parsed = parseSnippetEnv(commonConfigSnippet);
     if (parsed.error) return;
+    // 没有片段可比对时，推断不出任何信息——保持当前勾选状态，
+    // 否则会把 meta.commonConfigEnabled 静默改写成 false。
+    if (Object.keys(parsed.env).length === 0) return;
     const envObj = envStringToObj(envValue);
     setUseCommonConfig(
       hasEnvCommonConfigSnippet(envObj, parsed.env as Record<string, string>),
@@ -576,15 +529,9 @@ export function useGeminiCommonConfig({
     envValue,
     commonConfigSnippet,
     envStringToObj,
-    envObjToString,
     hasEnvCommonConfigSnippet,
     isLoading,
     parseSnippetEnv,
-    applySnippetToEnv,
-    onEnvChange,
-    initialData,
-    initialEnabled,
-    syncGuard,
   ]);
 
   // 从编辑器当前内容提取通用配置片段

--- a/src/components/providers/forms/hooks/useGeminiCommonConfig.ts
+++ b/src/components/providers/forms/hooks/useGeminiCommonConfig.ts
@@ -114,6 +114,11 @@ export function useGeminiCommonConfig({
   selectedPresetId,
 }: UseGeminiCommonConfigProps) {
   const { t } = useTranslation();
+  // 编辑态下 meta.commonConfigEnabled 是“是否应用通用配置”的权威来源：
+  // 后端保存时会从供应商快照中剥离通用配置片段（runtime overlay），
+  // 因此不能在编辑态用“当前 env 里是否包含片段”来反推勾选状态。
+  const isEditMode = Boolean(initialData);
+  const hasExplicitInitialEnabled = initialEnabled !== undefined;
   const [useCommonConfig, setUseCommonConfig] = useState(false);
   const [commonConfigSnippet, setCommonConfigSnippetState] = useState<string>(
     DEFAULT_GEMINI_COMMON_CONFIG_SNIPPET,
@@ -530,9 +535,14 @@ export function useGeminiCommonConfig({
     ],
   );
 
-  // 当 env 变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）
+  // 当 env 变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）。
+  // 编辑态且 meta.commonConfigEnabled 有显式值时跳过内容推断，防止打开编辑界面时
+  // 被“快照中暂无片段”的中间态 / 异步初始化竞态覆盖成未勾选。
   useEffect(() => {
     if (isUpdatingFromCommonConfig.current || isLoading) {
+      return;
+    }
+    if (isEditMode && hasExplicitInitialEnabled) {
       return;
     }
     const parsed = parseSnippetEnv(commonConfigSnippet);
@@ -548,6 +558,8 @@ export function useGeminiCommonConfig({
     hasEnvCommonConfigSnippet,
     isLoading,
     parseSnippetEnv,
+    isEditMode,
+    hasExplicitInitialEnabled,
   ]);
 
   // 从编辑器当前内容提取通用配置片段

--- a/src/components/providers/forms/hooks/useGeminiCommonConfig.ts
+++ b/src/components/providers/forms/hooks/useGeminiCommonConfig.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { configApi } from "@/lib/api";
+import { useCommonConfigSyncGuard } from "./useCommonConfigSyncGuard";
 
 const LEGACY_STORAGE_KEY = "cc-switch:gemini-common-config-snippet";
 const DEFAULT_GEMINI_COMMON_CONFIG_SNIPPET = "{}";
@@ -114,11 +115,6 @@ export function useGeminiCommonConfig({
   selectedPresetId,
 }: UseGeminiCommonConfigProps) {
   const { t } = useTranslation();
-  // 编辑态下 meta.commonConfigEnabled 是“是否应用通用配置”的权威来源：
-  // 后端保存时会从供应商快照中剥离通用配置片段（runtime overlay），
-  // 因此不能在编辑态用“当前 env 里是否包含片段”来反推勾选状态。
-  const isEditMode = Boolean(initialData);
-  const hasExplicitInitialEnabled = initialEnabled !== undefined;
   const [useCommonConfig, setUseCommonConfig] = useState(false);
   const [commonConfigSnippet, setCommonConfigSnippetState] = useState<string>(
     DEFAULT_GEMINI_COMMON_CONFIG_SNIPPET,
@@ -127,18 +123,22 @@ export function useGeminiCommonConfig({
   const [isLoading, setIsLoading] = useState(true);
   const [isExtracting, setIsExtracting] = useState(false);
 
-  // 用于跟踪是否正在通过通用配置更新
-  const isUpdatingFromCommonConfig = useRef(false);
+  // 程序性配置写入的回显保护（替代 setTimeout 重置标记）
+  const syncGuard = useCommonConfigSyncGuard();
   // 用于跟踪新建模式是否已初始化默认勾选
   const hasInitializedNewMode = useRef(false);
-  // 用于跟踪编辑模式是否已初始化显式开关/预览
-  const hasInitializedEditMode = useRef(false);
+  // 用于识别 initialData 被 live 配置替换后的“env 重置窗口”
+  const lastInitialDataRef = useRef<typeof initialData | undefined>(undefined);
+  const lastInitialEnabledRef = useRef<boolean | undefined>(undefined);
+  const preResetConfigRef = useRef<string | null>(null);
+  const pendingResetConfigRef = useRef<string | null>(null);
 
   // 当预设变化时，重置初始化标记，使新预设能够重新触发初始化逻辑
   useEffect(() => {
     hasInitializedNewMode.current = false;
-    hasInitializedEditMode.current = false;
-  }, [selectedPresetId, initialEnabled]);
+    lastInitialDataRef.current = undefined;
+    lastInitialEnabledRef.current = undefined;
+  }, [selectedPresetId]);
 
   const parseSnippetEnv = useCallback(
     (
@@ -283,78 +283,54 @@ export function useGeminiCommonConfig({
     };
   }, [parseSnippetEnv]);
 
-  // 初始化时检查通用配置片段（编辑模式）
+  // 编辑态初始化 / live 配置刷新：勾选状态以 meta.commonConfigEnabled 为准，
+  // 记录 env 即将重置到的快照值，由下面的同步 effect 等待重置落地后补回预览。
   useEffect(() => {
+    if (!initialData?.settingsConfig || isLoading) return;
     if (
-      !initialData?.settingsConfig ||
-      isLoading ||
-      hasInitializedEditMode.current
+      lastInitialDataRef.current === initialData &&
+      lastInitialEnabledRef.current === initialEnabled
     ) {
       return;
     }
 
-    hasInitializedEditMode.current = true;
+    lastInitialDataRef.current = initialData;
+    lastInitialEnabledRef.current = initialEnabled;
 
-    try {
-      const env =
-        isPlainObject(initialData.settingsConfig.env) &&
-        Object.keys(initialData.settingsConfig.env).length > 0
-          ? (initialData.settingsConfig.env as Record<string, string>)
-          : {};
-      const parsed = parseSnippetEnv(commonConfigSnippet);
-      if (parsed.error) {
-        if (commonConfigSnippet.trim()) {
-          setCommonConfigError(parsed.error);
-        }
-        setUseCommonConfig(false);
-        return;
+    const env = isPlainObject(initialData.settingsConfig.env)
+      ? (initialData.settingsConfig.env as Record<string, string>)
+      : {};
+    const expectedEnv = envObjToString(env as Record<string, unknown>);
+    const parsed = parseSnippetEnv(commonConfigSnippet);
+    if (parsed.error) {
+      if (commonConfigSnippet.trim()) {
+        setCommonConfigError(parsed.error);
       }
-      const inferredHasCommon = hasEnvCommonConfigSnippet(
-        env,
-        parsed.env as Record<string, string>,
-      );
-
-      // 优先级：显式设置的 initialEnabled > 从配置推断的值
-      // 如果 initialEnabled 为 undefined，使用推断值
-      const hasCommon =
-        initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
-
-      // 如果应该启用通用配置但配置中还没有，则自动添加
-      if (
-        hasCommon &&
-        !inferredHasCommon &&
-        Object.keys(parsed.env).length > 0
-      ) {
-        const currentEnv = envStringToObj(envValue);
-        const merged = applySnippetToEnv(currentEnv, parsed.env);
-        const nextEnvString = envObjToString(merged);
-
-        setCommonConfigError("");
-        setUseCommonConfig(true);
-        isUpdatingFromCommonConfig.current = true;
-        onEnvChange(nextEnvString);
-        setTimeout(() => {
-          isUpdatingFromCommonConfig.current = false;
-        }, 0);
-        return;
-      }
-
-      setCommonConfigError("");
-      setUseCommonConfig(hasCommon);
-    } catch {
-      // ignore parse error
+      setUseCommonConfig(false);
+      pendingResetConfigRef.current = null;
+      preResetConfigRef.current = null;
+      return;
     }
+
+    const inferredHasCommon = hasEnvCommonConfigSnippet(
+      env,
+      parsed.env as Record<string, string>,
+    );
+    const hasCommon =
+      initialEnabled !== undefined ? initialEnabled : inferredHasCommon;
+
+    setCommonConfigError("");
+    setUseCommonConfig(hasCommon);
+    preResetConfigRef.current = envValue;
+    pendingResetConfigRef.current = hasCommon ? expectedEnv : null;
   }, [
-    applySnippetToEnv,
     commonConfigSnippet,
     envObjToString,
-    envStringToObj,
     envValue,
     hasEnvCommonConfigSnippet,
     initialData,
     initialEnabled,
     isLoading,
-    onEnvChange,
     parseSnippetEnv,
   ]);
 
@@ -383,11 +359,8 @@ export function useGeminiCommonConfig({
     const merged = applySnippetToEnv(currentEnv, parsed.env);
     const nextEnvString = envObjToString(merged);
 
-    isUpdatingFromCommonConfig.current = true;
+    syncGuard.schedule(envValue, nextEnvString);
     onEnvChange(nextEnvString);
-    setTimeout(() => {
-      isUpdatingFromCommonConfig.current = false;
-    }, 0);
   }, [
     initialData,
     isLoading,
@@ -398,6 +371,7 @@ export function useGeminiCommonConfig({
     applySnippetToEnv,
     onEnvChange,
     parseSnippetEnv,
+    syncGuard,
   ]);
 
   // 处理通用配置开关
@@ -423,11 +397,9 @@ export function useGeminiCommonConfig({
       setCommonConfigError("");
       setUseCommonConfig(checked);
 
-      isUpdatingFromCommonConfig.current = true;
-      onEnvChange(envObjToString(updatedEnvObj));
-      setTimeout(() => {
-        isUpdatingFromCommonConfig.current = false;
-      }, 0);
+      const nextEnvString = envObjToString(updatedEnvObj);
+      syncGuard.schedule(envValue, nextEnvString);
+      onEnvChange(nextEnvString);
     },
     [
       applySnippetToEnv,
@@ -439,6 +411,7 @@ export function useGeminiCommonConfig({
       parseSnippetEnv,
       removeSnippetFromEnv,
       t,
+      syncGuard,
     ],
   );
 
@@ -461,7 +434,9 @@ export function useGeminiCommonConfig({
               currentEnv,
               parsedPrevious.env,
             );
-            onEnvChange(envObjToString(updatedEnv));
+            const nextEnvString = envObjToString(updatedEnv);
+            syncGuard.schedule(envValue, nextEnvString);
+            onEnvChange(nextEnvString);
           }
           setUseCommonConfig(false);
         }
@@ -501,11 +476,9 @@ export function useGeminiCommonConfig({
             ? applySnippetToEnv(withoutOld, nextEnv)
             : withoutOld;
 
-        isUpdatingFromCommonConfig.current = true;
-        onEnvChange(envObjToString(withNew));
-        setTimeout(() => {
-          isUpdatingFromCommonConfig.current = false;
-        }, 0);
+        const nextEnvString = envObjToString(withNew);
+        syncGuard.schedule(envValue, nextEnvString);
+        onEnvChange(nextEnvString);
       }
 
       setCommonConfigError("");
@@ -532,19 +505,67 @@ export function useGeminiCommonConfig({
       removeSnippetFromEnv,
       t,
       useCommonConfig,
+      syncGuard,
     ],
   );
 
-  // 当 env 变化时检查是否包含通用配置（但避免在通过通用配置更新时检查）。
-  // 编辑态且 meta.commonConfigEnabled 有显式值时跳过内容推断，防止打开编辑界面时
-  // 被“快照中暂无片段”的中间态 / 异步初始化竞态覆盖成未勾选。
+  // env 变化同步 effect：先处理程序性写入回显，再处理 env 重置窗口，
+  // 最后才进行用户编辑触发的内容推断（兼容没有 commonConfigEnabled 的旧供应商）。
   useEffect(() => {
-    if (isUpdatingFromCommonConfig.current || isLoading) {
-      return;
+    if (isLoading) return;
+    if (syncGuard.skip(envValue)) return;
+
+    // initialData 被 live 配置替换后，useGeminiConfigState 会把 env 重置为
+    // DB/live 快照（快照按设计不含片段）。等到重置值落地后把片段补回编辑预览。
+    if (pendingResetConfigRef.current !== null) {
+      const expected = pendingResetConfigRef.current;
+      if (envValue === expected) {
+        pendingResetConfigRef.current = null;
+        preResetConfigRef.current = null;
+
+        const parsed = parseSnippetEnv(commonConfigSnippet);
+        if (parsed.error) {
+          if (commonConfigSnippet.trim()) {
+            setCommonConfigError(parsed.error);
+          }
+          return;
+        }
+        const envObj = envStringToObj(envValue);
+        const hasCommon =
+          initialEnabled !== undefined
+            ? initialEnabled
+            : hasEnvCommonConfigSnippet(
+                envObj,
+                parsed.env as Record<string, string>,
+              );
+        if (
+          hasCommon &&
+          !hasEnvCommonConfigSnippet(
+            envObj,
+            parsed.env as Record<string, string>,
+          ) &&
+          Object.keys(parsed.env).length > 0
+        ) {
+          const merged = applySnippetToEnv(envObj, parsed.env);
+          const nextEnvString = envObjToString(merged);
+          if (nextEnvString !== envValue) {
+            syncGuard.schedule(envValue, nextEnvString);
+            onEnvChange(nextEnvString);
+          }
+        }
+        return;
+      }
+
+      if (envValue === preResetConfigRef.current) {
+        // 还没等到 env 重置
+        return;
+      }
+
+      // 重置没有如期发生（或用户先编辑了），清除窗口并按当前值继续处理
+      pendingResetConfigRef.current = null;
+      preResetConfigRef.current = null;
     }
-    if (isEditMode && hasExplicitInitialEnabled) {
-      return;
-    }
+
     const parsed = parseSnippetEnv(commonConfigSnippet);
     if (parsed.error) return;
     const envObj = envStringToObj(envValue);
@@ -555,11 +576,15 @@ export function useGeminiCommonConfig({
     envValue,
     commonConfigSnippet,
     envStringToObj,
+    envObjToString,
     hasEnvCommonConfigSnippet,
     isLoading,
     parseSnippetEnv,
-    isEditMode,
-    hasExplicitInitialEnabled,
+    applySnippetToEnv,
+    onEnvChange,
+    initialData,
+    initialEnabled,
+    syncGuard,
   ]);
 
   // 从编辑器当前内容提取通用配置片段

--- a/src/components/providers/forms/hooks/useInitialDataCommonConfig.ts
+++ b/src/components/providers/forms/hooks/useInitialDataCommonConfig.ts
@@ -1,0 +1,194 @@
+import { useEffect, useState } from "react";
+import { configApi, type AppId } from "@/lib/api";
+import { updateCommonConfigSnippet } from "@/utils/providerConfigUtils";
+import { isForbiddenCommonEnvKey } from "./useGeminiCommonConfig";
+
+/**
+ * 编辑供应商时，把通用配置片段合并进 `initialData.settingsConfig`。
+ *
+ * 后端存储的供应商快照按设计不含通用配置片段，`meta.commonConfigEnabled` 是
+ * 单一真相。编辑界面要展示"合并后"的配置，合并动作放在**数据层**——表单收到的
+ * `initialData` 已是最终形态，`form.reset` / `codexConfig` / `env` 一步到位。
+ *
+ * 这样表单内的通用配置 hook 就不需要观察编辑器的中间值去猜测"何时被重置、
+ * 何时该把片段补回去"，勾选状态与编辑器内容天然一致。
+ */
+
+/** 只有这三种应用有通用配置片段 */
+type CommonConfigAppId = "claude" | "codex" | "gemini";
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const LEGACY_STORAGE_KEYS: Record<CommonConfigAppId, string> = {
+  claude: "cc-switch:common-config-snippet",
+  codex: "cc-switch:codex-common-config-snippet",
+  gemini: "cc-switch:gemini-common-config-snippet",
+};
+
+/**
+ * 读取片段。config.json 为空时回退到 localStorage 遗留值（只读不清理——
+ * 迁移与清理由表单内的通用配置 hook 负责，这里只保证合并预览不落空）。
+ */
+async function loadSnippet(appId: CommonConfigAppId): Promise<string> {
+  let snippet = "";
+  try {
+    snippet = (await configApi.getCommonConfigSnippet(appId)) ?? "";
+  } catch (error) {
+    console.error("加载通用配置失败:", error);
+  }
+  if (snippet.trim()) return snippet;
+
+  const legacyKey = LEGACY_STORAGE_KEYS[appId];
+  if (typeof window === "undefined") return "";
+  try {
+    return window.localStorage.getItem(legacyKey) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+interface UseInitialDataCommonConfigProps {
+  appId: AppId;
+  /** 供应商的 `meta.commonConfigEnabled`；非 true 时不做任何合并 */
+  commonConfigEnabled?: boolean;
+  /** 已经过 live/DB 协调的配置快照 */
+  settingsConfig: Record<string, unknown>;
+  /** 关闭时跳过（编辑面板未打开） */
+  enabled?: boolean;
+}
+
+/** 合并结果连同它的来源快照一起存，用来判断结果是否仍对应当前入参 */
+interface MergeResult {
+  source: Record<string, unknown>;
+  value: Record<string, unknown>;
+}
+
+export function useInitialDataCommonConfig({
+  appId,
+  commonConfigEnabled,
+  settingsConfig,
+  enabled = true,
+}: UseInitialDataCommonConfigProps): Record<string, unknown> {
+  const [merged, setMerged] = useState<MergeResult | null>(null);
+
+  const mergeAppId: CommonConfigAppId | null =
+    appId === "claude" || appId === "codex" || appId === "gemini"
+      ? appId
+      : null;
+
+  useEffect(() => {
+    if (!enabled || commonConfigEnabled !== true || !mergeAppId) {
+      setMerged(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const run = async () => {
+      const snippet = await loadSnippet(mergeAppId);
+      if (cancelled) return;
+
+      let next = settingsConfig;
+      if (snippet.trim()) {
+        if (mergeAppId === "claude") {
+          next = mergeClaudeSnippet(settingsConfig, snippet);
+        } else if (mergeAppId === "gemini") {
+          next = mergeGeminiSnippet(settingsConfig, snippet);
+        } else {
+          next = await mergeCodexSnippet(settingsConfig, snippet);
+        }
+      }
+      if (cancelled) return;
+
+      // 未发生实际改动时保持入参引用，避免下游多一次无意义的表单重置
+      setMerged(
+        next === settingsConfig
+          ? null
+          : { source: settingsConfig, value: next },
+      );
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, commonConfigEnabled, mergeAppId, settingsConfig]);
+
+  // 合并结果与当前入参对不上（入参已变、合并还没跑完）时交出入参本身：
+  // 宁可短暂少显示片段，也不要把上一个快照的内容当成当前值渲染出去。
+  return merged?.source === settingsConfig ? merged.value : settingsConfig;
+}
+
+/** Claude：深合并进快照，失败时原样返回（同一引用表示"未改动"）。 */
+function mergeClaudeSnippet(
+  settings: Record<string, unknown>,
+  snippet: string,
+): Record<string, unknown> {
+  const { updatedConfig, error } = updateCommonConfigSnippet(
+    JSON.stringify(settings, null, 2),
+    snippet,
+    true,
+  );
+  if (error) return settings;
+
+  try {
+    const parsed = JSON.parse(updatedConfig);
+    return isPlainObject(parsed) ? parsed : settings;
+  } catch {
+    return settings;
+  }
+}
+
+/**
+ * Gemini：合并进 settingsConfig.env。
+ *
+ * 禁键判定与 useGeminiCommonConfig 共用同一个实现——片段会被合并进**其它**
+ * 供应商的 env，凭据绝不能进来，两处判定必须一致。片段只要有一个键不合规就
+ * 整体不应用，与编辑界面的行为保持一致。
+ */
+function mergeGeminiSnippet(
+  settings: Record<string, unknown>,
+  snippet: string,
+): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(snippet.trim());
+  } catch {
+    return settings;
+  }
+  if (!isPlainObject(parsed)) return settings;
+
+  const snippetEnv: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (isForbiddenCommonEnvKey(key)) return settings;
+    if (typeof value !== "string") return settings;
+    const normalized = value.trim();
+    if (normalized) snippetEnv[key] = normalized;
+  }
+  if (Object.keys(snippetEnv).length === 0) return settings;
+
+  const currentEnv = isPlainObject(settings.env) ? settings.env : {};
+  return { ...settings, env: { ...currentEnv, ...snippetEnv } };
+}
+
+async function mergeCodexSnippet(
+  settings: Record<string, unknown>,
+  snippet: string,
+): Promise<Record<string, unknown>> {
+  const config = typeof settings.config === "string" ? settings.config : "";
+
+  try {
+    const updated = await configApi.updateTomlCommonConfigSnippet(
+      config,
+      snippet,
+      true,
+    );
+    if (typeof updated !== "string" || updated === config) return settings;
+    return { ...settings, config: updated };
+  } catch (error) {
+    console.error("合并 Codex 通用配置失败:", error);
+    return settings;
+  }
+}

--- a/tests/hooks/useCommonConfigEditState.test.tsx
+++ b/tests/hooks/useCommonConfigEditState.test.tsx
@@ -1,0 +1,184 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCommonConfigSnippet } from "@/components/providers/forms/hooks/useCommonConfigSnippet";
+import { useCodexCommonConfig } from "@/components/providers/forms/hooks/useCodexCommonConfig";
+import { useGeminiCommonConfig } from "@/components/providers/forms/hooks/useGeminiCommonConfig";
+
+const apiMocks = vi.hoisted(() => ({
+  getCommonConfigSnippet: vi.fn(),
+  setCommonConfigSnippet: vi.fn(),
+  extractCommonConfigSnippet: vi.fn(),
+  updateTomlCommonConfigSnippet: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  configApi: {
+    getCommonConfigSnippet: apiMocks.getCommonConfigSnippet,
+    setCommonConfigSnippet: apiMocks.setCommonConfigSnippet,
+    extractCommonConfigSnippet: apiMocks.extractCommonConfigSnippet,
+    updateTomlCommonConfigSnippet: apiMocks.updateTomlCommonConfigSnippet,
+  },
+}));
+
+describe("编辑供应商时保留 meta.commonConfigEnabled 勾选状态", () => {
+  beforeEach(() => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue("");
+    apiMocks.setCommonConfigSnippet.mockResolvedValue(undefined);
+    apiMocks.extractCommonConfigSnippet.mockResolvedValue("");
+    apiMocks.updateTomlCommonConfigSnippet.mockImplementation(
+      async (configToml: string) => configToml,
+    );
+  });
+
+  it("Claude：快照不含片段时仍保持勾选，后续外部刷新快照也不会取消勾选", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      JSON.stringify({ plugin: "shared" }),
+    );
+
+    const onConfigChange = vi.fn();
+    const initialData = { settingsConfig: { apiKey: "provider-key" } };
+    const storedConfig = JSON.stringify(initialData.settingsConfig, null, 2);
+
+    const { result, rerender } = renderHook(
+      ({ settingsConfig }: { settingsConfig: string }) =>
+        useCommonConfigSnippet({
+          settingsConfig,
+          onConfigChange,
+          initialData,
+          initialEnabled: true,
+        }),
+      { initialProps: { settingsConfig: storedConfig } },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
+
+    // 模拟表单先显示合并后的预览，随后 EditProviderDialog 读取 live 失败，
+    // 重新以数据库快照（不含通用配置）初始化表单
+    await act(async () => {
+      rerender({
+        settingsConfig: JSON.stringify(
+          { apiKey: "provider-key", plugin: "shared" },
+          null,
+          2,
+        ),
+      });
+    });
+    expect(result.current.useCommonConfig).toBe(true);
+
+    await act(async () => {
+      rerender({ settingsConfig: storedConfig });
+    });
+    expect(result.current.useCommonConfig).toBe(true);
+
+    // 用户仍可正常取消勾选
+    await act(async () => {
+      result.current.handleCommonConfigToggle(false);
+    });
+    expect(result.current.useCommonConfig).toBe(false);
+  });
+
+  it("Codex：异步合并片段期间外部改写 config.toml 不会把勾选翻成 false", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      "[tui]\nnotifications = true\n",
+    );
+
+    let resolveMerge: ((value: string) => void) | undefined;
+    apiMocks.updateTomlCommonConfigSnippet.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveMerge = resolve;
+        }),
+    );
+
+    const onConfigChange = vi.fn();
+    const initialData = {
+      settingsConfig: { config: 'model = "gpt-5"\n' },
+    };
+
+    const { result, rerender } = renderHook(
+      ({ codexConfig }: { codexConfig: string }) =>
+        useCodexCommonConfig({
+          codexConfig,
+          onConfigChange,
+          initialData,
+          initialEnabled: true,
+        }),
+      { initialProps: { codexConfig: 'model = "gpt-5"\n' } },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
+
+    // 合并请求在飞期间，外部把 config.toml 替换成不含通用配置的内容
+    await act(async () => {
+      rerender({ codexConfig: 'model = "gpt-6-user-edit"\n' });
+      resolveMerge?.('model = "gpt-5"\n\n[tui]\nnotifications = true\n');
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.useCommonConfig).toBe(true);
+  });
+
+  it("Gemini：快照 env 不含片段时仍保持勾选，后续外部刷新 env 也不会取消勾选", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      JSON.stringify({ GEMINI_MODEL: "gemini-2.5-pro" }),
+    );
+
+    const envStringToObj = (env: string): Record<string, string> =>
+      Object.fromEntries(
+        env
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean)
+          .map((line) => {
+            const index = line.indexOf("=");
+            return [line.slice(0, index), line.slice(index + 1)];
+          }),
+      );
+    const envObjToString = (env: Record<string, unknown>): string =>
+      Object.entries(env)
+        .map(([key, value]) => `${key}=${String(value)}`)
+        .join("\n");
+
+    const onEnvChange = vi.fn();
+    const initialData = {
+      settingsConfig: { env: { GEMINI_API_KEY: "provider-key" } },
+    };
+
+    const { result, rerender } = renderHook(
+      ({ envValue }: { envValue: string }) =>
+        useGeminiCommonConfig({
+          envValue,
+          onEnvChange,
+          envStringToObj,
+          envObjToString,
+          initialData,
+          initialEnabled: true,
+        }),
+      { initialProps: { envValue: "GEMINI_API_KEY=provider-key" } },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
+
+    await act(async () => {
+      rerender({
+        envValue: "GEMINI_API_KEY=provider-key\nGEMINI_MODEL=gemini-2.5-pro",
+      });
+    });
+    expect(result.current.useCommonConfig).toBe(true);
+
+    await act(async () => {
+      rerender({ envValue: "GEMINI_API_KEY=provider-key" });
+    });
+    expect(result.current.useCommonConfig).toBe(true);
+
+    await act(async () => {
+      result.current.handleCommonConfigToggle(false);
+    });
+    expect(result.current.useCommonConfig).toBe(false);
+  });
+});

--- a/tests/hooks/useCommonConfigEditState.test.tsx
+++ b/tests/hooks/useCommonConfigEditState.test.tsx
@@ -4,6 +4,14 @@ import { useCommonConfigSnippet } from "@/components/providers/forms/hooks/useCo
 import { useCodexCommonConfig } from "@/components/providers/forms/hooks/useCodexCommonConfig";
 import { useGeminiCommonConfig } from "@/components/providers/forms/hooks/useGeminiCommonConfig";
 
+/**
+ * 通用配置片段由 useInitialDataCommonConfig 在数据层合并进 initialData
+ * （见 useInitialDataCommonConfig.test.tsx），表单收到的就是"合并后"的配置。
+ *
+ * 这里验证 UI 层剩下的那一半契约：勾选状态以 meta.commonConfigEnabled 为准，
+ * 不被表单重置打回，也不被"片段推断不出信息"的情况静默改写。
+ */
+
 const apiMocks = vi.hoisted(() => ({
   getCommonConfigSnippet: vi.fn(),
   setCommonConfigSnippet: vi.fn(),
@@ -20,7 +28,25 @@ vi.mock("@/lib/api", () => ({
   },
 }));
 
-describe("编辑供应商时保持勾选状态与配置预览一致", () => {
+const CLAUDE_SNIPPET = JSON.stringify({ plugin: "shared" });
+
+const envStringToObj = (env: string): Record<string, string> =>
+  Object.fromEntries(
+    env
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const index = line.indexOf("=");
+        return [line.slice(0, index), line.slice(index + 1)];
+      }),
+  );
+const envObjToString = (env: Record<string, unknown>): string =>
+  Object.entries(env)
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join("\n");
+
+describe("编辑供应商时的勾选状态", () => {
   beforeEach(() => {
     apiMocks.getCommonConfigSnippet.mockResolvedValue("");
     apiMocks.setCommonConfigSnippet.mockResolvedValue(undefined);
@@ -30,15 +56,18 @@ describe("编辑供应商时保持勾选状态与配置预览一致", () => {
     );
   });
 
-  it("Claude：live 刷新重置为不含片段的快照后，仍保持勾选并把片段合并回预览", async () => {
-    apiMocks.getCommonConfigSnippet.mockResolvedValue(
-      JSON.stringify({ plugin: "shared" }),
-    );
+  it("Claude：live 刷新换掉已合并的快照后仍保持勾选，且不再回写编辑器", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(CLAUDE_SNIPPET);
 
     const onConfigChange = vi.fn();
-    const storedData = { settingsConfig: { apiKey: "provider-key" } };
+    // 数据层已经合并过片段，表单拿到的是最终形态
+    const storedData = {
+      settingsConfig: { apiKey: "provider-key", plugin: "shared" },
+    };
     const storedConfig = JSON.stringify(storedData.settingsConfig, null, 2);
-    const liveData = { settingsConfig: { apiKey: "live-key" } };
+    const liveData = {
+      settingsConfig: { apiKey: "live-key", plugin: "shared" },
+    };
     const liveConfig = JSON.stringify(liveData.settingsConfig, null, 2);
 
     const { result, rerender } = renderHook(
@@ -62,65 +91,143 @@ describe("编辑供应商时保持勾选状态与配置预览一致", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
-    expect(JSON.parse(onConfigChange.mock.calls.at(-1)?.[0])).toEqual({
-      apiKey: "provider-key",
-      plugin: "shared",
-    });
+    // 合并已在数据层完成，hook 不该再往编辑器写任何东西
+    expect(onConfigChange).not.toHaveBeenCalled();
 
     // 模拟 EditProviderDialog 读到 live 配置后替换 initialData 并重置表单
+    await act(async () => {
+      rerender({ settingsConfig: storedConfig, initialData: liveData });
+    });
     await act(async () => {
       rerender({ settingsConfig: liveConfig, initialData: liveData });
     });
 
     expect(result.current.useCommonConfig).toBe(true);
-    expect(JSON.parse(onConfigChange.mock.calls.at(-1)?.[0])).toEqual({
-      apiKey: "live-key",
-      plugin: "shared",
-    });
+    expect(onConfigChange).not.toHaveBeenCalled();
+  });
 
-    // 模拟父组件应用了上面的合并预览
+  it("Claude：用户手动删掉片段后取消勾选", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(CLAUDE_SNIPPET);
+
+    const onConfigChange = vi.fn();
+    const initialData = {
+      settingsConfig: { apiKey: "k", plugin: "shared" },
+    };
+    const mergedConfig = JSON.stringify(initialData.settingsConfig, null, 2);
+
+    const { result, rerender } = renderHook(
+      ({ settingsConfig }: { settingsConfig: string }) =>
+        useCommonConfigSnippet({
+          settingsConfig,
+          onConfigChange,
+          initialData,
+          initialEnabled: true,
+        }),
+      { initialProps: { settingsConfig: mergedConfig } },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
+
     await act(async () => {
       rerender({
-        settingsConfig: JSON.stringify(
-          { apiKey: "live-key", plugin: "shared" },
-          null,
-          2,
-        ),
-        initialData: liveData,
-      });
-    });
-    expect(result.current.useCommonConfig).toBe(true);
-
-    // 用户手动从配置中移除片段时，仍按内容同步为未勾选
-    await act(async () => {
-      rerender({
-        settingsConfig: JSON.stringify({ apiKey: "live-key" }, null, 2),
-        initialData: liveData,
+        settingsConfig: JSON.stringify({ apiKey: "k" }, null, 2),
       });
     });
     expect(result.current.useCommonConfig).toBe(false);
   });
 
-  it("Codex：live 刷新重置 codexConfig 后，仍保持勾选并把片段合并回预览", async () => {
+  it("Claude：用户取消勾选后，同一 initialData 的重渲染不会把勾选状态恢复", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(CLAUDE_SNIPPET);
+
+    const onConfigChange = vi.fn();
+    const initialData = {
+      settingsConfig: { apiKey: "k", plugin: "shared" },
+    };
+    const mergedConfig = JSON.stringify(initialData.settingsConfig, null, 2);
+
+    const { result, rerender } = renderHook(
+      ({ settingsConfig }: { settingsConfig: string }) =>
+        useCommonConfigSnippet({
+          settingsConfig,
+          onConfigChange,
+          initialData,
+          initialEnabled: true,
+        }),
+      { initialProps: { settingsConfig: mergedConfig } },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
+
+    await act(async () => {
+      result.current.handleCommonConfigToggle(false);
+    });
+    const stripped = onConfigChange.mock.calls.at(-1)?.[0] as string;
+    expect(JSON.parse(stripped)).toEqual({ apiKey: "k" });
+
+    // 父组件应用剥离结果后重渲染：勾选状态必须保持用户的选择
+    await act(async () => {
+      rerender({ settingsConfig: stripped });
+    });
+    expect(result.current.useCommonConfig).toBe(false);
+  });
+
+  it("Claude：片段推断不出信息时保持 flag，不静默改写成未勾选", async () => {
+    // 后端没有存过片段，hook 落到内置默认片段，而快照里当然不含它
+    apiMocks.getCommonConfigSnippet.mockResolvedValue("");
+
+    const onConfigChange = vi.fn();
+    const initialData = { settingsConfig: { apiKey: "k" } };
+
+    const { result } = renderHook(() =>
+      useCommonConfigSnippet({
+        settingsConfig: JSON.stringify(initialData.settingsConfig, null, 2),
+        onConfigChange,
+        initialData,
+        initialEnabled: true,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await act(async () => {});
+    // 若这里被推断成 false，保存时会把 meta.commonConfigEnabled 从 true 改掉
+    expect(result.current.useCommonConfig).toBe(true);
+  });
+
+  it("Claude：没有 flag 的旧供应商按内容推断", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(CLAUDE_SNIPPET);
+
+    const onConfigChange = vi.fn();
+    const initialData = {
+      settingsConfig: { apiKey: "k", plugin: "shared" },
+    };
+
+    const { result } = renderHook(() =>
+      useCommonConfigSnippet({
+        settingsConfig: JSON.stringify(initialData.settingsConfig, null, 2),
+        onConfigChange,
+        initialData,
+        initialEnabled: undefined,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
+  });
+
+  it("Codex：live 刷新换掉已合并的 codexConfig 后仍保持勾选", async () => {
     apiMocks.getCommonConfigSnippet.mockResolvedValue(
       "[tui]\nnotifications = true\n",
     );
-    apiMocks.updateTomlCommonConfigSnippet.mockImplementation(
-      async (configToml: string, _snippet: string, enabled: boolean) =>
-        enabled ? `${configToml}\n\n[tui]\nnotifications = true\n` : configToml,
-    );
 
     const onConfigChange = vi.fn();
-    const storedData = {
-      settingsConfig: {
-        config: 'model_provider = "custom"\nmodel = "gpt-5"\n',
-      },
-    };
-    const liveData = {
-      settingsConfig: {
-        config: 'model_provider = "custom"\nmodel = "gpt-6-live"\n',
-      },
-    };
+    const storedConfig =
+      'model_provider = "custom"\nmodel = "gpt-5"\n\n[tui]\nnotifications = true\n';
+    const liveConfig =
+      'model_provider = "custom"\nmodel = "gpt-6-live"\n\n[tui]\nnotifications = true\n';
+    const storedData = { settingsConfig: { config: storedConfig } };
+    const liveData = { settingsConfig: { config: liveConfig } };
 
     const { result, rerender } = renderHook(
       ({
@@ -137,49 +244,33 @@ describe("编辑供应商时保持勾选状态与配置预览一致", () => {
           initialEnabled: true,
         }),
       {
-        initialProps: {
-          codexConfig: storedData.settingsConfig.config as string,
-          initialData: storedData,
-        },
+        initialProps: { codexConfig: storedConfig, initialData: storedData },
       },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
-    expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain("[tui]");
-    expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain('model = "gpt-5"');
+    expect(onConfigChange).not.toHaveBeenCalled();
 
     await act(async () => {
-      rerender({
-        codexConfig: liveData.settingsConfig.config as string,
-        initialData: liveData,
-      });
+      rerender({ codexConfig: storedConfig, initialData: liveData });
+    });
+    await act(async () => {
+      rerender({ codexConfig: liveConfig, initialData: liveData });
     });
 
-    await waitFor(() =>
-      expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain(
-        'model = "gpt-6-live"',
-      ),
-    );
-    expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain("[tui]");
     expect(result.current.useCommonConfig).toBe(true);
+    expect(onConfigChange).not.toHaveBeenCalled();
   });
 
-  it("Codex：codexConfig 晚于片段加载初始化时，等待稳定后再合并片段", async () => {
+  it("Codex：用户手动删掉片段后取消勾选", async () => {
     apiMocks.getCommonConfigSnippet.mockResolvedValue(
       "[tui]\nnotifications = true\n",
     );
-    apiMocks.updateTomlCommonConfigSnippet.mockImplementation(
-      async (configToml: string, _snippet: string, enabled: boolean) =>
-        enabled ? `${configToml}\n\n[tui]\nnotifications = true\n` : configToml,
-    );
 
     const onConfigChange = vi.fn();
-    const initialData = {
-      settingsConfig: {
-        config: 'model_provider = "custom"\nmodel = "gpt-5"\n',
-      },
-    };
+    const mergedConfig = 'model = "gpt-5"\n\n[tui]\nnotifications = true\n';
+    const initialData = { settingsConfig: { config: mergedConfig } };
 
     const { result, rerender } = renderHook(
       ({ codexConfig }: { codexConfig: string }) =>
@@ -189,51 +280,39 @@ describe("编辑供应商时保持勾选状态与配置预览一致", () => {
           initialData,
           initialEnabled: true,
         }),
-      { initialProps: { codexConfig: "" } },
+      { initialProps: { codexConfig: mergedConfig } },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
 
-    // 模拟 useCodexConfigState 在片段加载完成后才把 config.toml 填进来
     await act(async () => {
-      rerender({ codexConfig: initialData.settingsConfig.config as string });
+      rerender({ codexConfig: 'model = "gpt-5"\n' });
     });
-
-    await waitFor(() =>
-      expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain("[tui]"),
-    );
-    expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain('model = "gpt-5"');
-    expect(result.current.useCommonConfig).toBe(true);
+    expect(result.current.useCommonConfig).toBe(false);
   });
 
-  it("Gemini：live 刷新重置 env 后，仍保持勾选并把片段合并回预览", async () => {
+  it("Gemini：live 刷新换掉已合并的 env 后仍保持勾选", async () => {
     apiMocks.getCommonConfigSnippet.mockResolvedValue(
       JSON.stringify({ GEMINI_MODEL: "gemini-2.5-pro" }),
     );
 
-    const envStringToObj = (env: string): Record<string, string> =>
-      Object.fromEntries(
-        env
-          .split("\n")
-          .map((line) => line.trim())
-          .filter(Boolean)
-          .map((line) => {
-            const index = line.indexOf("=");
-            return [line.slice(0, index), line.slice(index + 1)];
-          }),
-      );
-    const envObjToString = (env: Record<string, unknown>): string =>
-      Object.entries(env)
-        .map(([key, value]) => `${key}=${String(value)}`)
-        .join("\n");
-
     const onEnvChange = vi.fn();
+    const storedEnv =
+      "GEMINI_API_KEY=provider-key\nGEMINI_MODEL=gemini-2.5-pro";
+    const liveEnv = "GEMINI_API_KEY=live-key\nGEMINI_MODEL=gemini-2.5-pro";
     const storedData = {
-      settingsConfig: { env: { GEMINI_API_KEY: "provider-key" } },
+      settingsConfig: {
+        env: {
+          GEMINI_API_KEY: "provider-key",
+          GEMINI_MODEL: "gemini-2.5-pro",
+        },
+      },
     };
     const liveData = {
-      settingsConfig: { env: { GEMINI_API_KEY: "live-key" } },
+      settingsConfig: {
+        env: { GEMINI_API_KEY: "live-key", GEMINI_MODEL: "gemini-2.5-pro" },
+      },
     };
 
     const { result, rerender } = renderHook(
@@ -253,29 +332,57 @@ describe("编辑供应商时保持勾选状态与配置预览一致", () => {
           initialEnabled: true,
         }),
       {
-        initialProps: {
-          envValue: "GEMINI_API_KEY=provider-key",
-          initialData: storedData,
-        },
+        initialProps: { envValue: storedEnv, initialData: storedData },
       },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
-    expect(onEnvChange.mock.calls.at(-1)?.[0]).toContain(
-      "GEMINI_MODEL=gemini-2.5-pro",
-    );
+    expect(onEnvChange).not.toHaveBeenCalled();
 
     await act(async () => {
-      rerender({ envValue: "GEMINI_API_KEY=live-key", initialData: liveData });
+      rerender({ envValue: storedEnv, initialData: liveData });
+    });
+    await act(async () => {
+      rerender({ envValue: liveEnv, initialData: liveData });
     });
 
     expect(result.current.useCommonConfig).toBe(true);
-    expect(onEnvChange.mock.calls.at(-1)?.[0]).toContain(
-      "GEMINI_API_KEY=live-key",
+    expect(onEnvChange).not.toHaveBeenCalled();
+  });
+
+  it("Gemini：用户手动删掉片段后取消勾选", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      JSON.stringify({ GEMINI_MODEL: "gemini-2.5-pro" }),
     );
-    expect(onEnvChange.mock.calls.at(-1)?.[0]).toContain(
-      "GEMINI_MODEL=gemini-2.5-pro",
+
+    const onEnvChange = vi.fn();
+    const mergedEnv = "GEMINI_API_KEY=k\nGEMINI_MODEL=gemini-2.5-pro";
+    const initialData = {
+      settingsConfig: {
+        env: { GEMINI_API_KEY: "k", GEMINI_MODEL: "gemini-2.5-pro" },
+      },
+    };
+
+    const { result, rerender } = renderHook(
+      ({ envValue }: { envValue: string }) =>
+        useGeminiCommonConfig({
+          envValue,
+          onEnvChange,
+          envStringToObj,
+          envObjToString,
+          initialData,
+          initialEnabled: true,
+        }),
+      { initialProps: { envValue: mergedEnv } },
     );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
+
+    await act(async () => {
+      rerender({ envValue: "GEMINI_API_KEY=k" });
+    });
+    expect(result.current.useCommonConfig).toBe(false);
   });
 });

--- a/tests/hooks/useCommonConfigEditState.test.tsx
+++ b/tests/hooks/useCommonConfigEditState.test.tsx
@@ -20,7 +20,7 @@ vi.mock("@/lib/api", () => ({
   },
 }));
 
-describe("编辑供应商时保留 meta.commonConfigEnabled 勾选状态", () => {
+describe("编辑供应商时保持勾选状态与配置预览一致", () => {
   beforeEach(() => {
     apiMocks.getCommonConfigSnippet.mockResolvedValue("");
     apiMocks.setCommonConfigSnippet.mockResolvedValue(undefined);
@@ -30,70 +30,155 @@ describe("编辑供应商时保留 meta.commonConfigEnabled 勾选状态", () =>
     );
   });
 
-  it("Claude：快照不含片段时仍保持勾选，后续外部刷新快照也不会取消勾选", async () => {
+  it("Claude：live 刷新重置为不含片段的快照后，仍保持勾选并把片段合并回预览", async () => {
     apiMocks.getCommonConfigSnippet.mockResolvedValue(
       JSON.stringify({ plugin: "shared" }),
     );
 
     const onConfigChange = vi.fn();
-    const initialData = { settingsConfig: { apiKey: "provider-key" } };
-    const storedConfig = JSON.stringify(initialData.settingsConfig, null, 2);
+    const storedData = { settingsConfig: { apiKey: "provider-key" } };
+    const storedConfig = JSON.stringify(storedData.settingsConfig, null, 2);
+    const liveData = { settingsConfig: { apiKey: "live-key" } };
+    const liveConfig = JSON.stringify(liveData.settingsConfig, null, 2);
 
     const { result, rerender } = renderHook(
-      ({ settingsConfig }: { settingsConfig: string }) =>
+      ({
+        settingsConfig,
+        initialData,
+      }: {
+        settingsConfig: string;
+        initialData: { settingsConfig: Record<string, unknown> };
+      }) =>
         useCommonConfigSnippet({
           settingsConfig,
           onConfigChange,
           initialData,
           initialEnabled: true,
         }),
-      { initialProps: { settingsConfig: storedConfig } },
+      {
+        initialProps: { settingsConfig: storedConfig, initialData: storedData },
+      },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
+    expect(JSON.parse(onConfigChange.mock.calls.at(-1)?.[0])).toEqual({
+      apiKey: "provider-key",
+      plugin: "shared",
+    });
 
-    // 模拟表单先显示合并后的预览，随后 EditProviderDialog 读取 live 失败，
-    // 重新以数据库快照（不含通用配置）初始化表单
+    // 模拟 EditProviderDialog 读到 live 配置后替换 initialData 并重置表单
+    await act(async () => {
+      rerender({ settingsConfig: liveConfig, initialData: liveData });
+    });
+
+    expect(result.current.useCommonConfig).toBe(true);
+    expect(JSON.parse(onConfigChange.mock.calls.at(-1)?.[0])).toEqual({
+      apiKey: "live-key",
+      plugin: "shared",
+    });
+
+    // 模拟父组件应用了上面的合并预览
     await act(async () => {
       rerender({
         settingsConfig: JSON.stringify(
-          { apiKey: "provider-key", plugin: "shared" },
+          { apiKey: "live-key", plugin: "shared" },
           null,
           2,
         ),
+        initialData: liveData,
       });
     });
     expect(result.current.useCommonConfig).toBe(true);
 
+    // 用户手动从配置中移除片段时，仍按内容同步为未勾选
     await act(async () => {
-      rerender({ settingsConfig: storedConfig });
-    });
-    expect(result.current.useCommonConfig).toBe(true);
-
-    // 用户仍可正常取消勾选
-    await act(async () => {
-      result.current.handleCommonConfigToggle(false);
+      rerender({
+        settingsConfig: JSON.stringify({ apiKey: "live-key" }, null, 2),
+        initialData: liveData,
+      });
     });
     expect(result.current.useCommonConfig).toBe(false);
   });
 
-  it("Codex：异步合并片段期间外部改写 config.toml 不会把勾选翻成 false", async () => {
+  it("Codex：live 刷新重置 codexConfig 后，仍保持勾选并把片段合并回预览", async () => {
     apiMocks.getCommonConfigSnippet.mockResolvedValue(
       "[tui]\nnotifications = true\n",
     );
+    apiMocks.updateTomlCommonConfigSnippet.mockImplementation(
+      async (configToml: string, _snippet: string, enabled: boolean) =>
+        enabled ? `${configToml}\n\n[tui]\nnotifications = true\n` : configToml,
+    );
 
-    let resolveMerge: ((value: string) => void) | undefined;
-    apiMocks.updateTomlCommonConfigSnippet.mockImplementationOnce(
-      () =>
-        new Promise<string>((resolve) => {
-          resolveMerge = resolve;
+    const onConfigChange = vi.fn();
+    const storedData = {
+      settingsConfig: {
+        config: 'model_provider = "custom"\nmodel = "gpt-5"\n',
+      },
+    };
+    const liveData = {
+      settingsConfig: {
+        config: 'model_provider = "custom"\nmodel = "gpt-6-live"\n',
+      },
+    };
+
+    const { result, rerender } = renderHook(
+      ({
+        codexConfig,
+        initialData,
+      }: {
+        codexConfig: string;
+        initialData: { settingsConfig: Record<string, unknown> };
+      }) =>
+        useCodexCommonConfig({
+          codexConfig,
+          onConfigChange,
+          initialData,
+          initialEnabled: true,
         }),
+      {
+        initialProps: {
+          codexConfig: storedData.settingsConfig.config as string,
+          initialData: storedData,
+        },
+      },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
+    expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain("[tui]");
+    expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain('model = "gpt-5"');
+
+    await act(async () => {
+      rerender({
+        codexConfig: liveData.settingsConfig.config as string,
+        initialData: liveData,
+      });
+    });
+
+    await waitFor(() =>
+      expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain(
+        'model = "gpt-6-live"',
+      ),
+    );
+    expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain("[tui]");
+    expect(result.current.useCommonConfig).toBe(true);
+  });
+
+  it("Codex：codexConfig 晚于片段加载初始化时，等待稳定后再合并片段", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      "[tui]\nnotifications = true\n",
+    );
+    apiMocks.updateTomlCommonConfigSnippet.mockImplementation(
+      async (configToml: string, _snippet: string, enabled: boolean) =>
+        enabled ? `${configToml}\n\n[tui]\nnotifications = true\n` : configToml,
     );
 
     const onConfigChange = vi.fn();
     const initialData = {
-      settingsConfig: { config: 'model = "gpt-5"\n' },
+      settingsConfig: {
+        config: 'model_provider = "custom"\nmodel = "gpt-5"\n',
+      },
     };
 
     const { result, rerender } = renderHook(
@@ -104,25 +189,25 @@ describe("编辑供应商时保留 meta.commonConfigEnabled 勾选状态", () =>
           initialData,
           initialEnabled: true,
         }),
-      { initialProps: { codexConfig: 'model = "gpt-5"\n' } },
+      { initialProps: { codexConfig: "" } },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
 
-    // 合并请求在飞期间，外部把 config.toml 替换成不含通用配置的内容
+    // 模拟 useCodexConfigState 在片段加载完成后才把 config.toml 填进来
     await act(async () => {
-      rerender({ codexConfig: 'model = "gpt-6-user-edit"\n' });
-      resolveMerge?.('model = "gpt-5"\n\n[tui]\nnotifications = true\n');
+      rerender({ codexConfig: initialData.settingsConfig.config as string });
     });
 
-    await act(async () => {
-      await Promise.resolve();
-    });
+    await waitFor(() =>
+      expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain("[tui]"),
+    );
+    expect(onConfigChange.mock.calls.at(-1)?.[0]).toContain('model = "gpt-5"');
     expect(result.current.useCommonConfig).toBe(true);
   });
 
-  it("Gemini：快照 env 不含片段时仍保持勾选，后续外部刷新 env 也不会取消勾选", async () => {
+  it("Gemini：live 刷新重置 env 后，仍保持勾选并把片段合并回预览", async () => {
     apiMocks.getCommonConfigSnippet.mockResolvedValue(
       JSON.stringify({ GEMINI_MODEL: "gemini-2.5-pro" }),
     );
@@ -144,12 +229,21 @@ describe("编辑供应商时保留 meta.commonConfigEnabled 勾选状态", () =>
         .join("\n");
 
     const onEnvChange = vi.fn();
-    const initialData = {
+    const storedData = {
       settingsConfig: { env: { GEMINI_API_KEY: "provider-key" } },
+    };
+    const liveData = {
+      settingsConfig: { env: { GEMINI_API_KEY: "live-key" } },
     };
 
     const { result, rerender } = renderHook(
-      ({ envValue }: { envValue: string }) =>
+      ({
+        envValue,
+        initialData,
+      }: {
+        envValue: string;
+        initialData: { settingsConfig: Record<string, unknown> };
+      }) =>
         useGeminiCommonConfig({
           envValue,
           onEnvChange,
@@ -158,27 +252,30 @@ describe("编辑供应商时保留 meta.commonConfigEnabled 勾选状态", () =>
           initialData,
           initialEnabled: true,
         }),
-      { initialProps: { envValue: "GEMINI_API_KEY=provider-key" } },
+      {
+        initialProps: {
+          envValue: "GEMINI_API_KEY=provider-key",
+          initialData: storedData,
+        },
+      },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     await waitFor(() => expect(result.current.useCommonConfig).toBe(true));
+    expect(onEnvChange.mock.calls.at(-1)?.[0]).toContain(
+      "GEMINI_MODEL=gemini-2.5-pro",
+    );
 
     await act(async () => {
-      rerender({
-        envValue: "GEMINI_API_KEY=provider-key\nGEMINI_MODEL=gemini-2.5-pro",
-      });
+      rerender({ envValue: "GEMINI_API_KEY=live-key", initialData: liveData });
     });
+
     expect(result.current.useCommonConfig).toBe(true);
-
-    await act(async () => {
-      rerender({ envValue: "GEMINI_API_KEY=provider-key" });
-    });
-    expect(result.current.useCommonConfig).toBe(true);
-
-    await act(async () => {
-      result.current.handleCommonConfigToggle(false);
-    });
-    expect(result.current.useCommonConfig).toBe(false);
+    expect(onEnvChange.mock.calls.at(-1)?.[0]).toContain(
+      "GEMINI_API_KEY=live-key",
+    );
+    expect(onEnvChange.mock.calls.at(-1)?.[0]).toContain(
+      "GEMINI_MODEL=gemini-2.5-pro",
+    );
   });
 });

--- a/tests/hooks/useInitialDataCommonConfig.test.tsx
+++ b/tests/hooks/useInitialDataCommonConfig.test.tsx
@@ -1,0 +1,292 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useInitialDataCommonConfig } from "@/components/providers/forms/hooks/useInitialDataCommonConfig";
+
+const apiMocks = vi.hoisted(() => ({
+  getCommonConfigSnippet: vi.fn(),
+  updateTomlCommonConfigSnippet: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  configApi: {
+    getCommonConfigSnippet: apiMocks.getCommonConfigSnippet,
+    updateTomlCommonConfigSnippet: apiMocks.updateTomlCommonConfigSnippet,
+  },
+}));
+
+describe("useInitialDataCommonConfig（数据层合并）", () => {
+  beforeEach(() => {
+    apiMocks.getCommonConfigSnippet.mockReset();
+    apiMocks.updateTomlCommonConfigSnippet.mockReset();
+    apiMocks.getCommonConfigSnippet.mockResolvedValue("");
+    apiMocks.updateTomlCommonConfigSnippet.mockImplementation(
+      async (configToml: string) => configToml,
+    );
+    window.localStorage.clear();
+  });
+
+  it("Claude：flag 为 true 时把片段合并进快照", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      JSON.stringify({ plugin: "shared" }),
+    );
+    const settingsConfig = { apiKey: "provider-key" };
+
+    const { result } = renderHook(() =>
+      useInitialDataCommonConfig({
+        appId: "claude",
+        commonConfigEnabled: true,
+        settingsConfig,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        apiKey: "provider-key",
+        plugin: "shared",
+      }),
+    );
+  });
+
+  it("flag 不为 true 时不合并，也不去读片段", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      JSON.stringify({ plugin: "shared" }),
+    );
+    const settingsConfig = { apiKey: "provider-key" };
+
+    const { result } = renderHook(() =>
+      useInitialDataCommonConfig({
+        appId: "claude",
+        commonConfigEnabled: false,
+        settingsConfig,
+      }),
+    );
+
+    await waitFor(() => expect(result.current).toBe(settingsConfig));
+    expect(apiMocks.getCommonConfigSnippet).not.toHaveBeenCalled();
+  });
+
+  it("片段为空时保持同一引用", async () => {
+    const settingsConfig = { apiKey: "provider-key" };
+
+    const { result } = renderHook(() =>
+      useInitialDataCommonConfig({
+        appId: "claude",
+        commonConfigEnabled: true,
+        settingsConfig,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(apiMocks.getCommonConfigSnippet).toHaveBeenCalledWith("claude"),
+    );
+    expect(result.current).toBe(settingsConfig);
+  });
+
+  it("Codex：走后端 toml_edit 合并 config 字段", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      "[tui]\nnotifications = true\n",
+    );
+    apiMocks.updateTomlCommonConfigSnippet.mockImplementation(
+      async (configToml: string, _snippet: string, enabled: boolean) =>
+        enabled ? `${configToml}\n[tui]\nnotifications = true\n` : configToml,
+    );
+    const settingsConfig = { config: 'model = "gpt-5"\n', auth: {} };
+
+    const { result } = renderHook(() =>
+      useInitialDataCommonConfig({
+        appId: "codex",
+        commonConfigEnabled: true,
+        settingsConfig,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.config).toContain("[tui]"));
+    expect(result.current.config).toContain('model = "gpt-5"');
+    // 非 config 字段原样保留
+    expect(result.current.auth).toEqual({});
+  });
+
+  it("Codex：后端合并失败时退回原快照", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue("[tui]\n");
+    apiMocks.updateTomlCommonConfigSnippet.mockRejectedValue(
+      new Error("toml parse failed"),
+    );
+    const settingsConfig = { config: 'model = "gpt-5"\n' };
+
+    const { result } = renderHook(() =>
+      useInitialDataCommonConfig({
+        appId: "codex",
+        commonConfigEnabled: true,
+        settingsConfig,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(apiMocks.updateTomlCommonConfigSnippet).toHaveBeenCalled(),
+    );
+    expect(result.current).toBe(settingsConfig);
+  });
+
+  it("Gemini：合并进 env", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      JSON.stringify({ GEMINI_MODEL: "gemini-2.5-pro" }),
+    );
+    const settingsConfig = { env: { GEMINI_API_KEY: "k" } };
+
+    const { result } = renderHook(() =>
+      useInitialDataCommonConfig({
+        appId: "gemini",
+        commonConfigEnabled: true,
+        settingsConfig,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.env).toEqual({
+        GEMINI_API_KEY: "k",
+        GEMINI_MODEL: "gemini-2.5-pro",
+      }),
+    );
+  });
+
+  it("Gemini：片段带凭据键时整体不合并", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      JSON.stringify({ GEMINI_MODEL: "gemini-2.5-pro", GOOGLE_API_KEY: "s" }),
+    );
+    const settingsConfig = { env: { GEMINI_API_KEY: "k" } };
+
+    const { result } = renderHook(() =>
+      useInitialDataCommonConfig({
+        appId: "gemini",
+        commonConfigEnabled: true,
+        settingsConfig,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(apiMocks.getCommonConfigSnippet).toHaveBeenCalledWith("gemini"),
+    );
+    // 凭据绝不能被合并进另一个供应商的 env 预览
+    expect(result.current).toBe(settingsConfig);
+  });
+
+  it("Gemini：片段值不是字符串时整体不合并", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      JSON.stringify({ GEMINI_MODEL: 42 }),
+    );
+    const settingsConfig = { env: {} };
+
+    const { result } = renderHook(() =>
+      useInitialDataCommonConfig({
+        appId: "gemini",
+        commonConfigEnabled: true,
+        settingsConfig,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(apiMocks.getCommonConfigSnippet).toHaveBeenCalledWith("gemini"),
+    );
+    expect(result.current).toBe(settingsConfig);
+  });
+
+  it("Claude：片段不是合法 JSON 时不合并", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue("{ not json");
+    const settingsConfig = { apiKey: "provider-key" };
+
+    const { result } = renderHook(() =>
+      useInitialDataCommonConfig({
+        appId: "claude",
+        commonConfigEnabled: true,
+        settingsConfig,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(apiMocks.getCommonConfigSnippet).toHaveBeenCalledWith("claude"),
+    );
+    expect(result.current).toBe(settingsConfig);
+  });
+
+  it("config.json 为空时回退到 localStorage 遗留片段", async () => {
+    window.localStorage.setItem(
+      "cc-switch:common-config-snippet",
+      JSON.stringify({ plugin: "legacy" }),
+    );
+    const settingsConfig = { apiKey: "provider-key" };
+
+    const { result } = renderHook(() =>
+      useInitialDataCommonConfig({
+        appId: "claude",
+        commonConfigEnabled: true,
+        settingsConfig,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        apiKey: "provider-key",
+        plugin: "legacy",
+      }),
+    );
+    // 迁移与清理仍由表单内的 hook 负责，这里只读不写
+    expect(
+      window.localStorage.getItem("cc-switch:common-config-snippet"),
+    ).not.toBeNull();
+  });
+
+  it("enabled 为 false 时不合并", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      JSON.stringify({ plugin: "shared" }),
+    );
+    const settingsConfig = { apiKey: "provider-key" };
+
+    const { result } = renderHook(() =>
+      useInitialDataCommonConfig({
+        appId: "claude",
+        commonConfigEnabled: true,
+        settingsConfig,
+        enabled: false,
+      }),
+    );
+
+    await waitFor(() => expect(result.current).toBe(settingsConfig));
+    expect(apiMocks.getCommonConfigSnippet).not.toHaveBeenCalled();
+  });
+
+  it("快照变化时不会把上一份合并结果当成当前值", async () => {
+    apiMocks.getCommonConfigSnippet.mockResolvedValue(
+      JSON.stringify({ plugin: "shared" }),
+    );
+    const stored = { apiKey: "stored" };
+    const live = { apiKey: "live" };
+
+    const { result, rerender } = renderHook(
+      ({ settingsConfig }: { settingsConfig: Record<string, unknown> }) =>
+        useInitialDataCommonConfig({
+          appId: "claude",
+          commonConfigEnabled: true,
+          settingsConfig,
+        }),
+      { initialProps: { settingsConfig: stored } },
+    );
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        apiKey: "stored",
+        plugin: "shared",
+      }),
+    );
+
+    rerender({ settingsConfig: live });
+    // 合并尚未完成时交出入参本身，绝不能显示上一个供应商快照的内容
+    expect(result.current.apiKey).toBe("live");
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        apiKey: "live",
+        plugin: "shared",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Problem

When suppliers A and B both have "Apply common config" checked, clicking Edit on supplier A can open an edit form where the checkbox appears unchecked; exiting and re-entering may show it checked again. This can happen for Claude, Codex, and Gemini suppliers.

The root cause is a mismatch between the frontend and backend models for "apply common config":

- Since the runtime-overlay change (`6d078e7f`), the backend strips the common config snippet from stored provider snapshots on save and keeps `meta.commonConfigEnabled` as the single source of truth. The snippet is merged dynamically only when writing live.
- The three frontend hooks still infer the checkbox from whether the currently edited JSON/TOML/env contains the snippet. That inference races with async snippet loading, the Codex TOML merge, and `EditProviderDialog`'s live-settings refresh, so an initialized `true` can be overwritten by an intermediate `false`.

## Fix

- `useCommonConfigSnippet.ts` / `useCodexCommonConfig.ts` / `useGeminiCommonConfig.ts`: in edit mode with an explicit `meta.commonConfigEnabled`, skip the content-derived sync effect and treat that flag as authoritative.
- `useCodexCommonConfig.ts`: during edit initialization, set the checkbox state synchronously from the flag before asynchronously merging the snippet for the editor preview; a failed or stale merge only reports an error and no longer unchecks the box.
- Legacy providers without the `commonConfigEnabled` field keep the previous content-inference behavior for compatibility.

## Test Coverage

- New `tests/hooks/useCommonConfigEditState.test.tsx` covering:
  - Claude: stays checked when the snapshot does not contain the snippet and after an external snapshot refresh.
  - Codex: an external `config.toml` rewrite during the in-flight merge does not uncheck the box.
  - Gemini: stays checked when the snapshot env does not contain the snippet and after an external env refresh.
  - All three scenarios also verify the user can still uncheck the box manually.
- Regression verification: all 3 new cases fail on the old code and pass after the fix; the full `pnpm test:unit` suite passes 136 files / 1077 tests.

## Files Changed

| File | Delta |
|------|-------|
| `src/components/providers/forms/hooks/useCommonConfigSnippet.ts` | +21, -2 |
| `src/components/providers/forms/hooks/useCodexCommonConfig.ts` | +32, -11 |
| `src/components/providers/forms/hooks/useGeminiCommonConfig.ts` | +14, -1 |
| `tests/hooks/useCommonConfigEditState.test.tsx` | +184 |