### PR TITLE
fix(i18n): use the Pi form's own term for the zh-TW duplicate-key message

### DIFF
--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -981,7 +981,7 @@
       "effectiveBaseUrlRequired": "模型 {{id}} 必須直接設定或從供應商繼承基礎 URL",
       "duplicateModel": "模型 ID {{id}} 重複",
       "modelRequired": "請至少新增一個模型",
-      "providerKeyDuplicate": "該供應商標識已存在"
+      "providerKeyDuplicate": "該供應商識別碼已存在"
     },
     "current": {
       "readFailed": "無法讀取 Pi 供應商設定",


### PR DESCRIPTION
Follow-up to your nit on #6768 — thank you for flagging it, you were right.

In zh-TW the Pi form labels the field **供應商識別碼** and says **供應商識別碼為必填** when it is empty, but the duplicate message I added said **供應商標識** — the term Hermes, OpenCode and OpenClaw use for *their* field. One form, two names for the same thing.

Checking the other three locales, they all keep the label and both messages on a single term, so zh-TW was the only one that split:

| locale | label | required | duplicate |
|---|---|---|---|
| en | Provider key | Provider key is required | This provider key already exists |
| ja | プロバイダーキー | プロバイダーキーを入力してください | このプロバイダーキーは既に存在します |
| zh | 供应商标识 | 供应商标识不能为空 | 该供应商标识已存在 |
| zh-TW | 供應商識別碼 | 供應商識別碼為必填 | 該供應商**標識**已存在 |

So this is not a new convention, just zh-TW joining the one already there.

**`hermes.form.providerKeyDuplicate` carries the same sentence and is deliberately untouched** — its own label is 供應商標識, so it is already self-consistent. The string appears twice in the file; only the `pi.form` one is changed.

## Verification

`vitest run tests/config/managementListLocales.test.ts` — 7/7.

Full unit suite: 1085/1087. The two failures are `tests/integration/App.test.tsx` cases that fail identically on `main` without this change; they pass when that file is run on its own, so they look order-dependent rather than related.

One note in case it saves you time later: my first full-suite run with this change showed a *third* App.test.tsx failure (`duplicates openclaw providers…`). Re-running gave the same two as the baseline, and that test does not touch i18n at all — it drives `switch-openclaw` / `duplicate` test ids. It looks flaky rather than real, but I would rather mention it than quietly drop it.

`prettier --check` clean.
