### PR TITLE
fix(opencode): expose top-level model modalities

### DIFF
--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -22,7 +22,7 @@ import {
 import { opencodeNpmPackages } from "@/config/opencodeProviderPresets";
 import { cn } from "@/lib/utils";
 import {
-  getModelExtraFields,
+  getModelAdvancedFields,
   isKnownModelKey,
   OPENCODE_EXTRA_OPTION_DRAFT_PREFIX,
 } from "./helpers/opencodeFormUtils";
@@ -121,17 +121,22 @@ function ModelOptionKeyInput({
   optionKey,
   onChange,
   placeholder,
+  placeholderPrefixes = ["option-"],
 }: {
   optionKey: string;
   onChange: (newKey: string) => void;
   placeholder?: string;
+  placeholderPrefixes?: string[];
 }) {
-  const displayValue = optionKey.startsWith("option-") ? "" : optionKey;
+  const isPlaceholderKey = placeholderPrefixes.some((prefix) =>
+    optionKey.startsWith(prefix),
+  );
+  const displayValue = isPlaceholderKey ? "" : optionKey;
   const [localValue, setLocalValue] = useState(displayValue);
 
   useEffect(() => {
-    setLocalValue(optionKey.startsWith("option-") ? "" : optionKey);
-  }, [optionKey]);
+    setLocalValue(isPlaceholderKey ? "" : optionKey);
+  }, [isPlaceholderKey, optionKey]);
 
   return (
     <ImeSafeInput
@@ -145,7 +150,7 @@ function ModelOptionKeyInput({
         // Reset to prop value: if parent accepted the rename, useEffect
         // will update localValue when the new optionKey prop arrives;
         // if parent rejected, this restores the correct display.
-        setLocalValue(optionKey.startsWith("option-") ? "" : optionKey);
+        setLocalValue(isPlaceholderKey ? "" : optionKey);
       }}
       placeholder={placeholder}
       className="flex-1"
@@ -396,17 +401,17 @@ export function OpenCodeFormFields({
     });
   };
 
