### PR TITLE
fix(codex): parse image generation usage from streamed events

### DIFF
--- a/src-tauri/src/proxy/usage/parser.rs
+++ b/src-tauri/src/proxy/usage/parser.rs
@@ -308,7 +308,7 @@ impl TokenUsage {
         }
     }
 
-    /// 智能 Codex 流式响应解析 - 自动检测 OpenAI 或 Codex 格式
+    /// 智能 Codex 流式响应解析 - 自动检测 Codex Responses / Images / OpenAI 格式
     pub fn from_codex_stream_events_auto(events: &[Value]) -> Option<Self> {
         log::debug!("[Codex] 智能解析流式事件，共 {} 个事件", events.len());
 
@@ -322,6 +322,20 @@ impl TokenUsage {
                     }
                 }
             }
+        }
+
+        // Images API 流式格式 (image_generation.completed 事件)：usage 直接挂在
+        // 事件顶层，字段形态与 Codex 非流式响应一致；倒序取最后一个能按该形态
+        // 解析的事件，跳过前面不含 usage 的 partial_image 事件。解析不成立时
+        // 继续走下面的 OpenAI 回退，不改变既有路径
+        if let Some(usage) = events
+            .iter()
+            .rev()
+            .filter(|event| event.pointer("/usage/input_tokens").is_some())
+            .find_map(Self::from_codex_response)
+        {
+            log::debug!("[Codex] 找到顶层 usage.input_tokens 事件");
+            return Some(usage);
         }
 
         // 回退到 OpenAI Chat Completions 格式 (最后一个 chunk 包含 usage)
@@ -1176,5 +1190,44 @@ mod tests {
         assert_eq!(usage.input_tokens, 100);
         assert_eq!(usage.output_tokens, 50);
         assert_eq!(usage.model, Some("gpt-4o".to_string()));
+    }
+
+    #[test]
+    fn test_codex_stream_events_auto_image_generation_completed() {
+        // Images API 流式格式：usage 挂在 image_generation.completed 事件顶层，
+        // 字段形态与 Codex 非流式响应一致 (input_tokens / output_tokens)
+        let events = vec![
+            json!({
+                "type": "image_generation.partial_image",
+                "b64_json": "cGFydGlhbA==",
+                "partial_image_index": 0
+            }),
+            json!({
+                "type": "image_generation.completed",
+                "b64_json": "aW1hZ2U=",
+                "created_at": 1778832973,
+                "usage": {
+                    "input_tokens": 1474,
+                    "input_tokens_details": {
+                        "image_tokens": 1457,
+                        "text_tokens": 17
+                    },
+                    "output_tokens": 1372,
+                    "output_tokens_details": {
+                        "image_tokens": 1372,
+                        "text_tokens": 0
+                    },
+                    "total_tokens": 2846
+                }
+            }),
+        ];
+
+        let usage = TokenUsage::from_codex_stream_events_auto(&events)
+            .expect("image_generation.completed usage should be parsed");
+        assert_eq!(usage.input_tokens, 1474);
+        assert_eq!(usage.output_tokens, 1372);
+        assert_eq!(usage.cache_read_tokens, 0);
+        assert_eq!(usage.cache_creation_tokens, 0);
+        assert_eq!(usage.model, None);
     }
 }


### PR DESCRIPTION
## Summary / 概述

#7036 的 follow-up：让 Codex 用量解析器认得 Images API 流式响应的 usage。

当 `/v1/images/generations`（或 `/v1/images/edits`）以 `stream: true` 调用时，上游以 SSE 返回 `image_generation.partial_image` / `image_generation.completed` 事件，用量挂在 `image_generation.completed` 事件的**顶层** `usage`（`input_tokens` / `output_tokens` / `total_tokens` + `input_tokens_details` / `output_tokens_details`）。现有 `TokenUsage::from_codex_stream_events_auto` 只识别 Responses API 的 `response.completed`，找不到就回退 OpenAI Chat Completions 流式格式，而后者要求 `prompt_tokens` / `completion_tokens`，于是返回 `None`，`response_processor` 落一条 0 token 的记录。

