### PR TITLE
fix(ui): persist last active app across restarts

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -57,6 +57,13 @@ pub async fn get_settings() -> Result<crate::settings::AppSettings, String> {
     Ok(crate::settings::get_settings_for_frontend())
 }
 
+/// 保存主页面最后聚焦的应用
+#[tauri::command]
+pub async fn set_last_active_app(app: crate::app_config::AppType) -> Result<bool, String> {
+    crate::settings::set_last_active_app(app).map_err(|e| e.to_string())?;
+    Ok(true)
+}
+
 /// 保存设置
 #[tauri::command]
 pub async fn save_settings(
@@ -68,7 +75,10 @@ pub async fn save_settings(
     let unify_codex_changed =
         merged.unify_codex_session_history != existing.unify_codex_session_history;
     let unify_codex_enabled = merged.unify_codex_session_history;
-    crate::settings::update_settings(merged).map_err(|e| e.to_string())?;
+    // last_active_app 由专用命令更新；锁内保留它，避免全量设置保存的旧快照
+    // 与应用切换并发时覆盖较新的选择。
+    crate::settings::update_settings_preserving_last_active_app(merged)
+        .map_err(|e| e.to_string())?;
 
     // 统一会话开关变更时立即重写当前官方 Codex 供应商的 live 配置，
     // 不必等下一次切换才生效。
@@ -82,7 +92,9 @@ pub async fn save_settings(
             crate::services::provider::reapply_current_codex_official_live(state.inner())
         {
             log::warn!("统一 Codex 会话历史开关变更后重写 live 配置失败，回滚设置: {err}");
-            if let Err(rollback_err) = crate::settings::update_settings(existing) {
+            if let Err(rollback_err) =
+                crate::settings::update_settings_preserving_last_active_app(existing)
+            {
                 log::error!("回滚统一会话开关设置失败: {rollback_err}");
             }
             return Err(format!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1403,6 +1403,7 @@ pub fn run() {
             commands::extract_common_config_snippet,
             commands::read_live_provider_settings,
             commands::get_settings,
+            commands::set_last_active_app,
             commands::save_settings,
             commands::has_codex_unify_history_backup,
             commands::restore_codex_unified_history,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -415,6 +415,9 @@ pub struct AppSettings {
     // ===== 主页面显示的应用 =====
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub visible_apps: Option<VisibleApps>,
+    /// 上次在主页面聚焦的应用
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_active_app: Option<AppType>,
 
     // ===== 设备级目录覆盖 =====
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -542,6 +545,7 @@ impl Default for AppSettings {
             common_config_confirmed: None,
             language: None,
             visible_apps: None,
+            last_active_app: None,
             claude_config_dir: None,
             codex_config_dir: None,
             gemini_config_dir: None,
@@ -786,6 +790,28 @@ pub fn update_settings(mut new_settings: AppSettings) -> Result<(), AppError> {
     });
     *guard = new_settings;
     Ok(())
+}
+
+fn replace_settings_preserving_last_active_app(
+    current: &mut AppSettings,
+    mut new_settings: AppSettings,
+) {
+    new_settings.last_active_app = current.last_active_app.clone();
+    *current = new_settings;
+}
+
+pub fn update_settings_preserving_last_active_app(
+    new_settings: AppSettings,
+) -> Result<(), AppError> {
+    mutate_settings(move |current| {
+        replace_settings_preserving_last_active_app(current, new_settings);
+    })
+}
+
+pub fn set_last_active_app(app: AppType) -> Result<(), AppError> {
+    mutate_settings(|settings| {
+        settings.last_active_app = Some(app);
+    })
 }
 
 fn mutate_settings<F>(mutator: F) -> Result<(), AppError>
@@ -1218,6 +1244,40 @@ mod tests {
         .expect("visible apps");
 
         assert!(!visible.is_visible(&AppType::ClaudeDesktop));
+    }
+
+    #[test]
+    fn last_active_app_round_trips_as_app_id() {
+        let settings: AppSettings = serde_json::from_value(serde_json::json!({
+            "lastActiveApp": "codex"
+        }))
+        .expect("settings");
+
+        assert_eq!(settings.last_active_app, Some(AppType::Codex));
+        assert_eq!(
+            serde_json::to_value(settings)
+                .expect("serialized settings")
+                .get("lastActiveApp"),
+            Some(&serde_json::json!("codex"))
+        );
+    }
+
+    #[test]
+    fn full_settings_replacement_preserves_last_active_app() {
+        let mut current = AppSettings {
+            last_active_app: Some(AppType::OpenCode),
+            ..Default::default()
+        };
+        let incoming = AppSettings {
+            last_active_app: Some(AppType::Claude),
+            language: Some("en".to_string()),
+            ..Default::default()
+        };
+
+        replace_settings_preserving_last_active_app(&mut current, incoming);
+
+        assert_eq!(current.last_active_app, Some(AppType::OpenCode));
+        assert_eq!(current.language.as_deref(), Some("en"));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useRef } from "react";
+import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "framer-motion";
 import { toast } from "sonner";
@@ -29,7 +29,7 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import type { Provider, VisibleApps } from "@/types";
+import type { Provider, Settings as AppSettings, VisibleApps } from "@/types";
 import type { EnvConflict } from "@/types/env";
 import { proxyKeys, useProvidersQuery, useSettingsQuery } from "@/lib/query";
 import {
@@ -139,13 +139,25 @@ const DEFAULT_DRAG_BAR_HEIGHT = isWindows() || isLinux() ? 0 : 28; // px
 const HEADER_HEIGHT = 64; // px
 
 const STORAGE_KEY = "cc-switch-last-app";
-const getInitialApp = (): AppId => {
-  const saved = localStorage.getItem(STORAGE_KEY) as AppId | null;
-  if (saved && APP_IDS.includes(saved)) {
-    return saved;
-  }
-  return "claude";
+let activeAppPersistence: Promise<unknown> = Promise.resolve();
+
+const persistLastActiveApp = (app: AppId) => {
+  activeAppPersistence = activeAppPersistence
+    .then(() => settingsApi.setLastActiveApp(app))
+    .catch((error) => {
+      console.warn("Failed to persist active app in settings", error);
+    });
 };
+
+const getStoredApp = (): AppId | null => {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY) as AppId | null;
+    return saved && APP_IDS.includes(saved) ? saved : null;
+  } catch {
+    return null;
+  }
+};
+const getInitialApp = (): AppId => getStoredApp() ?? "claude";
 
 const VIEW_STORAGE_KEY = "cc-switch-last-view";
 const VALID_VIEWS: View[] = [
@@ -178,6 +190,7 @@ function App() {
   const queryClient = useQueryClient();
 
   const [activeApp, setActiveApp] = useState<AppId>(getInitialApp);
+  const [hasRestoredActiveApp, setHasRestoredActiveApp] = useState(false);
   const sharedFeatureApp: AppId =
     activeApp === "claude-desktop" ? "claude" : activeApp;
   const [currentView, setCurrentView] = useState<View>(getInitialView);
@@ -214,15 +227,77 @@ function App() {
     [settingsData?.visibleApps],
   );
 
-  const getFirstVisibleApp = (): AppId => {
-    return APP_IDS.find((app) => visibleApps[app]) ?? "claude";
-  };
+  const firstVisibleApp = useMemo<AppId>(
+    () => APP_IDS.find((app) => visibleApps[app]) ?? "claude",
+    [visibleApps],
+  );
+
+  const setActiveAppLocally = useCallback((app: AppId) => {
+    setActiveApp(app);
+    try {
+      localStorage.setItem(STORAGE_KEY, app);
+    } catch (error) {
+      console.warn("Failed to persist active app in localStorage", error);
+    }
+  }, []);
+
+  const userSelectedApp = useRef(false);
+  const handleAppSwitch = useCallback(
+    (app: AppId) => {
+      userSelectedApp.current = true;
+      setActiveAppLocally(app);
+      queryClient.setQueryData<AppSettings>(["settings"], (current) =>
+        current ? { ...current, lastActiveApp: app } : current,
+      );
+      persistLastActiveApp(app);
+    },
+    [queryClient, setActiveAppLocally],
+  );
+
+  const restoredPersistedApp = useRef(false);
+  useEffect(() => {
+    if (!settingsData || restoredPersistedApp.current) return;
+    restoredPersistedApp.current = true;
+
+    if (userSelectedApp.current) {
+      queryClient.setQueryData<AppSettings>(["settings"], (current) =>
+        current ? { ...current, lastActiveApp: activeApp } : current,
+      );
+      setHasRestoredActiveApp(true);
+      return;
+    }
+
+    const persistedApp = settingsData.lastActiveApp ?? getStoredApp();
+    const resolvedApp =
+      persistedApp && visibleApps[persistedApp]
+        ? persistedApp
+        : firstVisibleApp;
+    setActiveAppLocally(resolvedApp);
+    if (persistedApp && settingsData.lastActiveApp !== resolvedApp) {
+      persistLastActiveApp(resolvedApp);
+    }
+    setHasRestoredActiveApp(true);
+  }, [
+    activeApp,
+    firstVisibleApp,
+    queryClient,
+    setActiveAppLocally,
+    settingsData,
+    visibleApps,
+  ]);
 
   useEffect(() => {
+    if (!hasRestoredActiveApp) return;
     if (!visibleApps[activeApp]) {
-      setActiveApp(getFirstVisibleApp());
+      handleAppSwitch(firstVisibleApp);
     }
-  }, [visibleApps, activeApp]);
+  }, [
+    visibleApps,
+    activeApp,
+    firstVisibleApp,
+    handleAppSwitch,
+    hasRestoredActiveApp,
+  ]);
 
   // Fallback from sessions view when switching to an app without session support
   useEffect(() => {
@@ -1404,7 +1479,7 @@ function App() {
               {currentView === "providers" && (
                 <AppSwitcher
                   activeApp={activeApp}
-                  onSwitch={setActiveApp}
+                  onSwitch={handleAppSwitch}
                   visibleApps={visibleApps}
                 />
               )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,25 +139,53 @@ const DEFAULT_DRAG_BAR_HEIGHT = isWindows() || isLinux() ? 0 : 28; // px
 const HEADER_HEIGHT = 64; // px
 
 const STORAGE_KEY = "cc-switch-last-app";
-let activeAppPersistence: Promise<unknown> = Promise.resolve();
+// 后端写入失败时在此记下待同步的选择。settings 里的值此时已知是旧的，
+// 下次启动必须以本地值为准，否则一次写入失败就会永久丢掉用户的选择。
+const PENDING_STORAGE_KEY = "cc-switch-last-app-pending";
 
-const persistLastActiveApp = (app: AppId) => {
-  activeAppPersistence = activeAppPersistence
-    .then(() => settingsApi.setLastActiveApp(app))
-    .catch((error) => {
-      console.warn("Failed to persist active app in settings", error);
-    });
-};
-
-const getStoredApp = (): AppId | null => {
+const readStoredApp = (key: string): AppId | null => {
   try {
-    const saved = localStorage.getItem(STORAGE_KEY) as AppId | null;
+    const saved = localStorage.getItem(key) as AppId | null;
     return saved && APP_IDS.includes(saved) ? saved : null;
   } catch {
     return null;
   }
 };
-const getInitialApp = (): AppId => getStoredApp() ?? "claude";
+
+const getStoredApp = (): AppId | null => readStoredApp(STORAGE_KEY);
+const getPendingApp = (): AppId | null => readStoredApp(PENDING_STORAGE_KEY);
+
+const setPendingApp = (app: AppId | null) => {
+  try {
+    if (app) {
+      localStorage.setItem(PENDING_STORAGE_KEY, app);
+    } else {
+      localStorage.removeItem(PENDING_STORAGE_KEY);
+    }
+  } catch (error) {
+    console.warn("Failed to record pending active app", error);
+  }
+};
+
+let activeAppPersistence: Promise<unknown> = Promise.resolve();
+let lastRequestedActiveApp: AppId | null = null;
+
+const persistLastActiveApp = (app: AppId) => {
+  lastRequestedActiveApp = app;
+  activeAppPersistence = activeAppPersistence
+    .then(() => settingsApi.setLastActiveApp(app))
+    .then(() => {
+      // 只有在没有更晚的选择时才清标记，避免旧请求清掉新请求留下的待同步值。
+      if (lastRequestedActiveApp === app) setPendingApp(null);
+    })
+    .catch((error) => {
+      if (lastRequestedActiveApp === app) setPendingApp(app);
+      console.warn("Failed to persist active app in settings", error);
+    });
+};
+
+const getInitialApp = (): AppId =>
+  getPendingApp() ?? getStoredApp() ?? "claude";
 
 const VIEW_STORAGE_KEY = "cc-switch-last-view";
 const VALID_VIEWS: View[] = [
@@ -267,14 +295,21 @@ function App() {
       return;
     }
 
-    const persistedApp = settingsData.lastActiveApp ?? getStoredApp();
+    // 上次写入失败时后端存的是旧值，此处不能把它当权威。
+    const pendingApp = getPendingApp();
+    const persistedApp =
+      pendingApp ?? settingsData.lastActiveApp ?? getStoredApp();
     const resolvedApp =
       persistedApp && visibleApps[persistedApp]
         ? persistedApp
         : firstVisibleApp;
     setActiveAppLocally(resolvedApp);
     if (persistedApp && settingsData.lastActiveApp !== resolvedApp) {
+      // 顺带重试上次失败的写入。
       persistLastActiveApp(resolvedApp);
+    } else if (pendingApp) {
+      // 后端其实已是该值（只是上次回包失败），清掉标记即可。
+      setPendingApp(null);
     }
     setHasRestoredActiveApp(true);
   }, [

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -25,8 +25,6 @@ interface AppSwitcherProps {
   visibleApps?: VisibleApps;
 }
 
-const STORAGE_KEY = "cc-switch-last-app";
-
 const APP_ICON_NAME: Record<AppId, string> = {
   claude: "claude",
   "claude-desktop": "claude",
@@ -98,7 +96,6 @@ export function AppSwitcher({
 
   const handleSwitch = (app: AppId) => {
     if (app === activeApp) return;
-    localStorage.setItem(STORAGE_KEY, app);
     onSwitch(app);
   };
 

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -39,6 +39,10 @@ export const settingsApi = {
     return await invoke("save_settings", { settings });
   },
 
+  async setLastActiveApp(app: AppId): Promise<boolean> {
+    return await invoke("set_last_active_app", { app });
+  },
+
   /** 是否存在统一 Codex 会话历史的迁移备份（关闭弹窗据此显示"恢复备份"勾选） */
   async hasCodexUnifyHistoryBackup(): Promise<boolean> {
     return await invoke("has_codex_unify_history_backup");

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { AppId } from "@/lib/api/types";
+
 export type ProviderCategory =
   | "official" // 官方
   | "cn_official" // 开源官方（原"国产官方"）
@@ -403,6 +405,8 @@ export interface Settings {
 
   // 主页面显示的应用（默认全部显示）
   visibleApps?: VisibleApps;
+  // 上次聚焦的应用（设备级持久化，避免依赖 WebView localStorage）
+  lastActiveApp?: AppId;
 
   // ===== 设备级目录覆盖 =====
   // 覆盖 Claude Code 配置目录（可选）

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -208,6 +208,7 @@ describe("App integration with MSW", () => {
     skillsPanelMocks.openDiscovery.mockReset();
     localStorage.removeItem("cc-switch-last-view");
     localStorage.removeItem("cc-switch-last-app");
+    localStorage.removeItem("cc-switch-last-app-pending");
   });
 
   it("covers basic provider flows via real hooks", async () => {
@@ -417,6 +418,43 @@ describe("App integration with MSW", () => {
     await waitFor(() => expect(getSettings().lastActiveApp).toBe("openclaw"));
     await delay(100);
     expect(getSettings().lastActiveApp).toBe("openclaw");
+  });
+
+  it("keeps a selection whose backend write failed and retries it on restart", async () => {
+    setSettings({ lastActiveApp: "claude" });
+    server.use(
+      http.post("http://tauri.local/set_last_active_app", () =>
+        HttpResponse.json(
+          { error: "settings file is locked" },
+          { status: 500 },
+        ),
+      ),
+    );
+    const { default: App } = await import("@/App");
+    const firstLaunch = renderApp(App);
+    await screen.findByTestId("app-switcher");
+
+    fireEvent.click(screen.getByText("switch-openclaw"));
+
+    await waitFor(() =>
+      expect(localStorage.getItem("cc-switch-last-app-pending")).toBe(
+        "openclaw",
+      ),
+    );
+    expect(getSettings().lastActiveApp).toBe("claude");
+
+    // 重启：后端恢复可写，待同步的选择应当胜过 settings 里的旧值。
+    firstLaunch.unmount();
+    server.resetHandlers();
+    renderApp(App);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("app-switcher")).toHaveTextContent("openclaw"),
+    );
+    await waitFor(() => expect(getSettings().lastActiveApp).toBe("openclaw"));
+    await waitFor(() =>
+      expect(localStorage.getItem("cc-switch-last-app-pending")).toBeNull(),
+    );
   });
 
   it("duplicates openclaw providers with a generated key that avoids live-only ids", async () => {

--- a/tests/integration/App.test.tsx
+++ b/tests/integration/App.test.tsx
@@ -2,13 +2,15 @@ import { Suspense, type ComponentType } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { http, HttpResponse } from "msw";
+import { delay, http, HttpResponse } from "msw";
 import { providersApi } from "@/lib/api/providers";
 import {
   resetProviderState,
   setCurrentProviderId,
   setLiveProviderIds,
   setProviders,
+  setSettings,
+  getSettings,
 } from "../msw/state";
 import { emitTauriEvent } from "../msw/tauriMocks";
 import { server } from "../msw/server";
@@ -305,6 +307,116 @@ describe("App integration with MSW", () => {
     await waitFor(() => {
       expect(toastErrorMock).toHaveBeenCalled();
     });
+  });
+
+  it("restores and persists the last active app through settings", async () => {
+    localStorage.setItem("cc-switch-last-app", "claude");
+    setSettings({ lastActiveApp: "codex" });
+    const { default: App } = await import("@/App");
+    renderApp(App);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("app-switcher")).toHaveTextContent("codex"),
+    );
+
+    fireEvent.click(screen.getByText("switch-openclaw"));
+
+    await waitFor(() => expect(getSettings().lastActiveApp).toBe("openclaw"));
+    expect(localStorage.getItem("cc-switch-last-app")).toBe("openclaw");
+  });
+
+  it("does not overwrite a visible backend app when the initial app is hidden", async () => {
+    setSettings({
+      lastActiveApp: "codex",
+      visibleApps: {
+        claude: false,
+        "claude-desktop": true,
+        codex: true,
+        gemini: false,
+        grokbuild: false,
+        opencode: true,
+        openclaw: false,
+        hermes: false,
+        pi: false,
+      },
+    });
+    const { default: App } = await import("@/App");
+    renderApp(App);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("app-switcher")).toHaveTextContent("codex"),
+    );
+    await delay(100);
+    expect(getSettings().lastActiveApp).toBe("codex");
+    expect(localStorage.getItem("cc-switch-last-app")).toBe("codex");
+  });
+
+  it("keeps a user selection made before settings finish loading", async () => {
+    const staleSettings = getSettings();
+    server.use(
+      http.post("http://tauri.local/get_settings", async () => {
+        await delay(75);
+        return HttpResponse.json(staleSettings);
+      }),
+    );
+    const { default: App } = await import("@/App");
+    renderApp(App);
+
+    fireEvent.click(await screen.findByText("switch-openclaw"));
+
+    await waitFor(() => expect(getSettings().lastActiveApp).toBe("openclaw"));
+    await delay(100);
+    expect(screen.getByTestId("app-switcher")).toHaveTextContent("openclaw");
+    expect(getSettings().lastActiveApp).toBe("openclaw");
+    expect(localStorage.getItem("cc-switch-last-app")).toBe("openclaw");
+  });
+
+  it("falls back and persists when the last active app is hidden", async () => {
+    setSettings({
+      lastActiveApp: "codex",
+      visibleApps: {
+        claude: true,
+        "claude-desktop": false,
+        codex: false,
+        gemini: false,
+        grokbuild: false,
+        opencode: true,
+        openclaw: false,
+        hermes: false,
+        pi: false,
+      },
+    });
+    const { default: App } = await import("@/App");
+    renderApp(App);
+
+    await waitFor(() => expect(getSettings().lastActiveApp).toBe("claude"));
+    expect(screen.getByTestId("app-switcher")).toHaveTextContent("claude");
+  });
+
+  it("serializes rapid switches so the latest selection wins", async () => {
+    server.use(
+      http.post(
+        "http://tauri.local/set_last_active_app",
+        async ({ request }) => {
+          const { app } = (await request.json()) as {
+            app: "claude" | "codex" | "openclaw";
+          };
+          if (app === "codex") await delay(75);
+          setSettings({ lastActiveApp: app });
+          return HttpResponse.json(true);
+        },
+      ),
+    );
+    const { default: App } = await import("@/App");
+    renderApp(App);
+    await screen.findByTestId("app-switcher");
+
+    fireEvent.click(screen.getByText("switch-codex"));
+    fireEvent.click(screen.getByText("switch-openclaw"));
+
+    await waitFor(() => expect(getSettings().lastActiveApp).toBe("openclaw"));
+    await delay(100);
+    expect(getSettings().lastActiveApp).toBe("openclaw");
   });
 
   it("duplicates openclaw providers with a generated key that avoids live-only ids", async () => {

--- a/tests/msw/handlers.ts
+++ b/tests/msw/handlers.ts
@@ -219,6 +219,12 @@ export const handlers = [
 
   http.post(`${TAURI_ENDPOINT}/get_settings`, () => success(getSettings())),
 
+  http.post(`${TAURI_ENDPOINT}/set_last_active_app`, async ({ request }) => {
+    const { app } = await withJson<{ app: AppId }>(request);
+    setSettings({ lastActiveApp: app });
+    return success(true);
+  }),
+
   http.post(`${TAURI_ENDPOINT}/check_env_conflicts`, () => success([])),
 
   http.post(`${TAURI_ENDPOINT}/save_settings`, async ({ request }) => {


### PR DESCRIPTION
## Summary / 概述

- Persist the last active app in device-level settings instead of relying only on WebView storage.
- Restore the backend value after settings load, with migration from the existing local value and a visible-app fallback.
- Serialize rapid app switches and protect the field from stale full-settings saves.
- Preserve a user selection made before the initial settings request completes.
- Add regression coverage for storage conflicts, hidden apps, startup effect ordering, delayed settings responses, and out-of-order writes.

## Related Issue / 关联 Issue

Fixes #6935

## Screenshots / 截图

Not applicable — this changes restart-time state restoration without changing the UI.

## Validation / 验证

- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit -- --maxWorkers=1 --minWorkers=1` (135 files, 1079 tests)
- `pnpm build:renderer`
- `cargo fmt --check`
- `cargo check --tests`
- `cargo clippy --tests` (passes with four pre-existing warnings outside this change)

`cargo test` could not complete locally because this Windows environment does not have the MSVC linker installed; `cargo check --tests` successfully compiled the test targets.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / No user-facing text changed