### PR TITLE
fix(database): make v10-to-v11 rollup migration retry-safe

### DIFF
--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -1351,6 +1351,85 @@ impl Database {
             return Ok(());
         }
 
+        // A prior partial migration can leave a fully migrated v11 table while
+        // user_version still reports v10. Rebuilding it again would erase both
+        // model dimensions in the SELECT below, collapsing otherwise distinct
+        // rows onto the same primary key. Only skip when the exact v11 key and
+        // every v10 value column are present. The rebuild below is likewise
+        // limited to the exact v10 shape so mixed schemas cannot lose data.
+        let table_columns = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT name, pk FROM pragma_table_info('usage_daily_rollups')
+                     ORDER BY cid",
+                )
+                .map_err(|e| {
+                    AppError::Database(format!("v10 -> v11 检查 usage_daily_rollups 结构失败: {e}"))
+                })?;
+            let columns = stmt
+                .query_map([], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+                })
+                .map_err(|e| {
+                    AppError::Database(format!("v10 -> v11 查询 usage_daily_rollups 结构失败: {e}"))
+                })?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| {
+                    AppError::Database(format!("v10 -> v11 读取 usage_daily_rollups 结构失败: {e}"))
+                })?;
+            columns
+        };
+        let mut primary_key_columns = table_columns
+            .iter()
+            .filter(|(_, pk)| *pk > 0)
+            .map(|(name, pk)| (*pk, name.as_str()))
+            .collect::<Vec<_>>();
+        primary_key_columns.sort_unstable_by_key(|(pk, _)| *pk);
+        let primary_key_matches = |expected: &[&str]| {
+            primary_key_columns
+                .iter()
+                .map(|(_, name)| *name)
+                .eq(expected.iter().copied())
+        };
+
+        const V10_PRIMARY_KEY: [&str; 4] = ["date", "app_type", "provider_id", "model"];
+        const V11_PRIMARY_KEY: [&str; 6] = [
+            "date",
+            "app_type",
+            "provider_id",
+            "model",
+            "request_model",
+            "pricing_model",
+        ];
+        const VALUE_COLUMNS: [&str; 8] = [
+            "request_count",
+            "success_count",
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_creation_tokens",
+            "total_cost_usd",
+            "avg_latency_ms",
+        ];
+        let has_all_value_columns = VALUE_COLUMNS
+            .iter()
+            .all(|expected| table_columns.iter().any(|(name, _)| name == expected));
+
+        if primary_key_matches(&V11_PRIMARY_KEY) && has_all_value_columns {
+            log::info!("v10 -> v11：usage_daily_rollups 已是 v11 主键结构，保留现有维度并跳过重建");
+            return Ok(());
+        }
+
+        let has_exact_v10_shape = primary_key_matches(&V10_PRIMARY_KEY)
+            && has_all_value_columns
+            && table_columns.len() == V10_PRIMARY_KEY.len() + VALUE_COLUMNS.len();
+        if !has_exact_v10_shape {
+            return Err(AppError::Database(
+                "v10 -> v11 无法安全迁移 usage_daily_rollups：表结构既不是预期的 v10，也不是已迁移的 v11；已停止迁移以避免丢失模型维度"
+                    .to_string(),
+            ));
+        }
+
         conn.execute_batch(
             "ALTER TABLE usage_daily_rollups RENAME TO usage_daily_rollups_v10;
              CREATE TABLE usage_daily_rollups (

--- a/src-tauri/src/database/tests.rs
+++ b/src-tauri/src/database/tests.rs
@@ -459,6 +459,205 @@ fn migration_v10_to_v11_rebuilds_rollups_with_request_model_dimension() {
 }
 
 #[test]
+fn migration_v10_to_v11_preserves_an_already_migrated_rollup_table() {
+    let conn = Connection::open_in_memory().expect("open memory db");
+
+    // Simulate an interrupted v10 -> v11 migration: the rollup table already
+    // has the v11 primary key, but user_version was not advanced. Distinct
+    // model-dimension rows must not be projected back to the legacy dimensions.
+    conn.execute_batch(
+        r#"
+        CREATE TABLE proxy_request_logs (
+            request_id TEXT PRIMARY KEY,
+            model TEXT NOT NULL,
+            request_model TEXT
+        );
+        CREATE TABLE usage_daily_rollups (
+            date TEXT NOT NULL,
+            app_type TEXT NOT NULL,
+            provider_id TEXT NOT NULL,
+            model TEXT NOT NULL,
+            request_model TEXT NOT NULL DEFAULT '',
+            pricing_model TEXT NOT NULL DEFAULT '',
+            request_count INTEGER NOT NULL DEFAULT 0,
+            success_count INTEGER NOT NULL DEFAULT 0,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+            total_cost_usd TEXT NOT NULL DEFAULT '0',
+            avg_latency_ms INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (date, app_type, provider_id, model, request_model, pricing_model)
+        );
+        INSERT INTO usage_daily_rollups
+            (date, app_type, provider_id, model, request_model, pricing_model,
+             request_count, success_count, input_tokens, output_tokens,
+             cache_read_tokens, cache_creation_tokens, total_cost_usd, avg_latency_ms)
+        VALUES
+            ('2026-05-09', 'claude', '_session', 'deepseek-v4-pro', '', '',
+             77, 70, 7700, 700, 70, 7, '0.77', 120),
+            ('2026-05-09', 'claude', '_session', 'deepseek-v4-pro',
+             'deepseek-v4-pro', 'deepseek-chat', 10, 9, 1000, 100, 90, 10, '0.10', 90);
+        "#,
+    )
+    .expect("seed already-migrated v11 rollup table");
+
+    Database::set_user_version(&conn, 10).expect("set user_version=10");
+    Database::apply_schema_migrations_on_conn(&conn).expect("resume migrations");
+
+    let rows = conn
+        .prepare(
+            "SELECT request_model, pricing_model, request_count, success_count,
+                    input_tokens, output_tokens, cache_read_tokens,
+                    cache_creation_tokens, total_cost_usd, avg_latency_ms
+             FROM usage_daily_rollups
+             ORDER BY request_model",
+        )
+        .expect("prepare preserved rollup query")
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, i64>(6)?,
+                row.get::<_, i64>(7)?,
+                row.get::<_, String>(8)?,
+                row.get::<_, i64>(9)?,
+            ))
+        })
+        .expect("query preserved rollups")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect preserved rollups");
+    assert_eq!(
+        rows,
+        vec![
+            (
+                "".to_string(),
+                "".to_string(),
+                77,
+                70,
+                7700,
+                700,
+                70,
+                7,
+                "0.77".to_string(),
+                120,
+            ),
+            (
+                "deepseek-v4-pro".to_string(),
+                "deepseek-chat".to_string(),
+                10,
+                9,
+                1000,
+                100,
+                90,
+                10,
+                "0.10".to_string(),
+                90,
+            ),
+        ]
+    );
+    assert!(
+        Database::has_column(&conn, "proxy_request_logs", "pricing_model")
+            .expect("inspect proxy_request_logs")
+    );
+    assert!(
+        Database::has_column(&conn, "usage_daily_rollups", "input_token_semantics")
+            .expect("inspect usage_daily_rollups")
+    );
+    assert_eq!(
+        Database::get_user_version(&conn).expect("version after resumed migration"),
+        SCHEMA_VERSION
+    );
+}
+
+#[test]
+fn migration_v10_to_v11_rejects_a_partially_migrated_rollup_key() {
+    let conn = Connection::open_in_memory().expect("open memory db");
+
+    conn.execute_batch(
+        r#"
+        CREATE TABLE proxy_request_logs (
+            request_id TEXT PRIMARY KEY,
+            model TEXT NOT NULL,
+            request_model TEXT
+        );
+        CREATE TABLE usage_daily_rollups (
+            date TEXT NOT NULL,
+            app_type TEXT NOT NULL,
+            provider_id TEXT NOT NULL,
+            model TEXT NOT NULL,
+            request_model TEXT NOT NULL DEFAULT '',
+            pricing_model TEXT NOT NULL DEFAULT '',
+            request_count INTEGER NOT NULL DEFAULT 0,
+            success_count INTEGER NOT NULL DEFAULT 0,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+            total_cost_usd TEXT NOT NULL DEFAULT '0',
+            avg_latency_ms INTEGER NOT NULL DEFAULT 0,
+            PRIMARY KEY (date, app_type, provider_id, model, request_model)
+        );
+        INSERT INTO usage_daily_rollups
+            (date, app_type, provider_id, model, request_model, pricing_model,
+             request_count)
+        VALUES
+            ('2026-05-09', 'claude', '_session', 'deepseek-v4-pro',
+             'client-alias', 'deepseek-chat', 1);
+        "#,
+    )
+    .expect("seed partially migrated rollup table");
+
+    Database::set_user_version(&conn, 10).expect("set user_version=10");
+    let error = Database::apply_schema_migrations_on_conn(&conn)
+        .expect_err("reject an unsafe rollup rebuild");
+    assert!(
+        error.to_string().contains("已停止迁移以避免丢失模型维度"),
+        "unexpected error: {error}"
+    );
+
+    let preserved: (String, String, i64) = conn
+        .query_row(
+            "SELECT request_model, pricing_model, request_count
+             FROM usage_daily_rollups",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("query preserved partial-migration row");
+    assert_eq!(
+        preserved,
+        ("client-alias".to_string(), "deepseek-chat".to_string(), 1)
+    );
+
+    let primary_key = conn
+        .prepare(
+            "SELECT name FROM pragma_table_info('usage_daily_rollups')
+             WHERE pk > 0 ORDER BY pk",
+        )
+        .expect("prepare primary key query")
+        .query_map([], |row| row.get::<_, String>(0))
+        .expect("query primary key")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("collect primary key");
+    assert_eq!(
+        primary_key,
+        vec!["date", "app_type", "provider_id", "model", "request_model"]
+    );
+    assert!(
+        !Database::has_column(&conn, "proxy_request_logs", "pricing_model")
+            .expect("inspect rolled-back proxy_request_logs")
+    );
+    assert_eq!(
+        Database::get_user_version(&conn).expect("version after rejected migration"),
+        10
+    );
+}
+
+#[test]
 fn schema_create_tables_repairs_dev_global_profile_marker() {
     let conn = Connection::open_in_memory().expect("open memory db");
 


### PR DESCRIPTION
## Summary / 概述

Fix a database initialization failure when `usage_daily_rollups` already has the v11 primary key, but `PRAGMA user_version` still reports v10.

The migration introduced in 42828566831b43d556ea183490ef409632f3ece3 unconditionally rebuilds the table and fills `request_model` and `pricing_model` with empty strings. Repeating it on an already-upgraded table can collapse distinct rows onto the same primary key, causing a `UNIQUE constraint failed` error and preventing startup.

This change inspects the table's column and primary-key layout before rebuilding:

- Preserve an already-upgraded v11 table when its expected primary key and statistics columns are present.
- Keep the existing migration behavior for the expected v10 layout.
- Reject unsupported or partially upgraded layouts instead of risking model-dimension loss. The existing migration transaction rolls back changes on failure.

No rows are discarded or merged, and primary-key constraints are unchanged.

### Validation / 验证

- All 3 v10→v11 migration tests pass, covering normal upgrades, preservation of already-upgraded rows, and rollback for unsupported layouts.
- Regression assertions verify that both model dimensions and all eight statistics fields are preserved.
- Full Rust library suite: 2761 passed, 0 failed, 5 ignored.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` passes.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` passes.
- `git diff --check` passes.

## Related Issue / 关联 Issue

Fixes #5718

## Screenshots / 截图

Not applicable — this change affects database migration behavior and does not change the UI layout.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
  - No locale files were changed. The new database diagnostic follows the existing backend error-reporting path.