### PR TITLE
feat: 支持供应商配置多个 API Key

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -1,6 +1,6 @@
 use http::header::{HeaderValue, InvalidHeaderValue};
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -442,6 +442,14 @@ impl LocalProxyRequestOverrides {
 /// 供应商元数据
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ProviderMeta {
+    /// Inactive API keys. The active key remains in `settings_config`.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_api_keys",
+        skip_serializing_if = "Vec::is_empty",
+        rename = "apiKeys"
+    )]
+    pub api_keys: Vec<ApiKeyEntry>,
     /// 自定义端点列表（按 URL 去重存储）
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub custom_endpoints: HashMap<String, crate::settings::CustomEndpoint>,
@@ -562,6 +570,34 @@ pub struct ProviderMeta {
     /// 用于多账号支持，关联到特定的 GitHub 账号
     #[serde(rename = "githubAccountId", skip_serializing_if = "Option::is_none")]
     pub github_account_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyEntry {
+    pub key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum StoredApiKey {
+    Legacy(String),
+    Entry(ApiKeyEntry),
+}
+
+fn deserialize_api_keys<'de, D>(deserializer: D) -> Result<Vec<ApiKeyEntry>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Vec::<StoredApiKey>::deserialize(deserializer).map(|keys| {
+        keys.into_iter()
+            .map(|key| match key {
+                StoredApiKey::Legacy(key) => ApiKeyEntry { key, note: None },
+                StoredApiKey::Entry(key) => key,
+            })
+            .collect()
+    })
 }
 
 /// 解析 Provider 级自定义 User-Agent 字符串（单一真理来源）。
@@ -1021,6 +1057,18 @@ mod tests {
     };
     use serde_json::json;
     use std::collections::HashMap;
