### PR TITLE
fix(xai): 修复 xAI 订阅额度查询在休眠唤醒后的死循环及网络错误误判

### DIFF
--- a/src-tauri/src/commands/xai_oauth.rs
+++ b/src-tauri/src/commands/xai_oauth.rs
@@ -1,6 +1,6 @@
 //! xAI OAuth state and xAI-specific commands.
 
-use crate::proxy::providers::xai_oauth_auth::XaiOAuthManager;
+use crate::proxy::providers::xai_oauth_auth::{XaiOAuthError, XaiOAuthManager};
 use crate::proxy::providers::XAI_API_BASE_URL;
 use crate::services::model_fetch::FetchedModel;
 use crate::services::subscription::{CredentialStatus, SubscriptionQuota};
@@ -48,6 +48,12 @@ pub(crate) async fn query_xai_oauth_quota_for(
     // 获取（必要时自动刷新）access_token
     let token = match manager.get_valid_token_for_account(&id).await {
         Ok(t) => t,
+        Err(XaiOAuthError::NetworkError(e)) => {
+            return Err(format!("Network error: {e}"));
+        }
+        Err(XaiOAuthError::AccountNotFound(_)) => {
+            return Ok(SubscriptionQuota::not_found("xai_oauth"));
+        }
         Err(e) => {
             return Ok(SubscriptionQuota::error(
                 "xai_oauth",
@@ -57,12 +63,35 @@ pub(crate) async fn query_xai_oauth_quota_for(
         }
     };
 
-    crate::services::subscription_grok::query_grok_quota(
+    let first_attempt = crate::services::subscription_grok::query_grok_quota(
         &token,
         "xai_oauth",
         "Please re-login via cc-switch.",
     )
-    .await
+    .await;
+
+    // 401 Unauthorized 自动失效与重试机制：
+    // 若查询返回凭据失效（HTTP 401/403），可能为本地 access_token 已被服务端注销或休眠时钟失准。
+    // 主动从内存中淘汰该 token，并尝试通过 refresh_token 获取新 token 重试一次，
+    // 避免用户陷入“反复刷新却一直复用失效死 Token”的问题。
+    match first_attempt {
+        Ok(quota) if !quota.success && quota.credential_status == CredentialStatus::Expired => {
+            manager.invalidate_cached_token(&id).await;
+            match manager.get_valid_token_for_account(&id).await {
+                Ok(new_token) => {
+                    crate::services::subscription_grok::query_grok_quota(
+                        &new_token,
+                        "xai_oauth",
+                        "Please re-login via cc-switch.",
+                    )
+                    .await
+                }
+                Err(XaiOAuthError::NetworkError(e)) => Err(format!("Network error: {e}")),
+                Err(_) => Ok(quota),
+            }
+        }
+        other => other,
+    }
 }
 
 /// 查询 xAI OAuth (SuperGrok 反代) 订阅额度

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -219,6 +219,7 @@ fn build_client(proxy_url: Option<&str>) -> Result<Client, String> {
         .connect_timeout(Duration::from_secs(30))
         .pool_max_idle_per_host(10)
         .tcp_keepalive(Duration::from_secs(60))
+        .pool_idle_timeout(Duration::from_secs(45))
         // 禁用 reqwest 自动解压：防止 reqwest 覆盖客户端原始 accept-encoding header。
         // 响应解压由 response_processor 根据 content-encoding 手动处理。
         .no_gzip()

--- a/src-tauri/src/proxy/providers/xai_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/xai_oauth_auth.rs
@@ -480,6 +480,11 @@ impl XaiOAuthManager {
         Ok(())
     }
 
+    /// 失效指定账号的内存 access_token 缓存（例如上游返回 401 Unauthorized 时）
+    pub async fn invalidate_cached_token(&self, account_id: &str) {
+        self.access_tokens.write().await.remove(account_id);
+    }
+
     async fn discover_endpoints(&self) -> Result<OAuthEndpoints, XaiOAuthError> {
         if let Some(endpoints) = self.discovered_endpoints.read().await.clone() {
             return Ok(endpoints);
@@ -1351,5 +1356,23 @@ mod tests {
         assert!(manager.list_accounts().await.is_empty());
         assert!(manager.access_tokens.read().await.is_empty());
         assert!(!data_dir.path().join("xai_oauth_auth.json").exists());
+    }
+
+    #[tokio::test]
+    async fn invalidate_cached_token_removes_token_from_memory() {
+        let data_dir = tempfile::tempdir().unwrap();
+        let manager = XaiOAuthManager::new(data_dir.path().to_path_buf());
+        let cached_token = CachedAccessToken {
+            token: "cached-access-token".to_string(),
+            expires_at_ms: chrono::Utc::now().timestamp_millis() + 3_600_000,
+        };
+        manager
+            .access_tokens
+            .write()
+            .await
+            .insert("acc-1".to_string(), cached_token);
+        assert!(manager.access_tokens.read().await.contains_key("acc-1"));
+        manager.invalidate_cached_token("acc-1").await;
+        assert!(!manager.access_tokens.read().await.contains_key("acc-1"));
     }
 }

--- a/src/components/SubscriptionQuotaFooter.tsx
+++ b/src/components/SubscriptionQuotaFooter.tsx
@@ -136,7 +136,10 @@ export const SubscriptionQuotaView: React.FC<SubscriptionQuotaViewProps> = ({
             <span>{t("subscription.expired")}</span>
           </div>
           <button
-            onClick={() => refetch()}
+            onClick={(e) => {
+              e.stopPropagation();
+              refetch();
+            }}
             disabled={loading}
             className="p-1 rounded hover:bg-muted transition-colors disabled:opacity-50 flex-shrink-0"
             title={t("subscription.refresh")}
@@ -159,7 +162,10 @@ export const SubscriptionQuotaView: React.FC<SubscriptionQuotaViewProps> = ({
             </div>
           </div>
           <button
-            onClick={() => refetch()}
+            onClick={(e) => {
+              e.stopPropagation();
+              refetch();
+            }}
             disabled={loading}
             className="p-1 rounded hover:bg-amber-100 dark:hover:bg-amber-800/30 transition-colors disabled:opacity-50 flex-shrink-0"
             title={t("subscription.refresh")}
@@ -181,7 +187,10 @@ export const SubscriptionQuotaView: React.FC<SubscriptionQuotaViewProps> = ({
             <span>{t("subscription.queryFailed")}</span>
           </div>
           <button
-            onClick={() => refetch()}
+            onClick={(e) => {
+              e.stopPropagation();
+              refetch();
+            }}
             disabled={loading}
             className="p-1 rounded hover:bg-muted transition-colors disabled:opacity-50 flex-shrink-0"
             title={t("subscription.refresh")}
@@ -199,7 +208,10 @@ export const SubscriptionQuotaView: React.FC<SubscriptionQuotaViewProps> = ({
             <span>{quota.error || t("subscription.queryFailed")}</span>
           </div>
           <button
-            onClick={() => refetch()}
+            onClick={(e) => {
+              e.stopPropagation();
+              refetch();
+            }}
             disabled={loading}
             className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50 flex-shrink-0"
             title={t("subscription.refresh")}

--- a/src/components/XaiOauthQuotaFooter.tsx
+++ b/src/components/XaiOauthQuotaFooter.tsx
@@ -8,6 +8,7 @@ interface XaiOauthQuotaFooterProps {
   inline?: boolean;
   /** 是否为当前激活的供应商 */
   isCurrent?: boolean;
+  autoQueryInterval?: number;
 }
 
 /**
@@ -21,13 +22,17 @@ const XaiOauthQuotaFooter: React.FC<XaiOauthQuotaFooterProps> = ({
   meta,
   inline = false,
   isCurrent = false,
+  autoQueryInterval,
 }) => {
   const {
     data: quota,
     isFetching: loading,
     refetch,
-  } = useXaiOauthQuota(meta, { enabled: true, autoQuery: isCurrent });
-
+  } = useXaiOauthQuota(meta, {
+    enabled: true,
+    autoQuery: isCurrent,
+    autoQueryIntervalMinutes: autoQueryInterval,
+  });
   return (
     <SubscriptionQuotaView
       quota={quota}

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -625,6 +625,9 @@ export function ProviderCard({
                   meta={provider.meta}
                   inline={true}
                   isCurrent={isCurrent}
+                  autoQueryInterval={
+                    provider.meta?.usage_script?.autoQueryInterval ?? 0
+                  }
                 />
               ) : isOfficial ? (
                 officialSubscriptionEnabled ? (

--- a/src/lib/query/queries.ts
+++ b/src/lib/query/queries.ts
@@ -144,9 +144,14 @@ export function isTransientUsageError(result: UsageLikeResult): boolean {
   const e = result.error?.toLowerCase() ?? "";
   if (!e) return false;
 
-  // 网络类（send 失败/超时/读取响应失败）
+  // 网络类（send 失败/超时/读取响应失败/OAuth 网络异常）
   if (
-    e.includes("network error") || // 原生路径
+    e.includes("network error") || // 原生路径 (en)
+    e.includes("网络错误") || // 原生路径 (zh)
+    e.includes("token unavailable") || // OAuth token 临时不可用
+    e.includes("timed out") ||
+    e.includes("timeout") ||
+    e.includes("超时") ||
     e.includes("request failed") || // JS 脚本 (en)
     e.includes("请求失败") || // JS 脚本 (zh)
     e.includes("failed to read response") || // JS 脚本 (en)

--- a/src/lib/query/subscription.ts
+++ b/src/lib/query/subscription.ts
@@ -176,17 +176,29 @@ export function useXaiOauthQuota(
   meta: ProviderMeta | undefined,
   options: UseCodexOauthQuotaOptions = {},
 ) {
-  const { enabled = true, autoQuery = false } = options;
+  const {
+    enabled = true,
+    autoQuery = false,
+    autoQueryIntervalMinutes = 5,
+  } = options;
+  const refetchInterval =
+    autoQuery && autoQueryIntervalMinutes > 0
+      ? Math.max(autoQueryIntervalMinutes, 1) * 60 * 1000
+      : false;
   const accountId = resolveManagedAccountId(meta, PROVIDER_TYPES.XAI_OAUTH);
   const query = useQuery({
     queryKey: ["xai_oauth", "quota", accountId ?? "default"],
     queryFn: () => subscriptionApi.getXaiOauthQuota(accountId),
     enabled,
-    refetchInterval: autoQuery ? REFETCH_INTERVAL : false,
-    refetchIntervalInBackground: autoQuery,
-    refetchOnWindowFocus: autoQuery,
-    staleTime: REFETCH_INTERVAL,
+    refetchInterval,
+    refetchIntervalInBackground: Boolean(refetchInterval),
+    refetchOnWindowFocus: Boolean(refetchInterval),
+    staleTime:
+      autoQueryIntervalMinutes > 0
+        ? Math.max(autoQueryIntervalMinutes, 1) * 60 * 1000
+        : REFETCH_INTERVAL,
     retry: 1,
+    retryDelay: 1500,
   });
 
   return useQuotaKeepLastGood(query, accountId ?? "default");

--- a/tests/lib/keepLastGoodUsage.test.ts
+++ b/tests/lib/keepLastGoodUsage.test.ts
@@ -31,6 +31,15 @@ describe("isTransientUsageError", () => {
       true,
     );
     expect(isTransientUsageError(fail("读取响应失败: eof"))).toBe(true);
+    expect(
+      isTransientUsageError(
+        fail("xAI OAuth token unavailable: 网络错误: 连接超时"),
+      ),
+    ).toBe(true);
+    expect(isTransientUsageError(fail("网络错误: 连接重置"))).toBe(true);
+    expect(
+      isTransientUsageError(fail("OAuth token unavailable: timed out")),
+    ).toBe(true);
   });
 
   it("确定性失败 → 非瞬时（false），必须立即透出", () => {


### PR DESCRIPTION
### 概述 (Summary)

修复休眠唤醒或网络波动后，xAI OAuth 订阅额度查询失败且难以刷新回来的问题。

### 问题分析 (Root Causes)

1. **401 未淘汰内存 Token 缓存**：当 `grok.com` 账单端点返回 401 Unauthorized（或会话在休眠后失效）时，`XaiOAuthManager` 未淘汰内存中的 access token。由于该 token 在本地记录的过期时间尚未到达，随后的手动“刷新”请求会持续复用同一失效 token，导致多次重试均失败。
2. **网络错误被误标记为凭据失效**：在 `query_xai_oauth_quota_for` 中，若因休眠唤醒网络未就绪导致 token 刷新失败，所有错误都被统统包装为 `CredentialStatus::Expired` 并以 `Ok` 返回，导致前端显示“凭据失效”并误导用户重新登录，且绕过了 React Query 的 retry 机制。
3. **前端瞬时错误识别缺失中文模式**：`isTransientUsageError` 仅匹配了英文 `network error` 等关键字，未包含 Rust 端格式化的 `"网络错误"`，导致临时网络异常被当成确定性失败清空了 `lastGood` 快照。
4. **HTTP Client 缺少连接池空闲超时**：休眠唤醒后可能复用已经失效的 TCP socket，发送非幂等的 POST 请求遇到超时或断连。
5. **刷新按钮点击事件冒泡**：失败态下的刷新按钮缺少 `e.stopPropagation()`，点击会冒泡触发外层 `ProviderCard` 点击。

### 解决方案 (Changes)

- **Backend (`src-tauri`)**:
  - `XaiOAuthManager`: 新增 `invalidate_cached_token` 方法并补充单元测试。
  - `commands/xai_oauth.rs`:
    - 将 `XaiOAuthError::NetworkError` 正确作为 `Err` 传递，避免将网络问题误报为凭据失效。
    - 针对 401 失败增加自愈机制：请求若返回 `CredentialStatus::Expired`，主动淘汰缓存并通过 refresh token 自动重试一次。
  - `proxy/http_client.rs`: 为全局 HTTP 客户端增加 `pool_idle_timeout(45s)`，休眠唤醒后丢弃死连接。
- **Frontend (`src`)**:
  - `queries.ts`: 在 `isTransientUsageError` 中补充 `"网络错误"`、`"token unavailable"`、`"timeout"` 等匹配。
  - `SubscriptionQuotaFooter.tsx`: 在失败态下的刷新按钮上补齐 `e.stopPropagation()`。
  - `subscription.ts` / `XaiOauthQuotaFooter.tsx` / `ProviderCard.tsx`: 支持可配置的 `autoQueryInterval`，并为 query 增加 `retryDelay: 1500`。
  - `keepLastGoodUsage.test.ts`: 增加对应中文网络错误与 token 异常识别的测试用例。

### 验证 (Verification)

- `bun run typecheck`: 通过 (0 errors)
- `bun run test:unit`: 135 test files passed, 1087 tests passed
- `bun run format:check`: 全部匹配 Prettier 风格