### PR TITLE
fix(codex): honor unified history during official proxy takeover

### DIFF
--- a/docs/guides/codex-unified-history-repair.md
+++ b/docs/guides/codex-unified-history-repair.md
@@ -1,0 +1,77 @@
+# Codex unified history and official proxy takeover
+
+The history bucket and the temporary proxy route are different concerns.
+With **Unify Codex session history** enabled, both direct official routing and
+official proxy takeover use the shared `custom` provider ID. With it disabled,
+official takeover keeps the legacy `cc-switch-official` ID. Authentication still
+uses native OpenAI login (`requires_openai_auth = true`); local takeover uses
+Responses HTTP/SSE, not WebSockets.
+
+## Existing sessions
+
+The previous official-history migration only handled `openai` metadata. A
+session created during official takeover could retain `cc-switch-official` in
+both its metadata and persisted `thread_settings_applied` events. Removing the
+temporary provider then caused resume to fail with "Model provider
+`cc-switch-official` not found", even when the session appeared in history.
+
+The version-2 migration covers both official IDs and updates:
+
+- JSONL `session_meta.payload.model_provider`;
+- matching `event_msg` / `thread_settings_applied` events' provider IDs;
+- SQLite `threads.model_provider`.
+
+It also repairs stale runtime settings in sessions whose metadata is already
+`custom`. Runtime edits are scoped to an eligible session segment; an explicit
+foreign thread ID is never rewritten. Message bodies and `encrypted_content`
+are not modified. Rollout modification times are preserved.
+
+Migration remains opt-in. Existing version-1 markers do not suppress this
+upgrade; successful version-2 markers remain bound to the Codex directory.
+
+1. Save work and quit Codex/ChatGPT desktop and all Codex CLI processes.
+2. In CC Switch, enable unified history and opt in to migrating existing history.
+3. Ensure the active Codex configuration uses the shared bucket. Select the
+   official provider again if an old takeover configuration is still active.
+4. Click the history migration/retry button in Settings. If writers were open
+   during the automatic attempt, no files were changed by that attempt.
+5. Reopen Codex and resume the old session.
+
+Do not launch a Codex writer while migration or restore is running. The process
+check is a conservative preflight, not an OS-level lock against new processes.
+Renamed executables or remote writers cannot be identified by this check.
+
+Backups and their source-directory metadata are recorded before mutations.
+When disabling unification, optional restore changes only sessions identified
+by the official backup ledger. Both original official IDs restore to the
+usable built-in `openai` ID, **not** to a removed temporary proxy route. New
+shared-bucket sessions without official ledger evidence are left unchanged.
+Quit writers before restore too. If restore fails, retain the backups and retry
+the enable/disable flow after resolving the error.
+
+## Takeover ownership
+
+`custom` alone is not evidence that a provider belongs to CC Switch. Official
+takeover writes a TOML comment containing a hash of the provider ID and proxy
+URL. Recognition additionally checks the exact official transport/auth table.
+The comment is saved atomically with the config and its rollback snapshots;
+it adds no unsupported Codex keys or credentials. An edited URL, extra
+credential, or absent marker prevents shared-table ownership recognition.
+
+History-setting changes reproject an active official takeover under the provider
+switch lock and roll back the live configuration and backup on projection
+failure. Re-enabling an existing legacy takeover also reconciles its bucket.
+
+## Scope and limits
+
+This fixes official takeover bucket divergence, including issue #5974. It is
+not a general importer for arbitrary third-party provider IDs or other machines.
+Seeing the same history does not guarantee cross-backend continuation: an
+upstream may reject reasoning content encrypted by a different backend. This
+change neither decrypts nor strips that content.
+
+Tests use synthetic fixtures and temporary directories; no real credentials or
+conversation contents are required. The regression coverage includes unified
+and non-unified takeover, hot switching, toggle reconciliation, conservative
+ownership detection, version-1 upgrades, runtime migration/ledger restore,
+mtime preservation, and the explicit retry UI.

--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -16,10 +16,8 @@ use std::process::{Command, Stdio};
 use toml_edit::DocumentMut;
 
 pub const CC_SWITCH_CODEX_MODEL_PROVIDER_ID: &str = "custom";
-/// Temporary model-provider id used while the built-in `codex-official`
-/// provider is routed through CC Switch.  A dedicated id is an ownership
-/// marker: unlike a generic localhost `base_url`, it can be detected and
-/// cleaned up without mistaking a user's own local provider for takeover.
+/// Legacy/non-unified official takeover id. Unified takeovers use `custom`
+/// with an ownership comment, rather than treating that shared id as ownership.
 pub const CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID: &str = "cc-switch-official";
 pub const CC_SWITCH_CODEX_MODEL_CATALOG_FILENAME: &str = "cc-switch-model-catalog.json";
 const CODEX_PROXY_AUTH_PLACEHOLDER: &str = "PROXY_MANAGED";