+
+    #[test]
+    fn provider_meta_reads_legacy_api_key_strings() {
+        let meta: ProviderMeta = serde_json::from_value(json!({
+            "apiKeys": ["primary", "backup"]
+        }))
+        .unwrap();
+
+        assert_eq!(meta.api_keys.len(), 2);
+        assert_eq!(meta.api_keys[1].key, "backup");
+        assert_eq!(meta.api_keys[1].note, None);
+    }
 
     #[test]
     fn proxy_injected_oauth_excludes_codex_oauth() {

--- a/src/components/providers/forms/ApiKeyInput.tsx
+++ b/src/components/providers/forms/ApiKeyInput.tsx
@@ -18,7 +18,7 @@ const ApiKeyInput: React.FC<ApiKeyInputProps> = ({
   placeholder,
   disabled = false,
   required = false,
-  label = "API Key",
+  label,
   id = "apiKey",
 }) => {
   const { t } = useTranslation();
@@ -36,9 +36,14 @@ const ApiKeyInput: React.FC<ApiKeyInputProps> = ({
 
   return (
     <div className="space-y-2">
-      <label htmlFor={id} className="block text-sm font-medium text-foreground">
-        {label} {required && "*"}
-      </label>
+      {label && (
+        <label
+          htmlFor={id}
+          className="block text-sm font-medium text-foreground"
+        >
+          {label} {required && "*"}
+        </label>
+      )}
       <div className="relative">
         <input
           type={showKey ? "text" : "password"}

--- a/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
+++ b/src/components/providers/forms/ClaudeDesktopProviderForm.tsx
@@ -37,6 +37,7 @@ import type {
   ClaudeApiFormat,
   ClaudeDesktopModelRoute,
   ProviderCategory,
+  ProviderApiKey,
   ProviderMeta,
 } from "@/types";
 import type { OpenClawSuggestedDefaults } from "@/config/openclawProviderPresets";
@@ -262,6 +263,9 @@ export function ClaudeDesktopProviderForm({
   const [apiKey, setApiKey] = useState(
     envString(initialData?.settingsConfig, "ANTHROPIC_AUTH_TOKEN") ||
       envString(initialData?.settingsConfig, "ANTHROPIC_API_KEY"),
+  );
+  const [apiKeys, setApiKeys] = useState<ProviderApiKey[]>(
+    () => initialData?.meta?.apiKeys ?? [],
   );
   const [apiKeyField, setApiKeyField] = useState<ApiKeyField>(() =>
     envString(initialData?.settingsConfig, "ANTHROPIC_API_KEY")
@@ -781,6 +785,12 @@ export function ClaudeDesktopProviderForm({
             ? apiFormat
             : "anthropic",
     };
+    meta.apiKeys = apiKeys
+      .filter(({ key }) => key.trim())
+      .map(({ key, note }) => ({
+        key: key.trim(),
+        ...(note?.trim() ? { note: note.trim() } : {}),
+      }));
 
     meta.claudeDesktopModelRoutes = routeMap;
     meta.providerType = activeProviderType;
@@ -923,6 +933,8 @@ export function ClaudeDesktopProviderForm({
               <ApiKeySection
                 value={apiKey}
                 onChange={setApiKey}
+                apiKeys={apiKeys.length ? apiKeys : [{ key: apiKey }]}
+                onApiKeysChange={setApiKeys}
                 category={apiKeyLinkCategory}
                 shouldShowLink={shouldShowApiKeyLink}
                 websiteUrl={apiKeyLinkWebsiteUrl}

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -49,6 +49,7 @@ import {
 import { CustomUserAgentField } from "./CustomUserAgentField";
 import { LocalProxyRequestOverridesField } from "./LocalProxyRequestOverridesField";
 import type {
+  ProviderApiKey,
   ProviderCategory,
   ClaudeApiFormat,
   ClaudeApiKeyField,
@@ -75,6 +76,8 @@ interface ClaudeFormFieldsProps {
   shouldShowApiKey: boolean;
   apiKey: string;
   onApiKeyChange: (key: string) => void;
+  apiKeys?: ProviderApiKey[];
+  onApiKeysChange?: (keys: ProviderApiKey[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -166,6 +169,8 @@ export function ClaudeFormFields({
   shouldShowApiKey,
   apiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -690,6 +695,8 @@ export function ClaudeFormFields({
         <ApiKeySection
           value={apiKey}
           onChange={onApiKeyChange}
+          apiKeys={apiKeys}
+          onApiKeysChange={onApiKeysChange}
           category={category}
           shouldShowLink={shouldShowApiKeyLink}
           websiteUrl={websiteUrl}

--- a/src/components/providers/forms/CodexFormFields.tsx
+++ b/src/components/providers/forms/CodexFormFields.tsx
@@ -60,6 +60,7 @@ import type {
   CodexChatReasoning,
   PromptCacheRoutingMode,
   ProviderCategory,
+  ProviderApiKey,
 } from "@/types";
 import type { ManagedAuthProvider } from "@/lib/api";
 import type { AppId } from "@/lib/api";
@@ -79,6 +80,8 @@ interface CodexFormFieldsProps {
   // API Key
   codexApiKey: string;
   onApiKeyChange: (key: string) => void;
+  apiKeys?: ProviderApiKey[];
+  onApiKeysChange?: (keys: ProviderApiKey[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -373,6 +376,8 @@ export function CodexFormFields({
   onXaiAccountSelect,
   codexApiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -759,6 +764,8 @@ export function CodexFormFields({
           label="API Key"
           value={codexApiKey}
           onChange={onApiKeyChange}
+          apiKeys={apiKeys}
+          onApiKeysChange={onApiKeysChange}
           category={category}
           shouldShowLink={shouldShowApiKeyLink}
           websiteUrl={websiteUrl}

--- a/src/components/providers/forms/GeminiFormFields.tsx
+++ b/src/components/providers/forms/GeminiFormFields.tsx
@@ -11,7 +11,7 @@ import {
   showFetchModelsError,
   type FetchedModel,
 } from "@/lib/api/model-fetch";
-import type { ProviderCategory } from "@/types";
+import type { ProviderApiKey, ProviderCategory } from "@/types";
 
 interface EndpointCandidate {
   url: string;
@@ -23,6 +23,8 @@ interface GeminiFormFieldsProps {
   shouldShowApiKey: boolean;
   apiKey: string;
   onApiKeyChange: (key: string) => void;
+  apiKeys?: ProviderApiKey[];
+  onApiKeysChange?: (keys: ProviderApiKey[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -53,6 +55,8 @@ export function GeminiFormFields({
   shouldShowApiKey,
   apiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -136,6 +140,8 @@ export function GeminiFormFields({
         <ApiKeySection
           value={apiKey}
           onChange={onApiKeyChange}
+          apiKeys={apiKeys}
+          onApiKeysChange={onApiKeysChange}
           category={category}
           shouldShowLink={shouldShowApiKeyLink}
           websiteUrl={websiteUrl}

--- a/src/components/providers/forms/GrokBuildProviderForm.tsx
+++ b/src/components/providers/forms/GrokBuildProviderForm.tsx
@@ -26,6 +26,7 @@ import type {
   CodexChatReasoning,
   PromptCacheRoutingMode,
   ProviderCategory,
+  ProviderApiKey,
   ProviderMeta,
 } from "@/types";
 import type { ProviderFormProps, ProviderFormValues } from "./ProviderForm";
@@ -104,6 +105,9 @@ export function GrokBuildProviderForm({
   );
   const [baseUrl, setBaseUrl] = useState(initialConfig.baseUrl);
   const [apiKey, setApiKey] = useState(initialConfig.apiKey);
+  const [apiKeys, setApiKeys] = useState<ProviderApiKey[]>(
+    () => initialData?.meta?.apiKeys ?? [],
+  );
   const [contextWindow, setContextWindow] = useState(
     String(initialConfig.contextWindow),
   );
@@ -399,6 +403,12 @@ export function GrokBuildProviderForm({
         Number.isInteger(parsedMaxOutputTokens) && parsedMaxOutputTokens > 0
           ? parsedMaxOutputTokens
           : undefined,
+      apiKeys: apiKeys
+        .filter(({ key }) => key.trim())
+        .map(({ key, note }) => ({
+          key: key.trim(),
+          ...(note?.trim() ? { note: note.trim() } : {}),
+        })),
     };
     if (!providerId && Object.keys(customEndpoints).length > 0) {
       meta.custom_endpoints = customEndpoints;
@@ -449,6 +459,8 @@ export function GrokBuildProviderForm({
                 setApiKey(value);
                 syncStructuredConfig({ apiKey: value });
               }}
+              apiKeys={apiKeys.length ? apiKeys : [{ key: apiKey }]}
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={Boolean(websiteUrl)}
               websiteUrl={websiteUrl}

--- a/src/components/providers/forms/HermesFormFields.tsx
+++ b/src/components/providers/forms/HermesFormFields.tsx
@@ -25,13 +25,15 @@ import {
   type HermesApiMode,
   type HermesModel,
 } from "@/config/hermesProviderPresets";
-import type { ProviderCategory } from "@/types";
+import type { ProviderApiKey, ProviderCategory } from "@/types";
 
 interface HermesFormFieldsProps {
   baseUrl: string;
   onBaseUrlChange: (value: string) => void;
   apiKey: string;
   onApiKeyChange: (value: string) => void;
+  apiKeys?: ProviderApiKey[];
+  onApiKeysChange?: (keys: ProviderApiKey[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -81,6 +83,8 @@ export function HermesFormFields({
   onBaseUrlChange,
   apiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -244,6 +248,8 @@ export function HermesFormFields({
       <ApiKeySection
         value={apiKey}
         onChange={onApiKeyChange}
+        apiKeys={apiKeys}
+        onApiKeysChange={onApiKeysChange}
         // Hermes 没有 OAuth-only 的免 key 官方供应商：即便是 official 预设
         // （如 Nous Research）也需用户自填 key，故不让 official 禁用输入框。
         category={category === "official" ? undefined : category}

--- a/src/components/providers/forms/OpenClawFormFields.tsx
+++ b/src/components/providers/forms/OpenClawFormFields.tsx
@@ -22,7 +22,7 @@ import {
   type FetchedModel,
 } from "@/lib/api/model-fetch";
 import { openclawApiProtocols } from "@/config/openclawProviderPresets";
-import type { ProviderCategory, OpenClawModel } from "@/types";
+import type { ProviderApiKey, ProviderCategory, OpenClawModel } from "@/types";
 
 interface OpenClawFormFieldsProps {
   // Base URL
@@ -32,6 +32,8 @@ interface OpenClawFormFieldsProps {
   // API Key
   apiKey: string;
   onApiKeyChange: (value: string) => void;
+  apiKeys?: ProviderApiKey[];
+  onApiKeysChange?: (keys: ProviderApiKey[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -56,6 +58,8 @@ export function OpenClawFormFields({
   onBaseUrlChange,
   apiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -246,6 +250,8 @@ export function OpenClawFormFields({
       <ApiKeySection
         value={apiKey}
         onChange={onApiKeyChange}
+        apiKeys={apiKeys}
+        onApiKeysChange={onApiKeysChange}
         // OpenClaw 的 API key 始终由用户自填，没有 OAuth-only 的免 key 官方供应商，
         // 故不让 official 禁用输入框（与 Hermes 对齐）。
         category={category === "official" ? undefined : category}

--- a/src/components/providers/forms/OpenCodeFormFields.tsx
+++ b/src/components/providers/forms/OpenCodeFormFields.tsx
@@ -27,7 +27,7 @@ import {
   OPENCODE_EXTRA_OPTION_DRAFT_PREFIX,
 } from "./helpers/opencodeFormUtils";
 import { RequestHeadersEditor } from "./RequestHeadersEditor";
-import type { ProviderCategory, OpenCodeModel } from "@/types";
+import type { ProviderApiKey, ProviderCategory, OpenCodeModel } from "@/types";
 
 /**
  * Model ID input with local state to prevent focus loss.
@@ -161,6 +161,8 @@ interface OpenCodeFormFieldsProps {
   // API Key
   apiKey: string;
   onApiKeyChange: (value: string) => void;
+  apiKeys?: ProviderApiKey[];
+  onApiKeysChange?: (keys: ProviderApiKey[]) => void;
   category?: ProviderCategory;
   shouldShowApiKeyLink: boolean;
   websiteUrl: string;
@@ -189,6 +191,8 @@ export function OpenCodeFormFields({
   onNpmChange,
   apiKey,
   onApiKeyChange,
+  apiKeys,
+  onApiKeysChange,
   category,
   shouldShowApiKeyLink,
   websiteUrl,
@@ -527,6 +531,8 @@ export function OpenCodeFormFields({
       <ApiKeySection
         value={apiKey}
         onChange={onApiKeyChange}
+        apiKeys={apiKeys}
+        onApiKeysChange={onApiKeysChange}
         category={category}
         shouldShowLink={shouldShowApiKeyLink}
         websiteUrl={websiteUrl}

--- a/src/components/providers/forms/PiProviderForm.tsx
+++ b/src/components/providers/forms/PiProviderForm.tsx
@@ -64,7 +64,7 @@ import {
 } from "@/lib/api/model-fetch";
 import { useDarkMode } from "@/hooks/useDarkMode";
 import { providerSchema, type ProviderFormData } from "@/lib/schemas/provider";
-import type { ProviderCategory } from "@/types";
+import type { ProviderApiKey, ProviderCategory } from "@/types";
 import { translatePiProviderMutationError } from "@/utils/errorUtils";
 
 const PI_API_FORMATS = [
@@ -451,6 +451,9 @@ export function PiProviderForm({
   );
   const includeModelsRef = useRef(!isEdit || hasOwn(initialConfig, "models"));
   const [apiKey, setApiKey] = useState(optionalText(initialConfig.apiKey));
+  const [apiKeys, setApiKeys] = useState<ProviderApiKey[]>(
+    () => initialData?.meta?.apiKeys ?? [],
+  );
   const initialHeaders = useMemo(
     () => asObject(initialConfig.headers),
     [initialConfig.headers],
@@ -1248,7 +1251,15 @@ export function PiProviderForm({
         providerKey: isEdit ? providerId : trimmedKey,
         presetId: selectedPresetId ?? undefined,
         presetCategory: category,
-        meta: initialData?.meta,
+        meta: {
+          ...(initialData?.meta ?? {}),
+          apiKeys: apiKeys
+            .filter(({ key }) => key.trim())
+            .map(({ key, note }) => ({
+              key: key.trim(),
+              ...(note?.trim() ? { note: note.trim() } : {}),
+            })),
+        },
       };
       await onSubmit(values);
     } catch (error) {
@@ -1420,6 +1431,8 @@ export function PiProviderForm({
               label={t("pi.form.credential")}
               value={apiKey}
               onChange={handleApiKeyChange}
+              apiKeys={apiKeys.length ? apiKeys : [{ key: apiKey }]}
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowLink={Boolean(selectedPreset?.apiKeyUrl)}
               websiteUrl={selectedPreset?.apiKeyUrl ?? ""}

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/api";
 import { useDarkMode } from "@/hooks/useDarkMode";
 import type {
+  ProviderApiKey,
   ProviderCategory,
   ProviderMeta,
   ClaudeApiFormat,
@@ -338,6 +339,9 @@ function ProviderFormFull({
 
   const [selectedPresetId, setSelectedPresetId] = useState<string | null>(
     initialData ? null : "custom",
+  );
+  const [apiKeys, setApiKeys] = useState<ProviderApiKey[]>(
+    () => initialData?.meta?.apiKeys ?? [],
   );
   const [activePreset, setActivePreset] = useState<{
     id: string;
@@ -1828,6 +1832,12 @@ function ProviderFormFull({
         localIsFullUrl
           ? true
           : undefined,
+      apiKeys: apiKeys
+        .filter(({ key }) => key.trim())
+        .map(({ key, note }) => ({
+          key: key.trim(),
+          ...(note?.trim() ? { note: note.trim() } : {}),
+        })),
     };
 
     if (!isClaudeCodexOauthProvider && "codexFastMode" in nextMeta) {
@@ -2368,6 +2378,8 @@ function ProviderFormFull({
               }
               apiKey={apiKey}
               onApiKeyChange={handleApiKeyChange}
+              apiKeys={apiKeys.length ? apiKeys : [{ key: apiKey }]}
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowClaudeApiKeyLink}
               websiteUrl={claudeWebsiteUrl}
@@ -2449,6 +2461,8 @@ function ProviderFormFull({
               onXaiAccountSelect={setSelectedXaiAccountId}
               codexApiKey={codexApiKey}
               onApiKeyChange={handleCodexApiKeyChange}
+              apiKeys={apiKeys.length ? apiKeys : [{ key: codexApiKey }]}
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowCodexApiKeyLink}
               websiteUrl={codexWebsiteUrl}
@@ -2521,6 +2535,8 @@ function ProviderFormFull({
               )}
               apiKey={geminiApiKey}
               onApiKeyChange={handleGeminiApiKeyChange}
+              apiKeys={apiKeys.length ? apiKeys : [{ key: geminiApiKey }]}
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowGeminiApiKeyLink}
               websiteUrl={geminiWebsiteUrl}
@@ -2547,6 +2563,12 @@ function ProviderFormFull({
               onNpmChange={opencodeForm.handleOpencodeNpmChange}
               apiKey={opencodeForm.opencodeApiKey}
               onApiKeyChange={opencodeForm.handleOpencodeApiKeyChange}
+              apiKeys={
+                apiKeys.length
+                  ? apiKeys
+                  : [{ key: opencodeForm.opencodeApiKey }]
+              }
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowOpencodeApiKeyLink}
               websiteUrl={opencodeWebsiteUrl}
@@ -2592,6 +2614,12 @@ function ProviderFormFull({
               onBaseUrlChange={openclawForm.handleOpenclawBaseUrlChange}
               apiKey={openclawForm.openclawApiKey}
               onApiKeyChange={openclawForm.handleOpenclawApiKeyChange}
+              apiKeys={
+                apiKeys.length
+                  ? apiKeys
+                  : [{ key: openclawForm.openclawApiKey }]
+              }
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowOpenclawApiKeyLink}
               websiteUrl={openclawWebsiteUrl}
@@ -2613,6 +2641,10 @@ function ProviderFormFull({
               onBaseUrlChange={hermesForm.handleHermesBaseUrlChange}
               apiKey={hermesForm.hermesApiKey}
               onApiKeyChange={hermesForm.handleHermesApiKeyChange}
+              apiKeys={
+                apiKeys.length ? apiKeys : [{ key: hermesForm.hermesApiKey }]
+              }
+              onApiKeysChange={setApiKeys}
               category={category}
               shouldShowApiKeyLink={shouldShowHermesApiKeyLink}
               websiteUrl={hermesWebsiteUrl}

--- a/src/components/providers/forms/shared/ApiKeySection.tsx
+++ b/src/components/providers/forms/shared/ApiKeySection.tsx
@@ -1,6 +1,9 @@
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Plus, Trash2 } from "lucide-react";
 import ApiKeyInput from "../ApiKeyInput";
-import type { ProviderCategory } from "@/types";
+import { Input } from "@/components/ui/input";
+import type { ProviderApiKey, ProviderCategory } from "@/types";
 
 interface ApiKeySectionProps {
   id?: string;
@@ -17,6 +20,8 @@ interface ApiKeySectionProps {
   disabled?: boolean;
   isPartner?: boolean;
   partnerPromotionKey?: string;
+  apiKeys?: ProviderApiKey[];
+  onApiKeysChange?: (keys: ProviderApiKey[]) => void;
 }
 
 export function ApiKeySection({
@@ -30,6 +35,8 @@ export function ApiKeySection({
   placeholder,
   disabled,
   partnerPromotionKey,
+  apiKeys,
+  onApiKeysChange,
 }: ApiKeySectionProps) {
   const { t } = useTranslation();
 
@@ -44,20 +51,114 @@ export function ApiKeySection({
 
   const finalPlaceholder = placeholder || defaultPlaceholder;
 
+  const keys = apiKeys ?? [{ key: value }];
+  const supportsMultiple = onApiKeysChange !== undefined;
+  const [selectedIndex, setSelectedIndex] = useState(() =>
+    Math.max(
+      keys.findIndex(({ key }) => key === value),
+      0,
+    ),
+  );
+  const changeKey = (index: number, key: string) => {
+    const next = [...keys];
+    next[index] = { ...next[index], key };
+    onApiKeysChange?.(next);
+    if (index === selectedIndex) onChange(key);
+  };
+  const changeNote = (index: number, note: string) => {
+    const next = [...keys];
+    next[index] = { ...next[index], note };
+    onApiKeysChange?.(next);
+  };
+  const selectKey = (index: number) => {
+    setSelectedIndex(index);
+    onChange(keys[index].key);
+  };
+  const addKey = () => {
+    const next = [...keys, { key: "" }];
+    onApiKeysChange?.(next);
+    setSelectedIndex(next.length - 1);
+    onChange("");
+  };
+  const removeKey = (index: number) => {
+    if (keys.length === 1) return;
+    const next = keys.filter((_, i) => i !== index);
+    onApiKeysChange?.(next);
+    if (index === selectedIndex) {
+      const nextIndex = Math.min(index, next.length - 1);
+      setSelectedIndex(nextIndex);
+      onChange(next[nextIndex].key);
+    } else if (index < selectedIndex) {
+      setSelectedIndex(selectedIndex - 1);
+    }
+  };
+
   return (
-    <div className="space-y-1">
-      <ApiKeyInput
-        id={id}
-        label={label}
-        value={value}
-        onChange={onChange}
-        placeholder={
-          category === "official"
-            ? finalPlaceholder.official
-            : finalPlaceholder.thirdParty
-        }
-        disabled={disabled ?? category === "official"}
-      />
+    <div className="space-y-2">
+      <label
+        htmlFor={id ?? "apiKey"}
+        className="block text-sm font-medium text-foreground"
+      >
+        {label ?? "API Key"}
+      </label>
+      {keys.map((entry, index) => (
+        <div key={index} className="flex items-center gap-2">
+          <div className="min-w-0 flex-1">
+            <ApiKeyInput
+              id={index === 0 ? id : `${id}-${index}`}
+              label=""
+              value={entry.key}
+              onChange={(next) => changeKey(index, next)}
+              placeholder={
+                category === "official"
+                  ? finalPlaceholder.official
+                  : finalPlaceholder.thirdParty
+              }
+              disabled={disabled ?? category === "official"}
+            />
+          </div>
+          <Input
+            value={entry.note ?? ""}
+            onChange={(event) => changeNote(index, event.target.value)}
+            placeholder={t("providerForm.apiKeyNote", { defaultValue: "备注" })}
+            disabled={disabled ?? category === "official"}
+            className="w-40"
+          />
+          <input
+            type="radio"
+            checked={index === selectedIndex}
+            onChange={() => selectKey(index)}
+            aria-label={t("providerForm.enableApiKey", {
+              defaultValue: "启用此 API Key",
+            })}
+            disabled={disabled ?? category === "official"}
+            className="size-4 shrink-0 accent-primary"
+          />
+          {supportsMultiple && keys.length > 1 && (
+            <button
+              type="button"
+              onClick={() => removeKey(index)}
+              className="mb-1 p-2 text-muted-foreground hover:text-destructive"
+              aria-label={t("providerForm.removeApiKey", {
+                defaultValue: "删除 API Key",
+              })}
+            >
+              <Trash2 size={16} />
+            </button>
+          )}
+        </div>
+      ))}
+      {supportsMultiple && (
+        <button
+          type="button"
+          onClick={addKey}
+          disabled={disabled ?? category === "official"}
+          className="flex items-center gap-1 text-sm text-primary hover:underline disabled:cursor-not-allowed disabled:text-muted-foreground"
+        >
+          <Plus size={16} />
+          {t("providerForm.addApiKey", { defaultValue: "新增 API Key" })}
+        </button>
+      )}
       {/* API Key 获取链接 */}
       {shouldShowLink && websiteUrl && (
         <div className="space-y-2 -mt-1 pl-1">

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,8 +171,15 @@ export interface LocalProxyRequestOverrides {
   body?: Record<string, unknown>;
 }
 
+export interface ProviderApiKey {
+  key: string;
+  note?: string;
+}
+
 // 供应商元数据（字段名与后端一致，保持 snake_case）
 export interface ProviderMeta {
+  // 备用 API Key（当前启用的 Key 仍保存在 settingsConfig 中）
+  apiKeys?: ProviderApiKey[];
   // 自定义端点：以 URL 为键，值为端点信息
   custom_endpoints?: Record<string, CustomEndpoint>;
   // 是否在切换/同步到 live 时应用通用配置片段

--- a/tests/components/ApiKeySection.test.tsx
+++ b/tests/components/ApiKeySection.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ApiKeySection } from "@/components/providers/forms/shared/ApiKeySection";
+
+describe("ApiKeySection", () => {
+  it("selects one key and adds a new active key", () => {
+    const onChange = vi.fn();
+    const onApiKeysChange = vi.fn();
+    render(
+      <ApiKeySection
+        value="first"
+        onChange={onChange}
+        apiKeys={[{ key: "first" }, { key: "second" }]}
+        onApiKeysChange={onApiKeysChange}
+        shouldShowLink={false}
+        websiteUrl=""
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("radio")[1]);
+    expect(onChange).toHaveBeenLastCalledWith("second");
+
+    fireEvent.change(screen.getAllByPlaceholderText("备注")[1], {
+      target: { value: "备用" },
+    });
+    expect(onApiKeysChange).toHaveBeenLastCalledWith([
+      { key: "first" },
+      { key: "second", note: "备用" },
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: /新增 API Key/ }));
+    expect(onApiKeysChange).toHaveBeenLastCalledWith([
+      { key: "first" },
+      { key: "second" },
+      { key: "" },
+    ]);
+    expect(onChange).toHaveBeenLastCalledWith("");
+  });
+});


### PR DESCRIPTION
Closes #7185\n\n- 支持为供应商维护多个 API Key、备注及单选启用\n- 覆盖 Claude、Codex 及其余 API Key 表单\n- 兼容旧版 API Key 字符串存储格式\n\n验证：\n- pnpm test:unit（136 files / 1088 tests）\n- pnpm typecheck\n- cargo test --manifest-path src-tauri/Cargo.toml provider_meta_reads_legacy_api_key_strings