### PR TITLE
fix(hermes): default api_mode to chat_completions for UI-created providers

### DIFF
--- a/src-tauri/src/hermes_config.rs
+++ b/src-tauri/src/hermes_config.rs
@@ -776,6 +776,28 @@ pub fn get_provider(name: &str) -> Result<Option<serde_json::Value>, AppError> {
     Ok(get_providers()?.get(name).cloned())
 }
 
+/// Forward-compat default for `api_mode` (#4011): the API Mode dropdown only
+/// serializes the field once touched, so a UI-created provider can omit it
+/// entirely. Hermes then falls back to its URL heuristics, which only
+/// recognize a handful of official endpoints — third-party gateways silently
+/// get the wrong protocol. The deeplink import path already writes
+/// `api_mode` explicitly for exactly this reason; the UI path now matches.
+///
+/// MUST run after the on-disk forward-compat merge, not before it — otherwise
+/// the injected default would occupy the key and an `api_mode` the user set
+/// outside the UI (Hermes Web UI / hand-edited YAML) would be reset.
+fn ensure_api_mode(provider: &mut serde_yaml::Value) {
+    const DEFAULT_API_MODE: &str = "chat_completions";
+    if provider.get("api_mode").is_none() {
+        if let serde_yaml::Value::Mapping(m) = provider {
+            m.insert(
+                serde_yaml::Value::String("api_mode".to_string()),
+                serde_yaml::Value::String(DEFAULT_API_MODE.to_string()),
+            );
+        }
+    }
+}
+
 /// Set (upsert) a custom provider by name.
 ///
 /// Upserts into the `custom_providers:` YAML sequence (matched by `name`).
@@ -851,8 +873,11 @@ pub fn set_provider(
                 new_map.entry(k.clone()).or_insert_with(|| v.clone());
             }
         }
+        // On-disk values already had their chance via the merge above.
+        ensure_api_mode(&mut yaml_val);
         *existing = yaml_val;
     } else {
+        ensure_api_mode(&mut yaml_val);
         providers.push(yaml_val);
     }
 

--- a/src-tauri/tests/hermes_roundtrip.rs
+++ b/src-tauri/tests/hermes_roundtrip.rs
@@ -122,3 +122,90 @@ fn get_providers_surfaces_rate_limit_delay_and_key_env() {
         );
     });
 }
+
+#[test]
+fn set_provider_injects_default_api_mode_when_missing() {
+    with_temp_hermes_dir(|dir| {
+        let config_path = dir.join("config.yaml");
+        std::fs::write(&config_path, "custom_providers: []\n").expect("seed config.yaml");
+
+        // Simulate the UI payload sent when the user never touched the
+        // API Mode dropdown (#4011): no `api_mode` field at all.
+        let patch = serde_json::json!({
+            "name": "selfuse",
+            "base_url": "https://api.example.com/v1",
+            "api_key": "sk-xxx",
+            "models": [{ "id": "gpt-4" }]
+        });
+
+        hermes_config::set_provider("selfuse", patch).expect("set_provider");
+
+        let written = std::fs::read_to_string(&config_path).expect("read written config");
+        assert!(
+            written.contains("api_mode: chat_completions"),
+            "default api_mode was not injected:\n{written}"
+        );
+    });
+}
+
+#[test]
+fn set_provider_preserves_explicit_api_mode() {
+    with_temp_hermes_dir(|dir| {
+        let config_path = dir.join("config.yaml");
+        std::fs::write(&config_path, "custom_providers: []\n").expect("seed config.yaml");
+
+        let patch = serde_json::json!({
+            "name": "anthropic-host",
+            "base_url": "https://api.example.com/v1",
+            "api_key": "sk-xxx",
+            "api_mode": "anthropic_messages",
+            "models": [{ "id": "claude-sonnet-5" }]
+        });
+
+        hermes_config::set_provider("anthropic-host", patch).expect("set_provider");
+
+        let written = std::fs::read_to_string(&config_path).expect("read written config");
+        assert!(
+            written.contains("api_mode: anthropic_messages"),
+            "explicit api_mode was lost:\n{written}"
+        );
+    });
+}
+
+#[test]
+fn set_provider_edit_keeps_on_disk_api_mode_when_payload_omits_it() {
+    with_temp_hermes_dir(|dir| {
+        // Provider on disk carries an api_mode the user set outside the UI
+        // (Hermes Web UI / hand-edited YAML). The DB-era UI payload predates
+        // the field and omits it entirely.
+        let yaml = r#"custom_providers:
+  - name: myhost
+    base_url: https://api.example.com/v1
+    api_key: sk-old
+    api_mode: anthropic_messages
+    models:
+      claude-sonnet-5: {}
+"#;
+        let config_path = dir.join("config.yaml");
+        std::fs::write(&config_path, yaml).expect("seed config.yaml");
+
+        let patch = serde_json::json!({
+            "name": "myhost",
+            "base_url": "https://api.example.com/v1",
+            "api_key": "sk-new",
+            "models": [{ "id": "claude-sonnet-5" }]
+        });
+
+        hermes_config::set_provider("myhost", patch).expect("set_provider");
+
+        let written = std::fs::read_to_string(&config_path).expect("read written config");
+        assert!(
+            written.contains("api_mode: anthropic_messages"),
+            "on-disk api_mode was reset to the default:\n{written}"
+        );
+        assert!(
+            written.contains("sk-new"),
+            "api_key was not updated:\n{written}"
+        );
+    });
+}

