### PR TITLE
chore(tsconfig): drop baseUrl so the config survives TypeScript 7

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,9 +14,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "types": ["vitest/globals"]
   },


### PR DESCRIPTION
TypeScript 6 reports this as an error:

```
Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
  Specify compilerOption '"ignoreDeprecations": "6.0"' to silence this error.
```

The repo pins `typescript@5.9.2`, so `npm run typecheck` is quiet today. An editor running a newer TypeScript flags it now, and it becomes a hard failure the moment the pin moves to 7.

## Why removing it rather than silencing it

`baseUrl` here only anchors `paths`, and `paths` has not needed it since TypeScript 4.4 — entries resolve relative to the tsconfig that declares them. That makes `"src/*"` → `"./src/*"` the only other change.

`"ignoreDeprecations": "6.0"` would also make the message go away, but it buys one major version and has to be revisited. This makes the config correct instead.

## Why it is safe

`baseUrl` has a second effect — it lets bare specifiers resolve against the base directory — so removing it can break imports that quietly relied on that. Checked: there are no `from "src/…"`-style imports anywhere under `src/`, only relative ones and the `@/` alias.

Build and tests never read this setting at all. Both `vite.config.ts` and `vitest.config.ts` declare the alias themselves:

```ts
resolve: { alias: { "@": path.resolve(__dirname, "./src") } }
```

so the change is type-level only.

## Verification

- `tsc --noEmit`: **0 errors before, 0 after**, with `@/` imports in **250 files** under `src/` still resolving — if the alias had broken, that would be hundreds of `Cannot find module` errors, not silence.
- Re-ran the same config under TypeScript **6.0.3**: the deprecation is gone, and no new diagnostic replaces it.
