### PR TITLE
fix(linux): 修复 Wayland 混合缩放下窗口尺寸膨胀成假最大化;增加 CC_SWITCH_WEBKIT_HW 硬件加速逃生开关

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1322,14 +1322,21 @@ pub fn run() {
             });
 
             // Linux: 禁用 WebKitGTK 硬件加速，防止 EGL 初始化失败导致白屏
+            // CC_SWITCH_WEBKIT_HW=1 逃生开关(与 main.rs 的环境变量开关注同一开关):
+            // 跳过禁用,保留硬件加速。软件渲染在 2K/4K 屏上拖动窗口会拖影。
             #[cfg(target_os = "linux")]
             {
-                if let Some(window) = app.get_webview_window("main") {
+                if std::env::var("CC_SWITCH_WEBKIT_HW").as_deref() == Ok("1") {
+                    log::info!("CC_SWITCH_WEBKIT_HW=1: 保留 WebKitGTK 硬件加速");
+                } else if let Some(window) = app.get_webview_window("main") {
                     let _ = window.with_webview(|webview| {
-                        use webkit2gtk::{WebViewExt, SettingsExt, HardwareAccelerationPolicy};
+                        use webkit2gtk::{SettingsExt, HardwareAccelerationPolicy, WebViewExt};
                         let wk_webview = webview.inner();
                         if let Some(settings) = WebViewExt::settings(&wk_webview) {
-                            SettingsExt::set_hardware_acceleration_policy(&settings, HardwareAccelerationPolicy::Never);
+                            SettingsExt::set_hardware_acceleration_policy(
+                                &settings,
+                                HardwareAccelerationPolicy::Never,
+                            );
                             log::info!("已禁用 WebKitGTK 硬件加速");
                         }
                     });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ mod services;
 mod session_manager;
 mod settings;
 mod store;
+mod window_state_guard;
 
 mod tray;
 mod usage_events;
@@ -341,6 +342,10 @@ fn macos_tray_icon() -> Option<Image<'static>> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // 在 Tauri Builder 构造(window-state 插件随后读取状态文件)之前,
+    // 先清理历史上可能被写坏的窗口尺寸(见 window_state_guard 模块文档)。
+    window_state_guard::startup_sanitize();
+
     // 设置 panic hook，在应用崩溃时记录日志到 <app_config_dir>/crash.log（默认 ~/.cc-switch/crash.log）
     panic_hook::setup_panic_hook();
 
@@ -2250,6 +2255,10 @@ pub fn save_window_state_before_exit(app_handle: &tauri::AppHandle) {
     } else {
         log::info!("已在退出前保存窗口状态");
     }
+    // tao GTK 后端在混合缩放/登录竞态下 inner_size() 可能返回膨胀值
+    // (物理/逻辑像素混淆),落盘后按窗口所在显示器的 scale 归一化为逻辑像素,
+    // 防止坏值在每次开机恢复时把窗口越变越大(配合 reapply_saved_size)。
+    window_state_guard::normalize_saved_state_to_logical(app_handle);
 }
 
 /// 主动释放 single-instance 锁。

--- a/src-tauri/src/linux_fix.rs
+++ b/src-tauri/src/linux_fix.rs
@@ -41,6 +41,12 @@ const RECONCILE_WAIT: Duration = Duration::from_millis(500);
 /// 调用是 fire-and-forget：内部 spawn 一个异步任务在 ~250ms 后完成。
 /// 调用线程立即返回，不阻塞 UI。
 pub(crate) fn nudge_main_window(window: WebviewWindow) {
+    // 先把超出所在显示器物理尺寸的窗口钳回边界:window-state 恢复的
+    // 膨胀尺寸会被合成器整体钳制成"假最大化",且让下面 ±1px 回写
+    // 把坏值原样存回。先对账,nudge 读到的就是修正后的尺寸。
+    // (见 window_state_guard 模块文档)
+    crate::window_state_guard::reconcile_window_to_monitor(&window);
+
     // 第一次 set_focus：webview 可能还没 realize，这一次通常是无效的，
     // 但成本极低（线程安全，内部 run_on_main_thread），顺手做掉。
     let _ = window.set_focus();
@@ -110,6 +116,11 @@ pub(crate) fn nudge_main_window(window: WebviewWindow) {
                         log::warn!("Linux nudge: 对账回读 inner_size 失败: {e}");
                     }
                 }
+
+                // nudge 序列完成、scale 缓存已稳定后,按状态文件里的逻辑像素
+                // 重新应用窗口尺寸,修正插件在窗口创建早期恢复出的错误尺寸
+                // (window_state_guard 的不动点方案,见该模块文档)。
+                crate::window_state_guard::reapply_saved_size(&window);
             }
             Err(e) => {
                 // 极罕见的失败路径；只做了 set_focus 也比什么都不做强，

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,14 +7,25 @@ fn main() {
     // 参考: https://github.com/tauri-apps/tauri/issues/9394
     #[cfg(target_os = "linux")]
     {
-        if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
-            std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
-        }
-        // 禁用 WebKitGTK 合成模式，规避 resize 时 webview 崩溃以及部分 Wayland
-        // 合成器下的 surface 协商问题（整窗 UI 点击无响应、必须最大化-还原才能恢复）。
-        // 参考: https://github.com/tauri-apps/tauri/issues/9394
-        if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err() {
-            std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        // 逃生开关:CC_SWITCH_WEBKIT_HW=1 时保留 WebKitGTK 硬件加速
+        // (DMABUF 渲染器 + 合成模式都不禁用)。软件渲染在 2K/4K 屏上
+        // 重绘跟不上窗口拖动,表现为拖影/残影;较新的 NVIDIA 驱动 +
+        // WebKitGTK 2.52 + Mesa 26 上默认路径已可正常走 GPU。
+        // 默认行为保持不变(零回归),仅在显式设置时生效。
+        let webkit_hw = std::env::var("CC_SWITCH_WEBKIT_HW").as_deref() == Ok("1");
+        if !webkit_hw {
+            // 在 Linux 上设置 WebKit 环境变量以解决 DMA-BUF 渲染问题
+            // 某些 Linux 系统（如 Debian 13.2、Nvidia GPU）上 WebKitGTK 的 DMA-BUF 渲染器可能导致白屏/黑屏
+            // 参考: https://github.com/tauri-apps/tauri/issues/9394
+            if std::env::var("WEBKIT_DISABLE_DMABUF_RENDERER").is_err() {
+                std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+            }
+            // 禁用 WebKitGTK 合成模式，规避 resize 时 webview 崩溃以及部分 Wayland
+            // 合成器下的 surface 协商问题（整窗 UI 点击无响应、必须最大化-还原才能恢复）。
+            // 参考: https://github.com/tauri-apps/tauri/issues/9394
+            if std::env::var("WEBKIT_DISABLE_COMPOSITING_MODE").is_err() {
+                std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+            }
         }
 
         // AppImage 的 GTK 启动钩子 (linuxdeploy-plugin-gtk.sh) 会无条件

--- a/src-tauri/src/window_state_guard.rs
+++ b/src-tauri/src/window_state_guard.rs
@@ -1,0 +1,363 @@
+//! 窗口状态文件(`.window-state.json`)的尺寸护栏。
+//!
+//! 背景:tao 的 GTK 后端 `inner_size()` 返回「缓存 logical 尺寸 × 缓存 scale」,
+//! `set_size()` 又用「当时缓存 scale」做物理→逻辑换算。在混合缩放多屏
+//! (如 scale 1.0 + 1.3333)或登录时显示器布局尚未就绪的竞态下,这一往返会把
+//! 物理像素当 logical 写回(或反之),窗口尺寸按 scale 比率逐周期膨胀,实测可
+//! 累积到 20480×11264 这类远超任何显示器的值。window-state 插件恢复该值后,
+//! Wayland 合成器把窗口钳制到整屏:表现为「假最大化 + 窗口控制按钮失效 +
+//! 巨型 WebView 视口拖影」,且退出时保存的仍是坏值,开机自启动每天复现。
+//!
+//! 本模块不修 tao(上游问题),只在 cc-switch 侧的收口点钳制:
+//! 1. `startup_sanitize`:进程启动、插件读取状态文件之前,把超出静态上限
+//!    (8K)或低于合理下限的窗口条目重置(删除条目,插件按默认尺寸创建)。
+//! 2. `clamp_state_file_to_monitors`:配合 `save_window_state_before_exit`,
+//!    在落盘后按当前显示器的最大物理尺寸钳制文件内容,保证坏值无法持久化。
+//! 3. `reconcile_window_to_monitor`:窗口显示路径上,若 `inner_size` 超出
+//!    所在显示器尺寸,立即修正(兜底同一会话内的异常,如运行中拔掉显示器)。
+
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager, WebviewWindow};
+
+const STATE_FILENAME: &str = ".window-state.json";
+// 与 tauri.conf.json 的 identifier 保持一致;此处无法通过 AppHandle 获取,
+// 因为 startup_sanitize 必须在 Tauri Builder 构造(插件读状态文件)之前执行。
+const APP_IDENTIFIER: &str = "com.ccswitch.desktop";
+
+/// 静态护栏:任何消费级显示器都不超过 8K;低于最小值视为脏数据。
+const HARD_MAX_W: u64 = 7680;
+const HARD_MAX_H: u64 = 4320;
+const HARD_MIN_W: u64 = 300;
+const HARD_MIN_H: u64 = 200;
+
+fn state_file_path() -> Option<PathBuf> {
+    // 与 tauri 的 app_config_dir 一致:Linux ~/.config/{id}、
+    // macOS ~/Library/Application Support/{id}、Windows %APPDATA%\{id}
+    dirs::config_dir().map(|d| d.join(APP_IDENTIFIER).join(STATE_FILENAME))
+}
+
+/// 进程启动时调用(须早于 Tauri Builder 构造)。
+pub fn startup_sanitize() {
+    if let Some(path) = state_file_path() {
+        sanitize_file(&path, HARD_MAX_W, HARD_MAX_H);
+    }
+}
+
+/// 读取状态文件,丢弃 width/height 越界的窗口条目,原子写回。
+fn sanitize_file(path: &Path, max_w: u64, max_h: u64) {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(_) => return, // 文件不存在或不可读:交给插件按首次启动处理
+    };
+    let mut root = match serde_json::from_str::<Value>(&raw) {
+        Ok(Value::Object(map)) => map,
+        _ => return, // 结构损坏:不碰,插件自己会忽略/重建
+    };
+
+    let mut changed = false;
+    root.retain(|_label, entry| {
+        let (w, h) = match (
+            entry.get("width").and_then(|v| v.as_u64()),
+            entry.get("height").and_then(|v| v.as_u64()),
+        ) {
+            (Some(w), Some(h)) => (w, h),
+            _ => return true, // 缺字段:结构由插件定义,不在这里猜
+        };
+        let keep = w >= HARD_MIN_W && h >= HARD_MIN_H && w <= max_w && h <= max_h;
+        if !keep {
+            changed = true;
+            log::warn!("窗口状态条目尺寸 {w}x{h} 越界(上限 {max_w}x{max_h}),已重置");
+        }
+        keep
+    });
+
+    if !changed {
+        return;
+    }
+    if root.is_empty() {
+        // 所有条目都越界:直接删文件,等价于首次启动
+        let _ = std::fs::remove_file(path);
+        return;
+    }
+    let tmp = path.with_extension("json.tmp");
+    match serde_json::to_string(&Value::Object(root)) {
+        Ok(text) => {
+            if std::fs::write(&tmp, text).is_ok() {
+                let _ = std::fs::rename(&tmp, path);
+            }
+        }
+        Err(e) => log::warn!("窗口状态文件重写失败: {e}"),
+    }
+}
+
+/// 在 `save_window_state` 落盘之后调用。
+///
+/// 插件保存的是物理像素,而 tao 的 scale 缓存在混合缩放多屏下保存/恢复两个
+/// 时刻读数可能不一致(窗口在 scale=1 的屏、缓存读到 1.3333),实测每循环
+/// 膨胀 ×1.3333。这里把主窗口的条目换算成「逻辑像素」存盘(用窗口真实所在
+/// 显示器的 scale),配合 [`reapply_saved_size`] 在 scale 稳定后按逻辑像素
+/// 重新应用,构成不动点:存什么恢复什么,不再漂移。
+///
+/// 查不到主窗口/显示器时(如轻量模式退出时窗口已销毁),退化为按所有显示器
+/// 的最大物理尺寸做越界清理,至少保证坏值有界。
+pub fn normalize_saved_state_to_logical(app: &AppHandle) {
+    // 主窗口当前显示器:scale 与逻辑尺寸上限
+    let (scale, max_w, max_h) = app
+        .get_webview_window("main")
+        .and_then(|w| w.current_monitor().ok().flatten())
+        .map(|m| {
+            let s = m.scale_factor();
+            let sz = m.size();
+            // 逻辑上限 = 物理尺寸 / scale,向上取整避免差 1px 误杀
+            (
+                s,
+                (sz.width as f64 / s).ceil() as u64,
+                (sz.height as f64 / s).ceil() as u64,
+            )
+        })
+        .unwrap_or((1.0, HARD_MAX_W, HARD_MAX_H));
+
+    if let Some(path) = state_file_path() {
+        rewrite_entries_logical(&path, scale, max_w.min(HARD_MAX_W), max_h.min(HARD_MAX_H));
+    }
+}
+
+/// 把状态文件中所有条目的 width/height 从物理像素换算为逻辑像素并钳制。
+/// 仅在插件刚写完物理值之后调用(每次保存插件都会整体重写文件,不会重复换算)。
+fn rewrite_entries_logical(path: &Path, scale: f64, max_w: u64, max_h: u64) {
+    if (scale - 1.0).abs() < f64::EPSILON && max_w == HARD_MAX_W && max_h == HARD_MAX_H {
+        // 无显示器信息且 scale=1:退化为纯清理(沿用物理上限语义)
+        sanitize_file(path, max_w, max_h);
+        return;
+    }
+    let raw = match std::fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(_) => return,
+    };
+    let mut root = match serde_json::from_str::<Value>(&raw) {
+        Ok(Value::Object(map)) => map,
+        _ => return,
+    };
+    let mut changed = false;
+    for (_label, entry) in root.iter_mut() {
+        let (w, h) = match (
+            entry.get("width").and_then(|v| v.as_u64()),
+            entry.get("height").and_then(|v| v.as_u64()),
+        ) {
+            (Some(w), Some(h)) => (w, h),
+            _ => continue,
+        };
+        let (lw, lh) = to_logical_clamped(w, h, scale, max_w, max_h);
+        if lw != w || lh != h {
+            if let Some(obj) = entry.as_object_mut() {
+                obj.insert("width".into(), Value::from(lw));
+                obj.insert("height".into(), Value::from(lh));
+                changed = true;
+            }
+        }
+    }
+    if changed {
+        let tmp = path.with_extension("json.tmp");
+        if serde_json::to_string(&Value::Object(root))
+            .map(|text| std::fs::write(&tmp, text).is_ok())
+            .unwrap_or(false)
+        {
+            let _ = std::fs::rename(&tmp, path);
+            log::info!("窗口状态已按显示器 scale={scale} 归一化为逻辑像素(上限 {max_w}x{max_h})");
+        }
+    }
+}
+
+/// 物理像素 → 逻辑像素(四舍五入到整数,插件字段是 u32),并钳制到逻辑上限。
+fn to_logical_clamped(w: u64, h: u64, scale: f64, max_w: u64, max_h: u64) -> (u64, u64) {
+    let lw = (w as f64 / scale).round() as u64;
+    let lh = (h as f64 / scale).round() as u64;
+    (lw.clamp(HARD_MIN_W, max_w), lh.clamp(HARD_MIN_H, max_h))
+}
+
+/// 窗口显示后约 1.2s(nudge 序列完成、scale 缓存已稳定)调用:
+/// 读取状态文件中本窗口的逻辑尺寸,以 LogicalSize 重新应用一次,
+/// 修正插件在窗口创建早期(缓存 scale 尚未就绪)恢复出的错误尺寸。
+/// 窗口处于最大化/全屏时跳过,避免破坏用户状态。
+pub fn reapply_saved_size(window: &WebviewWindow) {
+    let label = window.label().to_string();
+    let window = window.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
+        if window.is_maximized().unwrap_or(false) || window.is_fullscreen().unwrap_or(false) {
+            return;
+        }
+        let Some(path) = state_file_path() else {
+            return;
+        };
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(_) => return,
+        };
+        let entry = match serde_json::from_str::<Value>(&raw) {
+            Ok(Value::Object(map)) => map.get(&label).cloned(),
+            _ => None,
+        };
+        let Some(entry) = entry else { return };
+        let (w, h) = match (
+            entry.get("width").and_then(|v| v.as_u64()),
+            entry.get("height").and_then(|v| v.as_u64()),
+        ) {
+            (Some(w), Some(h)) => (w, h),
+            _ => return,
+        };
+        // 状态文件保存的是逻辑像素;越界值直接放弃,保持当前尺寸
+        if w < HARD_MIN_W || h < HARD_MIN_H || w > HARD_MAX_W || h > HARD_MAX_H {
+            log::warn!("状态文件尺寸 {w}x{h} 越界,跳过重新应用");
+            return;
+        }
+        match window.set_size(tauri::LogicalSize::new(w as f64, h as f64)) {
+            Ok(()) => log::info!("已按逻辑像素 {w}x{h} 重新应用窗口尺寸"),
+            Err(e) => log::warn!("重新应用窗口尺寸失败: {e}"),
+        }
+    });
+}
+
+/// 若窗口 inner_size 超出其所在显示器的物理尺寸,立即钳制到显示器边界。
+/// 在窗口显示路径(nudge 之前)调用;查询失败时静默跳过。
+pub fn reconcile_window_to_monitor(window: &WebviewWindow) {
+    let size = match window.inner_size() {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let monitor = match window.current_monitor() {
+        Ok(Some(m)) => m,
+        _ => return,
+    };
+    let m = monitor.size();
+    if size.width > m.width || size.height > m.height {
+        let w = size.width.min(m.width);
+        let h = size.height.min(m.height);
+        if let Err(e) = window.set_size(tauri::PhysicalSize::new(w, h)) {
+            log::warn!("窗口尺寸钳制失败: {e}");
+        } else {
+            log::warn!(
+                "窗口尺寸 {}x{} 超出显示器 {}x{},已钳制",
+                size.width,
+                size.height,
+                m.width,
+                m.height
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_state(dir: &Path, json: &str) -> PathBuf {
+        let p = dir.join(STATE_FILENAME);
+        std::fs::write(&p, json).unwrap();
+        p
+    }
+
+    #[test]
+    fn drops_oversized_entry_and_deletes_file_when_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_state(
+            dir.path(),
+            r#"{"main":{"width":20480,"height":11264,"x":0,"y":0,"maximized":false}}"#,
+        );
+        sanitize_file(&p, 2560, 1600);
+        assert!(!p.exists(), "唯一条目越界时应删除整个文件");
+    }
+
+    #[test]
+    fn keeps_sane_entries_when_dropping_garbage() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_state(
+            dir.path(),
+            r#"{"main":{"width":1000,"height":650,"x":10,"y":20,"maximized":false},"other":{"width":99999,"height":650,"x":0,"y":0,"maximized":false}}"#,
+        );
+        sanitize_file(&p, 2560, 1600);
+        let text = std::fs::read_to_string(&p).unwrap();
+        let root: Value = serde_json::from_str(&text).unwrap();
+        assert!(root.get("main").is_some(), "正常条目应保留");
+        assert!(root.get("other").is_none(), "越界条目应删除");
+    }
+
+    #[test]
+    fn keeps_entry_smaller_than_monitor_bounds() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_state(
+            dir.path(),
+            r#"{"main":{"width":2560,"height":1440,"x":0,"y":0,"maximized":false}}"#,
+        );
+        sanitize_file(&p, 2560, 1600);
+        assert!(p.exists(), "等于显示器尺寸的窗口(钳制后保存的)不应被重置");
+    }
+
+    #[test]
+    fn ignores_corrupt_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_state(dir.path(), "not json at all");
+        sanitize_file(&p, 2560, 1600);
+        assert_eq!(std::fs::read_to_string(&p).unwrap(), "not json at all");
+    }
+
+    #[test]
+    fn drops_too_small_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_state(
+            dir.path(),
+            r#"{"main":{"width":10,"height":10,"x":0,"y":0,"maximized":false}}"#,
+        );
+        sanitize_file(&p, 2560, 1600);
+        assert!(!p.exists());
+    }
+
+    #[test]
+    fn to_logical_clamped_undoes_scale_growth() {
+        // 实测场景:2000x1332 物理(mutter 报 scale=1.3333333730697632)
+        // → 应精确还原为 1500x999 逻辑
+        let (w, h) = to_logical_clamped(2000, 1332, 1.333_333_373_069_763_2, 1920, 1200);
+        assert_eq!((w, h), (1500, 999));
+    }
+
+    #[test]
+    fn to_logical_clamped_rounds_and_clamps() {
+        // 1000x650 物理 @4/3 → 750x488(650/1.3333=487.5 四舍五入)
+        let (w, h) = to_logical_clamped(1000, 650, 4.0 / 3.0, 1920, 1200);
+        assert_eq!((w, h), (750, 488));
+        // 超上限钳制
+        let (w, h) = to_logical_clamped(9999, 9999, 1.0, 1920, 1200);
+        assert_eq!((w, h), (1920, 1200));
+    }
+
+    #[test]
+    fn rewrite_entries_converts_physical_to_logical() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_state(
+            dir.path(),
+            r#"{"main":{"width":2000,"height":1332,"x":0,"y":0,"maximized":false}}"#,
+        );
+        rewrite_entries_logical(&p, 1.333_333_373_069_763_2, 1920, 1200);
+        let text = std::fs::read_to_string(&p).unwrap();
+        let root: Value = serde_json::from_str(&text).unwrap();
+        let entry = root.get("main").unwrap();
+        assert_eq!(entry.get("width").unwrap().as_u64(), Some(1500));
+        assert_eq!(entry.get("height").unwrap().as_u64(), Some(999));
+        // 其他字段不动
+        assert_eq!(entry.get("x").unwrap().as_u64(), Some(0));
+    }
+
+    #[test]
+    fn rewrite_entries_fallback_sanitize_when_no_monitor() {
+        let dir = tempfile::tempdir().unwrap();
+        // scale=1 + 默认上限 = 无显示器信息 → 纯清理语义(越界删除)
+        let p = write_state(
+            dir.path(),
+            r#"{"main":{"width":1000,"height":650,"x":0,"y":0,"maximized":false}}"#,
+        );
+        rewrite_entries_logical(&p, 1.0, HARD_MAX_W, HARD_MAX_H);
+        let text = std::fs::read_to_string(&p).unwrap();
+        assert!(text.contains("1000"), "正常尺寸不应被改动");
+    }
+}


