### PR TITLE
fix(codex): align OAuth client identity for GPT-6

### DIFF
--- a/src-tauri/src/proxy/providers/claude.rs
+++ b/src-tauri/src/proxy/providers/claude.rs
@@ -14,6 +14,7 @@
 //! - **OpenRouter**: 已支持 Claude Code 兼容接口，默认透传
 //! - **GitHubCopilot**: GitHub Copilot (OAuth + Copilot Token)
 
+use super::codex_oauth_auth::{CODEX_OAUTH_CLIENT_VERSION, CODEX_OAUTH_ORIGINATOR};
 use super::{AuthInfo, AuthStrategy, ProviderAdapter, ProviderType};
 use crate::provider::Provider;
 use crate::proxy::error::ProxyError;
@@ -26,13 +27,6 @@ const ANTHROPIC_REDACTED_THINKING_PLACEHOLDER: &str = "[redacted thinking]";
 // require thinking replay on tool-call turns, and injected placeholders
 // disrupt the model's chain of thought. Do not re-add without re-confirming.
 const REASONING_VENDOR_HINTS: &[&str] = &["deepseek", "mimo", "xiaomimimo"];
-
-// ChatGPT Codex 后端按 originator+version 组合做模型 cohort 路由：非官方身份会把
-// gpt-5.6-luna 解析到未部署的内部引擎（HTTP 404 Model not found，openai/codex#31967，
-// 本机 A/B 实测确认）。两个头必须成对发送，缺一即 404；version 需 ≥ 目标模型
-// catalog 的 minimal_client_version（luna=0.144.0），新模型抬门槛时同步 bump。
-const CODEX_OAUTH_ORIGINATOR: &str = "codex_cli_rs";
-const CODEX_OAUTH_CLIENT_VERSION: &str = "0.144.1";
 
 /// 获取 Claude 供应商的 API 格式
 ///
