### PR TITLE
fix(a11y): associate MCP form labels and expose control states

### DIFF
--- a/src/components/mcp/McpFormModal.tsx
+++ b/src/components/mcp/McpFormModal.tsx
@@ -493,8 +493,14 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
             {/* ID (标题) */}
             <div>
               <div className="flex items-center justify-between mb-2">
-                <label className="block text-sm font-medium text-foreground">
-                  {t("mcp.form.title")} <span className="text-red-500">*</span>
+                <label
+                  htmlFor="mcp-form-id"
+                  className="block text-sm font-medium text-foreground"
+                >
+                  {t("mcp.form.title")}{" "}
+                  <span aria-hidden="true" className="text-red-500">
+                    *
+                  </span>
                 </label>
                 {!isEditing && idError && (
                   <span className="text-xs text-red-500 dark:text-red-400">
@@ -503,7 +509,9 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
                 )}
               </div>
               <Input
+                id="mcp-form-id"
                 type="text"
+                aria-required="true"
                 placeholder={t("mcp.form.titlePlaceholder")}
                 value={formId}
                 onChange={(e) => handleIdChange(e.target.value)}
@@ -513,10 +521,14 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
 
             {/* Name */}
             <div>
-              <label className="block text-sm font-medium text-foreground mb-2">
+              <label
+                htmlFor="mcp-form-name"
+                className="block text-sm font-medium text-foreground mb-2"
+              >
                 {t("mcp.form.name")}
               </label>
               <Input
+                id="mcp-form-name"
                 type="text"
                 placeholder={t("mcp.form.namePlaceholder")}
                 value={formName}
@@ -526,10 +538,17 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
 
             {/* 启用到哪些应用 */}
             <div>
-              <label className="block text-sm font-medium text-foreground mb-3">
+              <div
+                id="mcp-enabled-apps-label"
+                className="block text-sm font-medium text-foreground mb-3"
+              >
                 {t("mcp.form.enabledApps")}
-              </label>
-              <div className="flex flex-wrap gap-4">
+              </div>
+              <div
+                className="flex flex-wrap gap-4"
+                role="group"
+                aria-labelledby="mcp-enabled-apps-label"
+              >
                 <div className="flex items-center gap-2">
                   <Checkbox
                     id="enable-claude"
@@ -633,6 +652,7 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
               <button
                 type="button"
                 onClick={() => setShowMetadata(!showMetadata)}