### PR DESCRIPTION
## 自检

- [x] 已阅读 README 中的常见问题
- [x] 已搜索已有 Issue(含已关闭):与 #4296(KDE 渐进放大+按钮不可点)、#5464(GNOME 按钮不可点)症状相关但机制不同,详见下文

## 环境

- CC Switch 3.20.1(.deb)
- Ubuntu 26.04 LTS / GNOME Shell 50.x / **Wayland 原生**(GTK3 + WebKitGTK 2.52.6)
- NVIDIA RTX 3060 Laptop(595.84)
- **混合缩放双屏**:内屏 2560×1600 @ scale 1.3333(小数缩放)+ 外接 DP 2560×1440 @ scale 1
- 触发方式:开机自启动

## 症状(每次开机必现)

1. 窗口占满外接屏但并非真最大化("假最大化")
2. 右上角最小化/关闭等窗口控制按钮点击无反应(页面内按钮正常)
3. 拖动窗口有拖影
4. 退出重开暂时恢复

## 实测证据(非推测)

- `~/.config/com.ccswitch.desktop/.window-state.json` 被写成 `width: 20480, height: 11264`(约 2.3 亿像素),`maximized: false`
- 带该文件启动时,AT-SPI 实测窗口被 mutter 钳制为 2560×1408(外接屏整屏-顶栏):GTK 请求尺寸与实际 surface 尺寸严重不一致 → 假最大化 + CSD 按钮 hit-testing 失效
- 删除该文件后启动,窗口恢复默认 1000×650,一切正常
- 连续观测两个退出/启动周期:1500×999 → **2000×1332(= ×4/3 整)**,即每保存/恢复循环尺寸 ×1.3333(内屏 scale),持续膨胀直至远超屏幕;20480×11264 = 钳制后尺寸 2560×1408 × 8