-  // Model extra field handlers (top-level properties like variants, cost)
-  const handleAddModelExtraField = (modelKey: string) => {
+  // Advanced field handlers (top-level properties like modalities, variants, cost)
+  const handleAddAdvancedField = (modelKey: string) => {
     const model = models[modelKey];
-    const newFieldKey = `option-${Date.now()}`;
+    const newFieldKey = `field-${Date.now()}`;
     onModelsChange({
       ...models,
       [modelKey]: { ...model, [newFieldKey]: "" },
     });
   };
 
-  const handleRemoveModelExtraField = (modelKey: string, fieldKey: string) => {
+  const handleRemoveAdvancedField = (modelKey: string, fieldKey: string) => {
     const model = models[modelKey];
     const newModel = { ...model };
     delete newModel[fieldKey];
@@ -416,14 +421,14 @@ export function OpenCodeFormFields({
     });
   };
 
-  const handleModelExtraFieldKeyChange = (
+  const handleAdvancedFieldKeyChange = (
     modelKey: string,
     oldKey: string,
     newKey: string,
   ) => {
     if (!newKey.trim() || oldKey === newKey) return;
     const model = models[modelKey];
-    // Reject reserved keys and duplicate extra field names
+    // Keep structured fields in their dedicated controls.
     if (isKnownModelKey(newKey) || (newKey !== oldKey && newKey in model))
       return;
     const newModel: Record<string, unknown> = {};
@@ -437,7 +442,7 @@ export function OpenCodeFormFields({
     });
   };
 
-  const handleModelExtraFieldValueChange = (
+  const handleAdvancedFieldValueChange = (
     modelKey: string,
     fieldKey: string,
     value: string,
@@ -813,91 +818,12 @@ export function OpenCodeFormFields({
                       </div>
                     </div>
 
-                    {/* Model Properties (extra fields like variants, cost) */}
+                    {/* Model Properties (nested model.options fields) */}
                     <div className="space-y-2">
                       <div className="flex items-center justify-between">
                         <span className="text-xs font-medium text-muted-foreground">
                           {t("opencode.modelExtraFields", {
                             defaultValue: "模型属性",
-                          })}
-                        </span>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleAddModelExtraField(key)}
-                          className="h-6 px-2 gap-1"
-                        >
-                          <Plus className="h-3 w-3" />
-                        </Button>
-                      </div>
-                      {Object.keys(getModelExtraFields(model)).length === 0 ? (
-                        <p className="text-xs text-muted-foreground py-1">
-                          {t("opencode.noModelExtraFields", {
-                            defaultValue:
-                              "模型属性 (variants, cost 等)，点击 + 添加",
-                          })}
-                        </p>
-                      ) : (
-                        Object.entries(getModelExtraFields(model)).map(
-                          ([fKey, fValue]) => (
-                            <div key={fKey} className="flex items-center gap-2">
-                              <ModelOptionKeyInput
-                                optionKey={fKey}
-                                onChange={(newKey) =>
-                                  handleModelExtraFieldKeyChange(
-                                    key,
-                                    fKey,
-                                    newKey,
-                                  )
-                                }
-                                placeholder={t(
-                                  "opencode.modelExtraFieldKeyPlaceholder",
-                                  {
-                                    defaultValue: "variants",
-                                  },
-                                )}
-                              />
-                              <ImeSafeInput
-                                value={fValue}
-                                onValueChange={(value) =>
-                                  handleModelExtraFieldValueChange(
-                                    key,
-                                    fKey,
-                                    value,
-                                  )
-                                }
-                                placeholder={t(
-                                  "opencode.modelOptionValuePlaceholder",
-                                  {
-                                    defaultValue: '{"order": ["baseten"]}',
-                                  },
-                                )}
-                                className="flex-1"
-                              />
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                onClick={() =>
-                                  handleRemoveModelExtraField(key, fKey)
-                                }
-                                className="h-9 w-9 text-muted-foreground hover:text-destructive"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            </div>
-                          ),
-                        )
-                      )}
-                    </div>
-
-                    {/* SDK Options (model.options) */}
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between">
-                        <span className="text-xs font-medium text-muted-foreground">
-                          {t("opencode.sdkOptions", {
-                            defaultValue: "SDK 选项",
                           })}
                         </span>
                         <Button
@@ -912,45 +838,35 @@ export function OpenCodeFormFields({
                       </div>
                       {Object.keys(model.options || {}).length === 0 ? (
                         <p className="text-xs text-muted-foreground py-1">
-                          {t("opencode.noModelOptions", {
-                            defaultValue: "模型选项，点击 + 添加",
+                          {t("opencode.noModelExtraFields", {
+                            defaultValue:
+                              "模型属性（写入 options 对象），点击 + 添加",
                           })}
                         </p>
                       ) : (
                         Object.entries(model.options || {}).map(
-                          ([optKey, optValue]) => (
-                            <div
-                              key={optKey}
-                              className="flex items-center gap-2"
-                            >
+                          ([fKey, fValue]) => (
+                            <div key={fKey} className="flex items-center gap-2">
                               <ModelOptionKeyInput
-                                optionKey={optKey}
+                                optionKey={fKey}
                                 onChange={(newKey) =>
-                                  handleModelOptionKeyChange(
-                                    key,
-                                    optKey,
-                                    newKey,
-                                  )
+                                  handleModelOptionKeyChange(key, fKey, newKey)
                                 }
                                 placeholder={t(
-                                  "opencode.modelOptionKeyPlaceholder",
+                                  "opencode.modelExtraFieldKeyPlaceholder",
                                   {
-                                    defaultValue: "provider",
+                                    defaultValue: "variants",
                                   },
                                 )}
                               />
                               <ImeSafeInput
                                 value={
-                                  typeof optValue === "string"
-                                    ? optValue
-                                    : JSON.stringify(optValue)
+                                  typeof fValue === "string"
+                                    ? fValue
+                                    : JSON.stringify(fValue)
                                 }
                                 onValueChange={(value) =>
-                                  handleModelOptionValueChange(
-                                    key,
-                                    optKey,
-                                    value,
-                                  )
+                                  handleModelOptionValueChange(key, fKey, value)
                                 }
                                 placeholder={t(
                                   "opencode.modelOptionValuePlaceholder",
@@ -965,7 +881,96 @@ export function OpenCodeFormFields({
                                 variant="ghost"
                                 size="icon"
                                 onClick={() =>
-                                  handleRemoveModelOption(key, optKey)
+                                  handleRemoveModelOption(key, fKey)
+                                }
+                                className="h-9 w-9 text-muted-foreground hover:text-destructive"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          ),
+                        )
+                      )}
+                    </div>
+
+                    {/* Advanced Properties (top-level fields, siblings of options) */}
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-muted-foreground">
+                          {t("opencode.advancedProperties", {
+                            defaultValue: "高级属性",
+                          })}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleAddAdvancedField(key)}
+                          className="h-6 px-2 gap-1"
+                        >
+                          <Plus className="h-3 w-3" />
+                        </Button>
+                      </div>
+                      {Object.keys(getModelAdvancedFields(model)).length ===
+                      0 ? (
+                        <p className="text-xs text-muted-foreground py-1">
+                          {t("opencode.noAdvancedProperties", {
+                            defaultValue:
+                              "高级属性（与 options 同级），点击 + 添加",
+                          })}
+                        </p>
+                      ) : (
+                        Object.entries(getModelAdvancedFields(model)).map(
+                          ([optKey, optValue]) => (
+                            <div
+                              key={optKey}
+                              className="flex items-center gap-2"
+                            >
+                              <ModelOptionKeyInput
+                                optionKey={optKey}
+                                onChange={(newKey) =>
+                                  handleAdvancedFieldKeyChange(
+                                    key,
+                                    optKey,
+                                    newKey,
+                                  )
+                                }
+                                placeholder={t(
+                                  "opencode.advancedPropertyKeyPlaceholder",
+                                  {
+                                    defaultValue: "modalities",
+                                  },
+                                )}
+                                placeholderPrefixes={["field-"]}
+                              />
+                              <ImeSafeInput
+                                value={
+                                  typeof optValue === "string"
+                                    ? optValue
+                                    : JSON.stringify(optValue)
+                                }
+                                onValueChange={(value) =>
+                                  handleAdvancedFieldValueChange(
+                                    key,
+                                    optKey,
+                                    value,
+                                  )
+                                }
+                                placeholder={t(
+                                  "opencode.advancedPropertyValuePlaceholder",
+                                  {
+                                    defaultValue:
+                                      '{"input":["text","image"],"output":["text"]}',
+                                  },
+                                )}
+                                className="flex-1"
+                              />
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() =>
+                                  handleRemoveAdvancedField(key, optKey)
                                 }
                                 className="h-9 w-9 text-muted-foreground hover:text-destructive"
                               >

--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -1,8 +1,7 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { ImeSafeInput } from "@/components/ui/ime-safe-input";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -11,22 +10,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { toast } from "sonner";
-import { Download, Plus, Trash2, ChevronRight, Loader2 } from "lucide-react";
-import { ApiKeySection, ModelDropdown } from "./shared";
-import {
-  fetchModelsForConfig,
-  showFetchModelsError,
-  type FetchedModel,
-} from "@/lib/api/model-fetch";
+import { Plus, Trash2, ChevronRight } from "lucide-react";
+import { ApiKeySection } from "./shared";
 import { opencodeNpmPackages } from "@/config/opencodeProviderPresets";
 import { cn } from "@/lib/utils";
 import {
-  getModelExtraFields,
-  isKnownModelKey,
-  OPENCODE_EXTRA_OPTION_DRAFT_PREFIX,
+  getModelAdvancedFields,
 } from "./helpers/opencodeFormUtils";
-import { RequestHeadersEditor } from "./RequestHeadersEditor";
 import type { ProviderCategory, OpenCodeModel } from "@/types";
 
 /**
@@ -52,13 +42,12 @@ function ModelIdInput({
   }, [modelId]);
 
   return (
-    <ImeSafeInput
+    <Input
       value={localValue}
-      onValueChange={setLocalValue}
-      onBlur={(event) => {
-        const nextValue = event.currentTarget.value;
-        if (nextValue !== modelId && nextValue.trim()) {
-          onChange(nextValue);
+      onChange={(e) => setLocalValue(e.target.value)}
+      onBlur={() => {
+        if (localValue !== modelId && localValue.trim()) {
+          onChange(localValue);
         }
       }}
       placeholder={placeholder}
@@ -76,35 +65,28 @@ function ExtraOptionKeyInput({
   optionKey,
   onChange,
   placeholder,
-  placeholderPrefixes = [OPENCODE_EXTRA_OPTION_DRAFT_PREFIX],
 }: {
   optionKey: string;
-  onChange: (newKey: string) => boolean | void;
+  onChange: (newKey: string) => void;
   placeholder?: string;
-  placeholderPrefixes?: string[];
 }) {
-  const isPlaceholderKey = placeholderPrefixes.some((prefix) =>
-    optionKey.startsWith(prefix),
-  );
-  const displayValue = isPlaceholderKey ? "" : optionKey;
+  // For new options with placeholder keys like "option-123", show empty string
+  const displayValue = optionKey.startsWith("option-") ? "" : optionKey;
   const [localValue, setLocalValue] = useState(displayValue);
 
   // Sync when external key changes
   useEffect(() => {
-    setLocalValue(isPlaceholderKey ? "" : optionKey);
-  }, [isPlaceholderKey, optionKey]);
+    setLocalValue(optionKey.startsWith("option-") ? "" : optionKey);
+  }, [optionKey]);
 
   return (
-    <ImeSafeInput
+    <Input
       value={localValue}
-      onValueChange={setLocalValue}
-      onBlur={(event) => {
-        const trimmed = event.currentTarget.value.trim();
+      onChange={(e) => setLocalValue(e.target.value)}
+      onBlur={() => {
+        const trimmed = localValue.trim();
         if (trimmed && trimmed !== optionKey) {
-          const accepted = onChange(trimmed);
-          if (accepted === false) {
-            setLocalValue(displayValue);
-          }
+          onChange(trimmed);
         }
       }}
       placeholder={placeholder}
@@ -134,11 +116,11 @@ function ModelOptionKeyInput({
   }, [optionKey]);
 
   return (
-    <ImeSafeInput
+    <Input
       value={localValue}
-      onValueChange={setLocalValue}
-      onBlur={(event) => {
-        const trimmed = event.currentTarget.value.trim();
+      onChange={(e) => setLocalValue(e.target.value)}
+      onBlur={() => {
+        const trimmed = localValue.trim();
         if (trimmed && trimmed !== optionKey) {
           onChange(trimmed);
         }
@@ -171,10 +153,6 @@ interface OpenCodeFormFieldsProps {
   baseUrl: string;
   onBaseUrlChange: (value: string) => void;
 
-  // Headers
-  headers: Record<string, string>;
-  onHeadersChange: (headers: Record<string, string>) => void;
-
   // Models
   models: Record<string, OpenCodeModel>;
   onModelsChange: (models: Record<string, OpenCodeModel>) => void;
@@ -196,44 +174,12 @@ export function OpenCodeFormFields({
   partnerPromotionKey,
   baseUrl,
   onBaseUrlChange,
-  headers,
-  onHeadersChange,
   models,
   onModelsChange,
   extraOptions,
   onExtraOptionsChange,
 }: OpenCodeFormFieldsProps) {
   const { t } = useTranslation();
-
-  const [fetchedModels, setFetchedModels] = useState<FetchedModel[]>([]);
-  const [isFetchingModels, setIsFetchingModels] = useState(false);
-
-  const handleFetchModels = useCallback(() => {
-    if (!baseUrl || !apiKey) {
-      showFetchModelsError(null, t, {
-        hasApiKey: !!apiKey,
-        hasBaseUrl: !!baseUrl,
-      });
-      return;
-    }
-    setIsFetchingModels(true);
-    fetchModelsForConfig(baseUrl, apiKey)
-      .then((models) => {
-        setFetchedModels(models);
-        if (models.length === 0) {
-          toast.info(t("providerForm.fetchModelsEmpty"));
-        } else {
-          toast.success(
-            t("providerForm.fetchModelsSuccess", { count: models.length }),
-          );
-        }
-      })
-      .catch((err) => {
-        console.warn("[ModelFetch] Failed:", err);
-        showFetchModelsError(err, t);
-      })
-      .finally(() => setIsFetchingModels(false));
-  }, [baseUrl, apiKey, t]);
 
   // Track which models have expanded options panel
   const [expandedModels, setExpandedModels] = useState<Set<string>>(new Set());
@@ -301,37 +247,8 @@ export function OpenCodeFormFields({
     });
   };
 
-  const handleModelLimitChange = (
-    modelKey: string,
-    limitKey: "context" | "output",
-    value: string,
-  ) => {
-    const model = models[modelKey];
-    const nextLimit = { ...(model.limit || {}) };
-    const trimmedValue = value.trim();
 
-    if (trimmedValue === "") {
-      delete nextLimit[limitKey];
-    } else {
-      const parsed = Number(trimmedValue);
-      if (!Number.isFinite(parsed) || parsed < 0) return;
-      nextLimit[limitKey] = Math.trunc(parsed);
-    }
-
-    const nextModel = { ...model };
-    if (Object.keys(nextLimit).length > 0) {
-      nextModel.limit = nextLimit;
-    } else {
-      delete nextModel.limit;
-    }
-
-    onModelsChange({
-      ...models,
-      [modelKey]: nextModel,
-    });
-  };
-
-  // Model options handlers
+  // Model options handlers (model.options - nested properties)
   const handleAddModelOption = (modelKey: string) => {
     const model = models[modelKey];
     const newOptionKey = `option-${Date.now()}`;
@@ -396,17 +313,17 @@ export function OpenCodeFormFields({
     });
   };
 
-  // Model extra field handlers (top-level properties like variants, cost)
-  const handleAddModelExtraField = (modelKey: string) => {
+  // Advanced field handlers (limit, modalities, variants, etc.)
+  const handleAddAdvancedField = (modelKey: string) => {
     const model = models[modelKey];
-    const newFieldKey = `option-${Date.now()}`;
+    const newFieldKey = `field-${Date.now()}`;
     onModelsChange({
       ...models,
       [modelKey]: { ...model, [newFieldKey]: "" },
     });
   };
 
-  const handleRemoveModelExtraField = (modelKey: string, fieldKey: string) => {
+  const handleRemoveAdvancedField = (modelKey: string, fieldKey: string) => {
     const model = models[modelKey];
     const newModel = { ...model };
     delete newModel[fieldKey];
@@ -416,15 +333,15 @@ export function OpenCodeFormFields({
     });
   };
 
-  const handleModelExtraFieldKeyChange = (
+  const handleAdvancedFieldKeyChange = (
     modelKey: string,
     oldKey: string,
     newKey: string,
   ) => {
     if (!newKey.trim() || oldKey === newKey) return;
     const model = models[modelKey];
-    // Reject reserved keys and duplicate extra field names
-    if (isKnownModelKey(newKey) || (newKey !== oldKey && newKey in model))
+    // Reject reserved keys (name, limit, options) and duplicates
+    if (newKey === "name" || newKey === "options" || (newKey !== oldKey && newKey in model))
       return;
     const newModel: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(model)) {
@@ -437,7 +354,7 @@ export function OpenCodeFormFields({
     });
   };
 
-  const handleModelExtraFieldValueChange = (
+  const handleAdvancedFieldValueChange = (
     modelKey: string,
     fieldKey: string,
     value: string,
@@ -457,7 +374,7 @@ export function OpenCodeFormFields({
 
   // Extra Options handlers
   const handleAddExtraOption = () => {
-    const newKey = `${OPENCODE_EXTRA_OPTION_DRAFT_PREFIX}${Date.now()}`;
+    const newKey = `option-${Date.now()}`;
     onExtraOptionsChange({
       ...extraOptions,
       [newKey]: "",
@@ -539,10 +456,10 @@ export function OpenCodeFormFields({
         <FormLabel htmlFor="opencode-baseurl">
           {t("opencode.baseUrl", { defaultValue: "Base URL" })}
         </FormLabel>
-        <ImeSafeInput
+        <Input
           id="opencode-baseurl"
           value={baseUrl}
-          onValueChange={onBaseUrlChange}
+          onChange={(e) => onBaseUrlChange(e.target.value)}
           placeholder="https://api.example.com/v1"
         />
         <p className="text-xs text-muted-foreground">
@@ -553,27 +470,12 @@ export function OpenCodeFormFields({
         </p>
       </div>
 
-      <RequestHeadersEditor
-        headers={headers}
-        onHeadersChange={onHeadersChange}
-      />
-
       {/* Extra Options Editor */}
-      <div className="space-y-2 border-l border-border-default pl-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="max-w-3xl space-y-1">
-            <FormLabel>
-              {t("opencode.extraOptions", {
-                defaultValue: "Extra SDK Options",
-              })}
-            </FormLabel>
-            <p className="text-xs text-muted-foreground">
-              {t("opencode.extraOptionsHint", {
-                defaultValue:
-                  "Advanced SDK options not exposed by the structured fields.",
-              })}
-            </p>
-          </div>
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <FormLabel>
+            {t("opencode.extraOptions", { defaultValue: "额外选项" })}
+          </FormLabel>
           <Button
             type="button"
             variant="outline"
@@ -582,98 +484,84 @@ export function OpenCodeFormFields({
             className="h-7 gap-1"
           >
             <Plus className="h-3.5 w-3.5" />
-            {t("opencode.addExtraOption", { defaultValue: "Add" })}
+            {t("opencode.addExtraOption", { defaultValue: "添加" })}
           </Button>
         </div>
 
-        <div className="max-w-3xl">
-          {Object.keys(extraOptions).length === 0 ? (
-            <p className="text-sm text-muted-foreground py-1">
-              {t("opencode.noExtraOptions", {
-                defaultValue: "No extra SDK options configured",
-              })}
-            </p>
-          ) : (
-            <div className="space-y-2">
-              <div className="flex items-center gap-2 text-xs text-muted-foreground px-1 mb-1">
-                <span className="flex-1">
-                  {t("opencode.extraOptionKey", { defaultValue: "Key" })}
-                </span>
-                <span className="flex-1">
-                  {t("opencode.extraOptionValue", { defaultValue: "Value" })}
-                </span>
-                <span className="w-9" />
-              </div>
-              {Object.entries(extraOptions).map(([key, value]) => (
-                <div key={key} className="flex items-center gap-2">
-                  <ExtraOptionKeyInput
-                    optionKey={key}
-                    onChange={(newKey) =>
-                      handleExtraOptionKeyChange(key, newKey)
-                    }
-                    placeholder={t("opencode.extraOptionKeyPlaceholder", {
-                      defaultValue: "timeout",
-                    })}
-                  />
-                  <ImeSafeInput
-                    value={value}
-                    onValueChange={(nextValue) =>
-                      handleExtraOptionValueChange(key, nextValue)
-                    }
-                    placeholder={t("opencode.extraOptionValuePlaceholder", {
-                      defaultValue: "600000",
-                    })}
-                    className="flex-1"
-                  />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => handleRemoveExtraOption(key)}
-                    className="h-9 w-9 text-muted-foreground hover:text-destructive"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                </div>
-              ))}
+        {Object.keys(extraOptions).length === 0 ? (
+          <p className="text-sm text-muted-foreground py-2">
+            {t("opencode.noExtraOptions", {
+              defaultValue: "暂无额外选项",
+            })}
+          </p>
+        ) : (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-xs text-muted-foreground px-1 mb-1">
+              <span className="flex-1">
+                {t("opencode.extraOptionKey", { defaultValue: "键名" })}
+              </span>
+              <span className="flex-1">
+                {t("opencode.extraOptionValue", { defaultValue: "值" })}
+              </span>
+              <span className="w-9" />
             </div>
-          )}
-        </div>
+            {Object.entries(extraOptions).map(([key, value]) => (
+              <div key={key} className="flex items-center gap-2">
+                <ExtraOptionKeyInput
+                  optionKey={key}
+                  onChange={(newKey) => handleExtraOptionKeyChange(key, newKey)}
+                  placeholder={t("opencode.extraOptionKeyPlaceholder", {
+                    defaultValue: "timeout",
+                  })}
+                />
+                <Input
+                  value={value}
+                  onChange={(e) =>
+                    handleExtraOptionValueChange(key, e.target.value)
+                  }
+                  placeholder={t("opencode.extraOptionValuePlaceholder", {
+                    defaultValue: "600000",
+                  })}
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => handleRemoveExtraOption(key)}
+                  className="h-9 w-9 text-muted-foreground hover:text-destructive"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <p className="text-xs text-muted-foreground">
+          {t("opencode.extraOptionsHint", {
+            defaultValue:
+              "配置额外的 SDK 选项，如 timeout、setCacheKey 等。值会自动解析类型（数字、布尔值等）。",
+          })}
+        </p>
       </div>
 
       {/* Models Editor */}
-      <div className="space-y-3 border-l border-border-default pl-3">
+      <div className="space-y-3">
         <div className="flex items-center justify-between">
           <FormLabel>
             {t("opencode.models", { defaultValue: "Models" })}
           </FormLabel>
-          <div className="flex gap-1">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={handleFetchModels}
-              disabled={isFetchingModels}
-              className="h-7 gap-1"
-            >
-              {isFetchingModels ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Download className="h-3.5 w-3.5" />
-              )}
-              {t("providerForm.fetchModels")}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={handleAddModel}
-              className="h-7 gap-1"
-            >
-              <Plus className="h-3.5 w-3.5" />
-              {t("opencode.addModel", { defaultValue: "Add" })}
-            </Button>
-          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleAddModel}
+            className="h-7 gap-1"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t("opencode.addModel", { defaultValue: "Add" })}
+          </Button>
         </div>
 
         {Object.keys(models).length === 0 ? (
@@ -703,9 +591,6 @@ export function OpenCodeFormFields({
                     variant="ghost"
                     size="icon"
                     onClick={() => toggleModelExpand(key)}
-                    aria-label={t("opencode.toggleModelDetails", {
-                      defaultValue: "Toggle model details",
-                    })}
                     className="h-9 w-9 shrink-0"
                   >
                     <ChevronRight
@@ -715,24 +600,16 @@ export function OpenCodeFormFields({
                       )}
                     />
                   </Button>
-                  <div className="flex gap-1 flex-1">
-                    <ModelIdInput
-                      modelId={key}
-                      onChange={(newId) => handleModelIdChange(key, newId)}
-                      placeholder={t("opencode.modelId", {
-                        defaultValue: "Model ID",
-                      })}
-                    />
-                    {fetchedModels.length > 0 && (
-                      <ModelDropdown
-                        models={fetchedModels}
-                        onSelect={(id) => handleModelIdChange(key, id)}
-                      />
-                    )}
-                  </div>
-                  <ImeSafeInput
+                  <ModelIdInput
+                    modelId={key}
+                    onChange={(newId) => handleModelIdChange(key, newId)}
+                    placeholder={t("opencode.modelId", {
+                      defaultValue: "Model ID",
+                    })}
+                  />
+                  <Input
                     value={model.name}
-                    onValueChange={(value) => handleModelNameChange(key, value)}
+                    onChange={(e) => handleModelNameChange(key, e.target.value)}
                     placeholder={t("opencode.modelName", {
                       defaultValue: "Display Name",
                     })}
@@ -752,152 +629,12 @@ export function OpenCodeFormFields({
                 {/* Expanded model details */}
                 {expandedModels.has(key) && (
                   <div className="ml-9 pl-4 border-l-2 border-muted space-y-3">
-                    {/* Token limits (model.limit) */}
-                    <div className="space-y-2">
-                      <span className="text-xs font-medium text-muted-foreground">
-                        {t("opencode.modelLimits", {
-                          defaultValue: "Token Limits",
-                        })}
-                      </span>
-                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                        <div className="space-y-1">
-                          <FormLabel
-                            htmlFor={`opencode-${key}-limit-context`}
-                            className="text-xs text-muted-foreground"
-                          >
-                            {t("opencode.limitContext", {
-                              defaultValue: "Context",
-                            })}
-                          </FormLabel>
-                          <Input
-                            id={`opencode-${key}-limit-context`}
-                            type="number"
-                            min={0}
-                            step={1}
-                            value={model.limit?.context ?? ""}
-                            onChange={(e) =>
-                              handleModelLimitChange(
-                                key,
-                                "context",
-                                e.target.value,
-                              )
-                            }
-                            placeholder="1048576"
-                          />
-                        </div>
-                        <div className="space-y-1">
-                          <FormLabel
-                            htmlFor={`opencode-${key}-limit-output`}
-                            className="text-xs text-muted-foreground"
-                          >
-                            {t("opencode.limitOutput", {
-                              defaultValue: "Output",
-                            })}
-                          </FormLabel>
-                          <Input
-                            id={`opencode-${key}-limit-output`}
-                            type="number"
-                            min={0}
-                            step={1}
-                            value={model.limit?.output ?? ""}
-                            onChange={(e) =>
-                              handleModelLimitChange(
-                                key,
-                                "output",
-                                e.target.value,
-                              )
-                            }
-                            placeholder="131072"
-                          />
-                        </div>
-                      </div>
-                    </div>
-
                     {/* Model Properties (extra fields like variants, cost) */}
                     <div className="space-y-2">
                       <div className="flex items-center justify-between">
                         <span className="text-xs font-medium text-muted-foreground">
                           {t("opencode.modelExtraFields", {
                             defaultValue: "模型属性",
-                          })}
-                        </span>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleAddModelExtraField(key)}
-                          className="h-6 px-2 gap-1"
-                        >
-                          <Plus className="h-3 w-3" />
-                        </Button>
-                      </div>
-                      {Object.keys(getModelExtraFields(model)).length === 0 ? (
-                        <p className="text-xs text-muted-foreground py-1">
-                          {t("opencode.noModelExtraFields", {
-                            defaultValue:
-                              "模型属性 (variants, cost 等)，点击 + 添加",
-                          })}
-                        </p>
-                      ) : (
-                        Object.entries(getModelExtraFields(model)).map(
-                          ([fKey, fValue]) => (
-                            <div key={fKey} className="flex items-center gap-2">
-                              <ModelOptionKeyInput
-                                optionKey={fKey}
-                                onChange={(newKey) =>
-                                  handleModelExtraFieldKeyChange(
-                                    key,
-                                    fKey,
-                                    newKey,
-                                  )
-                                }
-                                placeholder={t(
-                                  "opencode.modelExtraFieldKeyPlaceholder",
-                                  {
-                                    defaultValue: "variants",
-                                  },
-                                )}
-                              />
-                              <ImeSafeInput
-                                value={fValue}
-                                onValueChange={(value) =>
-                                  handleModelExtraFieldValueChange(
-                                    key,
-                                    fKey,
-                                    value,
-                                  )
-                                }
-                                placeholder={t(
-                                  "opencode.modelOptionValuePlaceholder",
-                                  {
-                                    defaultValue: '{"order": ["baseten"]}',
-                                  },
-                                )}
-                                className="flex-1"
-                              />
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                onClick={() =>
-                                  handleRemoveModelExtraField(key, fKey)
-                                }
-                                className="h-9 w-9 text-muted-foreground hover:text-destructive"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            </div>
-                          ),
-                        )
-                      )}
-                    </div>
-
-                    {/* SDK Options (model.options) */}
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between">
-                        <span className="text-xs font-medium text-muted-foreground">
-                          {t("opencode.sdkOptions", {
-                            defaultValue: "SDK 选项",
                           })}
                         </span>
                         <Button
@@ -912,17 +649,15 @@ export function OpenCodeFormFields({
                       </div>
                       {Object.keys(model.options || {}).length === 0 ? (
                         <p className="text-xs text-muted-foreground py-1">
-                          {t("opencode.noModelOptions", {
-                            defaultValue: "模型选项，点击 + 添加",
+                          {t("opencode.noModelExtraFields", {
+                            defaultValue:
+                              "模型属性 (插入到 options 对象)，点击 + 添加",
                           })}
                         </p>
                       ) : (
                         Object.entries(model.options || {}).map(
                           ([optKey, optValue]) => (
-                            <div
-                              key={optKey}
-                              className="flex items-center gap-2"
-                            >
+                            <div key={optKey} className="flex items-center gap-2">
                               <ModelOptionKeyInput
                                 optionKey={optKey}
                                 onChange={(newKey) =>
@@ -933,23 +668,23 @@ export function OpenCodeFormFields({
                                   )
                                 }
                                 placeholder={t(
-                                  "opencode.modelOptionKeyPlaceholder",
+                                  "opencode.modelExtraFieldKeyPlaceholder",
                                   {
                                     defaultValue: "provider",
                                   },
                                 )}
                               />
-                              <ImeSafeInput
+                              <Input
                                 value={
                                   typeof optValue === "string"
                                     ? optValue
                                     : JSON.stringify(optValue)
                                 }
-                                onValueChange={(value) =>
+                                onChange={(e) =>
                                   handleModelOptionValueChange(
                                     key,
                                     optKey,
-                                    value,
+                                    e.target.value,
                                   )
                                 }
                                 placeholder={t(
@@ -966,6 +701,85 @@ export function OpenCodeFormFields({
                                 size="icon"
                                 onClick={() =>
                                   handleRemoveModelOption(key, optKey)
+                                }
+                                className="h-9 w-9 text-muted-foreground hover:text-destructive"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          ),
+                        )
+                      )}
+                    </div>
+
+                    {/* Advanced Properties (top-level fields like limit, modalities, variants) */}
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-muted-foreground">
+                          {t("opencode.advancedProperties", {
+                            defaultValue: "高级属性",
+                          })}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleAddAdvancedField(key)}
+                          className="h-6 px-2 gap-1"
+                        >
+                          <Plus className="h-3 w-3" />
+                        </Button>
+                      </div>
+                      {Object.keys(getModelAdvancedFields(model)).length === 0 ? (
+                        <p className="text-xs text-muted-foreground py-1">
+                          {t("opencode.noAdvancedProperties", {
+                            defaultValue:
+                              "高级属性 (与 options 同级的顶层字段)，点击 + 添加",
+                          })}
+                        </p>
+                      ) : (
+                        Object.entries(getModelAdvancedFields(model)).map(
+                          ([fKey, fValue]) => (
+                            <div key={fKey} className="flex items-center gap-2">
+                              <ModelOptionKeyInput
+                                optionKey={fKey}
+                                onChange={(newKey) =>
+                                  handleAdvancedFieldKeyChange(
+                                    key,
+                                    fKey,
+                                    newKey,
+                                  )
+                                }
+                                placeholder={t(
+                                  "opencode.advancedPropertyKeyPlaceholder",
+                                  {
+                                    defaultValue: "limit",
+                                  },
+                                )}
+                              />
+                              <Input
+                                value={fValue}
+                                onChange={(e) =>
+                                  handleAdvancedFieldValueChange(
+                                    key,
+                                    fKey,
+                                    e.target.value,
+                                  )
+                                }
+                                placeholder={t(
+                                  "opencode.advancedPropertyValuePlaceholder",
+                                  {
+                                    defaultValue: '{"context":200000,"output":64000}',
+                                  },
+                                )}
+                                className="flex-1"
+                              />
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() =>
+                                  handleRemoveAdvancedField(key, fKey)
                                 }
                                 className="h-9 w-9 text-muted-foreground hover:text-destructive"
                               >

--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { FormLabel } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { ImeSafeInput } from "@/components/ui/ime-safe-input";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -10,13 +11,22 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Plus, Trash2, ChevronRight } from "lucide-react";
-import { ApiKeySection } from "./shared";
+import { toast } from "sonner";
+import { Download, Plus, Trash2, ChevronRight, Loader2 } from "lucide-react";
+import { ApiKeySection, ModelDropdown } from "./shared";
+import {
+  fetchModelsForConfig,
+  showFetchModelsError,
+  type FetchedModel,
+} from "@/lib/api/model-fetch";
 import { opencodeNpmPackages } from "@/config/opencodeProviderPresets";
 import { cn } from "@/lib/utils";
 import {
-  getModelAdvancedFields,
+  getModelExtraFields,
+  isKnownModelKey,
+  OPENCODE_EXTRA_OPTION_DRAFT_PREFIX,
 } from "./helpers/opencodeFormUtils";
+import { RequestHeadersEditor } from "./RequestHeadersEditor";
 import type { ProviderCategory, OpenCodeModel } from "@/types";
 
 /**
@@ -42,12 +52,13 @@ function ModelIdInput({
   }, [modelId]);
 
   return (
-    <Input
+    <ImeSafeInput
       value={localValue}
-      onChange={(e) => setLocalValue(e.target.value)}
-      onBlur={() => {
-        if (localValue !== modelId && localValue.trim()) {
-          onChange(localValue);
+      onValueChange={setLocalValue}
+      onBlur={(event) => {
+        const nextValue = event.currentTarget.value;
+        if (nextValue !== modelId && nextValue.trim()) {
+          onChange(nextValue);
         }
       }}
       placeholder={placeholder}
@@ -65,28 +76,35 @@ function ExtraOptionKeyInput({
   optionKey,
   onChange,
   placeholder,
+  placeholderPrefixes = [OPENCODE_EXTRA_OPTION_DRAFT_PREFIX],
 }: {
   optionKey: string;
-  onChange: (newKey: string) => void;
+  onChange: (newKey: string) => boolean | void;
   placeholder?: string;
+  placeholderPrefixes?: string[];
 }) {
-  // For new options with placeholder keys like "option-123", show empty string
-  const displayValue = optionKey.startsWith("option-") ? "" : optionKey;
+  const isPlaceholderKey = placeholderPrefixes.some((prefix) =>
+    optionKey.startsWith(prefix),
+  );
+  const displayValue = isPlaceholderKey ? "" : optionKey;
   const [localValue, setLocalValue] = useState(displayValue);
 
   // Sync when external key changes
   useEffect(() => {
-    setLocalValue(optionKey.startsWith("option-") ? "" : optionKey);
-  }, [optionKey]);
+    setLocalValue(isPlaceholderKey ? "" : optionKey);
+  }, [isPlaceholderKey, optionKey]);
 
   return (
-    <Input
+    <ImeSafeInput
       value={localValue}
-      onChange={(e) => setLocalValue(e.target.value)}
-      onBlur={() => {
-        const trimmed = localValue.trim();
+      onValueChange={setLocalValue}
+      onBlur={(event) => {
+        const trimmed = event.currentTarget.value.trim();
         if (trimmed && trimmed !== optionKey) {
-          onChange(trimmed);
+          const accepted = onChange(trimmed);
+          if (accepted === false) {
+            setLocalValue(displayValue);
+          }
         }
       }}
       placeholder={placeholder}
@@ -116,11 +134,11 @@ function ModelOptionKeyInput({
   }, [optionKey]);
 
   return (
-    <Input
+    <ImeSafeInput
       value={localValue}
-      onChange={(e) => setLocalValue(e.target.value)}
-      onBlur={() => {
-        const trimmed = localValue.trim();
+      onValueChange={setLocalValue}
+      onBlur={(event) => {
+        const trimmed = event.currentTarget.value.trim();
         if (trimmed && trimmed !== optionKey) {
           onChange(trimmed);
         }
@@ -153,6 +171,10 @@ interface OpenCodeFormFieldsProps {
   baseUrl: string;
   onBaseUrlChange: (value: string) => void;
 
+  // Headers
+  headers: Record<string, string>;
+  onHeadersChange: (headers: Record<string, string>) => void;
+
   // Models
   models: Record<string, OpenCodeModel>;
   onModelsChange: (models: Record<string, OpenCodeModel>) => void;
@@ -174,12 +196,44 @@ export function OpenCodeFormFields({
   partnerPromotionKey,
   baseUrl,
   onBaseUrlChange,
+  headers,
+  onHeadersChange,
   models,
   onModelsChange,
   extraOptions,
   onExtraOptionsChange,
 }: OpenCodeFormFieldsProps) {
   const { t } = useTranslation();
+
+  const [fetchedModels, setFetchedModels] = useState<FetchedModel[]>([]);
+  const [isFetchingModels, setIsFetchingModels] = useState(false);
+
+  const handleFetchModels = useCallback(() => {
+    if (!baseUrl || !apiKey) {
+      showFetchModelsError(null, t, {
+        hasApiKey: !!apiKey,
+        hasBaseUrl: !!baseUrl,
+      });
+      return;
+    }
+    setIsFetchingModels(true);
+    fetchModelsForConfig(baseUrl, apiKey)
+      .then((models) => {
+        setFetchedModels(models);
+        if (models.length === 0) {
+          toast.info(t("providerForm.fetchModelsEmpty"));
+        } else {
+          toast.success(
+            t("providerForm.fetchModelsSuccess", { count: models.length }),
+          );
+        }
+      })
+      .catch((err) => {
+        console.warn("[ModelFetch] Failed:", err);
+        showFetchModelsError(err, t);
+      })
+      .finally(() => setIsFetchingModels(false));
+  }, [baseUrl, apiKey, t]);
 
   // Track which models have expanded options panel
   const [expandedModels, setExpandedModels] = useState<Set<string>>(new Set());
@@ -247,8 +301,37 @@ export function OpenCodeFormFields({
     });
   };
 
+  const handleModelLimitChange = (
+    modelKey: string,
+    limitKey: "context" | "output",
+    value: string,
+  ) => {
+    const model = models[modelKey];
+    const nextLimit = { ...(model.limit || {}) };
+    const trimmedValue = value.trim();
 
-  // Model options handlers (model.options - nested properties)
+    if (trimmedValue === "") {
+      delete nextLimit[limitKey];
+    } else {
+      const parsed = Number(trimmedValue);
+      if (!Number.isFinite(parsed) || parsed < 0) return;
+      nextLimit[limitKey] = Math.trunc(parsed);
+    }
+
+    const nextModel = { ...model };
+    if (Object.keys(nextLimit).length > 0) {
+      nextModel.limit = nextLimit;
+    } else {
+      delete nextModel.limit;
+    }
+
+    onModelsChange({
+      ...models,
+      [modelKey]: nextModel,
+    });
+  };
+
+  // Model options handlers
   const handleAddModelOption = (modelKey: string) => {
     const model = models[modelKey];
     const newOptionKey = `option-${Date.now()}`;
@@ -313,17 +396,17 @@ export function OpenCodeFormFields({
     });
   };
 
-  // Advanced field handlers (limit, modalities, variants, etc.)
-  const handleAddAdvancedField = (modelKey: string) => {
+  // Model extra field handlers (top-level properties like variants, cost)
+  const handleAddModelExtraField = (modelKey: string) => {
     const model = models[modelKey];
-    const newFieldKey = `field-${Date.now()}`;
+    const newFieldKey = `option-${Date.now()}`;
     onModelsChange({
       ...models,
       [modelKey]: { ...model, [newFieldKey]: "" },
     });
   };
 
-  const handleRemoveAdvancedField = (modelKey: string, fieldKey: string) => {
+  const handleRemoveModelExtraField = (modelKey: string, fieldKey: string) => {
     const model = models[modelKey];
     const newModel = { ...model };
     delete newModel[fieldKey];
@@ -333,15 +416,15 @@ export function OpenCodeFormFields({
     });
   };
 
-  const handleAdvancedFieldKeyChange = (
+  const handleModelExtraFieldKeyChange = (
     modelKey: string,
     oldKey: string,
     newKey: string,
   ) => {
     if (!newKey.trim() || oldKey === newKey) return;
     const model = models[modelKey];
-    // Reject reserved keys (name, limit, options) and duplicates
-    if (newKey === "name" || newKey === "options" || (newKey !== oldKey && newKey in model))
+    // Reject reserved keys and duplicate extra field names
+    if (isKnownModelKey(newKey) || (newKey !== oldKey && newKey in model))
       return;
     const newModel: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(model)) {
@@ -354,7 +437,7 @@ export function OpenCodeFormFields({
     });
   };
 
-  const handleAdvancedFieldValueChange = (
+  const handleModelExtraFieldValueChange = (
     modelKey: string,
     fieldKey: string,
     value: string,
@@ -374,7 +457,7 @@ export function OpenCodeFormFields({
 
   // Extra Options handlers
   const handleAddExtraOption = () => {
-    const newKey = `option-${Date.now()}`;
+    const newKey = `${OPENCODE_EXTRA_OPTION_DRAFT_PREFIX}${Date.now()}`;
     onExtraOptionsChange({
       ...extraOptions,
       [newKey]: "",
@@ -456,10 +539,10 @@ export function OpenCodeFormFields({
         <FormLabel htmlFor="opencode-baseurl">
           {t("opencode.baseUrl", { defaultValue: "Base URL" })}
         </FormLabel>
-        <Input
+        <ImeSafeInput
           id="opencode-baseurl"
           value={baseUrl}
-          onChange={(e) => onBaseUrlChange(e.target.value)}
+          onValueChange={onBaseUrlChange}
           placeholder="https://api.example.com/v1"
         />
         <p className="text-xs text-muted-foreground">
@@ -470,12 +553,27 @@ export function OpenCodeFormFields({
         </p>
       </div>
 
+      <RequestHeadersEditor
+        headers={headers}
+        onHeadersChange={onHeadersChange}
+      />
+
       {/* Extra Options Editor */}
-      <div className="space-y-3">
-        <div className="flex items-center justify-between">
-          <FormLabel>
-            {t("opencode.extraOptions", { defaultValue: "额外选项" })}
-          </FormLabel>
+      <div className="space-y-2 border-l border-border-default pl-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="max-w-3xl space-y-1">
+            <FormLabel>
+              {t("opencode.extraOptions", {
+                defaultValue: "Extra SDK Options",
+              })}
+            </FormLabel>
+            <p className="text-xs text-muted-foreground">
+              {t("opencode.extraOptionsHint", {
+                defaultValue:
+                  "Advanced SDK options not exposed by the structured fields.",
+              })}
+            </p>
+          </div>
           <Button
             type="button"
             variant="outline"
@@ -484,84 +582,98 @@ export function OpenCodeFormFields({
             className="h-7 gap-1"
           >
             <Plus className="h-3.5 w-3.5" />
-            {t("opencode.addExtraOption", { defaultValue: "添加" })}
+            {t("opencode.addExtraOption", { defaultValue: "Add" })}
           </Button>
         </div>
 
-        {Object.keys(extraOptions).length === 0 ? (
-          <p className="text-sm text-muted-foreground py-2">
-            {t("opencode.noExtraOptions", {
-              defaultValue: "暂无额外选项",
-            })}
-          </p>
-        ) : (
-          <div className="space-y-2">
-            <div className="flex items-center gap-2 text-xs text-muted-foreground px-1 mb-1">
-              <span className="flex-1">
-                {t("opencode.extraOptionKey", { defaultValue: "键名" })}
-              </span>
-              <span className="flex-1">
-                {t("opencode.extraOptionValue", { defaultValue: "值" })}
-              </span>
-              <span className="w-9" />
-            </div>
-            {Object.entries(extraOptions).map(([key, value]) => (
-              <div key={key} className="flex items-center gap-2">
-                <ExtraOptionKeyInput
-                  optionKey={key}
-                  onChange={(newKey) => handleExtraOptionKeyChange(key, newKey)}
-                  placeholder={t("opencode.extraOptionKeyPlaceholder", {
-                    defaultValue: "timeout",
-                  })}
-                />
-                <Input
-                  value={value}
-                  onChange={(e) =>
-                    handleExtraOptionValueChange(key, e.target.value)
-                  }
-                  placeholder={t("opencode.extraOptionValuePlaceholder", {
-                    defaultValue: "600000",
-                  })}
-                  className="flex-1"
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => handleRemoveExtraOption(key)}
-                  className="h-9 w-9 text-muted-foreground hover:text-destructive"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
+        <div className="max-w-3xl">
+          {Object.keys(extraOptions).length === 0 ? (
+            <p className="text-sm text-muted-foreground py-1">
+              {t("opencode.noExtraOptions", {
+                defaultValue: "No extra SDK options configured",
+              })}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-xs text-muted-foreground px-1 mb-1">
+                <span className="flex-1">
+                  {t("opencode.extraOptionKey", { defaultValue: "Key" })}
+                </span>
+                <span className="flex-1">
+                  {t("opencode.extraOptionValue", { defaultValue: "Value" })}
+                </span>
+                <span className="w-9" />
               </div>
-            ))}
-          </div>
-        )}
-
-        <p className="text-xs text-muted-foreground">
-          {t("opencode.extraOptionsHint", {
-            defaultValue:
-              "配置额外的 SDK 选项，如 timeout、setCacheKey 等。值会自动解析类型（数字、布尔值等）。",
-          })}
-        </p>
+              {Object.entries(extraOptions).map(([key, value]) => (
+                <div key={key} className="flex items-center gap-2">
+                  <ExtraOptionKeyInput
+                    optionKey={key}
+                    onChange={(newKey) =>
+                      handleExtraOptionKeyChange(key, newKey)
+                    }
+                    placeholder={t("opencode.extraOptionKeyPlaceholder", {
+                      defaultValue: "timeout",
+                    })}
+                  />
+                  <ImeSafeInput
+                    value={value}
+                    onValueChange={(nextValue) =>
+                      handleExtraOptionValueChange(key, nextValue)
+                    }
+                    placeholder={t("opencode.extraOptionValuePlaceholder", {
+                      defaultValue: "600000",
+                    })}
+                    className="flex-1"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleRemoveExtraOption(key)}
+                    className="h-9 w-9 text-muted-foreground hover:text-destructive"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Models Editor */}
-      <div className="space-y-3">
+      <div className="space-y-3 border-l border-border-default pl-3">
         <div className="flex items-center justify-between">
           <FormLabel>
             {t("opencode.models", { defaultValue: "Models" })}
           </FormLabel>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={handleAddModel}
-            className="h-7 gap-1"
-          >
-            <Plus className="h-3.5 w-3.5" />
-            {t("opencode.addModel", { defaultValue: "Add" })}
-          </Button>
+          <div className="flex gap-1">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleFetchModels}
+              disabled={isFetchingModels}
+              className="h-7 gap-1"
+            >
+              {isFetchingModels ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Download className="h-3.5 w-3.5" />
+              )}
+              {t("providerForm.fetchModels")}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleAddModel}
+              className="h-7 gap-1"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              {t("opencode.addModel", { defaultValue: "Add" })}
+            </Button>
+          </div>
         </div>
 
         {Object.keys(models).length === 0 ? (
@@ -591,6 +703,9 @@ export function OpenCodeFormFields({
                     variant="ghost"
                     size="icon"
                     onClick={() => toggleModelExpand(key)}
+                    aria-label={t("opencode.toggleModelDetails", {
+                      defaultValue: "Toggle model details",
+                    })}
                     className="h-9 w-9 shrink-0"
                   >
                     <ChevronRight
@@ -600,16 +715,24 @@ export function OpenCodeFormFields({
                       )}
                     />
                   </Button>
-                  <ModelIdInput
-                    modelId={key}
-                    onChange={(newId) => handleModelIdChange(key, newId)}
-                    placeholder={t("opencode.modelId", {
-                      defaultValue: "Model ID",
-                    })}
-                  />
-                  <Input
+                  <div className="flex gap-1 flex-1">
+                    <ModelIdInput
+                      modelId={key}
+                      onChange={(newId) => handleModelIdChange(key, newId)}
+                      placeholder={t("opencode.modelId", {
+                        defaultValue: "Model ID",
+                      })}
+                    />
+                    {fetchedModels.length > 0 && (
+                      <ModelDropdown
+                        models={fetchedModels}
+                        onSelect={(id) => handleModelIdChange(key, id)}
+                      />
+                    )}
+                  </div>
+                  <ImeSafeInput
                     value={model.name}
-                    onChange={(e) => handleModelNameChange(key, e.target.value)}
+                    onValueChange={(value) => handleModelNameChange(key, value)}
                     placeholder={t("opencode.modelName", {
                       defaultValue: "Display Name",
                     })}
@@ -629,12 +752,152 @@ export function OpenCodeFormFields({
                 {/* Expanded model details */}
                 {expandedModels.has(key) && (
                   <div className="ml-9 pl-4 border-l-2 border-muted space-y-3">
+                    {/* Token limits (model.limit) */}
+                    <div className="space-y-2">
+                      <span className="text-xs font-medium text-muted-foreground">
+                        {t("opencode.modelLimits", {
+                          defaultValue: "Token Limits",
+                        })}
+                      </span>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                        <div className="space-y-1">
+                          <FormLabel
+                            htmlFor={`opencode-${key}-limit-context`}
+                            className="text-xs text-muted-foreground"
+                          >
+                            {t("opencode.limitContext", {
+                              defaultValue: "Context",
+                            })}
+                          </FormLabel>
+                          <Input
+                            id={`opencode-${key}-limit-context`}
+                            type="number"
+                            min={0}
+                            step={1}
+                            value={model.limit?.context ?? ""}
+                            onChange={(e) =>
+                              handleModelLimitChange(
+                                key,
+                                "context",
+                                e.target.value,
+                              )
+                            }
+                            placeholder="1048576"
+                          />
+                        </div>
+                        <div className="space-y-1">
+                          <FormLabel
+                            htmlFor={`opencode-${key}-limit-output`}
+                            className="text-xs text-muted-foreground"
+                          >
+                            {t("opencode.limitOutput", {
+                              defaultValue: "Output",
+                            })}
+                          </FormLabel>
+                          <Input
+                            id={`opencode-${key}-limit-output`}
+                            type="number"
+                            min={0}
+                            step={1}
+                            value={model.limit?.output ?? ""}
+                            onChange={(e) =>
+                              handleModelLimitChange(
+                                key,
+                                "output",
+                                e.target.value,
+                              )
+                            }
+                            placeholder="131072"
+                          />
+                        </div>
+                      </div>
+                    </div>
+
                     {/* Model Properties (extra fields like variants, cost) */}
                     <div className="space-y-2">
                       <div className="flex items-center justify-between">
                         <span className="text-xs font-medium text-muted-foreground">
                           {t("opencode.modelExtraFields", {
                             defaultValue: "模型属性",
+                          })}
+                        </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => handleAddModelExtraField(key)}
+                          className="h-6 px-2 gap-1"
+                        >
+                          <Plus className="h-3 w-3" />
+                        </Button>
+                      </div>
+                      {Object.keys(getModelExtraFields(model)).length === 0 ? (
+                        <p className="text-xs text-muted-foreground py-1">
+                          {t("opencode.noModelExtraFields", {
+                            defaultValue:
+                              "模型属性 (variants, cost 等)，点击 + 添加",
+                          })}
+                        </p>
+                      ) : (
+                        Object.entries(getModelExtraFields(model)).map(
+                          ([fKey, fValue]) => (
+                            <div key={fKey} className="flex items-center gap-2">
+                              <ModelOptionKeyInput
+                                optionKey={fKey}
+                                onChange={(newKey) =>
+                                  handleModelExtraFieldKeyChange(
+                                    key,
+                                    fKey,
+                                    newKey,
+                                  )
+                                }
+                                placeholder={t(
+                                  "opencode.modelExtraFieldKeyPlaceholder",
+                                  {
+                                    defaultValue: "variants",
+                                  },
+                                )}
+                              />
+                              <ImeSafeInput
+                                value={fValue}
+                                onValueChange={(value) =>
+                                  handleModelExtraFieldValueChange(
+                                    key,
+                                    fKey,
+                                    value,
+                                  )
+                                }
+                                placeholder={t(
+                                  "opencode.modelOptionValuePlaceholder",
+                                  {
+                                    defaultValue: '{"order": ["baseten"]}',
+                                  },
+                                )}
+                                className="flex-1"
+                              />
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon"
+                                onClick={() =>
+                                  handleRemoveModelExtraField(key, fKey)
+                                }
+                                className="h-9 w-9 text-muted-foreground hover:text-destructive"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </div>
+                          ),
+                        )
+                      )}
+                    </div>
+
+                    {/* SDK Options (model.options) */}
+                    <div className="space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs font-medium text-muted-foreground">
+                          {t("opencode.sdkOptions", {
+                            defaultValue: "SDK 选项",
                           })}
                         </span>
                         <Button
@@ -649,15 +912,17 @@ export function OpenCodeFormFields({
                       </div>
                       {Object.keys(model.options || {}).length === 0 ? (
                         <p className="text-xs text-muted-foreground py-1">
-                          {t("opencode.noModelExtraFields", {
-                            defaultValue:
-                              "模型属性 (插入到 options 对象)，点击 + 添加",
+                          {t("opencode.noModelOptions", {
+                            defaultValue: "模型选项，点击 + 添加",
                           })}
                         </p>
                       ) : (
                         Object.entries(model.options || {}).map(
                           ([optKey, optValue]) => (
-                            <div key={optKey} className="flex items-center gap-2">
+                            <div
+                              key={optKey}
+                              className="flex items-center gap-2"
+                            >
                               <ModelOptionKeyInput
                                 optionKey={optKey}
                                 onChange={(newKey) =>
@@ -668,23 +933,23 @@ export function OpenCodeFormFields({
                                   )
                                 }
                                 placeholder={t(
-                                  "opencode.modelExtraFieldKeyPlaceholder",
+                                  "opencode.modelOptionKeyPlaceholder",
                                   {
                                     defaultValue: "provider",
                                   },
                                 )}
                               />
-                              <Input
+                              <ImeSafeInput
                                 value={
                                   typeof optValue === "string"
                                     ? optValue
                                     : JSON.stringify(optValue)
                                 }
-                                onChange={(e) =>
+                                onValueChange={(value) =>
                                   handleModelOptionValueChange(
                                     key,
                                     optKey,
-                                    e.target.value,
+                                    value,
                                   )
                                 }
                                 placeholder={t(
@@ -701,85 +966,6 @@ export function OpenCodeFormFields({
                                 size="icon"
                                 onClick={() =>
                                   handleRemoveModelOption(key, optKey)
-                                }
-                                className="h-9 w-9 text-muted-foreground hover:text-destructive"
-                              >
-                                <Trash2 className="h-4 w-4" />
-                              </Button>
-                            </div>
-                          ),
-                        )
-                      )}
-                    </div>
-
-                    {/* Advanced Properties (top-level fields like limit, modalities, variants) */}
-                    <div className="space-y-2">
-                      <div className="flex items-center justify-between">
-                        <span className="text-xs font-medium text-muted-foreground">
-                          {t("opencode.advancedProperties", {
-                            defaultValue: "高级属性",
-                          })}
-                        </span>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleAddAdvancedField(key)}
-                          className="h-6 px-2 gap-1"
-                        >
-                          <Plus className="h-3 w-3" />
-                        </Button>
-                      </div>
-                      {Object.keys(getModelAdvancedFields(model)).length === 0 ? (
-                        <p className="text-xs text-muted-foreground py-1">
-                          {t("opencode.noAdvancedProperties", {
-                            defaultValue:
-                              "高级属性 (与 options 同级的顶层字段)，点击 + 添加",
-                          })}
-                        </p>
-                      ) : (
-                        Object.entries(getModelAdvancedFields(model)).map(
-                          ([fKey, fValue]) => (
-                            <div key={fKey} className="flex items-center gap-2">
-                              <ModelOptionKeyInput
-                                optionKey={fKey}
-                                onChange={(newKey) =>
-                                  handleAdvancedFieldKeyChange(
-                                    key,
-                                    fKey,
-                                    newKey,
-                                  )
-                                }
-                                placeholder={t(
-                                  "opencode.advancedPropertyKeyPlaceholder",
-                                  {
-                                    defaultValue: "limit",
-                                  },
-                                )}
-                              />
-                              <Input
-                                value={fValue}
-                                onChange={(e) =>
-                                  handleAdvancedFieldValueChange(
-                                    key,
-                                    fKey,
-                                    e.target.value,
-                                  )
-                                }
-                                placeholder={t(
-                                  "opencode.advancedPropertyValuePlaceholder",
-                                  {
-                                    defaultValue: '{"context":200000,"output":64000}',
-                                  },
-                                )}
-                                className="flex-1"
-                              />
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon"
-                                onClick={() =>
-                                  handleRemoveAdvancedField(key, fKey)
                                 }
                                 className="h-9 w-9 text-muted-foreground hover:text-destructive"
                               >

--- a/src/components/providers/forms/helpers/opencodeFormUtils.ts
+++ b/src/components/providers/forms/helpers/opencodeFormUtils.ts
@@ -133,16 +133,17 @@ export function isKnownModelKey(key: string): boolean {
   );
 }
 
-export function getModelExtraFields(
+/** Return editable top-level model properties that are siblings of `options`. */
+export function getModelAdvancedFields(
   model: OpenCodeModel,
 ): Record<string, string> {
-  const extra: Record<string, string> = {};
-  for (const [k, v] of Object.entries(model)) {
-    if (!isKnownModelKey(k)) {
-      extra[k] = typeof v === "string" ? v : JSON.stringify(v);
+  const advanced: Record<string, string> = {};
+  for (const [key, value] of Object.entries(model)) {
+    if (!isKnownModelKey(key)) {
+      advanced[key] = typeof value === "string" ? value : JSON.stringify(value);
     }
   }
-  return extra;
+  return advanced;
 }
 
 export function toOpencodeExtraOptions(

--- a/src/components/providers/forms/helpers/opencodeFormUtils.ts
+++ b/src/components/providers/forms/helpers/opencodeFormUtils.ts
@@ -133,52 +133,16 @@ export function isKnownModelKey(key: string): boolean {
   );
 }
 
-/**
- * 获取模型的额外字段（用户自定义字段）
- * 排除保留字段（name, limit, options）和高级字段
- * 这些字段不会在 UI 中显示，仅用于内部处理
- */
 export function getModelExtraFields(
   model: OpenCodeModel,
 ): Record<string, string> {
   const extra: Record<string, string> = {};
   for (const [k, v] of Object.entries(model)) {
-    if (!isKnownModelKey(k) && !isAdvancedModelKey(k)) {
+    if (!isKnownModelKey(k)) {
       extra[k] = typeof v === "string" ? v : JSON.stringify(v);
     }
   }
   return extra;
-}
-
-// 高级属性：limit, modalities, variants 等顶层字段（排除 name 和 options）
-export const OPENCODE_ADVANCED_MODEL_KEYS = ["limit", "modalities", "variants", "cost", "contextLimit", "outputLimit"] as const;
-
-/**
- * 检查字段是否为高级模型属性
- * 高级属性包括：limit, modalities, variants, cost, contextLimit, outputLimit
- * 这些字段在 UI 的"高级属性"区域显示，与 options 同级（顶层字段）
- */
-export function isAdvancedModelKey(key: string): boolean {
-  return OPENCODE_ADVANCED_MODEL_KEYS.includes(
-    key as (typeof OPENCODE_ADVANCED_MODEL_KEYS)[number],
-  );
-}
-
-/**
- * 获取模型的高级属性字段（顶层字段，与 options 同级）
- * 返回所有非保留字段（排除 name, limit, options），包括高级字段和用户自定义字段
- */
-export function getModelAdvancedFields(
-  model: OpenCodeModel,
-): Record<string, string> {
-  const advanced: Record<string, string> = {};
-  for (const [k, v] of Object.entries(model)) {
-    // 排除保留字段 name, limit, options，返回所有其他顶层字段
-    if (k !== "name" && k !== "limit" && k !== "options") {
-      advanced[k] = typeof v === "string" ? v : JSON.stringify(v);
-    }
-  }
-  return advanced;
 }
 
 export function toOpencodeExtraOptions(

--- a/src/components/providers/forms/helpers/opencodeFormUtils.ts
+++ b/src/components/providers/forms/helpers/opencodeFormUtils.ts
@@ -133,16 +133,52 @@ export function isKnownModelKey(key: string): boolean {
   );
 }
 
+/**
+ * 获取模型的额外字段（用户自定义字段）
+ * 排除保留字段（name, limit, options）和高级字段
+ * 这些字段不会在 UI 中显示，仅用于内部处理
+ */
 export function getModelExtraFields(
   model: OpenCodeModel,
 ): Record<string, string> {
   const extra: Record<string, string> = {};
   for (const [k, v] of Object.entries(model)) {
-    if (!isKnownModelKey(k)) {
+    if (!isKnownModelKey(k) && !isAdvancedModelKey(k)) {
       extra[k] = typeof v === "string" ? v : JSON.stringify(v);
     }
   }
   return extra;
+}
+
+// 高级属性：limit, modalities, variants 等顶层字段（排除 name 和 options）
+export const OPENCODE_ADVANCED_MODEL_KEYS = ["limit", "modalities", "variants", "cost", "contextLimit", "outputLimit"] as const;
+
+/**
+ * 检查字段是否为高级模型属性
+ * 高级属性包括：limit, modalities, variants, cost, contextLimit, outputLimit
+ * 这些字段在 UI 的"高级属性"区域显示，与 options 同级（顶层字段）
+ */
+export function isAdvancedModelKey(key: string): boolean {
+  return OPENCODE_ADVANCED_MODEL_KEYS.includes(
+    key as (typeof OPENCODE_ADVANCED_MODEL_KEYS)[number],
+  );
+}
+
+/**
+ * 获取模型的高级属性字段（顶层字段，与 options 同级）
+ * 返回所有非保留字段（排除 name, limit, options），包括高级字段和用户自定义字段
+ */
+export function getModelAdvancedFields(
+  model: OpenCodeModel,
+): Record<string, string> {
+  const advanced: Record<string, string> = {};
+  for (const [k, v] of Object.entries(model)) {
+    // 排除保留字段 name, limit, options，返回所有其他顶层字段
+    if (k !== "name" && k !== "limit" && k !== "options") {
+      advanced[k] = typeof v === "string" ? v : JSON.stringify(v);
+    }
+  }
+  return advanced;
 }
 
 export function toOpencodeExtraOptions(

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1649,6 +1649,10 @@
     "noModelExtraFields": "Model properties (variants, cost, etc.), click + to add",
     "modelExtraFieldKeyPlaceholder": "variants",
     "sdkOptions": "SDK Options",
+    "advancedProperties": "Advanced Properties",
+    "noAdvancedProperties": "Advanced properties (top-level fields alongside options), click + to add",
+    "advancedPropertyKeyPlaceholder": "modalities",
+    "advancedPropertyValuePlaceholder": "{\"input\":[\"text\",\"image\"],\"output\":[\"text\"]}",
     "modelOptionKeyPlaceholder": "provider",
     "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}"
   },

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1649,6 +1649,10 @@
     "noModelExtraFields": "モデルプロパティ（variants、cost など）、+ をクリックして追加",
     "modelExtraFieldKeyPlaceholder": "variants",
     "sdkOptions": "SDK オプション",
+    "advancedProperties": "詳細プロパティ",
+    "noAdvancedProperties": "options と同じ階層の詳細プロパティ。+ をクリックして追加",
+    "advancedPropertyKeyPlaceholder": "modalities",
+    "advancedPropertyValuePlaceholder": "{\"input\":[\"text\",\"image\"],\"output\":[\"text\"]}",
     "modelOptionKeyPlaceholder": "provider",
     "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}"
   },

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1650,6 +1650,10 @@
     "noModelExtraFields": "模型屬性 (variants, cost 等)，點擊 + 新增",
     "modelExtraFieldKeyPlaceholder": "variants",
     "sdkOptions": "SDK 選項",
+    "advancedProperties": "進階屬性",
+    "noAdvancedProperties": "與 options 同層的進階屬性，點擊 + 新增",
+    "advancedPropertyKeyPlaceholder": "modalities",
+    "advancedPropertyValuePlaceholder": "{\"input\":[\"text\",\"image\"],\"output\":[\"text\"]}",
     "modelOptionKeyPlaceholder": "provider",
     "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}"
   },

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1649,6 +1649,10 @@
     "noModelExtraFields": "模型属性 (variants, cost 等)，点击 + 添加",
     "modelExtraFieldKeyPlaceholder": "variants",
     "sdkOptions": "SDK 选项",
+    "advancedProperties": "高级属性",
+    "noAdvancedProperties": "高级属性（与 options 同级的顶层字段），点击 + 添加",
+    "advancedPropertyKeyPlaceholder": "modalities",
+    "advancedPropertyValuePlaceholder": "{\"input\":[\"text\",\"image\"],\"output\":[\"text\"]}",
     "modelOptionKeyPlaceholder": "provider",
     "modelOptionValuePlaceholder": "{\"order\": [\"baseten\"]}"
   },

--- a/tests/components/OpenCodeFormFields.test.tsx
+++ b/tests/components/OpenCodeFormFields.test.tsx
@@ -359,4 +359,36 @@ describe("OpenCodeFormFields", () => {
       },
     });
   });
+
+  it("edits top-level modalities in the advanced properties section", () => {
+    const onModelsChange = vi.fn();
+    renderOpenCodeForm({
+      onModelsChange,
+      models: {
+        "kimi-k2": {
+          name: "Kimi K2",
+          modalities: { input: ["text"], output: ["text"] },
+          options: { provider: "baseten" },
+        },
+      },
+    });
+
+    expandFirstModel();
+    const modalitiesInput = screen.getByDisplayValue(
+      '{"input":["text"],"output":["text"]}',
+    );
+    fireEvent.change(modalitiesInput, {
+      target: {
+        value: '{"input":["text","image"],"output":["text"]}',
+      },
+    });
+
+    expect(onModelsChange).toHaveBeenLastCalledWith({
+      "kimi-k2": {
+        name: "Kimi K2",
+        modalities: { input: ["text", "image"], output: ["text"] },
+        options: { provider: "baseten" },
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary / 概述

OpenCode model editing now separates nested SDK options from top-level advanced properties. This makes it possible to configure model-level `modalities` (including image input) directly in CC Switch and preserve the value when syncing to `opencode.json`.

## Changes

- Keep “Model Properties” bound to `model.options.*`.
- Add “Advanced Properties” bound to top-level model fields alongside `options`.
- Support adding/editing/removing `modalities`, `variants`, `cost`, and other preserved top-level fields.
- Add localized labels and placeholders for English, Simplified Chinese, Traditional Chinese, and Japanese.
- Add a regression test covering top-level `modalities` editing.

Fixes #1556

## Verification

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm exec vitest run tests/components/OpenCodeFormFields.test.tsx`

The focused test passes. The full unit suite was also run; 134 files passed and 2 pre-existing integration tests failed due to timeout/duplicate test DOM state in `tests/integration/App.test.tsx`.