### PR TITLE
feat: 支持供应商配置多个 API Key

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -442,6 +442,9 @@ impl LocalProxyRequestOverrides {
 /// 供应商元数据
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProviderMeta {
+    /// Inactive API keys. The active key remains in `settings_config`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty", rename = "apiKeys")]
+    pub api_keys: Vec<String>,
     /// 自定义端点列表（按 URL 去重存储）
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub custom_endpoints: HashMap<String, crate::settings::CustomEndpoint>,

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -75,6 +75,8 @@ interface ClaudeFormFieldsProps {
   shouldShowApiKey: boolean;
   apiKey: string;
   onApiKeyChange: (key: string) => void;
+  apiKeys?: string[];
+  onApiKeysChange?: (keys: string[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -166,6 +168,8 @@ export function ClaudeFormFields({
   shouldShowApiKey,
   apiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -690,6 +694,8 @@ export function ClaudeFormFields({
         <ApiKeySection
           value={apiKey}
           onChange={onApiKeyChange}
+          apiKeys={apiKeys}
+          onApiKeysChange={onApiKeysChange}
           category={category}
           shouldShowLink={shouldShowApiKeyLink}
           websiteUrl={websiteUrl}

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -79,6 +79,8 @@ interface CodexFormFieldsProps {
   // API Key
   codexApiKey: string;
   onApiKeyChange: (key: string) => void;
+  apiKeys?: string[];
+  onApiKeysChange?: (keys: string[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -373,6 +375,8 @@ export function CodexFormFields({
   onXaiAccountSelect,
   codexApiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -759,6 +763,8 @@ export function CodexFormFields({
           label="API Key"
           value={codexApiKey}
           onChange={onApiKeyChange}
+          apiKeys={apiKeys}
+          onApiKeysChange={onApiKeysChange}
           category={category}
           shouldShowLink={shouldShowApiKeyLink}
           websiteUrl={websiteUrl}

--- a/src/components/providers/forms/GeminiFormFields.tsx
+++ b/src/components/providers/forms/GeminiFormFields.tsx
@@ -23,6 +23,8 @@ interface GeminiFormFieldsProps {
   shouldShowApiKey: boolean;
   apiKey: string;
   onApiKeyChange: (key: string) => void;
+  apiKeys?: string[];
+  onApiKeysChange?: (keys: string[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -53,6 +55,8 @@ export function GeminiFormFields({
   shouldShowApiKey,
   apiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -136,6 +140,8 @@ export function GeminiFormFields({
         <ApiKeySection
           value={apiKey}
           onChange={onApiKeyChange}
+          apiKeys={apiKeys}
+          onApiKeysChange={onApiKeysChange}
           category={category}
           shouldShowLink={shouldShowApiKeyLink}
           websiteUrl={websiteUrl}

--- a/src/components/providers/forms/HermesFormFields.tsx
+++ b/src/components/providers/forms/HermesFormFields.tsx
@@ -32,6 +32,8 @@ interface HermesFormFieldsProps {
   onBaseUrlChange: (value: string) => void;
   apiKey: string;
   onApiKeyChange: (value: string) => void;
+  apiKeys?: string[];
+  onApiKeysChange?: (keys: string[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -81,6 +83,8 @@ export function HermesFormFields({
   onBaseUrlChange,
   apiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -244,6 +248,8 @@ export function HermesFormFields({
       <ApiKeySection
         value={apiKey}
         onChange={onApiKeyChange}
+        apiKeys={apiKeys}
+        onApiKeysChange={onApiKeysChange}
         // Hermes 没有 OAuth-only 的免 key 官方供应商：即便是 official 预设
         // （如 Nous Research）也需用户自填 key，故不让 official 禁用输入框。
         category={category === "official" ? undefined : category}

--- a/src/components/providers/forms/OpenClawFormFields.tsx
+++ b/src/components/providers/forms/OpenClawFormFields.tsx
@@ -32,6 +32,8 @@ interface OpenClawFormFieldsProps {
   // API Key
   apiKey: string;
   onApiKeyChange: (value: string) => void;
+  apiKeys?: string[];
+  onApiKeysChange?: (keys: string[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -56,6 +58,8 @@ export function OpenClawFormFields({
   onBaseUrlChange,
   apiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -246,6 +250,8 @@ export function OpenClawFormFields({
       <ApiKeySection
         value={apiKey}
         onChange={onApiKeyChange}
+        apiKeys={apiKeys}
+        onApiKeysChange={onApiKeysChange}
         // OpenClaw 的 API key 始终由用户自填，没有 OAuth-only 的免 key 官方供应商，
         // 故不让 official 禁用输入框（与 Hermes 对齐）。
         category={category === "official" ? undefined : category}

--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -161,6 +161,8 @@ interface OpenCodeFormFieldsProps {
   // API Key
   apiKey: string;
   onApiKeyChange: (value: string) => void;
+  apiKeys?: string[];
+  onApiKeysChange?: (keys: string[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -189,6 +191,8 @@ export function OpenCodeFormFields({
   onNpmChange,
   apiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -527,6 +531,8 @@ export function OpenCodeFormFields({
       <ApiKeySection
         value={apiKey}
         onChange={onApiKeyChange}
+        apiKeys={apiKeys}
+        onApiKeysChange={onApiKeysChange}
         category={category}
         shouldShowLink={shouldShowApiKeyLink}
         websiteUrl={websiteUrl}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -339,6 +339,9 @@ function ProviderFormFull({
   const [selectedPresetId, setSelectedPresetId] = useState<string | null>(
     initialData ? null : "custom",
   );
+  const [apiKeys, setApiKeys] = useState<string[]>(
+    () => initialData?.meta?.apiKeys ?? [],
+  );
   const [activePreset, setActivePreset] = useState<{
     id: string;
     category?: ProviderCategory;
@@ -1828,6 +1831,7 @@ function ProviderFormFull({
         localIsFullUrl
           ? true
           : undefined,
+      apiKeys: apiKeys.filter(Boolean),
     };
 
     if (!isClaudeCodexOauthProvider && "codexFastMode" in nextMeta) {
@@ -2368,6 +2372,8 @@ function ProviderFormFull({
               }
               apiKey={apiKey}
               onApiKeyChange={handleApiKeyChange}
+              apiKeys={apiKeys.length ? apiKeys : [apiKey]}
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowClaudeApiKeyLink}
               websiteUrl={claudeWebsiteUrl}
@@ -2449,6 +2455,8 @@ function ProviderFormFull({
               onXaiAccountSelect={setSelectedXaiAccountId}
               codexApiKey={codexApiKey}
               onApiKeyChange={handleCodexApiKeyChange}
+              apiKeys={apiKeys.length ? apiKeys : [codexApiKey]}
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowCodexApiKeyLink}
               websiteUrl={codexWebsiteUrl}
@@ -2521,6 +2529,8 @@ function ProviderFormFull({
               )}
               apiKey={geminiApiKey}
               onApiKeyChange={handleGeminiApiKeyChange}
+              apiKeys={apiKeys.length ? apiKeys : [geminiApiKey]}
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowGeminiApiKeyLink}
               websiteUrl={geminiWebsiteUrl}
@@ -2547,6 +2557,8 @@ function ProviderFormFull({
               onNpmChange={opencodeForm.handleOpencodeNpmChange}
               apiKey={opencodeForm.opencodeApiKey}
               onApiKeyChange={opencodeForm.handleOpencodeApiKeyChange}
+              apiKeys={apiKeys.length ? apiKeys : [opencodeForm.opencodeApiKey]}
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowOpencodeApiKeyLink}
               websiteUrl={opencodeWebsiteUrl}
@@ -2592,6 +2604,8 @@ function ProviderFormFull({
               onBaseUrlChange={openclawForm.handleOpenclawBaseUrlChange}
               apiKey={openclawForm.openclawApiKey}
               onApiKeyChange={openclawForm.handleOpenclawApiKeyChange}
+              apiKeys={apiKeys.length ? apiKeys : [openclawForm.openclawApiKey]}
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowOpenclawApiKeyLink}
               websiteUrl={openclawWebsiteUrl}
@@ -2613,6 +2627,8 @@ function ProviderFormFull({
               onBaseUrlChange={hermesForm.handleHermesBaseUrlChange}
               apiKey={hermesForm.hermesApiKey}
               onApiKeyChange={hermesForm.handleHermesApiKeyChange}
+              apiKeys={apiKeys.length ? apiKeys : [hermesForm.hermesApiKey]}
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowHermesApiKeyLink}
               websiteUrl={hermesWebsiteUrl}

--- a/src/components/providers/forms/shared/ApiKeySection.tsx
+++ b/src/components/providers/forms/shared/ApiKeySection.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Plus, Trash2 } from "lucide-react";
 import ApiKeyInput from "../ApiKeyInput";
 import type { ProviderCategory } from "@/types";
 
@@ -17,6 +19,8 @@ interface ApiKeySectionProps {
   disabled?: boolean;
   isPartner?: boolean;
   partnerPromotionKey?: string;
+  apiKeys?: string[];
+  onApiKeysChange?: (keys: string[]) => void;
 }
 
 export function ApiKeySection({
@@ -30,6 +34,8 @@ export function ApiKeySection({
   placeholder,
   disabled,
   partnerPromotionKey,
+  apiKeys,
+  onApiKeysChange,
 }: ApiKeySectionProps) {
   const { t } = useTranslation();
 
@@ -44,20 +50,93 @@ export function ApiKeySection({
 
   const finalPlaceholder = placeholder || defaultPlaceholder;
 
+  const keys = apiKeys ?? [value];
+  const supportsMultiple = onApiKeysChange !== undefined;
+  const [selectedIndex, setSelectedIndex] = useState(() =>
+    Math.max(keys.indexOf(value), 0),
+  );
+  const changeKey = (index: number, key: string) => {
+    const next = [...keys];
+    next[index] = key;
+    onApiKeysChange?.(next);
+    if (keys[index] === value) onChange(key);
+  };
+  const selectKey = (index: number) => {
+    setSelectedIndex(index);
+    onChange(keys[index]);
+  };
+  const addKey = () => {
+    const next = [...keys, ""];
+    onApiKeysChange?.(next);
+    setSelectedIndex(next.length - 1);
+    onChange("");
+  };
+  const removeKey = (index: number) => {
+    if (keys.length === 1) return;
+    const next = keys.filter((_, i) => i !== index);
+    onApiKeysChange?.(next);
+    if (index === selectedIndex) {
+      const nextIndex = Math.min(index, next.length - 1);
+      setSelectedIndex(nextIndex);
+      onChange(next[nextIndex]);
+    } else if (index < selectedIndex) {
+      setSelectedIndex(selectedIndex - 1);
+    }
+  };
+
   return (
     <div className="space-y-1">
-      <ApiKeyInput
-        id={id}
-        label={label}
-        value={value}
-        onChange={onChange}
-        placeholder={
-          category === "official"
-            ? finalPlaceholder.official
-            : finalPlaceholder.thirdParty
-        }
-        disabled={disabled ?? category === "official"}
-      />
+      {keys.map((key, index) => (
+        <div key={index} className="flex items-end gap-2">
+          <input
+            type="radio"
+            checked={index === selectedIndex}
+            onChange={() => selectKey(index)}
+            aria-label={t("providerForm.enableApiKey", {
+              defaultValue: "启用此 API Key",
+            })}
+            disabled={disabled ?? category === "official"}
+            className="mb-3 size-4 shrink-0 accent-primary"
+          />
+          <div className="min-w-0 flex-1">
+            <ApiKeyInput
+              id={index === 0 ? id : `${id}-${index}`}
+              label={index === 0 ? label : undefined}
+              value={key}
+              onChange={(next) => changeKey(index, next)}
+              placeholder={
+                category === "official"
+                  ? finalPlaceholder.official
+                  : finalPlaceholder.thirdParty
+              }
+              disabled={disabled ?? category === "official"}
+            />
+          </div>
+          {supportsMultiple && keys.length > 1 && (
+            <button
+              type="button"
+              onClick={() => removeKey(index)}
+              className="mb-1 p-2 text-muted-foreground hover:text-destructive"
+              aria-label={t("providerForm.removeApiKey", {
+                defaultValue: "删除 API Key",
+              })}
+            >
+              <Trash2 size={16} />
+            </button>
+          )}
+        </div>
+      ))}
+      {supportsMultiple && (
+        <button
+          type="button"
+          onClick={addKey}
+          disabled={disabled ?? category === "official"}
+          className="flex items-center gap-1 text-sm text-primary hover:underline disabled:cursor-not-allowed disabled:text-muted-foreground"
+        >
+          <Plus size={16} />
+          {t("providerForm.addApiKey", { defaultValue: "新增 API Key" })}
+        </button>
+      )}
       {/* API Key 获取链接 */}
       {shouldShowLink && websiteUrl && (
         <div className="space-y-2 -mt-1 pl-1">

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,6 +173,8 @@ export interface LocalProxyRequestOverrides {
 
 // 供应商元数据（字段名与后端一致，保持 snake_case）
 export interface ProviderMeta {
+  // 备用 API Key（当前启用的 Key 仍保存在 settingsConfig 中）
+  apiKeys?: string[];
   // 自定义端点：以 URL 为键，值为端点信息
   custom_endpoints?: Record<string, CustomEndpoint>;
   // 是否在切换/同步到 live 时应用通用配置片段

--- a/tests/components/ApiKeySection.test.tsx
+++ b/tests/components/ApiKeySection.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ApiKeySection } from "@/components/providers/forms/shared/ApiKeySection";
+
+describe("ApiKeySection", () => {
+  it("selects one key and adds a new active key", () => {
+    const onChange = vi.fn();
+    const onApiKeysChange = vi.fn();
+    render(
+      <ApiKeySection
+        value="first"
+        onChange={onChange}
+        apiKeys={["first", "second"]}
+        onApiKeysChange={onApiKeysChange}
+        shouldShowLink={false}
+        websiteUrl=""
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("radio")[1]);
+    expect(onChange).toHaveBeenLastCalledWith("second");
+
+    fireEvent.click(screen.getByRole("button", { name: /新增 API Key/ }));
+    expect(onApiKeysChange).toHaveBeenLastCalledWith(["first", "second", ""]);
+    expect(onChange).toHaveBeenLastCalledWith("");
+  });
+});


### PR DESCRIPTION
## Summary\n- 支持在供应商表单中新增、删除并单选启用 API Key\n- 将备用 Key 保存到供应商元数据，当前启用 Key 同步写入实际配置\n- 覆盖 Claude、Codex、Gemini、OpenCode、OpenClaw、Hermes 表单\n\nCloses #7185\n\n## Tests\n- pnpm typecheck\n- pnpm test:unit\n