+                aria-expanded={showMetadata}
                 className="flex items-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
               >
                 {showMetadata ? (
@@ -648,10 +668,14 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
             {showMetadata && (
               <>
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
+                  <label
+                    htmlFor="mcp-form-description"
+                    className="block text-sm font-medium text-foreground mb-2"
+                  >
                     {t("mcp.form.description")}
                   </label>
                   <Input
+                    id="mcp-form-description"
                     type="text"
                     placeholder={t("mcp.form.descriptionPlaceholder")}
                     value={formDescription}
@@ -660,10 +684,14 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
+                  <label
+                    htmlFor="mcp-form-tags"
+                    className="block text-sm font-medium text-foreground mb-2"
+                  >
                     {t("mcp.form.tags")}
                   </label>
                   <Input
+                    id="mcp-form-tags"
                     type="text"
                     placeholder={t("mcp.form.tagsPlaceholder")}
                     value={formTags}
@@ -672,10 +700,14 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
+                  <label
+                    htmlFor="mcp-form-homepage"
+                    className="block text-sm font-medium text-foreground mb-2"
+                  >
                     {t("mcp.form.homepage")}
                   </label>
                   <Input
+                    id="mcp-form-homepage"
                     type="text"
                     placeholder={t("mcp.form.homepagePlaceholder")}
                     value={formHomepage}
@@ -684,10 +716,14 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
                 </div>
 
                 <div>
-                  <label className="block text-sm font-medium text-foreground mb-2">
+                  <label
+                    htmlFor="mcp-form-docs"
+                    className="block text-sm font-medium text-foreground mb-2"
+                  >
                     {t("mcp.form.docs")}
                   </label>
                   <Input
+                    id="mcp-form-docs"
                     type="text"
                     placeholder={t("mcp.form.docsPlaceholder")}
                     value={formDocs}
@@ -717,6 +753,11 @@ const McpFormModal: React.FC<McpFormModalProps> = ({
             <div className="flex-1 min-h-0 flex flex-col">
               <div className="flex-1 min-h-0">
                 <JsonEditor
+                  ariaLabel={
+                    useToml
+                      ? t("mcp.form.tomlConfig")
+                      : t("mcp.form.jsonConfig")
+                  }
                   value={formConfig}
                   onChange={handleConfigChange}
                   placeholder={

--- a/src/components/mcp/McpWizardModal.tsx
+++ b/src/components/mcp/McpWizardModal.tsx
@@ -248,13 +248,24 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
           <div className="space-y-4 min-h-[400px]">
             {/* Type */}
             <div>
-              <label className="mb-2 block text-sm font-medium text-foreground">
-                {t("mcp.wizard.type")} <span className="text-red-500">*</span>
-              </label>
-              <div className="flex gap-4">
+              <div
+                id="mcp-wizard-type-label"
+                className="mb-2 block text-sm font-medium text-foreground"
+              >
+                {t("mcp.wizard.type")}{" "}
+                <span aria-hidden="true" className="text-red-500">
+                  *
+                </span>
+              </div>
+              <div
+                className="flex gap-4"
+                role="radiogroup"
+                aria-labelledby="mcp-wizard-type-label"
+              >
                 <label className="inline-flex items-center gap-2 cursor-pointer">
                   <input
                     type="radio"
+                    name="mcp-wizard-type"
                     value="stdio"
                     checked={wizardType === "stdio"}
                     onChange={(e) =>
@@ -269,6 +280,7 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
                 <label className="inline-flex items-center gap-2 cursor-pointer">
                   <input
                     type="radio"
+                    name="mcp-wizard-type"
                     value="http"
                     checked={wizardType === "http"}
                     onChange={(e) =>
@@ -283,6 +295,7 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
                 <label className="inline-flex items-center gap-2 cursor-pointer">
                   <input
                     type="radio"
+                    name="mcp-wizard-type"
                     value="sse"
                     checked={wizardType === "sse"}
                     onChange={(e) =>
@@ -299,11 +312,19 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
 
             {/* Title */}
             <div>
-              <label className="mb-1 block text-sm font-medium text-foreground">
-                {t("mcp.form.title")} <span className="text-red-500">*</span>
+              <label
+                htmlFor="mcp-wizard-title"
+                className="mb-1 block text-sm font-medium text-foreground"
+              >
+                {t("mcp.form.title")}{" "}
+                <span aria-hidden="true" className="text-red-500">
+                  *
+                </span>
               </label>
               <Input
+                id="mcp-wizard-title"
                 type="text"
+                aria-required="true"
                 value={wizardTitle}
                 onChange={(e) => setWizardTitle(e.target.value)}
                 onKeyDown={handleKeyDown}
@@ -317,12 +338,19 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
               <>
                 {/* Command */}
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-foreground">
+                  <label
+                    htmlFor="mcp-wizard-command"
+                    className="mb-1 block text-sm font-medium text-foreground"
+                  >
                     {t("mcp.wizard.command")}{" "}
-                    <span className="text-red-500">*</span>
+                    <span aria-hidden="true" className="text-red-500">
+                      *
+                    </span>
                   </label>
                   <Input
+                    id="mcp-wizard-command"
                     type="text"
+                    aria-required="true"
                     value={wizardCommand}
                     onChange={(e) => setWizardCommand(e.target.value)}
                     onKeyDown={handleKeyDown}
@@ -333,10 +361,14 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
 
                 {/* Args */}
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-foreground">
+                  <label
+                    htmlFor="mcp-wizard-args"
+                    className="mb-1 block text-sm font-medium text-foreground"
+                  >
                     {t("mcp.wizard.args")}
                   </label>
                   <textarea
+                    id="mcp-wizard-args"
                     value={wizardArgs}
                     onChange={(e) => setWizardArgs(e.target.value)}
                     placeholder={t("mcp.wizard.argsPlaceholder")}
@@ -347,10 +379,14 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
 
                 {/* Env */}
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-foreground">
+                  <label
+                    htmlFor="mcp-wizard-env"
+                    className="mb-1 block text-sm font-medium text-foreground"
+                  >
                     {t("mcp.wizard.env")}
                   </label>
                   <textarea
+                    id="mcp-wizard-env"
                     value={wizardEnv}
                     onChange={(e) => setWizardEnv(e.target.value)}
                     placeholder={t("mcp.wizard.envPlaceholder")}
@@ -366,12 +402,19 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
               <>
                 {/* URL */}
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-foreground">
+                  <label
+                    htmlFor="mcp-wizard-url"
+                    className="mb-1 block text-sm font-medium text-foreground"
+                  >
                     {t("mcp.wizard.url")}{" "}
-                    <span className="text-red-500">*</span>
+                    <span aria-hidden="true" className="text-red-500">
+                      *
+                    </span>
                   </label>
                   <Input
+                    id="mcp-wizard-url"
                     type="text"
+                    aria-required="true"
                     value={wizardUrl}
                     onChange={(e) => setWizardUrl(e.target.value)}
                     onKeyDown={handleKeyDown}
@@ -382,10 +425,14 @@ const McpWizardModal: React.FC<McpWizardModalProps> = ({
 
                 {/* Headers */}
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-foreground">
+                  <label
+                    htmlFor="mcp-wizard-headers"
+                    className="mb-1 block text-sm font-medium text-foreground"
+                  >
                     {t("mcp.wizard.headers")}
                   </label>
                   <textarea
+                    id="mcp-wizard-headers"
                     value={wizardHeaders}
                     onChange={(e) => setWizardHeaders(e.target.value)}
                     placeholder={t("mcp.wizard.headersPlaceholder")}

--- a/tests/components/McpFormModal.test.tsx
+++ b/tests/components/McpFormModal.test.tsx
@@ -80,12 +80,12 @@ vi.mock("@/components/ui/textarea", () => ({
 }));
 
 vi.mock("@/components/JsonEditor", () => ({
-  default: ({ value, onChange, placeholder, ...rest }: any) => (
+  default: ({ value, onChange, placeholder, ariaLabel }: any) => (
     <textarea
       value={value}
       placeholder={placeholder}
+      aria-label={ariaLabel}
       onChange={(event) => onChange?.(event.target.value)}
-      {...rest}
     />
   ),
 }));
@@ -168,6 +168,39 @@ describe("McpFormModal", () => {
     );
     return { onSave, onClose };
   };
+
+  it("associates MCP form labels with their controls", () => {
+    renderForm();
+
+    expect(
+      screen.getByRole("textbox", { name: "mcp.form.title" }),
+    ).toHaveAttribute("aria-required", "true");
+    expect(
+      screen.getByRole("textbox", { name: "mcp.form.name" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("group", { name: "mcp.form.enabledApps" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("textbox", { name: "mcp.form.jsonConfig" }),
+    ).toBeInTheDocument();
+
+    const additionalInfoButton = screen.getByRole("button", {
+      name: "mcp.form.additionalInfo",
+    });
+    expect(additionalInfoButton).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(additionalInfoButton);
+    expect(additionalInfoButton).toHaveAttribute("aria-expanded", "true");
+
+    for (const name of [
+      "mcp.form.description",
+      "mcp.form.tags",
+      "mcp.form.homepage",
+      "mcp.form.docs",
+    ]) {
+      expect(screen.getByRole("textbox", { name })).toBeInTheDocument();
+    }
+  });
 
   it("应用预设后填充 ID 与配置内容", async () => {
     renderForm();


### PR DESCRIPTION
## Summary / 概述

MCP form and wizard fields have visible labels that are not associated with their inputs. Associate those labels and reuse existing translations for the configuration editor's accessible name, so screen readers announce the intended field names.

Expose required fields, the enabled-apps group, and the additional-information button's expanded state. Give the wizard's native type radio buttons a shared name and a labelled group for arrow-key selection. Visual styling, mouse operation, and save logic are preserved.

## Related Issue / 关联 Issue

Fixes #7180

## Screenshots / 截图

Not applicable: no visual layout or styling changes.

## Testing

- Contributor-confirmed manual screen-reader testing on Windows: MCP form labels, required fields, additional-information fields and expanded state, configuration editor name, wizard field names, and type selection; mouse operation and layout also checked.
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm test:unit` (135 files, 1074 tests passed)
- `pnpm build:renderer`
- `pnpm tauri build --no-bundle` (Windows release build used for manual testing)

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` not applicable (no Rust code changed) / 不适用（未修改 Rust 代码）
- [x] Existing i18n strings reused; no new user-facing text / 复用现有国际化文案，无新增用户可见文本
