### PR TITLE
feat(codex): add evidence-based provider model verifier

### DIFF
--- a/src/components/providers/ModelVerifierDialog.tsx
+++ b/src/components/providers/ModelVerifierDialog.tsx
@@ -1,0 +1,362 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+  X,
+  XCircle,
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import type { AppId } from "@/lib/api";
+import {
+  modelVerifierApi,
+  type ModelVerificationResult,
+  type VerificationVerdict,
+} from "@/lib/api/modelVerifier";
+import type { Provider } from "@/types";
+
+interface ModelVerifierDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  appId: AppId;
+  provider: Provider;
+}
+
+const verdictTone = (verdict: VerificationVerdict) => {
+  switch (verdict) {
+    case "officialEndpointConsistent":
+    case "reportedExactMatch":
+    case "reportedFamilyMatch":
+      return "text-emerald-600 dark:text-emerald-400";
+    case "reportedMismatch":
+    case "requestFailed":
+      return "text-red-600 dark:text-red-400";
+    default:
+      return "text-amber-600 dark:text-amber-400";
+  }
+};
+
+const verdictIcon = (verdict: VerificationVerdict) => {
+  switch (verdict) {
+    case "officialEndpointConsistent":
+    case "reportedExactMatch":
+    case "reportedFamilyMatch":
+      return CheckCircle2;
+    case "reportedMismatch":
+    case "requestFailed":
+      return XCircle;
+    default:
+      return AlertTriangle;
+  }
+};
+
+export function ModelVerifierDialog({
+  open,
+  onOpenChange,
+  appId,
+  provider,
+}: ModelVerifierDialogProps) {
+  const { t } = useTranslation();
+  const [result, setResult] = useState<ModelVerificationResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const verify = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const next = await modelVerifierApi.verifyProvider(appId, provider);
+      setResult(next);
+    } catch (err) {
+      setResult(null);
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [appId, provider]);
+
+  useEffect(() => {
+    if (!open) return;
+    setResult(null);
+    setError(null);
+    void verify();
+  }, [open, provider.id, verify]);
+
+  const verdictLabel = useMemo(() => {
+    if (!result) return "";
+    switch (result.verdict) {
+      case "officialEndpointConsistent":
+        return t("modelVerifier.verdict.official", {
+          defaultValue: "官方端点证据一致",
+        });
+      case "reportedExactMatch":
+        return t("modelVerifier.verdict.exact", {
+          defaultValue: "第三方声明完全一致",
+        });
+      case "reportedFamilyMatch":
+        return t("modelVerifier.verdict.family", {
+          defaultValue: "第三方声明为同一模型系列",
+        });
+      case "reportedMismatch":
+        return t("modelVerifier.verdict.mismatch", {
+          defaultValue: "服务端声明模型不一致",
+        });
+      case "requestFailed":
+        return t("modelVerifier.verdict.failed", {
+          defaultValue: "真实请求失败",
+        });
+      default:
+        return t("modelVerifier.verdict.insufficient", {
+          defaultValue: "证据不足",
+        });
+    }
+  }, [result, t]);
+
+  const VerdictIcon = result ? verdictIcon(result.verdict) : ShieldCheck;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl" zIndex="alert">
+        <DialogHeader className="relative pr-16">
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5" />
+            {t("modelVerifier.title", { defaultValue: "模型核验" })}
+          </DialogTitle>
+          <DialogDescription>
+            {t("modelVerifier.description", {
+              defaultValue:
+                "通过 CC Switch 现有的安全请求通道发送一次极小真实 API 请求，比较配置模型与服务端返回的模型标识。",
+            })}
+          </DialogDescription>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="absolute right-4 top-4 h-8 w-8"
+            onClick={() => onOpenChange(false)}
+            aria-label={t("common.close", { defaultValue: "关闭" })}
+            title={t("common.close", { defaultValue: "关闭" })}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto py-2 pr-2">
+          {isLoading && (
+            <div className="flex min-h-48 flex-col items-center justify-center gap-3 text-muted-foreground">
+              <Loader2 className="h-7 w-7 animate-spin" />
+              <span>
+                {t("modelVerifier.running", {
+                  defaultValue: "正在核验真实请求…",
+                })}
+              </span>
+            </div>
+          )}
+
+          {!isLoading && error && (
+            <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-4 text-sm">
+              <div className="mb-2 flex items-center gap-2 font-medium text-red-600 dark:text-red-400">
+                <XCircle className="h-4 w-4" />
+                {t("modelVerifier.error", { defaultValue: "核验失败" })}
+              </div>
+              <div className="break-words text-muted-foreground">{error}</div>
+            </div>
+          )}
+
+          {!isLoading && result && (
+            <>
+              <div className="flex flex-col gap-3 rounded-lg border border-border bg-muted/30 p-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center gap-3">
+                  <VerdictIcon
+                    className={cn(
+                      "h-6 w-6 shrink-0",
+                      verdictTone(result.verdict),
+                    )}
+                  />
+                  <div>
+                    <div
+                      className={cn(
+                        "font-semibold",
+                        verdictTone(result.verdict),
+                      )}
+                    >
+                      {verdictLabel}
+                    </div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {t("modelVerifier.score", {
+                        defaultValue: "证据一致性评分",
+                      })}
+                      :{" "}
+                      <span className="font-mono font-semibold">
+                        {result.confidenceScore}/100
+                      </span>
+                    </div>
+                  </div>
+                </div>
+                <div className="text-left text-xs text-muted-foreground sm:text-right">
+                  {result.success
+                    ? t("modelVerifier.requestSuccess", {
+                        defaultValue: "请求成功",
+                      })
+                    : t("modelVerifier.requestFailed", {
+                        defaultValue: "请求失败",
+                      })}
+                  <br />
+                  {result.responseTimeMs} ms
+                </div>
+              </div>
+
+              <div className="grid gap-2 text-sm sm:grid-cols-[10rem_1fr]">
+                <Field
+                  label={t("modelVerifier.requestedModel", {
+                    defaultValue: "配置/请求模型",
+                  })}
+                  value={result.requestedModel}
+                  mono
+                />
+                <Field
+                  label={t("modelVerifier.reportedModel", {
+                    defaultValue: "服务端返回模型",
+                  })}
+                  value={result.reportedModel || "—"}
+                  mono
+                />
+                <Field
+                  label={t("modelVerifier.protocol", { defaultValue: "协议" })}
+                  value={result.protocol}
+                  mono
+                />
+                <Field
+                  label={t("modelVerifier.endpoint", {
+                    defaultValue: "请求端点",
+                  })}
+                  value={result.endpoint}
+                  mono
+                />
+                <Field
+                  label="response.id"
+                  value={result.responseId || "—"}
+                  mono
+                />
+                <Field
+                  label="response.object"
+                  value={result.responseObject || "—"}
+                  mono
+                />
+                <Field
+                  label="system_fingerprint"
+                  value={result.systemFingerprint || "—"}
+                  mono
+                />
+                <Field
+                  label="usage"
+                  value={result.hasUsage ? "present" : "—"}
+                  mono
+                />
+              </div>
+
+              {result.error && (
+                <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-3 text-sm text-red-700 dark:text-red-300">
+                  {result.error}
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <div className="text-sm font-medium">
+                  {t("modelVerifier.evidence", { defaultValue: "核验证据" })}
+                </div>
+                <div className="divide-y divide-border rounded-lg border border-border">
+                  {result.evidence.map((item) => (
+                    <div
+                      key={item.id}
+                      className="flex gap-3 px-3 py-2.5 text-sm"
+                    >
+                      {item.passed ? (
+                        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-500" />
+                      ) : (
+                        <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                      )}
+                      <div className="min-w-0 flex-1">
+                        <div className="break-words">{item.summary}</div>
+                        <div className="mt-0.5 text-xs text-muted-foreground">
+                          weight {item.weight}
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-xs leading-relaxed text-amber-800 dark:text-amber-200">
+                <div className="flex gap-2">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    {result.officialOpenaiEndpoint
+                      ? t("modelVerifier.officialWarning", {
+                          defaultValue:
+                            "请求目标为 api.openai.com，证据强度较高；model 字段仍是服务端元数据，不是对底层模型权重的密码学证明。",
+                        })
+                      : t("modelVerifier.thirdPartyWarning", {
+                          defaultValue:
+                            "第三方 API 可以伪造 model、id、system_fingerprint 等响应字段，因此这里衡量的是证据一致性，不能 100% 证明底层实际模型。第三方评分最高限制为 74。",
+                        })}
+                  </span>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void verify()}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="h-4 w-4" />
+            )}
+            {t("modelVerifier.rerun", { defaultValue: "重新核验" })}
+          </Button>
+          <Button type="button" onClick={() => onOpenChange(false)}>
+            {t("common.close", { defaultValue: "关闭" })}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Field({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <>
+      <div className="text-muted-foreground">{label}</div>
+      <div className={cn("min-w-0 break-all", mono && "font-mono text-xs")}>
+        {value}
+      </div>
+    </>
+  );
+}

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -4,6 +4,7 @@ import {
   GripVertical,
   ChevronDown,
   ChevronUp,
+  ShieldCheck,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useQuery } from "@tanstack/react-query";
@@ -15,7 +16,9 @@ import type { OpenClawProviderConfig, Provider } from "@/types";
 import type { AppId } from "@/lib/api";
 import { authApi } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { ProviderActions } from "@/components/providers/ProviderActions";
+import { ModelVerifierDialog } from "@/components/providers/ModelVerifierDialog";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import UsageFooter from "@/components/UsageFooter";
 import SubscriptionQuotaFooter from "@/components/SubscriptionQuotaFooter";
@@ -305,6 +308,12 @@ export function ProviderCard({
       : provider.meta?.providerType === PROVIDER_TYPES.CODEX_OAUTH;
   // xAI OAuth (SuperGrok 反代)：额度经自管 OAuth token 自动显示，与 codex_oauth 同构
   const isXaiOauth = provider.meta?.providerType === PROVIDER_TYPES.XAI_OAUTH;
+  const supportsModelVerifier =
+    appId === "codex" &&
+    provider.category !== "official" &&
+    !isCopilot &&
+    provider.meta?.providerType !== PROVIDER_TYPES.CODEX_OAUTH &&
+    provider.meta?.providerType !== PROVIDER_TYPES.XAI_OAUTH;
   // 统一权威谓词（详见 providerNeedsRouting）：以 providerType 为准，不受
   // apiFormat 被改动/缺省影响。此 badge 仅在 Codex 视图渲染，故加 appId 守卫。
   const codexNeedsRouting =
@@ -327,6 +336,7 @@ export function ProviderCard({
     usage?.success && usage.data && usage.data.length > 1 && !isTokenPlan;
 
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showModelVerifier, setShowModelVerifier] = useState(false);
 
   useEffect(() => {
     if (hasMultiplePlans) {
@@ -681,6 +691,17 @@ export function ProviderCard({
           </div>
 
           <div className="flex items-center gap-1.5 flex-shrink-0 opacity-0 pointer-events-none group-hover:opacity-100 group-focus-within:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto transition-opacity duration-200">
+            {supportsModelVerifier && (
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={() => setShowModelVerifier(true)}
+                title={t("modelVerifier.action", { defaultValue: "验证模型" })}
+                className="h-8 w-8 p-1 hover:text-emerald-600 dark:hover:text-emerald-400"
+              >
+                <ShieldCheck className="h-4 w-4" />
+              </Button>
+            )}
             <ProviderActions
               appId={appId}
               isCurrent={isCurrent}
@@ -749,6 +770,15 @@ export function ProviderCard({
             inline={false}
           />
         </div>
+      )}
+
+      {supportsModelVerifier && (
+        <ModelVerifierDialog
+          open={showModelVerifier}
+          onOpenChange={setShowModelVerifier}
+          appId={appId}
+          provider={provider}
+        />
       )}
     </div>
   );

--- a/src/lib/api/modelVerifier.ts
+++ b/src/lib/api/modelVerifier.ts
@@ -1,0 +1,412 @@
+import type { Provider } from "@/types";
+import { usageApi } from "./usage";
+import type { AppId } from "./types";
+import { parse as parseToml } from "smol-toml";
+import {
+  codexApiFormatFromWireApi,
+  extractCodexBaseUrl,
+  extractCodexModelName,
+  extractCodexWireApi,
+} from "@/utils/providerConfigUtils";
+
+export type VerificationVerdict =
+  | "officialEndpointConsistent"
+  | "reportedExactMatch"
+  | "reportedFamilyMatch"
+  | "reportedMismatch"
+  | "insufficientEvidence"
+  | "requestFailed";
+
+export interface VerificationEvidence {
+  id: string;
+  passed: boolean;
+  weight: number;
+  summary: string;
+}
+
+export interface ModelVerificationResult {
+  success: boolean;
+  providerId: string;
+  providerName: string;
+  requestedModel: string;
+  reportedModel?: string | null;
+  protocol: "openai_responses" | "openai_chat";
+  endpoint: string;
+  endpointHost?: string | null;
+  officialOpenaiEndpoint: boolean;
+  responseTimeMs: number;
+  responseId?: string | null;
+  responseObject?: string | null;
+  systemFingerprint?: string | null;
+  hasUsage: boolean;
+  confidenceScore: number;
+  verdict: VerificationVerdict;
+  evidence: VerificationEvidence[];
+  error?: string | null;
+  testedAt: number;
+}
+
+interface ProbePayload {
+  reportedModel: string | null;
+  responseId: string | null;
+  responseObject: string | null;
+  systemFingerprint: string | null;
+  hasUsage: boolean;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === "object" && !Array.isArray(value));
+
+const sameModelFamily = (requested: string, reported: string): boolean => {
+  const left = requested.trim().toLowerCase();
+  const right = reported.trim().toLowerCase();
+  if (!left || !right) return false;
+  if (left === right) return true;
+
+  const boundaryPrefix = (shorter: string, longer: string) => {
+    if (!longer.startsWith(shorter)) return false;
+    const rest = longer.slice(shorter.length);
+    return rest.startsWith("-") || rest.startsWith("_");
+  };
+
+  return boundaryPrefix(left, right) || boundaryPrefix(right, left);
+};
+
+const extractCodexQueryParams = (
+  configText: string,
+): Record<string, string> => {
+  if (!configText.trim()) return {};
+
+  try {
+    const parsed = parseToml(configText) as unknown;
+    if (!isRecord(parsed)) return {};
+
+    const providerName =
+      typeof parsed.model_provider === "string"
+        ? parsed.model_provider.trim()
+        : "";
+    const providerTables = isRecord(parsed.model_providers)
+      ? parsed.model_providers
+      : null;
+    const activeProvider =
+      providerName && providerTables && isRecord(providerTables[providerName])
+        ? providerTables[providerName]
+        : null;
+
+    const rawParams =
+      activeProvider && isRecord(activeProvider.query_params)
+        ? activeProvider.query_params
+        : isRecord(parsed.query_params)
+          ? parsed.query_params
+          : null;
+    if (!rawParams) return {};
+
+    return Object.fromEntries(
+      Object.entries(rawParams).flatMap(([key, value]) => {
+        if (
+          value === null ||
+          value === undefined ||
+          typeof value === "object"
+        ) {
+          return [];
+        }
+        return [[key, String(value)]];
+      }),
+    );
+  } catch {
+    return {};
+  }
+};
+
+const buildEndpoint = (
+  baseUrl: string,
+  leaf: string,
+  isFullUrl: boolean,
+  queryParams: Record<string, string>,
+): string => {
+  const rawBase = baseUrl.trim();
+  if (!rawBase) return "";
+
+  // Full-URL providers are already configured with the production endpoint.
+  // Do not append a protocol leaf or rewrite their query string.
+  if (isFullUrl) return rawBase;
+
+  try {
+    const parsed = new URL(rawBase);
+    const path = parsed.pathname.replace(/\/+$/, "");
+    const basePath = !path || path === "/" ? "/v1" : path;
+    parsed.pathname = `${basePath}/${leaf}`.replace(/\/{2,}/g, "/");
+
+    for (const [key, value] of Object.entries(queryParams)) {
+      parsed.searchParams.set(key, value);
+    }
+
+    return parsed.toString();
+  } catch {
+    const base = rawBase.replace(/\/+$/, "");
+    const endpoint = `${base}/${leaf}`;
+    const query = new URLSearchParams(queryParams).toString();
+    if (!query) return endpoint;
+    return `${endpoint}${endpoint.includes("?") ? "&" : "?"}${query}`;
+  }
+};
+
+const buildProbeScript = (
+  requestedModel: string,
+  protocol: "openai_responses" | "openai_chat",
+  endpoint: string,
+  customUserAgent?: string,
+): string => {
+  const requestBody =
+    protocol === "openai_chat"
+      ? {
+          model: requestedModel,
+          messages: [{ role: "user", content: "Reply with exactly OK." }],
+          stream: false,
+        }
+      : {
+          model: requestedModel,
+          input: "Reply with exactly OK.",
+          stream: false,
+        };
+
+  const headers: Record<string, string> = {
+    Authorization: "Bearer {{apiKey}}",
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    "Accept-Encoding": "identity",
+  };
+  if (customUserAgent?.trim()) headers["User-Agent"] = customUserAgent.trim();
+
+  const headersJson = JSON.stringify(headers);
+  const bodyJson = JSON.stringify(JSON.stringify(requestBody));
+  const endpointJson = JSON.stringify(endpoint);
+
+  return `({
+    request: {
+      url: ${endpointJson},
+      method: "POST",
+      headers: ${headersJson},
+      body: ${bodyJson}
+    },
+    extractor: function (response) {
+      var reportedModel = response && typeof response.model === "string" ? response.model : null;
+      return {
+        planName: reportedModel,
+        extra: JSON.stringify({
+          reportedModel: reportedModel,
+          responseId: response && typeof response.id === "string" ? response.id : null,
+          responseObject: response && typeof response.object === "string" ? response.object : null,
+          systemFingerprint: response && typeof response.system_fingerprint === "string" ? response.system_fingerprint : null,
+          hasUsage: !!(response && response.usage)
+        })
+      };
+    }
+  })`;
+};
+
+const assess = (
+  requestedModel: string,
+  payload: ProbePayload | null,
+  officialEndpoint: boolean,
+  requestSucceeded: boolean,
+): Pick<
+  ModelVerificationResult,
+  "confidenceScore" | "verdict" | "evidence"
+> => {
+  const reported = payload?.reportedModel?.trim() || null;
+  const exactMatch = Boolean(
+    reported && reported.toLowerCase() === requestedModel.trim().toLowerCase(),
+  );
+  const familyMatch = Boolean(
+    reported && sameModelFamily(requestedModel, reported),
+  );
+
+  const evidence: VerificationEvidence[] = [
+    {
+      id: "request_success",
+      passed: requestSucceeded,
+      weight: 20,
+      summary: requestSucceeded
+        ? "真实 API 请求成功并返回可解析 JSON"
+        : "真实 API 请求失败",
+    },
+    {
+      id: "reported_model",
+      passed: Boolean(reported),
+      weight: 20,
+      summary: reported
+        ? `服务端响应声明模型为 \`${reported}\``
+        : "响应没有提供 model 字段",
+    },
+    {
+      id: "model_match",
+      passed: exactMatch || familyMatch,
+      weight: 30,
+      summary: exactMatch
+        ? "返回模型与配置模型完全一致"
+        : familyMatch
+          ? "返回模型与配置模型属于同一别名/模型系列"
+          : reported
+            ? "返回模型与配置模型不一致"
+            : "缺少可比较的模型标识",
+    },
+    {
+      id: "official_endpoint",
+      passed: officialEndpoint,
+      weight: 20,
+      summary: officialEndpoint
+        ? "请求目标是 api.openai.com"
+        : "请求目标是第三方 API；其返回字段理论上可以被伪造",
+    },
+    {
+      id: "response_identity",
+      passed: Boolean(payload?.responseId || payload?.responseObject),
+      weight: 5,
+      summary:
+        payload?.responseId || payload?.responseObject
+          ? "响应包含 id/object 等协议身份字段"
+          : "未观察到 id/object 协议身份字段",
+    },
+    {
+      id: "system_fingerprint",
+      passed: Boolean(payload?.systemFingerprint),
+      weight: 5,
+      summary: payload?.systemFingerprint
+        ? "响应包含 system_fingerprint"
+        : "响应未提供 system_fingerprint",
+    },
+  ];
+
+  let score = evidence
+    .filter((item) => item.passed)
+    .reduce((sum, item) => sum + item.weight, 0);
+  if (reported && !exactMatch && !familyMatch) score = Math.max(0, score - 20);
+  if (!officialEndpoint) score = Math.min(score, 74);
+
+  const verdict: VerificationVerdict = !requestSucceeded
+    ? "requestFailed"
+    : reported && !exactMatch && !familyMatch
+      ? "reportedMismatch"
+      : officialEndpoint && (exactMatch || familyMatch)
+        ? "officialEndpointConsistent"
+        : exactMatch
+          ? "reportedExactMatch"
+          : familyMatch
+            ? "reportedFamilyMatch"
+            : "insufficientEvidence";
+
+  return { confidenceScore: Math.min(score, 100), verdict, evidence };
+};
+
+export const modelVerifierApi = {
+  verifyProvider: async (
+    appType: AppId,
+    provider: Provider,
+  ): Promise<ModelVerificationResult> => {
+    if (appType !== "codex") {
+      throw new Error("Model Verifier v1 仅支持 Codex Provider");
+    }
+
+    const settings = provider.settingsConfig as Record<string, unknown>;
+    const configText =
+      typeof settings.config === "string" ? settings.config : "";
+    const requestedModel =
+      (typeof settings.model === "string" ? settings.model.trim() : "") ||
+      extractCodexModelName(configText)?.trim() ||
+      "";
+    if (!requestedModel)
+      throw new Error("该 Provider 没有配置可核验的上游模型");
+
+    const apiFormat =
+      provider.meta?.apiFormat ??
+      (typeof settings.apiFormat === "string"
+        ? settings.apiFormat
+        : undefined) ??
+      (typeof settings.api_format === "string"
+        ? settings.api_format
+        : undefined) ??
+      codexApiFormatFromWireApi(extractCodexWireApi(configText)) ??
+      "openai_responses";
+    if (apiFormat === "anthropic") {
+      throw new Error(
+        "Model Verifier v1 暂不支持 Anthropic-wire Codex Provider",
+      );
+    }
+
+    const protocol: "openai_responses" | "openai_chat" =
+      apiFormat === "openai_chat" ? "openai_chat" : "openai_responses";
+    const baseUrl = extractCodexBaseUrl(configText) ?? "";
+    if (!baseUrl) throw new Error("无法从 Provider 配置中解析 Base URL");
+
+    const queryParams = extractCodexQueryParams(configText);
+    const endpoint = buildEndpoint(
+      baseUrl,
+      protocol === "openai_chat" ? "chat/completions" : "responses",
+      provider.meta?.isFullUrl === true,
+      queryParams,
+    );
+    const endpointHost = (() => {
+      try {
+        return new URL(endpoint).hostname || null;
+      } catch {
+        return null;
+      }
+    })();
+    const officialOpenaiEndpoint = endpointHost === "api.openai.com";
+
+    const script = buildProbeScript(
+      requestedModel,
+      protocol,
+      endpoint,
+      provider.meta?.customUserAgent,
+    );
+    const started = performance.now();
+    const usageResult = await usageApi.testScript(
+      provider.id,
+      appType,
+      script,
+      30,
+    );
+    const responseTimeMs = Math.round(performance.now() - started);
+
+    let payload: ProbePayload | null = null;
+    const extra = usageResult.data?.[0]?.extra;
+    if (typeof extra === "string" && extra.trim()) {
+      try {
+        payload = JSON.parse(extra) as ProbePayload;
+      } catch {
+        payload = null;
+      }
+    }
+
+    const assessment = assess(
+      requestedModel,
+      payload,
+      officialOpenaiEndpoint,
+      usageResult.success,
+    );
+
+    return {
+      success: usageResult.success,
+      providerId: provider.id,
+      providerName: provider.name,
+      requestedModel,
+      reportedModel: payload?.reportedModel ?? null,
+      protocol,
+      endpoint,
+      endpointHost,
+      officialOpenaiEndpoint,
+      responseTimeMs,
+      responseId: payload?.responseId ?? null,
+      responseObject: payload?.responseObject ?? null,
+      systemFingerprint: payload?.systemFingerprint ?? null,
+      hasUsage: payload?.hasUsage ?? false,
+      confidenceScore: assessment.confidenceScore,
+      verdict: assessment.verdict,
+      evidence: assessment.evidence,
+      error: usageResult.error ?? null,
+      testedAt: Math.floor(Date.now() / 1000),
+    };
+  },
+};


### PR DESCRIPTION
## Summary

Add an evidence-based model verifier for custom Codex/OpenAI-compatible providers.

The verifier sends one minimal real request through CC Switch's existing `testUsageScript` backend path, compares the configured upstream model with the model identity reported by the response, and presents an evidence-consistency score in a dedicated dialog.

This is intentionally separate from Stream Check: Stream Check answers whether an endpoint is reachable, while this feature asks whether a real model response is consistent with the configured model identity.

## UX

- Adds a shield verification action on eligible Codex provider cards.
- Runs the probe automatically when the dialog opens, with a manual rerun action.
- The dialog is scrollable and has explicit close controls.
- Shows:
  - configured/requested model
  - reported `model`
  - protocol (`openai_responses` / `openai_chat`)
  - request endpoint
  - response `id` / `object`
  - `system_fingerprint` when exposed
  - whether usage metadata was returned
  - request duration
  - per-signal evidence breakdown and score

## Evidence semantics

This does **not** claim cryptographic proof of model weights.

A third-party gateway controls its response body and can spoof fields such as `model`, `id`, and `system_fingerprint`. For that reason:

- third-party endpoints are explicitly labeled as evidence consistency only;
- third-party scores are hard-capped at 74/100;
- a mismatched reported model is surfaced explicitly and penalized;
- only a request targeting `api.openai.com` can receive the `officialEndpointConsistent` verdict, and the UI still explains that server metadata is not cryptographic attestation.

## Security / integration

The implementation deliberately reuses the existing usage-script request channel rather than adding another network/credential IPC surface:

- API keys stay on the Rust/backend side and are resolved from the Provider by the existing `testUsageScript` path;
- the existing usage-script URL validation enforces HTTPS (except loopback) and same-host/same-port requests for this probe;
- the probe URL is derived from the Provider's configured Codex endpoint, while authentication still uses the existing `{{apiKey}}` backend substitution;
- no credential is returned to the verifier UI or persisted by this feature.

Managed OAuth/Copilot/xAI OAuth and explicit official providers are not offered the verifier action in v1. Anthropic-wire Codex providers are also rejected by the verifier because the first version only builds OpenAI Responses/Chat requests.

## Routing parity

The verifier follows Codex Provider URL semantics instead of assuming every `base_url` is a prefix:

- `meta.isFullUrl === true` uses the configured URL verbatim, including its existing query string;
- non-full-URL providers append the appropriate Responses/Chat leaf;
- active `[model_providers.<model_provider>].query_params` are parsed and applied to the probe URL (for example Azure OpenAI `api-version`).

## Scope

Only three files differ from the current upstream baseline:

- `src/lib/api/modelVerifier.ts` (new)
- `src/components/providers/ModelVerifierDialog.tsx` (new)
- `src/components/providers/ProviderCard.tsx` (+30 lines for the action/dialog wiring)

No Stream Check, proxy routing, failover, database schema, or Rust command registration is changed.

## Validation

- Branch is based directly on current upstream `main` commit `9692ff5e22327f0d2340d24271cf897f9d64fafd`.
- Final branch contains one commit and a three-file diff only.
- The two verifier files were formatted with the repository-pinned `pnpm@10.12.3` / Prettier 3.6.2 toolchain after the previous CI formatting failure.
- Existing CC Switch helpers are reused for Codex model/base URL/wire-format parsing (`extractCodexModelName`, `extractCodexBaseUrl`, `extractCodexWireApi`, `codexApiFormatFromWireApi`).
- Existing `testUsageScript` behavior was checked against its backend implementation: provider credential fallback, HTTPS validation, same-origin host/port validation, and optional `UsageData.extra` are all part of the current path.
- Codex review feedback about full-URL endpoints and provider `query_params` is addressed in the current head.

The prior CI run reached the frontend checks, passed dependency installation and TypeScript typecheck, and failed only at Prettier formatting. This head includes the exact Prettier output and should be treated as the new CI gate for remaining unit/backend checks.