### PR TITLE
fix(proxy): clamp Claude Desktop probe token limits for Copilot/Responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to CC Switch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Claude Desktop probe `max_tokens=1` no longer fails OpenAI/Copilot Responses**: Claude Desktop's configured-model check sends `max_tokens=1`. The local gateway forwarded that value as `max_output_tokens` (or `max_tokens` / Gemini `maxOutputTokens`), and GitHub Copilot plus other Responses upstreams reject anything below 16 with HTTP 400 — which Desktop then shows as "Configured model not available". The Desktop route mapper and the Chat / Responses / Gemini transforms now clamp the limit to 16. Normal requests above 16 are unchanged. (#7103)
+
 ## [3.20.1] - 2026-08-28
 
 This release is dominated by two Codex storylines. The first is an urgent compatibility break: Codex CLI 0.149 stopped letting custom providers inherit ambient credentials from `auth.json`, turning third-party switches made in the old default mode into 401 errors (#6744). Rather than patching around it, cc-switch now switches Codex providers config-only — the key travels in the provider's own `config.toml` table, `auth.json` returns to being purely the official ChatGPT login file — and a whole family of legacy config shapes 0.149 refuses to load is repaired on every switch, with a new preflight refusing unloadable shapes instead of reporting a "successful" switch Codex cannot start from. The second is account safety: two members of the same ChatGPT Team workspace no longer overwrite each other in the Auth Center (#6780, fixes #2245) — existing managed accounts need one re-login (see upgrade notes). Around them: provider edits now always reach the live config file (#6779), the Codex edit dialog no longer shows another provider's key (#6534), restores no longer wipe hand-written prompt files (#6810), the usage dashboard gains an auto/manual session-scan toggle plus an incremental byte-cursor scanner (a 12 MB active session file: 6.04 s → 9.3 ms) behind this release's schema migration (v17 → v18), and Otty joins the macOS terminal picker (#6620).

--- a/src-tauri/src/claude_desktop_config.rs
+++ b/src-tauri/src/claude_desktop_config.rs
@@ -747,10 +747,29 @@ pub fn map_proxy_request_model(mut body: Value, provider: &Provider) -> Result<V
         })?;
 
     body["model"] = json!(upstream_model);
+    clamp_desktop_probe_token_limits(&mut body);
     if should_normalize_mimo_anthropic_thinking_history(provider, &upstream_model) {
         normalize_mimo_anthropic_thinking_history(&mut body);
     }
     Ok(body)
+}
+
+/// Claude Desktop's model-availability probe uses `max_tokens=1`. Copilot and
+/// other OpenAI-compatible upstreams reject that (`max_output_tokens >= 16`).
+fn clamp_desktop_probe_token_limits(body: &mut Value) {
+    const MIN_OUTPUT_TOKENS: u64 = 16;
+    for key in ["max_tokens", "max_output_tokens"] {
+        let Some(n) = body.get(key).and_then(|value| {
+            value
+                .as_u64()
+                .or_else(|| value.as_i64().map(|n| n.max(0) as u64))
+        }) else {
+            continue;
+        };
+        if n < MIN_OUTPUT_TOKENS {
+            body[key] = json!(MIN_OUTPUT_TOKENS);
+        }
+    }
 }
 
 fn strip_one_m_suffix_for_route_lookup(model: &str) -> &str {
@@ -1620,6 +1639,18 @@ mod tests {
         )
         .expect("map route");
         assert_eq!(mapped["model"], json!("kimi-k2"));
+
+        let probed = map_proxy_request_model(
+            json!({
+                "model": "claude-sonnet-4-6",
+                "max_tokens": 1,
+                "messages": []
+            }),
+            &provider,
+        )
+        .expect("clamp desktop probe max_tokens");
+        assert_eq!(probed["model"], json!("kimi-k2"));
+        assert_eq!(probed["max_tokens"], json!(16));
 
         let models = model_list_response(&provider).expect("model list");
         assert_eq!(models["data"][0]["id"], json!("claude-sonnet-4-6"));

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -61,6 +61,24 @@ pub fn is_openai_o_series(model: &str) -> bool {
         && model.as_bytes().get(1).is_some_and(|b| b.is_ascii_digit())
 }
 
+/// OpenAI Responses, Copilot, and several chat/Gemini upstreams reject an
+/// output-token limit below this. Claude Desktop availability probes send
+/// `max_tokens=1`, which those APIs return as HTTP 400.
+pub(crate) const MIN_OPENAI_OUTPUT_TOKENS: u64 = 16;
+
+pub(crate) fn clamp_min_output_tokens(value: &Value) -> Value {
+    match output_token_limit(value) {
+        Some(n) if n < MIN_OPENAI_OUTPUT_TOKENS => json!(MIN_OPENAI_OUTPUT_TOKENS),
+        _ => value.clone(),
+    }
+}
+
+fn output_token_limit(value: &Value) -> Option<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_i64().map(|n| n.max(0) as u64))
+}
+
 /// Detect Responses-compatible models that support reasoning effort.
 ///
 /// Supported families:
@@ -190,10 +208,11 @@ pub fn anthropic_to_openai_with_reasoning_content(
     // 转换参数 — o-series 模型需要 max_completion_tokens
     let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("");
     if let Some(v) = body.get("max_tokens") {
+        let clamped = clamp_min_output_tokens(v);
         if is_openai_o_series(model) {
-            result["max_completion_tokens"] = v.clone();
+            result["max_completion_tokens"] = clamped;
         } else {
-            result["max_tokens"] = v.clone();
+            result["max_tokens"] = clamped;
         }
     }
     if let Some(v) = body.get("temperature") {
@@ -1936,6 +1955,28 @@ mod tests {
         let result = anthropic_to_openai(input).unwrap();
         assert_eq!(result["max_tokens"], 1024);
         assert!(result.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_to_openai_clamps_probe_max_tokens() {
+        let input = json!({
+            "model": "gpt-4o",
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+
+        let result = anthropic_to_openai(input).unwrap();
+        assert_eq!(result["max_tokens"], MIN_OPENAI_OUTPUT_TOKENS);
+    }
+
+    #[test]
+    fn test_clamp_min_output_tokens() {
+        assert_eq!(clamp_min_output_tokens(&json!(1)), json!(16));
+        assert_eq!(clamp_min_output_tokens(&json!(0)), json!(16));
+        assert_eq!(clamp_min_output_tokens(&json!(-3)), json!(16));
+        assert_eq!(clamp_min_output_tokens(&json!(16)), json!(16));
+        assert_eq!(clamp_min_output_tokens(&json!(1024)), json!(1024));
+        assert_eq!(clamp_min_output_tokens(&json!(null)), json!(null));
     }
 
     fn run_tool_choice(value: Value) -> Value {

--- a/src-tauri/src/proxy/providers/transform_gemini.rs
+++ b/src-tauri/src/proxy/providers/transform_gemini.rs
@@ -350,7 +350,10 @@ fn build_generation_config(body: &Value) -> Option<Value> {
     let mut config = Map::new();
 
     if let Some(value) = body.get("max_tokens") {
-        config.insert("maxOutputTokens".to_string(), value.clone());
+        config.insert(
+            "maxOutputTokens".to_string(),
+            super::transform::clamp_min_output_tokens(value),
+        );
     }
     if let Some(value) = body.get("temperature") {
         config.insert("temperature".to_string(), value.clone());
@@ -1288,6 +1291,18 @@ mod tests {
         assert_eq!(result["contents"][0]["role"], "user");
         assert_eq!(result["contents"][0]["parts"][0]["text"], "Hello");
         assert_eq!(result["generationConfig"]["maxOutputTokens"], 128);
+    }
+
+    #[test]
+    fn anthropic_to_gemini_clamps_probe_max_output_tokens() {
+        let input = json!({
+            "model": "gemini-3.8-flash",
+            "max_tokens": 1,
+            "messages": [{ "role": "user", "content": "hi" }]
+        });
+
+        let result = anthropic_to_gemini(input).unwrap();
+        assert_eq!(result["generationConfig"]["maxOutputTokens"], 16);
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -1806,8 +1806,9 @@ pub fn anthropic_to_responses(
     }
 
     // max_tokens → max_output_tokens (Responses API uses max_output_tokens for all models)
+    // Claude Desktop probes send max_tokens=1; OpenAI/Copilot require >= 16.
     if let Some(v) = body.get("max_tokens") {
-        result["max_output_tokens"] = v.clone();
+        result["max_output_tokens"] = super::transform::clamp_min_output_tokens(v);
     }
 
     // 直接透传的参数
@@ -3186,6 +3187,27 @@ mod tests {
         assert_eq!(result["input"][0]["content"][0]["text"], "Hello");
         // stop_sequences should not appear
         assert!(result.get("stop_sequences").is_none());
+    }
+
+    #[test]
+    fn test_max_output_tokens_clamped_to_minimum() {
+        // Claude Desktop sends max_tokens=1 as a model-availability probe;
+        // OpenAI / Copilot Responses require >= 16.
+        let input = json!({
+            "model": "gpt-5.6-sol",
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["max_output_tokens"], 16);
+
+        let input2 = json!({
+            "model": "gpt-5.6-sol",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "hi"}]
+        });
+        let result2 = anthropic_to_responses(input2, None, false, false).unwrap();
+        assert_eq!(result2["max_output_tokens"], 1024);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Claude Desktop's configured-model check sends `max_tokens=1`. The local gateway forwarded that as `max_output_tokens` (or Chat `max_tokens` / Gemini `maxOutputTokens`), and Copilot plus other Responses upstreams reject anything below 16 with HTTP 400 — Desktop then shows **Configured model not available**.
- Clamp the outgoing limit to 16 in the Desktop route mapper and the Chat / Responses / Gemini transforms. Requests already at or above 16 are unchanged.
- Fixes #7103. Adjacent to, but not a substitute for, #6069 and #5219 (those remap token *field names* for GPT-5 / API variants; this one only raises a probe-sized limit).

## Test plan
- [x] Unit tests: `test_clamp_min_output_tokens`, `test_anthropic_to_openai_clamps_probe_max_tokens`, `test_max_output_tokens_clamped_to_minimum`, `anthropic_to_gemini_clamps_probe_max_output_tokens`, and the Desktop route mapper probe (`max_tokens: 1` → `16`)
- [ ] Claude Desktop local routing to a Copilot / OpenAI Responses / OpenCode Zen upstream: fully quit Desktop, reopen, **Check again** — model should become available
- [ ] A normal chat with `max_tokens` ≥ 16 still forwards the original limit
- [ ] Gemini-mapped Desktop routes no longer fail the same probe with `maxOutputTokens=1`


Made with [Cursor](https://cursor.com)