@@ -1140,6 +1134,31 @@ mod tests {
         let auth = adapter.extract_auth(&provider).unwrap();
         assert_eq!(auth.api_key, "sk-direct");
         assert_eq!(auth.strategy, AuthStrategy::Anthropic);
+    }
+
+    #[test]
+    fn codex_oauth_generation_uses_gpt6_compatible_identity() {
+        let headers: http::HeaderMap = ClaudeAdapter::new()
+            .get_auth_headers(&AuthInfo::new(
+                "test-token".into(),
+                AuthStrategy::CodexOAuth,
+            ))
+            .unwrap()
+            .into_iter()
+            .collect();
+        assert_eq!(headers["authorization"], "Bearer test-token");
+        assert_eq!(headers["originator"], "codex_cli_rs");
+        let version: Vec<u32> = headers["version"]
+            .to_str()
+            .unwrap()
+            .split('.')
+            .map(|part| part.parse().unwrap())
+            .collect();
+        // Official rust-v0.153.4 catalog: gpt-6-astra requires 0.153.0.
+        assert!(
+            version.as_slice() >= [0, 153, 0].as_slice(),
+            "gpt-6-astra requires Codex >= 0.153.0; sent {version:?}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -66,6 +66,12 @@ const POLLING_SAFETY_MARGIN_SECS: u64 = 3;
 /// User-Agent
 const CODEX_USER_AGENT: &str = "cc-switch-codex-oauth";
 
+// Shared by model discovery and generation: ChatGPT gates models by this
+// client identity. gpt-6-astra requires >= 0.153.0 in the rust-v0.153.4 catalog.
+// Bump together when a new model raises its minimal_client_version.
+pub(crate) const CODEX_OAUTH_ORIGINATOR: &str = "codex_cli_rs";
+pub(crate) const CODEX_OAUTH_CLIENT_VERSION: &str = "0.153.4";
+
 /// Codex OAuth 错误
 #[derive(Debug, thiserror::Error)]
 pub enum CodexOAuthError {

--- a/src-tauri/src/services/codex_oauth_models.rs
+++ b/src-tauri/src/services/codex_oauth_models.rs
@@ -3,6 +3,9 @@
 //! ChatGPT Codex exposes models through `chatgpt.com/backend-api/codex/models`,
 //! which is not an OpenAI-compatible `/v1/models` endpoint.
 
+use crate::proxy::providers::codex_oauth_auth::{
+    CODEX_OAUTH_CLIENT_VERSION, CODEX_OAUTH_ORIGINATOR,
+};
 use crate::services::model_fetch::FetchedModel;
 use serde_json::Value;
 use std::time::Duration;
@@ -10,20 +13,13 @@ use std::time::Duration;
 const CODEX_OAUTH_MODELS_URL: &str = "https://chatgpt.com/backend-api/codex/models";
 const CODEX_OAUTH_FETCH_TIMEOUT_SECS: u64 = 15;
 const ERROR_BODY_MAX_CHARS: usize = 512;
-const CODEX_OAUTH_CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub async fn fetch_models_with_token(
     token: &str,
     account_id: &str,
 ) -> Result<Vec<FetchedModel>, String> {
     let client = crate::proxy::http_client::get();
-    let response = client
-        .get(CODEX_OAUTH_MODELS_URL)
-        .query(&[("client_version", CODEX_OAUTH_CLIENT_VERSION)])
-        .header("Authorization", format!("Bearer {token}"))
-        .header("originator", "cc-switch")
-        .header("chatgpt-account-id", account_id)
-        .timeout(Duration::from_secs(CODEX_OAUTH_FETCH_TIMEOUT_SECS))
+    let response = build_models_request(&client, token, account_id)
         .send()
         .await
         .map_err(|e| format!("Request failed: {e}"))?;
@@ -40,6 +36,21 @@ pub async fn fetch_models_with_token(
         .map_err(|e| format!("Failed to parse response: {e}"))?;
 
     Ok(parse_models(value))
+}
+
+fn build_models_request(
+    client: &reqwest::Client,
+    token: &str,
+    account_id: &str,
+) -> reqwest::RequestBuilder {
+    client
+        .get(CODEX_OAUTH_MODELS_URL)
+        .query(&[("client_version", CODEX_OAUTH_CLIENT_VERSION)])
+        .header("Authorization", format!("Bearer {token}"))
+        .header("originator", CODEX_OAUTH_ORIGINATOR)
+        .header("version", CODEX_OAUTH_CLIENT_VERSION)
+        .header("chatgpt-account-id", account_id)
+        .timeout(Duration::from_secs(CODEX_OAUTH_FETCH_TIMEOUT_SECS))
 }
 
 fn parse_models(value: Value) -> Vec<FetchedModel> {
@@ -130,6 +141,34 @@ fn truncate_body(body: String) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn codex_oauth_model_discovery_uses_gpt6_compatible_identity() {
+        let request = build_models_request(&reqwest::Client::new(), "test-token", "test-account")
+            .build()
+            .unwrap();
+        assert_eq!(request.headers()["authorization"], "Bearer test-token");
+        assert_eq!(request.headers()["chatgpt-account-id"], "test-account");
+        assert_eq!(request.headers()["originator"], "codex_cli_rs");
+        let version = request
+            .url()
+            .query_pairs()
+            .find(|(key, _)| key == "client_version")
+            .unwrap()
+            .1
+            .into_owned();
+        let parts: Vec<u32> = version
+            .split('.')
+            .map(|part| part.parse().unwrap())
+            .collect();
+        // Official rust-v0.153.4 catalog: gpt-6-astra requires 0.153.0.
+        assert!(parts.as_slice() >= [0, 153, 0].as_slice());
+        assert_eq!(request.headers()["version"], version);
+        let models = parse_models(json!({"models": [{
+            "slug": "gpt-6-astra", "minimal_client_version": "0.153.0"
+        }]}));
+        assert_eq!(models[0].id, "gpt-6-astra");
+    }
 
     #[test]
     fn parse_codex_oauth_models_accepts_openai_style_data() {


### PR DESCRIPTION
## Summary / 概述

Requests for `gpt-6-astra` through the Claude-to-Codex OAuth route advertised
Codex `0.144.1`, below the model's `0.153.0` minimum, causing the reported
HTTP 400 upgrade error. Update the compatibility version to `0.153.4` and share
the originator/version constants with model discovery, which previously used
CC Switch's package version and a different originator.

The two regression tests failed before the fix and pass afterward. They check
the actual generation headers and model-list request, while preserving bearer
authentication and account selection.

## Related Issue / 关联 Issue

Refs #7129, specifically the GPT-6 client-upgrade error reported in its comment.

## Screenshots / 截图

Not applicable; no UI changes.

## Validation

- Live, same-account `gpt-6-astra` A/B: old request identity returned the exact
  HTTP 400 upgrade error; the new identity completed with HTTP 200 and `OK`.
- Model discovery returned GPT-6 before and after on the tested account; the
  missing-list symptom itself was not reproduced.
- Local Windows release EXE built and loaded its main page successfully.
- Broader Windows library suite: 2,762 passed, 3 failed, 6 ignored. The same
  three failures reproduced on unchanged upstream: two symlink privilege
  errors (1314) and one occupied-port error (10048). Integration tests were
  not reached after those library failures.

- [Native platform verification](https://github.com/RemindZ/cc-switch/actions/runs/33938168058)
  passed on Windows x64, macOS 15 ARM64, and macOS 15 Intel. Each platform ran
  70 Rust adapter/discovery tests and 15 frontend tests, then built a production
  testing application. Both Mac apps passed a 10-second startup check and
  logged that their main window was shown. The exact Windows CI artifact also
  loaded its main page in a fresh local test profile.
- The authenticated live A/B was performed on Windows; account credentials
  were not sent to CI. Mac verification covers native tests, build, and startup.

The validation branch differs from this source branch only by its fork-only
workflow. That workflow is not included in this PR.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes.
- [x] `pnpm format:check` passes.
- [x] `cargo clippy --locked -j 1 -- -D warnings` passes.
- [x] i18n updates are not needed; no user-facing text changed.