## 根因(源码逐行核实:tao 0.34.6 + tauri-plugin-window-state 2.4.1)

- tao GTK 后端 `inner_size()` 返回「缓存 logical × 缓存 scale」(tao `window.rs:496`),`set_inner_size()` 用**当时的**缓存 scale 做物理→逻辑换算(`window.rs:507`)
- 主窗口 `visible:false` 创建、插件在 `on_window_ready` 恢复尺寸,此时窗口未映射、GDK Wayland 的 surface scale 尚未由合成器下发;混合缩放多屏下保存/恢复两个时刻 scale 缓存读数不一致 → 单位往返有损,每循环 ×scale 比
- `nudge_main_window` 的 `inner_size()`→`set_size()` 回写(`linux_fix.rs`)与托盘重建路径(`lightweight.rs` 先保存再 destroy)会放大该问题
- 关于症状 3(拖影)的更正:后续深入排查确认拖影与渲染模式无关(本机 NVIDIA 专有驱动 + Wayland 下 WebKitGTK 的加速路径会静默回退软件渲染,开启硬件加速前后 WebProcess 均无 GPU 显存),实际相关变量是**启动时机**——开机自启(显示器布局未就绪)时创建的 WebView surface 会拖影,会话稳定后启动则干净。该问题与本 PR 两个提交均无直接关系,本 PR 只解决症状 1/2/4