本 PR 在回退 OpenAI 格式之前增加一步：倒序找最后一个顶层带 `usage.input_tokens` 的事件，交给既有 `from_codex_response` 解析（Images 的 usage 字段形态与 Codex 非流式响应一致，无需新的解析器）。

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| Images API `stream: true`，SSE 以 `image_generation.completed` 收尾 | 找不到 `response.completed`，回退 OpenAI 格式失败，记录 0 token | 从 `image_generation.completed` 顶层 `usage` 记录 `input_tokens` / `output_tokens` |
| Responses API 流式（`response.completed`） | 正常 | 不变，仍优先走 `response.completed` |
| OpenAI Chat Completions 流式（末 chunk `prompt_tokens`） | 正常 | 不变，仍走既有回退 |

### Root Cause

`src-tauri/src/proxy/usage/parser.rs` `from_codex_stream_events_auto`：只匹配 `type == "response.completed"` 后取 `event.response`，否则 `from_openai_stream_events` → `from_openai_response` 要求 `prompt_tokens`。Images 流式事件的 usage 既不在 `response` 下，也不用 `prompt_tokens`，两条路径都取不到。

为什么按字段形态而不是按 `type` 判定：与同文件 `from_codex_response_auto` 的做法一致（按 `prompt_tokens` / `input_tokens` 区分格式），也能覆盖把 Images 流式事件改名转发的网关。与既有两种格式没有重叠：Responses 事件的 usage 嵌在 `response` 下（且已在前一步处理），Chat 流式 chunk 用 `prompt_tokens`，都不会命中 `usage.input_tokens` 这一顶层探测。`codex_stream_usage_event_filter` 已按 `"usage"` 字符串放行事件，`codex_auto_model_extractor` 在 usage 无 `model` 时回退到出站 / 请求模型名，两者都不需要改。

### Out of Scope

- Codex 客户端本身不发流式生图请求（上游 `ImagesClient` 走非流式 `execute`），本 PR 只影响把本地路由当通用 Images 网关、显式传 `stream: true` 的调用方。
- `input_tokens_details.image_tokens` / `text_tokens` 的分项计价。

## Related Issue / 关联 Issue

Related #7036 —— 维护者合并时列出的 follow-up（https://github.com/farion1231/cc-switch/pull/7036#pullrequestreview-5127947330）。
N/A —— 已检索现有 issues（关键词 `image_generation.completed`、`imagegen`、`gpt-image`、`生图`），未发现对应的 bug issue。

## Screenshots / 截图

N/A —— 纯后端用量解析改动，无 UI 变化。行为矩阵见上表。

## Testing / 测试

| 检查项 | 结果 |
| --- | --- |
| `cargo test --manifest-path src-tauri/Cargo.toml proxy::usage::parser::tests::test_codex_stream_events_auto_image_generation_completed -- --exact` | 通过；`partial_image` + `completed` 两事件，断言 `input_tokens=1474`、`output_tokens=1372`、cache 两项为 0、`model=None`。修复前该用例在 `.expect` 处得到 `None` |
| `cargo test --manifest-path src-tauri/Cargo.toml proxy::usage::parser::tests::` | 通过，28 个测试；含既有 `test_codex_stream_events_auto_codex_format` / `test_codex_stream_events_auto_openai_format`，确认 Responses 与 Chat 两条路径不变 |
| `cargo fmt --check --manifest-path src-tauri/Cargo.toml` | 通过 |
| `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` | 通过 |
| `cargo test --manifest-path src-tauri/Cargo.toml`（全量） | 通过，2927 passed，0 failed，5 ignored |
| `git diff --check` | 通过 |
| `pnpm typecheck` / `pnpm format:check` | 未运行，本 PR 未修改前端或 TypeScript 文件 |

## Source References

- openai/openai-python [`src/openai/types/image_gen_completed_event.py`](https://github.com/openai/openai-python/blob/main/src/openai/types/image_gen_completed_event.py)：`ImageGenCompletedEvent` 的 `usage: Usage` 位于事件顶层，`Usage` 含 `input_tokens`、`input_tokens_details{image_tokens, text_tokens}`、`output_tokens`、`total_tokens`。
- openai/codex [`codex-rs/codex-api/src/endpoint/images.rs`](https://github.com/openai/codex/blob/121f91fd5d9dc66017866ce9bdc49f1e182721df/codex-rs/codex-api/src/endpoint/images.rs#L58-L80)：`post_image_request` 走 `session.execute`（非流式），说明 Codex 自身不会触发本路径。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查（已确认不适用：未修改前端或 TypeScript 文件）
- [x] `pnpm format:check` passes / 通过代码格式检查（已确认不适用：未修改前端或 TypeScript 文件）
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件（已确认不适用：无用户可见文案变更）