--- a/src/components/providers/forms/hooks/useHermesFormState.ts
+++ b/src/components/providers/forms/hooks/useHermesFormState.ts
@@ -22,6 +22,10 @@ const HERMES_DEFAULT_CONFIG_OBJ = {
   name: "",
   base_url: "",
   api_key: "",
+  // Must ship in the default JSON: UI-created providers save this object as
+  // the settings config, and without `api_mode` Hermes falls back to guessing
+  // the protocol from the URL (issue #4011).
+  api_mode: HERMES_DEFAULT_API_MODE,
 } as const;
 
 export const HERMES_DEFAULT_CONFIG = JSON.stringify(

--- a/tests/hooks/useHermesFormState.apiMode.test.ts
+++ b/tests/hooks/useHermesFormState.apiMode.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { HERMES_DEFAULT_CONFIG } from "@/components/providers/forms/hooks/useHermesFormState";
+
+// Regression test for issue #4011: UI-created custom Hermes providers were
+// saved without `api_mode` when the user never touched the API Mode dropdown,
+// leaving Hermes to guess the protocol from the URL — which only works for a
+// handful of official endpoints.
+describe("HERMES_DEFAULT_CONFIG", () => {
+  it("ships with a valid default api_mode", () => {
+    const config = JSON.parse(HERMES_DEFAULT_CONFIG);
+
+    expect(config.api_mode).toBe("chat_completions");
+  });
+});


### PR DESCRIPTION
## Summary / 概述

UI-created custom Hermes providers can be saved without `api_mode`: the API
Mode dropdown only serializes the field once touched. Hermes then falls back
to its URL heuristics, which only recognize a handful of official endpoints —
third-party gateways silently get the wrong protocol.

The deeplink import path already writes `api_mode` explicitly for exactly
this reason (`build_hermes_settings`); this PR makes the UI path match.

- inject `api_mode: chat_completions` in `set_provider` **after** the on-disk
  forward-compat merge (both update and insert branches), so an `api_mode`
  set outside the UI (Hermes Web UI / hand-edited YAML) always wins over the
  default
- ship `api_mode` in `HERMES_DEFAULT_CONFIG_OBJ` so the add-mode form
  serializes the field into the DB record from the start
- 3 new roundtrip tests (default injected on add / explicit value preserved /
  on-disk value kept when an older payload omits the field) + 1 frontend test

Verified with a patched dev build on Windows + Hermes 0.21: provider add
writes `api_mode` correctly and an explicit protocol selection survives the
on-disk merge.

## Related Issue / 关联 Issue

Fixes #4011

Note: #6029 addresses the same issue — this PR implements the backend-first
approach proposed there, plus the frontend default and the on-disk
preservation test. Happy to coordinate if that PR gets revived.

## Screenshots / 截图

N/A (no UI change)

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 无用户可见文本改动