### PR TITLE
fix(tray): open main window on left click outside lightweight mode

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -77,7 +77,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::{fmt, sync::Arc};
 #[cfg(target_os = "macos")]
 use tauri::image::Image;
-use tauri::tray::{TrayIconBuilder, TrayIconEvent};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::RunEvent;
 use tauri::{Emitter, Manager};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
@@ -1085,6 +1085,19 @@ pub fn run() {
                     // 让用户下一次（或快速打开菜单的那一刻）看到较新的数字。
                     // refresh_all_usage_in_tray 内部有 10 秒防抖。
                     TrayIconEvent::Enter { .. } | TrayIconEvent::Click { .. } => {
+                        // 仅在普通模式下响应左键释放，复用菜单的窗口恢复与聚焦逻辑。
+                        // Linux 不派发托盘点击事件，继续通过菜单打开主界面。
+                        if matches!(
+                            event,
+                            TrayIconEvent::Click {
+                                button: MouseButton::Left,
+                                button_state: MouseButtonState::Up,
+                                ..
+                            }
+                        ) && !crate::lightweight::is_lightweight_mode()
+                        {
+                            tray::handle_tray_menu_event(tray.app_handle(), "show_main");
+                        }
                         let app = tray.app_handle().clone();
                         tauri::async_runtime::spawn(async move {
                             crate::tray::refresh_all_usage_in_tray(&app).await;
@@ -1096,7 +1109,7 @@ pub fn run() {
                 .on_menu_event(|app, event| {
                     tray::handle_tray_menu_event(app, &event.id.0);
                 })
-                .show_menu_on_left_click(true);
+                .show_menu_on_left_click(crate::lightweight::is_lightweight_mode());
 
             // 使用平台对应的托盘图标（macOS 使用模板图标适配深浅色）
             #[cfg(target_os = "macos")]

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -962,6 +962,15 @@ fn update_tray_usage_labels(app: &tauri::AppHandle) {
 pub fn refresh_tray_menu(app: &tauri::AppHandle) {
     use crate::store::AppState;
 
+    // 轻量模式切换后同步左键行为，即使菜单重建失败也不保留旧模式的策略。
+    // Linux 不支持此设置，会保留系统托盘菜单的原有行为。
+    if let Some(tray) = app.tray_by_id(TRAY_ID) {
+        if let Err(e) = tray.set_show_menu_on_left_click(crate::lightweight::is_lightweight_mode())
+        {
+            log::error!("更新托盘左键菜单行为失败: {e}");
+        }
+    }
+
     if let Some(state) = app.try_state::<AppState>() {
         if let Ok(new_menu) = create_tray_menu(app, state.inner()) {
             if let Some(tray) = app.tray_by_id(TRAY_ID) {


### PR DESCRIPTION
## Summary / 概述

普通模式下，托盘左键单击直接恢复并聚焦主窗口，省去先打开菜单再选择「打开主界面」的操作；右键继续显示菜单。

轻量模式保持左右键均显示菜单，点击图标不会重建窗口或退出轻量模式。进入和退出轻量模式时同步更新左键菜单策略；窗口显示复用现有的平台处理，托盘用量刷新保持不变。

## Related Issue / 关联 Issue

Fixes #7118

## Screenshots / 截图

不涉及界面布局或文案变更，无截图。

## Validation / 验证

- macOS：`cargo test --manifest-path src-tauri/Cargo.toml --locked --lib tray::tests -- --test-threads=1`，31 项通过。
- `rustfmt --check --edition 2021 --config skip_children=true src-tauri/src/lib.rs src-tauri/src/tray.rs` 通过。
- `git diff --check` 通过。
- 尚未进行桌面托盘点击实测或 Windows/Linux 运行验证。Linux 的 Tauri 托盘后端不派发点击事件、不支持左键菜单开关，保留原菜单入口。

## Checklist / 检查清单

- [x] `pnpm typecheck` 通过。
- [x] `pnpm format:check` 通过。
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --locked --lib` 通过；现有代码有两条警告（`src/gemini_mcp.rs:52` 的 `for_kv_map` 和 `src/tray.rs:785` 的 `useless_borrows_in_formatting`），均不在本次修改范围内。
- [x] 无用户可见文本变更，无需更新 i18n。