@@ -3366,6 +3364,24 @@ pub fn apply_codex_official_proxy_route(
     config_text: &str,
     proxy_base_url: &str,
 ) -> Result<String, AppError> {
+    apply_codex_official_proxy_route_with_history(
+        config_text,
+        proxy_base_url,
+        crate::settings::unify_codex_session_history(),
+    )
+}
+
+fn official_takeover_marker(provider_id: &str, base_url: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(format!("{provider_id}\n{base_url}").as_bytes());
+    format!("# cc-switch:official-takeover:{digest:x}")
+}
+
+fn apply_codex_official_proxy_route_with_history(
+    config_text: &str,
+    proxy_base_url: &str,
+    unified: bool,
+) -> Result<String, AppError> {
     let mut doc = config_text
         .parse::<DocumentMut>()
         .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
@@ -3373,7 +3389,12 @@ pub fn apply_codex_official_proxy_route(
     // A third-party takeover may have left the proxy placeholder in config.toml.
     // The official route must use Codex's native OpenAI login instead.
     doc.as_table_mut().remove("experimental_bearer_token");
-    doc["model_provider"] = toml_edit::value(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID);
+    let provider_id = if unified {
+        CC_SWITCH_CODEX_MODEL_PROVIDER_ID
+    } else {
+        CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID
+    };
+    doc["model_provider"] = toml_edit::value(provider_id);
 
     let mut providers = match doc.as_table_mut().remove("model_providers") {
         Some(item) => item.into_table().map_err(|_| {
@@ -3393,31 +3414,65 @@ pub fn apply_codex_official_proxy_route(
     remove_codex_proxy_placeholders_from_providers(&mut providers);
 
     // The local proxy currently exposes HTTP/SSE, not Codex websocket routes.
-    let table = codex_official_provider_table(Some(proxy_base_url), false);
+    let mut table = codex_official_provider_table(Some(proxy_base_url), false);
+    // The comment travels atomically with config.toml and its rollback snapshot.
+    // It introduces no unsupported Codex settings and contains no credentials.
+    table.decor_mut().set_prefix(format!(
+        "\n{}\n",
+        official_takeover_marker(provider_id, proxy_base_url.trim_end_matches('/'))
+    ));
 
-    providers.insert(
-        CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
-        toml_edit::Item::Table(table),
-    );
+    providers.insert(provider_id, toml_edit::Item::Table(table));
     doc["model_providers"] = toml_edit::Item::Table(providers);
     Ok(doc.to_string())
 }
 
 /// Whether a live Codex config is the official route projected by CC Switch.
 pub fn codex_config_has_official_proxy_route(config_text: &str) -> bool {
-    if !config_text.contains(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID) {
+    let Ok(doc) = config_text.parse::<DocumentMut>() else {
+        return false;
+    };
+    let Some(id) = doc.get("model_provider").and_then(|item| item.as_str()) else {
+        return false;
+    };
+    if id == CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID {
+        // Preserve recognition of pre-unification takeovers on upgrade.
+        return true;
+    }
+    if id != CC_SWITCH_CODEX_MODEL_PROVIDER_ID {
         return false;
     }
-    config_text
-        .parse::<DocumentMut>()
-        .ok()
-        .and_then(|doc| {
-            doc.get("model_provider")
-                .and_then(|item| item.as_str())
-                .map(str::to_string)
-        })
-        .as_deref()
-        == Some(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID)
+    let Some(table) = doc
+        .get("model_providers")
+        .and_then(|item| item.get(id))
+        .and_then(|item| item.as_table())
+    else {
+        return false;
+    };
+    let Some(url) = table.get("base_url").and_then(|item| item.as_str()) else {
+        return false;
+    };
+    // A user-edited table (especially one with a credential) is no longer ours.
+    table.len() == 5
+        && table.get("name").and_then(|item| item.as_str()) == Some("OpenAI")
+        && table
+            .get("requires_openai_auth")
+            .and_then(|item| item.as_bool())
+            == Some(true)
+        && table
+            .get("supports_websockets")
+            .and_then(|item| item.as_bool())
+            == Some(false)
+        && table.get("wire_api").and_then(|item| item.as_str()) == Some("responses")
+        && table
+            .decor()
+            .prefix()
+            .and_then(|raw| raw.as_str())
+            .is_some_and(|prefix| {
+                prefix
+                    .lines()
+                    .any(|line| line == official_takeover_marker(id, url))
+            })
 }
 
 /// Remove only the official takeover route owned by CC Switch. This is a
@@ -3426,11 +3481,13 @@ pub fn remove_codex_official_proxy_route(config_text: &str) -> Result<String, Ap
     let mut doc = config_text
         .parse::<DocumentMut>()
         .map_err(|e| AppError::Message(format!("Invalid Codex config.toml: {e}")))?;
-    if doc.get("model_provider").and_then(|item| item.as_str())
-        != Some(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID)
-    {
+    if !codex_config_has_official_proxy_route(config_text) {
         return Ok(config_text.to_string());
     }
+    let provider_id = doc["model_provider"]
+        .as_str()
+        .expect("owned active route")
+        .to_string();
 
     doc.as_table_mut().remove("model_provider");
     if let Some(item) = doc.as_table_mut().remove("model_providers") {
@@ -3439,7 +3496,7 @@ pub fn remove_codex_official_proxy_route(config_text: &str) -> Result<String, Ap
                 "Invalid Codex config.toml: model_providers must be a table".to_string(),
             )
         })?;
-        providers.remove(CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID);
+        providers.remove(&provider_id);
         remove_codex_proxy_placeholders_from_providers(&mut providers);
         if !providers.is_empty() {
             doc["model_providers"] = toml_edit::Item::Table(providers);
@@ -4371,6 +4428,61 @@ command = "example"
             Some(false)
         );
         assert!(codex_config_has_official_proxy_route(&output));
+    }
+
+    // Keep these pure projection tests independent of process-global settings.
+    fn apply_codex_official_proxy_route(text: &str, url: &str) -> Result<String, AppError> {
+        apply_codex_official_proxy_route_with_history(text, url, false)
+    }
+
+    #[test]
+    fn unified_official_takeover_uses_custom_without_changing_auth_or_transport() {
+        let text = apply_codex_official_proxy_route_with_history(
+            "model = \"gpt-5.4\"\n[mcp_servers.example]\ncommand = \"example\"\n",
+            "http://127.0.0.1:15721/v1/",
+            true,
+        )
+        .unwrap();
+        let doc: toml::Value = toml::from_str(&text).unwrap();
+        assert_eq!(doc["model_provider"].as_str(), Some("custom"));
+        let table = &doc["model_providers"]["custom"];
+        assert_eq!(table["requires_openai_auth"].as_bool(), Some(true));
+        assert_eq!(table["supports_websockets"].as_bool(), Some(false));
+        assert_eq!(table["wire_api"].as_str(), Some("responses"));
+        assert_eq!(
+            table["base_url"].as_str(),
+            Some("http://127.0.0.1:15721/v1")
+        );
+        assert!(table.get("experimental_bearer_token").is_none());
+        assert!(codex_config_has_official_proxy_route(&text));
+        let cleaned = remove_codex_official_proxy_route(&text).unwrap();
+        let clean: toml::Value = toml::from_str(&cleaned).unwrap();
+        assert!(clean.get("model_provider").is_none());
+        assert!(clean.get("model_providers").is_none());
+        assert!(clean.get("mcp_servers").is_some());
+    }
+
+    #[test]
+    fn shared_id_and_local_url_alone_do_not_own_a_third_party_table() {
+        let text =
+            apply_codex_official_proxy_route_with_history("", "http://127.0.0.1:15721/v1", true)
+                .unwrap();
+        let no_marker = text
+            .lines()
+            .filter(|line| !line.starts_with("# cc-switch:"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        for modified in [
+            no_marker,
+            text.replace("15721", "15722"),
+            format!("{text}experimental_bearer_token = \"user-key\"\n"),
+        ] {
+            assert!(!codex_config_has_official_proxy_route(&modified));
+            assert_eq!(
+                remove_codex_official_proxy_route(&modified).unwrap(),
+                modified
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/codex_history_migration.rs
+++ b/src-tauri/src/codex_history_migration.rs
@@ -1143,8 +1143,8 @@ fn rewrite_codex_session_provider_line(
 ) -> Option<String> {
     // Leave large message/image/reasoning records byte-for-byte intact without
     // parsing their potentially expensive payloads.
-    if !line.contains("\"session_meta\"")
-        && !(line.contains("\"event_msg\"") && line.contains("\"thread_settings_applied\""))
+    if !(line.contains("\"session_meta\"")
+        || line.contains("\"event_msg\"") && line.contains("\"thread_settings_applied\""))
     {
         return None;
     }

--- a/src-tauri/src/codex_history_migration.rs
+++ b/src-tauri/src/codex_history_migration.rs
@@ -5,6 +5,7 @@
 
 use crate::codex_config::{
     get_codex_config_dir, read_codex_config_text, CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+    CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
 };
 use crate::codex_state_db::codex_state_db_paths;
 use crate::config::{atomic_write, copy_file, get_app_config_dir};
@@ -40,6 +41,58 @@ fn lock_codex_official_history_op() -> std::sync::MutexGuard<'static, ()> {
     CODEX_OFFICIAL_HISTORY_OP_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Replacing an open rollout can strand the writer on the old inode even if
+/// its size/mtime did not change during our read. Require an offline migration.
+fn ensure_codex_history_writers_stopped() -> Result<(), AppError> {
+    #[cfg(windows)]
+    let output = {
+        use std::os::windows::process::CommandExt;
+        std::process::Command::new("tasklist")
+            .args(["/FO", "CSV", "/NH"])
+            .creation_flags(0x08000000)
+            .output()
+    };
+    #[cfg(not(windows))]
+    let output = std::process::Command::new("ps")
+        .args(["-axo", "comm="])
+        .output();
+    let output =
+        output.map_err(|e| AppError::Message(format!("Cannot check Codex writers: {e}")))?;
+    if !output.status.success() {
+        return Err(AppError::Message(
+            "Cannot check Codex writers; history was not migrated".into(),
+        ));
+    }
+    if String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .any(is_codex_writer_process)
+    {
+        return Err(AppError::Message(
+            "Quit Codex/ChatGPT and Codex CLI sessions, then retry history migration in Settings"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_codex_writer_process(line: &str) -> bool {
+    let executable = line
+        .trim()
+        .trim_start_matches('"')
+        .split("\",\"")
+        .next()
+        .unwrap_or("");
+    let name = executable
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    matches!(
+        name.as_str(),
+        "codex" | "chatgpt" | "codex.exe" | "chatgpt.exe"
+    )
 }
 /// Codex 内建默认 provider id：config.toml 没有 `model_provider` 键时会话归入此桶。
 /// 官方订阅（ChatGPT OAuth / OpenAI API key）的历史会话都记录这个 id。
@@ -98,11 +151,13 @@ const CC_SWITCH_LEGACY_CODEX_MODEL_PROVIDER_IDS: &[&str] = &[
     "zhipu_glm_en",
 ];
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CodexHistoryProviderBucketMigrationOutcome {
     pub source_provider_ids: Vec<String>,
     pub migrated_jsonl_files: usize,
     pub migrated_state_rows: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub skipped_reason: Option<String>,
 }
 
@@ -222,8 +277,8 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
     }
     // live 必须已实际路由到共享 custom 桶才允许迁移：官方配置的注入可能被拒
     // （已有显式 model_provider / 形态冲突的 custom 表，见
-    // `inject_codex_unified_session_bucket`），代理接管期间的 live 也不带统一
-    // 路由（注入只进备份）。这些状态下新会话仍落 "openai" 桶，迁移只会把
+    // `inject_codex_unified_session_bucket`）。旧版本的官方接管配置也可能仍
+    // 使用独立桶；必须先重新投影 live，否则迁移只会把
     // 历史搬进当前 live 看不见的桶里。开关与迁移意愿保持不动，待 live 真正
     // 统一后（下次切换 / 接管释放后的启动重试）再迁。
     if !codex_config_text_routes_custom(&read_codex_config_text().unwrap_or_default()) {
@@ -233,16 +288,22 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
         });
     }
 
-    let source_provider_ids: BTreeSet<String> =
-        std::iter::once(OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID.to_string()).collect();
+    ensure_codex_history_writers_stopped()?;
+    let source_provider_ids: BTreeSet<String> = [
+        OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID.to_string(),
+        CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID.to_string(),
+    ]
+    .into_iter()
+    .collect();
     let backup_root = migration_backup_root(OFFICIAL_UNIFY_MIGRATION_NAME);
+    // Record the directory before the first fallible mutation, including when
+    // a later SQLite write fails and only a partial generation can be restored.
+    fs::create_dir_all(&backup_root).map_err(|e| AppError::io(&backup_root, e))?;
+    write_backup_generation_meta(&backup_root, &codex_dir_key)?;
     let migrated_jsonl_files =
         migrate_codex_jsonl_files(&codex_dir, &source_provider_ids, &backup_root)?;
     let migrated_state_rows =
         migrate_codex_state_dbs(&codex_dir, &source_provider_ids, &backup_root)?;
-    // 备份代际记录来源目录，restore 据此只取当前目录的账本。
-    write_backup_generation_meta(&backup_root, &codex_dir_key)?;
-
     let outcome = CodexHistoryProviderBucketMigrationOutcome {
         source_provider_ids: source_provider_ids.into_iter().collect(),
         migrated_jsonl_files,
@@ -255,6 +316,7 @@ pub fn maybe_migrate_codex_official_history_to_unified_bucket(
     // 与关闭路径（update_settings + 清标记）共用同一把锁，无检查-写入窗口。
     let marker_written = crate::settings::mark_codex_official_history_unify_migrated_if_enabled(
         CodexOfficialHistoryUnifyMigration {
+            version: 2,
             completed_at: Utc::now().to_rfc3339(),
             target_provider_id: CC_SWITCH_CODEX_MODEL_PROVIDER_ID.to_string(),
             migrated_jsonl_files,
@@ -345,8 +407,9 @@ fn has_official_history_unify_backup_for_dir(ledger_parent: &Path, codex_dir_key
 /// 关闭统一会话开关时的可选还原：按迁移备份账本，把当时迁入共享 custom 桶的
 /// 官方会话精确翻回 "openai" 桶。
 ///
-/// 备份是唯一可信的归属证据：备份里 model_provider=="openai" 的会话必定源自
-/// 官方桶。开启期间新产生的会话不在任何备份里，**永不触碰**——它们可能来自
+/// 备份是唯一可信的归属证据：备份里 openai / cc-switch-official 的会话
+/// 源自官方桶。后者恢复到可用的内建 openai，而非已移除的临时代理路由。
+/// 开启期间新产生的会话不在任何备份里，**永不触碰**——它们可能来自
 /// 第三方，方向无法判定（产品决策：宁可留在第三方历史）。
 /// 扫描全部备份代际取并集，多次开关循环后仍能还原早期迁入的会话；
 /// 还原前改动目标先备份到独立的 restore 目录（保持迁移账本目录纯净），
@@ -364,6 +427,7 @@ pub fn restore_codex_official_history_from_backups(
         });
     }
     let config_text = read_codex_config_text().unwrap_or_default();
+    ensure_codex_history_writers_stopped()?;
     restore_codex_official_history_inner(
         &get_codex_config_dir(),
         &official_history_unify_backup_parent(),
@@ -392,9 +456,17 @@ fn restore_codex_official_history_inner(
     collect_jsonl_files(&codex_dir.join("sessions"), &mut files, 0, 8);
     collect_jsonl_files(&codex_dir.join("archived_sessions"), &mut files, 0, 4);
     let mut restored_jsonl_files = 0;
+    let source_ids = HashSet::from([CC_SWITCH_CODEX_MODEL_PROVIDER_ID.to_string()]);
     for file_path in files {
+        let mut active_thread = None;
         if rewrite_codex_session_file_lines(&file_path, codex_dir, restore_backup_root, |line| {
-            rewrite_codex_session_meta_line_for_restore(line, &official_session_ids)
+            rewrite_codex_session_provider_line(
+                line,
+                &source_ids,
+                OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID,
+                Some(&official_session_ids),
+                &mut active_thread,
+            )
         })? {
             restored_jsonl_files += 1;
         }
@@ -500,8 +572,10 @@ fn collect_official_session_ids_from_backup(path: &Path, session_ids: &mut HashS
         let Some(payload) = value.get("payload") else {
             continue;
         };
-        if payload.get("model_provider").and_then(Value::as_str)
-            != Some(OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID)
+        if !payload
+            .get("model_provider")
+            .and_then(Value::as_str)
+            .is_some_and(is_official_history_provider)
         {
             continue;
         }
@@ -528,12 +602,17 @@ fn collect_official_thread_ids_from_backup(db_path: &Path, thread_ids: &mut BTre
     if !has_threads {
         return;
     }
-    let Ok(mut stmt) = conn.prepare("SELECT id FROM threads WHERE model_provider = ?1") else {
+    let Ok(mut stmt) = conn.prepare("SELECT id FROM threads WHERE model_provider IN (?1, ?2)")
+    else {
         return;
     };
-    let Ok(rows) = stmt.query_map([OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID], |row| {
-        row.get::<_, String>(0)
-    }) else {
+    let Ok(rows) = stmt.query_map(
+        [
+            OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID,
+            CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID,
+        ],
+        |row| row.get::<_, String>(0),
+    ) else {
         return;
     };
     for thread_id in rows.flatten() {
@@ -562,32 +641,6 @@ fn collect_files_with_extension(
             files.push(path);
         }
     }
-}
-
-fn rewrite_codex_session_meta_line_for_restore(
-    line: &str,
-    official_session_ids: &HashSet<String>,
-) -> Option<String> {
-    if !line.contains("\"session_meta\"") || !line.contains("\"model_provider\"") {
-        return None;
-    }
-    let mut value: Value = serde_json::from_str(line).ok()?;
-    if value.get("type").and_then(Value::as_str) != Some("session_meta") {
-        return None;
-    }
-    let payload = value.get_mut("payload")?.as_object_mut()?;
-    if payload.get("model_provider")?.as_str()? != CC_SWITCH_CODEX_MODEL_PROVIDER_ID {
-        return None;
-    }
-    let session_id = payload.get("id")?.as_str()?;
-    if !official_session_ids.contains(session_id) {
-        return None;
-    }
-    payload.insert(
-        "model_provider".to_string(),
-        Value::String(OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID.to_string()),
-    );
-    serde_json::to_string(&value).ok()
 }
 
 fn restore_codex_state_db_official_threads(
@@ -1014,8 +1067,15 @@ fn rewrite_codex_session_file_for_provider_bucket(
     source_provider_ids: &HashSet<String>,
     backup_root: &Path,
 ) -> Result<bool, AppError> {
+    let mut active_thread = None;
     rewrite_codex_session_file_lines(path, codex_dir, backup_root, |line| {
-        rewrite_codex_session_meta_line(line, source_provider_ids)
+        rewrite_codex_session_provider_line(
+            line,
+            source_provider_ids,
+            CC_SWITCH_CODEX_MODEL_PROVIDER_ID,
+            None,
+            &mut active_thread,
+        )
     })
 }
 
@@ -1023,7 +1083,7 @@ fn rewrite_codex_session_file_lines(
     path: &Path,
     codex_dir: &Path,
     backup_root: &Path,
-    rewrite_line: impl Fn(&str) -> Option<String>,
+    mut rewrite_line: impl FnMut(&str) -> Option<String>,
 ) -> Result<bool, AppError> {
     let metadata_before = fs::metadata(path).map_err(|e| AppError::io(path, e))?;
     let modified_before = metadata_before.modified().ok();
@@ -1054,7 +1114,88 @@ fn rewrite_codex_session_file_lines(
     backup_codex_jsonl_file(path, codex_dir, backup_root)?;
     ensure_codex_session_file_unchanged(path, modified_before, len_before)?;
     atomic_write(path, rewritten.as_bytes())?;
+    if let Some(modified) = modified_before {
+        fs::File::options()
+            .write(true)
+            .open(path)
+            .and_then(|file| file.set_modified(modified))
+            .map_err(|e| AppError::io(path, e))?;
+    }
     Ok(true)
+}
+
+fn is_official_history_provider(id: &str) -> bool {
+    matches!(
+        id,
+        OFFICIAL_OPENAI_CODEX_MODEL_PROVIDER_ID | CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID
+    )
+}
+
+/// Replay settings must agree with the history bucket. Explicit thread IDs
+/// take precedence over the surrounding segment; embedded foreign segments
+/// never inherit a previous thread's migration/restore authorization.
+fn rewrite_codex_session_provider_line(
+    line: &str,
+    sources: &HashSet<String>,
+    target: &str,
+    ledger: Option<&HashSet<String>>,
+    active_thread: &mut Option<String>,
+) -> Option<String> {
+    // Leave large message/image/reasoning records byte-for-byte intact without
+    // parsing their potentially expensive payloads.
+    if !line.contains("\"session_meta\"")
+        && !(line.contains("\"event_msg\"") && line.contains("\"thread_settings_applied\""))
+    {
+        return None;
+    }
+    let mut value: Value = match serde_json::from_str(line) {
+        Ok(value) => value,
+        Err(_) => {
+            if line.contains("\"session_meta\"") {
+                *active_thread = None;
+            }
+            return None;
+        }
+    };
+    let is_meta = value.get("type").and_then(Value::as_str) == Some("session_meta");
+    let is_event = value.get("type").and_then(Value::as_str) == Some("event_msg");
+    if is_meta {
+        *active_thread = None;
+    }
+    let payload = value.get_mut("payload")?.as_object_mut()?;
+    if is_meta {
+        let id = payload.get("id").and_then(Value::as_str);
+        if ledger.is_some_and(|ids| !id.is_some_and(|id| ids.contains(id))) {
+            return None;
+        }
+        let provider = payload.get("model_provider")?.as_str()?;
+        if !sources.contains(provider) && provider != target {
+            return None;
+        }
+        *active_thread = id.map(str::to_string);
+        if !sources.contains(provider) {
+            return None;
+        }
+        payload.insert("model_provider".into(), Value::String(target.into()));
+    } else if is_event
+        && payload.get("type").and_then(Value::as_str) == Some("thread_settings_applied")
+    {
+        let active = active_thread.as_deref()?;
+        if payload
+            .get("thread_id")
+            .is_some_and(|id| id.as_str() != Some(active))
+        {
+            return None;
+        }
+        let settings = payload.get_mut("thread_settings")?.as_object_mut()?;
+        if !sources.contains(settings.get("model_provider_id")?.as_str()?) {
+            return None;
+        }
+        settings.insert("model_provider_id".into(), Value::String(target.into()));
+    } else {
+        return None;
+    }
+    serde_json::to_string(&value).ok()
 }
 
 fn ensure_codex_session_file_unchanged(
@@ -1070,32 +1211,6 @@ fn ensure_codex_session_file_unchanged(
         )));
     }
     Ok(())
-}
-
-fn rewrite_codex_session_meta_line(
-    line: &str,
-    source_provider_ids: &HashSet<String>,
-) -> Option<String> {
-    if !line.contains("\"session_meta\"") || !line.contains("\"model_provider\"") {
-        return None;
-    }
-
-    let mut value: Value = serde_json::from_str(line).ok()?;
-    if value.get("type").and_then(Value::as_str) != Some("session_meta") {
-        return None;
-    }
-
-    let payload = value.get_mut("payload")?.as_object_mut()?;
-    let current_provider = payload.get("model_provider")?.as_str()?;
-    if !source_provider_ids.contains(current_provider) {
-        return None;
-    }
-
-    payload.insert(
-        "model_provider".to_string(),
-        Value::String(CC_SWITCH_CODEX_MODEL_PROVIDER_ID.to_string()),
-    );
-    serde_json::to_string(&value).ok()
 }
 
 fn migrate_codex_state_dbs(
@@ -1311,6 +1426,166 @@ mod tests {
 
     fn source_ids(values: &[&str]) -> BTreeSet<String> {
         values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn identifies_desktop_and_cli_writers_without_matching_other_tools() {
+        for name in [
+            "/Applications/ChatGPT.app/Contents/MacOS/ChatGPT",
+            "/opt/homebrew/bin/codex",
+            "\"Codex.exe\",\"123\",\"Console\"",
+        ] {
+            assert!(is_codex_writer_process(name));
+        }
+        for name in [
+            "/opt/homebrew/bin/cc-switch",
+            "codex-history-sync",
+            "ps",
+            "node",
+        ] {
+            assert!(!is_codex_writer_process(name));
+        }
+    }
+
+    #[test]
+    fn repairs_runtime_after_metadata_only_migration_without_leaking_segment_scope() {
+        let sources = HashSet::from(["cc-switch-official".to_string()]);
+        let mut active = None;
+        let meta = r#"{"type":"session_meta","payload":{"id":"a","model_provider":"custom"}}"#;
+        let event = r#"{"type":"event_msg","payload":{"type":"thread_settings_applied","thread_settings":{"model_provider_id":"cc-switch-official"}}}"#;
+        assert!(
+            rewrite_codex_session_provider_line(event, &sources, "custom", None, &mut active)
+                .is_none()
+        );
+        assert!(
+            rewrite_codex_session_provider_line(meta, &sources, "custom", None, &mut active)
+                .is_none()
+        );
+        let updated =
+            rewrite_codex_session_provider_line(event, &sources, "custom", None, &mut active)
+                .unwrap();
+        assert_eq!(
+            serde_json::from_str::<Value>(&updated).unwrap()["payload"]["thread_settings"]
+                ["model_provider_id"],
+            "custom"
+        );
+        for boundary in [
+            r#"{"type":"session_meta","payload":{"id":"b","model_provider":"other"}}"#,
+            r#"{"type":"session_meta","payload":null}"#,
+            r#"{"type":"session_meta","payload":BROKEN"#,
+        ] {
+            active = Some("a".into());
+            assert!(rewrite_codex_session_provider_line(
+                boundary,
+                &sources,
+                "custom",
+                None,
+                &mut active
+            )
+            .is_none());
+            assert!(active.is_none());
+            assert!(rewrite_codex_session_provider_line(
+                event,
+                &sources,
+                "custom",
+                None,
+                &mut active
+            )
+            .is_none());
+        }
+    }
+
+    #[test]
+    fn legacy_takeover_migration_updates_runtime_and_restores_only_ledger_threads() {
+        let dir = tempdir().unwrap();
+        let codex_dir = dir.path().join("codex");
+        let sessions = codex_dir.join("sessions");
+        fs::create_dir_all(&sessions).unwrap();
+        let path = sessions.join("rollout-main_resumed.jsonl");
+        let original = concat!(
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"official\",\"model_provider\":\"cc-switch-official\"}}\n",
+            "{\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_settings_applied\",\"thread_id\":\"official\",\"thread_settings\":{\"model_provider_id\":\"cc-switch-official\"}}}\n",
+            "{\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_settings_applied\",\"thread_id\":\"foreign\",\"thread_settings\":{\"model_provider_id\":\"cc-switch-official\"}}}\n",
+            "{\"type\":\"response_item\",\"payload\":{\"encrypted_content\":\"opaque-preserve-exactly\",\"text\":\"cc-switch-official\"}}\n",
+            "{\"type\":\"session_meta\",\"payload\":{\"id\":\"third-party\",\"model_provider\":\"custom\"}}\n",
+            "{\"type\":\"event_msg\",\"payload\":{\"type\":\"thread_settings_applied\",\"thread_id\":\"third-party\",\"thread_settings\":{\"model_provider_id\":\"custom\"}}}\n",
+        );
+        fs::write(&path, original).unwrap();
+        let mtime = fs::metadata(&path).unwrap().modified().unwrap();
+        let db_path = codex_dir.join(CODEX_STATE_DB_FILENAME);
+        let db = Connection::open(&db_path).unwrap();
+        db.execute_batch("CREATE TABLE threads (id TEXT PRIMARY KEY, model_provider TEXT); INSERT INTO threads VALUES ('official','cc-switch-official'),('third-party','custom')").unwrap();
+        drop(db);
+        let ledger = dir.path().join("ledger");
+        let backup = ledger.join("generation");
+        fs::create_dir_all(&backup).unwrap();
+        write_backup_generation_meta(&backup, &canonical_dir_string(&codex_dir)).unwrap();
+        let sources = source_ids(&["openai", "cc-switch-official"]);
+        assert_eq!(
+            migrate_codex_jsonl_files(&codex_dir, &sources, &backup).unwrap(),
+            1
+        );
+        assert_eq!(
+            migrate_codex_state_db_provider_bucket(&db_path, &codex_dir, &sources, &backup)
+                .unwrap(),
+            1
+        );
+        let migrated = fs::read_to_string(&path).unwrap();
+        let rows: Vec<Value> = migrated
+            .lines()
+            .map(|s| serde_json::from_str(s).unwrap())
+            .collect();
+        assert_eq!(rows[0]["payload"]["model_provider"], "custom");
+        assert_eq!(
+            rows[1]["payload"]["thread_settings"]["model_provider_id"],
+            "custom"
+        );
+        assert_eq!(
+            rows[2]["payload"]["thread_settings"]["model_provider_id"],
+            "cc-switch-official"
+        );
+        assert_eq!(migrated.lines().nth(3), original.lines().nth(3));
+        assert_eq!(fs::metadata(&path).unwrap().modified().unwrap(), mtime);
+        assert_eq!(
+            migrate_codex_jsonl_files(&codex_dir, &sources, &backup).unwrap(),
+            0
+        );
+        let restored = restore_codex_official_history_inner(
+            &codex_dir,
+            &ledger,
+            &dir.path().join("restore"),
+            "",
+        )
+        .unwrap();
+        assert_eq!(restored.restored_jsonl_files, 1);
+        assert_eq!(restored.restored_state_rows, 1);
+        let text = fs::read_to_string(&path).unwrap();
+        let rows: Vec<Value> = text
+            .lines()
+            .map(|s| serde_json::from_str(s).unwrap())
+            .collect();
+        // Return legacy official sessions to the usable built-in official id,
+        // not a removed transport-specific provider with a stale proxy URL.
+        assert_eq!(rows[0]["payload"]["model_provider"], "openai");
+        assert_eq!(
+            rows[1]["payload"]["thread_settings"]["model_provider_id"],
+            "openai"
+        );
+        assert_eq!(rows[4]["payload"]["model_provider"], "custom");
+        assert_eq!(
+            rows[5]["payload"]["thread_settings"]["model_provider_id"],
+            "custom"
+        );
+        assert_eq!(text.lines().nth(3), original.lines().nth(3));
+        let db = Connection::open(&db_path).unwrap();
+        let provider: String = db
+            .query_row(
+                "SELECT model_provider FROM threads WHERE id='official'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(provider, "openai");
     }
 
     #[test]

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -78,9 +78,17 @@ pub async fn save_settings(
         // 迁走而新会话仍写 openai 桶；关闭=会话还原而 live 仍写 custom）。
         // 报错让前端 saved=false 短路还原；回滚是整次保存的事务语义
         // （本开关的保存只携带开关相关字段）。
-        if let Err(err) =
-            crate::services::provider::reapply_current_codex_official_live(state.inner())
-        {
+        // Await the switch lock rather than blocking the async command's
+        // executor while another provider switch may need to make progress.
+        let reapply_result = match state.proxy_service.reapply_codex_official_takeover().await {
+            Ok(true) => Ok(true),
+            Ok(false) => {
+                crate::services::provider::reapply_current_codex_official_live(state.inner())
+                    .map_err(|e| e.to_string())
+            }
+            Err(error) => Err(error),
+        };
+        if let Err(err) = reapply_result {
             log::warn!("统一 Codex 会话历史开关变更后重写 live 配置失败，回滚设置: {err}");
             if let Err(rollback_err) = crate::settings::update_settings(existing) {
                 log::error!("回滚统一会话开关设置失败: {rollback_err}");
@@ -140,6 +148,20 @@ pub struct CodexUnifyHistoryRestoreResult {
 #[tauri::command]
 pub async fn has_codex_unify_history_backup() -> Result<bool, String> {
     Ok(crate::codex_history_migration::has_codex_official_history_unify_backup())
+}
+
+/// Retry an opted-in, offline migration after quitting Codex writers.
+#[tauri::command]
+pub async fn migrate_codex_unified_history(
+    state: tauri::State<'_, crate::store::AppState>,
+) -> Result<crate::codex_history_migration::CodexHistoryProviderBucketMigrationOutcome, String> {
+    let _guard = state.proxy_service.lock_switch_for_app("codex").await;
+    tauri::async_runtime::spawn_blocking(
+        crate::codex_history_migration::maybe_migrate_codex_official_history_to_unified_bucket,
+    )
+    .await
+    .map_err(|e| e.to_string())?
+    .map_err(|e| e.to_string())
 }
 
 /// 按迁移备份账本把当时迁入共享桶的官方会话还原回 "openai" 桶。
@@ -518,6 +540,7 @@ mod tests {
                     migrated_provider_ids: vec!["legacy".to_string()],
                 }),
                 codex_official_history_unify_v1: Some(CodexOfficialHistoryUnifyMigration {
+                    version: 2,
                     completed_at: "2026-06-12T00:00:00Z".to_string(),
                     target_provider_id: "custom".to_string(),
                     migrated_jsonl_files: 5,
@@ -571,6 +594,7 @@ mod tests {
                 codex_third_party_history_provider_bucket_v1: None,
                 codex_provider_template_v1: None,
                 codex_official_history_unify_v1: Some(CodexOfficialHistoryUnifyMigration {
+                    version: 2,
                     completed_at: "2026-06-12T00:00:00Z".to_string(),
                     target_provider_id: "custom".to_string(),
                     migrated_jsonl_files: 1,
@@ -604,6 +628,7 @@ mod tests {
         let incoming = AppSettings {
             local_migrations: Some(LocalMigrations {
                 codex_official_history_unify_v1: Some(CodexOfficialHistoryUnifyMigration {
+                    version: 2,
                     completed_at: "2026-06-12T00:00:00Z".to_string(),
                     target_provider_id: "custom".to_string(),
                     migrated_jsonl_files: 1,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1405,6 +1405,7 @@ pub fn run() {
             commands::get_settings,
             commands::save_settings,
             commands::has_codex_unify_history_backup,
+            commands::migrate_codex_unified_history,
             commands::restore_codex_unified_history,
             commands::get_rectifier_config,
             commands::set_rectifier_config,

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -716,6 +716,50 @@ impl ProxyService {
             .await
     }
 
+    /// Reproject an official takeover after a history-setting change under the
+    /// same lock as provider switches. Restore both live and backup on failure.
+    pub async fn reapply_codex_official_takeover(&self) -> Result<bool, String> {
+        let _guard = self.lock_switch_for_app("codex").await;
+        if !self.is_running().await {
+            return Ok(false);
+        }
+        let Some(provider) = self.get_current_provider_for_app(&AppType::Codex)? else {
+            return Ok(false);
+        };
+        if !crate::proxy::providers::is_codex_official_provider(&provider)
+            || !Self::is_codex_live_taken_over(&self.read_codex_live()?)
+        {
+            return Ok(false);
+        }
+        let previous_backup = self
+            .db
+            .get_live_backup("codex")
+            .await
+            .map_err(|e| e.to_string())?;
+        let snapshot =
+            crate::codex_config::CodexLiveStateSnapshot::capture().map_err(|e| e.to_string())?;
+        let result = async {
+            self.update_live_backup_from_provider_inner("codex", &provider, None)
+                .await?;
+            self.sync_codex_live_from_provider_while_proxy_active(&provider)
+                .await
+        }
+        .await;
+        if let Err(error) = result {
+            self.rollback_hot_switch_preparation(
+                &AppType::Codex,
+                previous_backup.as_ref(),
+                Some(&provider.id),
+                true,
+                true,
+                Some(&snapshot),
+            )
+            .await;
+            return Err(error);
+        }
+        Ok(true)
+    }
+
     pub(crate) async fn sync_codex_live_from_provider_while_proxy_active_guarded(
         &self,
         provider: &Provider,
@@ -2515,7 +2559,27 @@ impl ProxyService {
                             Self::proxy_urls_match(url, &proxy_codex_base_url)
                         })
                     });
-                Ok(Self::is_codex_live_taken_over(&config) && base_url_matches)
+                let official_bucket_matches = config
+                    .get("config")
+                    .and_then(|v| v.as_str())
+                    .is_none_or(|text| {
+                        if !crate::codex_config::codex_config_has_official_proxy_route(text) {
+                            return true;
+                        }
+                        let expected = if crate::settings::unify_codex_session_history() {
+                            crate::codex_config::CC_SWITCH_CODEX_MODEL_PROVIDER_ID
+                        } else {
+                            crate::codex_config::CC_SWITCH_CODEX_OFFICIAL_PROXY_PROVIDER_ID
+                        };
+                        text.parse::<toml_edit::DocumentMut>()
+                            .ok()
+                            .is_some_and(|doc| {
+                                doc.get("model_provider").and_then(|v| v.as_str()) == Some(expected)
+                            })
+                    });
+                Ok(Self::is_codex_live_taken_over(&config)
+                    && base_url_matches
+                    && official_bucket_matches)
             }
             AppType::Gemini => {
                 let config = self.read_gemini_live()?;
@@ -2585,14 +2649,15 @@ impl ProxyService {
         }
 
         if let Some(cfg_str) = config.get("config").and_then(|v| v.as_str()) {
-            let updated = Self::remove_local_toml_base_url(cfg_str);
+            // Check ownership before removing URL fields used by the marker.
+            let updated = crate::codex_config::remove_codex_official_proxy_route(cfg_str)
+                .map_err(|e| format!("清理 Codex 官方接管路由失败: {e}"))?;
+            let updated = Self::remove_local_toml_base_url(&updated);
             let updated =
                 crate::codex_config::remove_codex_experimental_bearer_token_if(&updated, |token| {
                     token == PROXY_TOKEN_PLACEHOLDER
                 })
                 .map_err(|e| format!("清理 Codex 接管占位符失败: {e}"))?;
-            let updated = crate::codex_config::remove_codex_official_proxy_route(&updated)
-                .map_err(|e| format!("清理 Codex 官方接管路由失败: {e}"))?;
             config["config"] = json!(updated);
         }
 
@@ -5051,12 +5116,25 @@ wire_api = "responses"
     #[tokio::test]
     #[serial]
     async fn codex_takeover_hot_switches_between_builtin_official_and_third_party() {
+        exercise_official_takeover_history(false).await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn unified_official_takeover_survives_hot_switch_toggle_and_restore() {
+        exercise_official_takeover_history(true).await;
+    }
+
+    async fn exercise_official_takeover_history(unified: bool) {
         let _home = TempHome::new();
         crate::settings::reload_settings().expect("reload settings");
         // Exercise the default setting: takeover itself must now preserve native
         // auth regardless of the legacy compatibility toggle.
-        crate::settings::update_settings(crate::settings::AppSettings::default())
-            .expect("reset settings");
+        crate::settings::update_settings(crate::settings::AppSettings {
+            unify_codex_session_history: unified,
+            ..Default::default()
+        })
+        .expect("reset settings");
 
         let db = Arc::new(Database::memory().expect("init db"));
         use_ephemeral_proxy_port(&db).await;
@@ -5097,6 +5175,13 @@ wire_api = "responses"
             None,
         );
         third_party.category = Some("custom".to_string());
+        if unified {
+            let text = third_party.settings_config["config"]
+                .as_str()
+                .unwrap()
+                .replace("rightcode", "custom");
+            third_party.settings_config["config"] = json!(text);
+        }
         db.save_provider("codex", &third_party)
             .expect("save third-party provider");
         db.set_current_provider("codex", "codex-official")
@@ -5122,6 +5207,39 @@ wire_api = "responses"
         assert!(official_live.contains("requires_openai_auth = true"));
         assert!(!official_live.contains(PROXY_TOKEN_PLACEHOLDER));
 
+        let read_bucket = || {
+            let text =
+                std::fs::read_to_string(crate::codex_config::get_codex_config_path()).unwrap();
+            let doc: toml::Value = toml::from_str(&text).unwrap();
+            doc.get("model_provider")
+                .and_then(|v| v.as_str())
+                .unwrap_or("openai")
+                .to_string()
+        };
+        assert_eq!(
+            read_bucket(),
+            if unified {
+                "custom"
+            } else {
+                "cc-switch-official"
+            }
+        );
+
+        if unified {
+            let mut settings = crate::settings::get_settings();
+            settings.unify_codex_session_history = false;
+            crate::settings::update_settings(settings.clone()).unwrap();
+            assert!(service.reapply_codex_official_takeover().await.unwrap());
+            assert_eq!(read_bucket(), "cc-switch-official");
+            settings.unify_codex_session_history = true;
+            crate::settings::update_settings(settings).unwrap();
+            // Upgrade/re-enable must not incorrectly reuse a legacy route.
+            service.set_takeover_for_app("codex", true).await.unwrap();
+            assert_eq!(read_bucket(), "custom");
+            assert!(service.reapply_codex_official_takeover().await.unwrap());
+            assert_eq!(read_auth(), oauth_auth);
+        }
+
         service
             .hot_switch_provider("codex", "rightcode")
             .await
@@ -5138,6 +5256,9 @@ wire_api = "responses"
         assert!(!crate::codex_config::codex_config_has_official_proxy_route(
             &third_party_live
         ));
+        if unified {
+            assert_eq!(read_bucket(), "custom");
+        }
 
         service
             .hot_switch_provider("codex", "codex-official")
@@ -5160,6 +5281,7 @@ wire_api = "responses"
             .await
             .expect("disable takeover");
         assert_eq!(read_auth(), oauth_auth);
+        assert_eq!(read_bucket(), if unified { "custom" } else { "openai" });
     }
 
     #[tokio::test]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -326,6 +326,9 @@ pub struct CodexProviderTemplateMigration {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodexOfficialHistoryUnifyMigration {
+    /// V2 also covers official takeover IDs and persisted runtime settings.
+    #[serde(default)]
+    pub version: u32,
     pub completed_at: String,
     pub target_provider_id: String,
     #[serde(default)]
@@ -336,6 +339,12 @@ pub struct CodexOfficialHistoryUnifyMigration {
     /// 切换 codex_config_dir 后旧标记不会挡住新目录的迁移。
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub codex_config_dir: Option<String>,
+}
+
+impl CodexOfficialHistoryUnifyMigration {
+    fn covers_directory(&self, codex_dir: &str) -> bool {
+        self.version >= 2 && self.codex_config_dir.as_deref() == Some(codex_dir)
+    }
 }
 
 /// 应用设置结构
@@ -853,7 +862,7 @@ pub fn is_codex_official_history_unify_migrated_for_dir(codex_dir: &str) -> bool
         .local_migrations
         .as_ref()
         .and_then(|migrations| migrations.codex_official_history_unify_v1.as_ref())
-        .is_some_and(|migration| migration.codex_config_dir.as_deref() == Some(codex_dir))
+        .is_some_and(|migration| migration.covers_directory(codex_dir))
 }
 
 /// 条件写入迁移完成标记：仅当此刻开关仍开启且迁移意愿仍在时才写。
@@ -1188,6 +1197,20 @@ pub fn update_s3_sync_status(status: WebDavSyncStatus) -> Result<(), AppError> {
 mod tests {
     use super::*;
     use crate::app_config::AppType;
+
+    #[test]
+    fn legacy_history_marker_does_not_skip_runtime_and_takeover_upgrade() {
+        let mut marker: CodexOfficialHistoryUnifyMigration =
+            serde_json::from_value(serde_json::json!({
+                "completedAt": "2026-01-01T00:00:00Z", "targetProviderId": "custom",
+                "codexConfigDir": "/fixture/codex", "migratedJsonlFiles": 2,
+            }))
+            .unwrap();
+        assert!(!marker.covers_directory("/fixture/codex"));
+        marker.version = 2;
+        assert!(marker.covers_directory("/fixture/codex"));
+        assert!(!marker.covers_directory("/another/codex"));
+    }
 
     #[test]
     fn visible_apps_old_settings_default_claude_desktop_visible() {

--- a/src/components/settings/CodexAuthSettings.tsx
+++ b/src/components/settings/CodexAuthSettings.tsx
@@ -6,6 +6,7 @@ import type { SettingsFormState } from "@/hooks/useSettings";
 import { ToggleRow } from "@/components/ui/toggle-row";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { settingsApi } from "@/lib/api";
+import { Button } from "@/components/ui/button";
 
 interface CodexAuthSettingsProps {
   settings: SettingsFormState;
@@ -23,6 +24,30 @@ export function CodexAuthSettings({
   const [showEnableConfirm, setShowEnableConfirm] = useState(false);
   const [showDisableConfirm, setShowDisableConfirm] = useState(false);
   const [hasUnifyBackup, setHasUnifyBackup] = useState(false);
+  const [migrating, setMigrating] = useState(false);
+
+  const retryMigration = async () => {
+    setMigrating(true);
+    try {
+      const result = await settingsApi.migrateCodexUnifiedHistory();
+      if (result.skippedReason) {
+        toast.info(t("settings.unifyCodexHistoryMigrationSkipped"));
+      } else {
+        toast.success(
+          t("settings.unifyCodexHistoryMigrationCompleted", {
+            files: result.migratedJsonlFiles,
+            rows: result.migratedStateRows,
+          }),
+        );
+      }
+    } catch (error) {
+      toast.error(t("settings.unifyCodexHistoryMigrationFailed"), {
+        description: String(error),
+      });
+    } finally {
+      setMigrating(false);
+    }
+  };
 
   const handleUnifyHistoryChange = (checked: boolean) => {
     if (checked) {
@@ -84,7 +109,9 @@ export function CodexAuthSettings({
       );
     } catch (error) {
       console.error("Failed to restore codex unified history:", error);
-      toast.error(t("settings.unifyCodexHistoryRestoreFailed"));
+      toast.error(t("settings.unifyCodexHistoryRestoreFailed"), {
+        description: String(error),
+      });
     }
   };
 
@@ -122,6 +149,22 @@ export function CodexAuthSettings({
         onConfirm={handleEnableConfirm}
         onCancel={() => setShowEnableConfirm(false)}
       />
+
+      {settings.unifyCodexSessionHistory &&
+        settings.unifyCodexMigrateExisting && (
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              {t("settings.unifyCodexHistoryMigrationHint")}
+            </p>
+            <Button
+              variant="outline"
+              disabled={migrating}
+              onClick={() => void retryMigration()}
+            >
+              {t("settings.unifyCodexHistoryMigrationRetry")}
+            </Button>
+          </div>
+        )}
 
       <ConfirmDialog
         isOpen={showDisableConfirm}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -339,6 +339,11 @@
     }
   },
   "settings": {
+    "unifyCodexHistoryMigrationHint": "Quit Codex/ChatGPT and Codex CLI sessions before migrating or restoring existing history. If migration was deferred, retry here after quitting.",
+    "unifyCodexHistoryMigrationRetry": "Retry history migration",
+    "unifyCodexHistoryMigrationCompleted": "History migrated ({{files}} session files, {{rows}} index rows)",
+    "unifyCodexHistoryMigrationSkipped": "Migration skipped: already completed, not requested, or the active route is not unified.",
+    "unifyCodexHistoryMigrationFailed": "History migration failed",
     "title": "Settings",
     "general": "General",
     "tabGeneral": "General",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -339,6 +339,11 @@
     }
   },
   "settings": {
+    "unifyCodexHistoryMigrationHint": "既存の履歴を移行・復元する前に Codex/ChatGPT と Codex CLI を終了してください。移行が保留された場合は、終了後ここから再試行できます。",
+    "unifyCodexHistoryMigrationRetry": "履歴の移行を再試行",
+    "unifyCodexHistoryMigrationCompleted": "履歴を移行しました（会話ファイル {{files}} 件、インデックス {{rows}} 件）",
+    "unifyCodexHistoryMigrationSkipped": "移行をスキップしました。完了済み、移行未選択、または現在のルートが未統一です。",
+    "unifyCodexHistoryMigrationFailed": "履歴の移行に失敗しました",
     "title": "設定",
     "general": "一般",
     "tabGeneral": "一般",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -339,6 +339,11 @@
     }
   },
   "settings": {
+    "unifyCodexHistoryMigrationHint": "遷移或還原既有歷史前，請完全退出 Codex/ChatGPT 和 Codex CLI 工作階段。若遷移尚未執行，退出後可在此重試。",
+    "unifyCodexHistoryMigrationRetry": "重試歷史遷移",
+    "unifyCodexHistoryMigrationCompleted": "歷史遷移完成（{{files}} 個會話檔案、{{rows}} 條索引記錄）",
+    "unifyCodexHistoryMigrationSkipped": "已略過遷移：可能已完成、未選擇遷移，或目前路由尚未統一。",
+    "unifyCodexHistoryMigrationFailed": "歷史遷移失敗",
     "title": "設定",
     "general": "通用",
     "tabGeneral": "通用",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -339,6 +339,11 @@
     }
   },
   "settings": {
+    "unifyCodexHistoryMigrationHint": "迁移或还原既有历史前，请完全退出 Codex/ChatGPT 和 Codex CLI 会话。若迁移尚未执行，退出后可在此重试。",
+    "unifyCodexHistoryMigrationRetry": "重试历史迁移",
+    "unifyCodexHistoryMigrationCompleted": "历史迁移完成（{{files}} 个会话文件、{{rows}} 条索引记录）",
+    "unifyCodexHistoryMigrationSkipped": "已跳过迁移：可能已完成、未选择迁移，或当前路由尚未统一。",
+    "unifyCodexHistoryMigrationFailed": "历史迁移失败",
     "title": "设置",
     "general": "通用",
     "tabGeneral": "通用",

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -49,6 +49,14 @@ export const settingsApi = {
     return await invoke("restore_codex_unified_history");
   },
 
+  async migrateCodexUnifiedHistory(): Promise<{
+    migratedJsonlFiles: number;
+    migratedStateRows: number;
+    skippedReason?: string;
+  }> {
+    return await invoke("migrate_codex_unified_history");
+  },
+
   async restart(): Promise<boolean> {
     return await invoke("restart_app");
   },

--- a/tests/components/CodexAuthSettings.test.tsx
+++ b/tests/components/CodexAuthSettings.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
+import { CodexAuthSettings } from "@/components/settings/CodexAuthSettings";
+
+const mocks = vi.hoisted(() => ({
+  migrate: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+}));
+vi.mock("@/lib/api", () => ({
+  settingsApi: { migrateCodexUnifiedHistory: mocks.migrate },
+}));
+vi.mock("sonner", () => ({ toast: mocks }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+function mount(migrateExisting: boolean) {
+  const settings = {
+    unifyCodexSessionHistory: true,
+    unifyCodexMigrateExisting: migrateExisting,
+  } as ComponentProps<typeof CodexAuthSettings>["settings"];
+  return render(<CodexAuthSettings settings={settings} onChange={vi.fn()} />);
+}
+
+describe("Codex history migration retry", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("does not offer migration without existing-history consent", () => {
+    mount(false);
+    expect(
+      screen.queryByText("settings.unifyCodexHistoryMigrationRetry"),
+    ).toBeNull();
+    expect(mocks.migrate).not.toHaveBeenCalled();
+  });
+
+  it("retries only on click and reports completed migration", async () => {
+    mocks.migrate.mockResolvedValue({
+      migratedJsonlFiles: 3,
+      migratedStateRows: 1,
+    });
+    mount(true);
+    expect(mocks.migrate).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByText("settings.unifyCodexHistoryMigrationRetry"),
+    );
+    await waitFor(() => expect(mocks.success).toHaveBeenCalled());
+    expect(mocks.migrate).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows writer errors without claiming success and permits retry", async () => {
+    mocks.migrate.mockRejectedValue("Quit Codex before migrating");
+    mount(true);
+    const button = screen.getByText("settings.unifyCodexHistoryMigrationRetry");
+    fireEvent.click(button);
+    await waitFor(() =>
+      expect(mocks.error).toHaveBeenCalledWith(
+        "settings.unifyCodexHistoryMigrationFailed",
+        { description: "Quit Codex before migrating" },
+      ),
+    );
+    expect(mocks.success).not.toHaveBeenCalled();
+    await waitFor(() => expect(button).not.toBeDisabled());
+  });
+
+  it("does not report skipped migrations as successful", async () => {
+    mocks.migrate.mockResolvedValue({ skippedReason: "live_not_unified" });
+    mount(true);
+    fireEvent.click(
+      screen.getByText("settings.unifyCodexHistoryMigrationRetry"),
+    );
+    await waitFor(() => expect(mocks.info).toHaveBeenCalled());
+    expect(mocks.success).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary / 概述

Honor the unified-history setting during official Codex proxy takeover and
repair existing official-takeover sessions that retain the obsolete provider ID.

- Use `custom` for unified official takeover; keep `cc-switch-official` when
  unification is disabled. Preserve native OpenAI authentication and HTTP/SSE.
- Separate takeover ownership from the shared provider ID with an atomic TOML
  ownership comment plus strict table/URL checks. Do not treat an arbitrary
  third-party `custom` table as an official takeover.
- Reconcile active takeovers when toggling the setting or re-enabling an old
  takeover; serialize with provider switches and roll back live/backup state
  on projection failure.
- Upgrade opted-in official-history migration to version 2, covering both
  `openai` and `cc-switch-official`, JSONL metadata, persisted runtime settings,
  and SQLite provider buckets. Existing V1 markers do not skip this repair.
- Require Codex writers to be stopped; expose an explicit migration retry action.
  Preserve message/encrypted payloads and rollout mtimes. Restore only
  ledger-proven official sessions to the usable built-in `openai` provider.
- Add synthetic regression fixtures, retry UI tests, documentation, and four
  locale translations. No private histories or credentials are included.

## Related Issue / 关联 Issue

Addresses #5974. Kept as a draft until manual desktop resume validation is done.

Related open work: #6633 (runtime provider consistency) and #7073 (configurable
official IDs/ownership). This is a focused implementation on current `main`,
not a merge of those branches. It does not introduce configurable provider IDs.

## Validation

- Frontend: 136 files / 1,079 tests passed with
  `pnpm exec vitest run --maxWorkers=2 --minWorkers=1`.
- The first default-concurrency run had seven App integration timeouts; the
  isolated App/retry tests and complete reduced-concurrency rerun passed.
- TypeScript, Prettier, Rust format, and renderer production build passed.
- Rust library run: 2,793 passed, 5 ignored, 1 failed. All new Codex regressions
  passed. The existing
  `services::provider::tests::update_current_claude_desktop_provider_syncs_profile_when_proxy_takeover_is_active`
  test fails with `Address already in use` on default port 15721, occupied by
  the user's running CC Switch. An isolated rerun reproduces it; that service
  was not stopped. Cargo stops before integration tests on this failure.
- Rerun with only that conflicting test filtered out: 2,921 passed, 5 ignored,
  including integration suites (`cargo test -- --skip <full test name above>`).
- Strict Clippy is blocked by two existing `dead_code` errors at
  `transform_responses.rs:2477` and `:2481`. That file is byte-identical to base
  `db346128` (Git blob `18cce8a0ed66fb411d226b55dc52f71f1a309bfa`).
  `cargo clippy -- -D warnings -A dead_code` passes. The new code's boolean
  simplification lint has been fixed; unrelated upstream functions are unchanged.
- Manual GUI resume, native authentication, and cross-backend continuation:
  pending. Automated routing tests are not a substitute for these checks.
- A local macOS arm64 debug app was built successfully with ad-hoc signing.
  The exported ZIP was extracted and passed `codesign --verify --deep --strict`.
  It is not notarized and has not been launched against real user history.

## Boundaries

Migration is opt-in and backs up targets before writing. The writer process
check is a preflight, not a lock preventing new/renamed/remote writers. Users
must keep Codex closed throughout migration and restore. Shared history does
not guarantee that another backend can decrypt existing reasoning content.
Arbitrary third-party provider IDs and history on another machine are out of scope.

## Screenshots / 截图

Not attached yet; the new UI adds an offline-migration hint and retry action
under the existing unified-history toggle.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [x] Updated en / zh / zh-TW / ja translations
- [ ] Manual desktop resume verification
