### PR TITLE
fix(pi): allow provider key rename after removal from live config

### DIFF
--- a/src-tauri/src/services/provider/pi.rs
+++ b/src-tauri/src/services/provider/pi.rs
@@ -115,16 +115,56 @@ pub(super) fn update(
     let _guard =
         futures::executor::block_on(state.proxy_service.lock_switch_for_app(app_type.as_str()));
     let original_id = original_id.unwrap_or(&provider.id).to_string();
-    if original_id != provider.id {
-        return Err(AppError::InvalidInput(
-            "Pi provider keys cannot be renamed".to_string(),
-        ));
-    }
 
     state
         .db
         .get_provider_by_id(&original_id, app_type.as_str())?
         .ok_or_else(|| AppError::InvalidInput(format!("Pi provider '{original_id}' not found")))?;
+
+    // Rename is only allowed once the provider is no longer present in
+    // models.json (i.e. the user removed it from live config). This mirrors
+    // the behavior of opencode and the other additive-mode apps: while the key
+    // is still in live config it stays locked; after removal it is editable.
+    if original_id != provider.id {
+        if crate::pi_config::pi_provider_exists(&original_id)? {
+            return Err(AppError::InvalidInput(
+                "Pi provider keys cannot be renamed while the provider is added to models.json"
+                    .to_string(),
+            ));
+        }
+        if state
+            .db
+            .get_provider_by_id(&provider.id, app_type.as_str())?
+            .is_some()
+            || crate::pi_config::pi_provider_exists(&provider.id)?
+        {
+            return Err(AppError::InvalidInput(format!(
+                "Pi provider '{}' already exists",
+                provider.id
+            )));
+        }
+        strip_unsupported_pi_metadata(&mut provider);
+        ProviderService::validate_provider_settings(&app_type, &provider)?;
+        ProviderService::normalize_usage_script_credential_overrides(&app_type, &mut provider);
+
+        if let Err(error) = state.db.save_provider(app_type.as_str(), &provider) {
+            return Err(error);
+        }
+        if let Err(error) = state.db.delete_provider(app_type.as_str(), &original_id) {
+            // Roll back the rename to keep the catalog consistent.
+            if let Err(rollback) = state.db.delete_provider(app_type.as_str(), &provider.id) {
+                return Err(AppError::Config(format!(
+                    "failed to delete original Pi provider: {error}; rollback failed: {rollback}"
+                )));
+            }
+            return Err(error);
+        }
+        if crate::settings::get_current_provider(&app_type).as_deref() == Some(&original_id) {
+            crate::settings::set_current_provider(&app_type, Some(provider.id.as_str()))?;
+        }
+        return Ok(true);
+    }
+
     strip_unsupported_pi_metadata(&mut provider);
     ProviderService::validate_provider_settings(&app_type, &provider)?;
     ProviderService::normalize_usage_script_credential_overrides(&app_type, &mut provider);
@@ -771,6 +811,56 @@ mod tests {
 
         let providers = ProviderService::list(&state, AppType::Pi).expect("sync native provider");
         assert_eq!(providers["cc-switch-test-copy"].name, "Native OAuth");
+    }
+
+    #[test]
+    #[serial]
+    fn provider_key_is_locked_while_in_live_and_editable_after_removal() {
+        let _agent = TestAgentDir::new();
+        let state = state();
+
+        // Add into live config: the key is now in models.json.
+        ProviderService::add(&state, AppType::Pi, input("model-a"), true)
+            .expect("add live provider");
+        assert!(crate::pi_config::pi_provider_exists("cc-switch-test").unwrap());
+
+        // Rename must be rejected while the provider is still in models.json.
+        let mut renamed = input("model-a");
+        renamed.id = "cc-switch-renamed".to_string();
+        let error = update(&state, Some("cc-switch-test"), renamed.clone())
+            .expect_err("rename of a live provider must be rejected");
+        assert!(error.to_string().contains("models.json"));
+        assert!(state
+            .db
+            .get_provider_by_id("cc-switch-test", "pi")
+            .unwrap()
+            .is_some());
+        assert!(!crate::pi_config::pi_provider_exists("cc-switch-renamed").unwrap());
+
+        // Remove from live config: the key leaves models.json but stays in DB.
+        ProviderService::remove_from_live_config(&state, AppType::Pi, "cc-switch-test")
+            .expect("remove from live config");
+        assert!(!crate::pi_config::pi_provider_exists("cc-switch-test").unwrap());
+        assert!(state
+            .db
+            .get_provider_by_id("cc-switch-test", "pi")
+            .unwrap()
+            .is_some());
+
+        // Now rename succeeds.
+        update(&state, Some("cc-switch-test"), renamed.clone()).expect("rename after removal");
+        assert!(state
+            .db
+            .get_provider_by_id("cc-switch-renamed", "pi")
+            .unwrap()
+            .is_some());
+        assert!(state
+            .db
+            .get_provider_by_id("cc-switch-test", "pi")
+            .unwrap()
+            .is_none());
+        assert!(!crate::pi_config::pi_provider_exists("cc-switch-test").unwrap());
+        assert!(!crate::pi_config::pi_provider_exists("cc-switch-renamed").unwrap());
     }
 
     #[test]

--- a/src-tauri/src/services/provider/pi.rs
+++ b/src-tauri/src/services/provider/pi.rs
@@ -147,9 +147,7 @@ pub(super) fn update(
         ProviderService::validate_provider_settings(&app_type, &provider)?;
         ProviderService::normalize_usage_script_credential_overrides(&app_type, &mut provider);
 
-        if let Err(error) = state.db.save_provider(app_type.as_str(), &provider) {
-            return Err(error);
-        }
+        state.db.save_provider(app_type.as_str(), &provider)?;
         if let Err(error) = state.db.delete_provider(app_type.as_str(), &original_id) {
             // Roll back the rename to keep the catalog consistent.
             if let Err(rollback) = state.db.delete_provider(app_type.as_str(), &provider.id) {

--- a/src/components/providers/forms/PiProviderForm.tsx
+++ b/src/components/providers/forms/PiProviderForm.tsx
@@ -63,6 +63,7 @@ import {
   type FetchedModel,
 } from "@/lib/api/model-fetch";
 import { useDarkMode } from "@/hooks/useDarkMode";
+import { usePiCurrentState } from "@/lib/query/pi";
 import { providerSchema, type ProviderFormData } from "@/lib/schemas/provider";
 import type { ProviderCategory } from "@/types";
 import { translatePiProviderMutationError } from "@/utils/errorUtils";
@@ -399,6 +400,11 @@ export function PiProviderForm({
     [initialData?.settingsConfig],
   );
   const isEdit = Boolean(initialData);
+  const { data: piCurrentState } = usePiCurrentState(true);
+  const isProviderKeyLocked = useMemo(() => {
+    if (!isEdit || !providerId) return false;
+    return piCurrentState?.enabledProviderIds.includes(providerId) ?? false;
+  }, [isEdit, providerId, piCurrentState]);
   const initialNativeName = optionalText(initialConfig.name);
   const initialDisplayName = initialData?.name ?? initialNativeName;
   const initialConfigHasNativeName = hasOwn(initialConfig, "name");
@@ -1081,7 +1087,7 @@ export function PiProviderForm({
           'input[name="name"]',
         );
       }
-      if (!isEdit && !trimmedKey) {
+      if (!trimmedKey) {
         throw new PiFormValidationError(
           t("pi.form.providerKeyRequired"),
           "#pi-provider-key",
@@ -1245,7 +1251,7 @@ export function PiProviderForm({
         settingsConfig: JSON.stringify(settingsConfig),
         icon: identity.icon || selectedPreset?.icon || "pi",
         iconColor: identity.iconColor || selectedPreset?.iconColor || "",
-        providerKey: isEdit ? providerId : trimmedKey,
+        providerKey: trimmedKey,
         presetId: selectedPresetId ?? undefined,
         presetCategory: category,
         meta: initialData?.meta,
@@ -1367,12 +1373,12 @@ export function PiProviderForm({
                       onChange={(event) =>
                         handleProviderKeyChange(event.target.value)
                       }
-                      disabled={isEdit}
+                      disabled={isProviderKeyLocked}
                       placeholder="my-provider"
                       autoComplete="off"
                     />
                     <p className="text-xs text-muted-foreground">
-                      {isEdit
+                      {isProviderKeyLocked
                         ? t("opencode.providerKeyLockedHint", {
                             defaultValue:
                               "该供应商已添加到应用配置中，供应商标识不可修改",

--- a/src/components/providers/forms/PiProviderForm.tsx
+++ b/src/components/providers/forms/PiProviderForm.tsx
@@ -400,7 +400,9 @@ export function PiProviderForm({
     [initialData?.settingsConfig],
   );
   const isEdit = Boolean(initialData);
-  const { data: piCurrentState } = usePiCurrentState(true);
+  const { data: piCurrentState, isLoading: isPiCurrentStateLoading } =
+    usePiCurrentState(true);
+  const isProviderKeyLockStateLoading = isEdit && isPiCurrentStateLoading;
   const isProviderKeyLocked = useMemo(() => {
     if (!isEdit || !providerId) return false;
     return piCurrentState?.enabledProviderIds.includes(providerId) ?? false;
@@ -1373,7 +1375,9 @@ export function PiProviderForm({
                       onChange={(event) =>
                         handleProviderKeyChange(event.target.value)
                       }
-                      disabled={isProviderKeyLocked}
+                      disabled={
+                        isProviderKeyLocked || isProviderKeyLockStateLoading
+                      }
                       placeholder="my-provider"
                       autoComplete="off"
                     />

--- a/tests/components/PiProviderForm.test.tsx
+++ b/tests/components/PiProviderForm.test.tsx
@@ -1,18 +1,40 @@
 import {
+  act,
   fireEvent,
-  render,
+  render as testingLibraryRender,
   screen,
   waitFor,
   within,
 } from "@testing-library/react";
+import { QueryClientProvider } from "@tanstack/react-query";
 import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PiProviderForm } from "@/components/providers/forms/PiProviderForm";
+import { piKeys } from "@/lib/query/pi";
 import { http, HttpResponse } from "msw";
 import { server } from "../msw/server";
+import { createTestQueryClient } from "../utils/testQueryClient";
 
 const TAURI_ENDPOINT = "http://tauri.local";
+
+function render(
+  ui: ReactElement,
+  { seedPiCurrentState = true }: { seedPiCurrentState?: boolean } = {},
+) {
+  const queryClient = createTestQueryClient();
+  queryClient.setQueryDefaults(piKeys.currentState, { staleTime: Infinity });
+  if (seedPiCurrentState) {
+    queryClient.setQueryData(piKeys.currentState, {
+      enabledProviderIds: [],
+      defaultProviderId: null,
+    });
+  }
+  return testingLibraryRender(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
 
 function completeModel(id: string, name = id.trim() || "Model") {
   return {
@@ -71,6 +93,7 @@ describe("PiProviderForm", () => {
     expect(screen.getByLabelText("provider.name")).toBeInTheDocument();
     expect(screen.getByLabelText("provider.notes")).toBeInTheDocument();
     expect(screen.getByLabelText("provider.websiteUrl")).toBeInTheDocument();
+    expect(screen.getByLabelText(/pi\.form\.providerKey/)).toBeEnabled();
     expect(screen.getByRole("button", { name: "Save preset" })).toBeEnabled();
     await waitFor(() =>
       expect(onSubmitReadyChange).toHaveBeenLastCalledWith(true),
@@ -78,6 +101,56 @@ describe("PiProviderForm", () => {
     expect(screen.queryByText("pi.form.stepPreset")).not.toBeInTheDocument();
     expect(screen.queryByText("pi.form.stepAuth")).not.toBeInTheDocument();
     expect(screen.queryByText("pi.form.stepModel")).not.toBeInTheDocument();
+  });
+
+  it("keeps the provider key locked while the live state is unresolved", async () => {
+    let resolveCurrentState!: () => void;
+    const currentStateReady = new Promise<void>((resolve) => {
+      resolveCurrentState = resolve;
+    });
+    server.use(
+      http.post(`${TAURI_ENDPOINT}/get_pi_current_state`, async () => {
+        await currentStateReady;
+        return HttpResponse.json({
+          enabledProviderIds: ["live-provider"],
+          defaultProviderId: "live-provider",
+        });
+      }),
+    );
+    const user = userEvent.setup();
+
+    render(
+      <PiProviderForm
+        appId="pi"
+        providerId="live-provider"
+        submitLabel="Save live provider"
+        onSubmit={() => {}}
+        onCancel={() => {}}
+        initialData={{
+          name: "Live provider",
+          settingsConfig: {
+            name: "Live provider",
+            baseUrl: "https://api.example.com/v1",
+          },
+        }}
+      />,
+      { seedPiCurrentState: false },
+    );
+
+    const providerKeyInput = screen.getByLabelText(/pi\.form\.providerKey/);
+    expect(providerKeyInput).toBeDisabled();
+    await user.type(providerKeyInput, "-renamed");
+    expect(providerKeyInput).toHaveValue("live-provider");
+
+    act(() => resolveCurrentState());
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("该供应商已添加到应用配置中，供应商标识不可修改"),
+      ).toBeInTheDocument(),
+    );
+    expect(providerKeyInput).toBeDisabled();
+    expect(providerKeyInput).toHaveValue("live-provider");
   });
 
   it("uses the OpenCode-style provider hierarchy without per-model endpoints", () => {


### PR DESCRIPTION
## Summary / 概述

Provider key was locked by record-existence (isEdit) rather than live-config membership, so removing a provider from models.json left its id permanently uneditable. Align Pi with opencode/openclaw/hermes by gating the key lock on piCurrentState.enabledProviderIds, and allow the backend to rename once the key is no longer in models.json.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
