### PR TITLE
fix(proxy): sanitize orphan function_call_output without call_id

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1287,6 +1287,10 @@ impl RequestForwarder {
                 super::model_mapper::strip_one_m_suffix_for_upstream_from_body(mapped_body);
         }
 
+        if matches!(app_type, AppType::Codex | AppType::GrokBuild) {
+            mapped_body = sanitize_codex_orphan_function_call_outputs(mapped_body);
+        }
+
         // --- Copilot 优化器：分类 + 请求体优化（在格式转换之前执行） ---
         // 注意：确定性 ID 也在此处计算，因为 mapped_body 在格式转换时会被 move
         //
@@ -3622,6 +3626,32 @@ fn is_protected_local_proxy_override_header(name: &http::HeaderName) -> bool {
     )
 }
 
+/// Sanitize Codex / GrokBuild input history by removing orphan `function_call_output` items
+/// that lack a `call_id` (#7074).
+///
+/// Codex App injects `automation_update` outputs without a `call_id` during automated/cron runs.
+/// Strict upstream APIs (e.g. DeepSeek /v1/responses or Chat completions) reject these with
+/// `missing field call_id` or 400 invalid tool message ordering.
+pub(crate) fn sanitize_codex_orphan_function_call_outputs(mut body: Value) -> Value {
+    if let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) {
+        input.retain(|item| {
+            if item.get("type").and_then(Value::as_str) == Some("function_call_output") {
+                let call_id = item.get("call_id").and_then(Value::as_str).unwrap_or("");
+                if call_id.is_empty() {
+                    log::debug!(
+                        "[Codex] Dropping function_call_output lacking call_id: id={:?}, name={:?}",
+                        item.get("id"),
+                        item.get("name")
+                    );
+                    return false;
+                }
+            }
+            true
+        });
+    }
+    body
+}
+
 fn prepare_upstream_request_body(request_body: Value) -> Value {
     canonicalize_value(filter_private_params_with_whitelist(request_body, &[]))
 }
@@ -5246,5 +5276,37 @@ mod tests {
         });
         let body = body_with_image("any-model");
         assert!(fwd.media_retry_should_trigger("Claude", false, &body, &image_unsupported_error()));
+    }
+
+    #[test]
+    fn sanitize_codex_orphan_function_call_outputs_drops_item_without_call_id() {
+        let body = json!({
+            "model": "deepseek-v4-flash",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}]
+                },
+                {
+                    "type": "function_call_output",
+                    "id": "fco_test",
+                    "name": "automation_update",
+                    "output": "Automation: daily review"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_valid_123",
+                    "output": "{\"status\":\"ok\"}"
+                }
+            ]
+        });
+
+        let sanitized = sanitize_codex_orphan_function_call_outputs(body);
+        let input = sanitized["input"].as_array().expect("input must be array");
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[0]["type"], "message");
+        assert_eq!(input[1]["type"], "function_call_output");
+        assert_eq!(input[1]["call_id"], "call_valid_123");
     }
 }

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -705,7 +705,7 @@ fn append_responses_item_as_chat_message(
                     item.get("id"),
                     item.get("name")
                 );
-                return;
+                return Ok(());
             }
             let media_plan = item
                 .get("output")

--- a/src-tauri/src/proxy/providers/transform_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/transform_codex_chat.rs
@@ -699,6 +699,14 @@ fn append_responses_item_as_chat_message(
                 last_assistant_index,
             );
             let call_id = item.get("call_id").and_then(|v| v.as_str()).unwrap_or("");
+            if call_id.is_empty() {
+                log::debug!(
+                    "[Codex] Dropping function_call_output lacking call_id in chat transform: id={:?}, name={:?}",
+                    item.get("id"),
+                    item.get("name")
+                );
+                return;
+            }
             let media_plan = item
                 .get("output")
                 .cloned()


### PR DESCRIPTION
## Summary

Revives the orphan `function_call_output` sanitizer from commit `7f5babba`, originally authored by @loulanyue for #7074, and fixes a compilation error in its defensive Responses-to-Chat handling.

The original commit is still present in the upstream repository, but it is no longer associated with an active pull request. This PR intentionally preserves @loulanyue's original commit and authorship rather than squashing or re-attributing that implementation.

My additional code change is a separate commit fixing the invalid bare `return;` in `append_responses_item_as_chat_message`. That function returns `Result<(), ProxyError>`, so dropping an invalid `function_call_output` must return `Ok(())`.

## Problem

Codex Desktop can persist/inject standalone `function_call_output` items without a usable `call_id`, including outputs associated with automation flows.

Strict Responses-compatible upstreams can reject such histories before sampling. I independently reproduced this with CC Switch's managed xAI OAuth provider and Grok 4.6.

This is not limited to xAI; #7074 reports the same interoperability problem with DeepSeek.

## Changes

The original @loulanyue commit:

- filters orphan `function_call_output` items without a usable `call_id` at the Codex/GrokBuild request boundary;
- preserves valid `function_call_output` items that contain a `call_id`;
- defensively drops the same invalid item during Responses-to-Chat transformation;
- adds a focused sanitizer regression test.

My follow-up commit:

- changes the defensive transform path from the invalid `return;` to `return Ok(());`, matching the function's `Result<(), ProxyError>` return type.

## Runtime validation

I tested the sanitizer locally on macOS with Codex Desktop, CC Switch, managed xAI OAuth, and Grok 4.6.

Results:

- fresh cross-thread / worker request: PASS
- replacement thread: PASS
- already-poisoned thread containing a persisted orphan `function_call_output`: recovered successfully
- subsequent Grok sampling on the recovered thread: PASS

The poisoned history did not need to be rewritten or deleted. Sanitizing each forwarded request was sufficient to recover it.

I also posted the independent cross-provider runtime findings in #7074 and the poisoned-thread recovery behavior in #6995.

## Attribution

The sanitizer implementation in commit `7f5babba` was authored by @loulanyue.

I am preserving that commit's original Git author metadata. My contribution is kept separately: the compilation fix, rebasing/revival against current `main`, and independent xAI/Grok runtime validation.

Closes #7074
Related: #6995