## 修复内容(两个提交)

**1. `window_state_guard` 模块(窗口尺寸不动点方案)**
- `startup_sanitize`:Builder 构造前清理越界条目(静态 8K 上限,防历史坏值)
- `normalize_saved_state_to_logical`:save 落盘后按窗口**真实所在显示器**的 scale 归一化为逻辑像素
- `reapply_saved_size`:nudge 序列完成后(scale 缓存已稳定)按逻辑像素重新应用一次
- 归一化 + 重应用构成不动点:存什么恢复什么,跨显示器视觉尺寸一致
- 附单元测试(含 2000×1332→1500×999 的实测换算用例)

**2. `CC_SWITCH_WEBKIT_HW=1` 逃生开关**
- 设置时跳过三重软件渲染,保留硬件加速;默认行为不变(零回归)
- 仿照现有 `CC_SWITCH_GDK_BACKEND` 的开关模式
- 诚实说明:在提交者的机器(NVIDIA 专有驱动 + Wayland)上,WebKitGTK 的加速路径本身静默回退软件渲染,该开关不改变实际渲染路径;其价值在于加速路径可用的环境(如 Intel/AMD 核显、或 NVIDIA dmabuf 问题已修复的驱动栈,见 #6514 的诉求),让这些机器不必被一刀切地锁在软件渲染

## 验证

- fork 分支 CI:rustfmt / clippy(-D warnings)/ 单元测试 / deb 构建全绿
- 本机多个开机/重启周期实测:窗口尺寸稳定在用户设定值(AT-SPI 实测与状态文件逐像素一致)、假最大化与按钮失效消失(症状 1/2/4)

## 相关

- #4296(KDE 下渐进放大 +30px/次的机制与本 PR 不同,但"按钮不可点+窗口变大"症状同族)
- #5464(GNOME Wayland 按钮不可点)
- #6514(强制 WEBKIT_DISABLE_DMABUF_RENDERER=1 在 WebKitGTK 2.52 + Mesa 26 的副作用,本 PR 的逃生开关为该方向提供了用户侧过渡方案)
