### PR TITLE
fix(prompts): refresh active prompts after external file edits

### DIFF
--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -59,7 +59,19 @@ impl PromptService {
         if matches!(app, AppType::Pi) {
             return get_pi_prompts(state);
         }
-        state.db.get_prompts(app.as_str())
+        let mut prompts = state.db.get_prompts(app.as_str())?;
+        // External editors change the live file without updating the saved
+        // selection. Refresh only that selection; inactive templates are separate.
+        if let Some(prompt) = prompts.values_mut().find(|prompt| prompt.enabled) {
+            if let Some(content) = Self::get_current_file_content(app.clone())? {
+                if prompt.content != content {
+                    prompt.content = content;
+                    prompt.updated_at = Some(get_unix_timestamp()?);
+                    state.db.save_prompt(app.as_str(), prompt)?;
+                }
+            }
+        }
+        Ok(prompts)
     }
 
     pub fn upsert_prompt(

--- a/src-tauri/src/services/prompt.rs
+++ b/src-tauri/src/services/prompt.rs
@@ -63,12 +63,17 @@ impl PromptService {
         // External editors change the live file without updating the saved
         // selection. Refresh only that selection; inactive templates are separate.
         if let Some(prompt) = prompts.values_mut().find(|prompt| prompt.enabled) {
-            if let Some(content) = Self::get_current_file_content(app.clone())? {
-                if prompt.content != content {
+            match Self::get_current_file_content(app.clone()) {
+                Ok(Some(content)) if prompt.content != content => {
                     prompt.content = content;
                     prompt.updated_at = Some(get_unix_timestamp()?);
                     state.db.save_prompt(app.as_str(), prompt)?;
                 }
+                Ok(_) => {}
+                Err(error) => log::warn!(
+                    "Failed to refresh {} prompt from live file; keeping saved prompts: {error}",
+                    app.as_str()
+                ),
             }
         }
         Ok(prompts)

--- a/src-tauri/tests/prompt_live_sync.rs
+++ b/src-tauri/tests/prompt_live_sync.rs
@@ -50,12 +50,33 @@ fn prompt_list_refreshes_external_edits_without_changing_inactive_templates() {
         }
 
         let mut saved = state.db.get_prompts(app.as_str()).unwrap()["active"].clone();
+        saved.content = "saved instructions".into();
+        fs::write(&path, &saved.content).unwrap();
         saved.updated_at = Some(42);
         state.db.save_prompt(app.as_str(), &saved).unwrap();
         assert_eq!(
             PromptService::get_prompts(&state, app.clone()).unwrap()["active"].updated_at,
             Some(42)
         );
+
+        // An editor may save UTF-16: the live read fails, but saved templates
+        // must remain available so the user can repair the file from the UI.
+        let utf16 = [0xff, 0xfe, b'A', 0];
+        fs::write(&path, utf16).unwrap();
+        let prompts = PromptService::get_prompts(&state, app.clone()).unwrap();
+        assert_eq!(prompts["active"].content, saved.content);
+        assert_eq!(prompts["active"].updated_at, Some(42));
+        assert_eq!(prompts["inactive"].content, "original");
+        assert_eq!(fs::read(&path).unwrap(), utf16);
+        assert_eq!(
+            state.db.get_prompts(app.as_str()).unwrap()["active"].updated_at,
+            Some(42)
+        );
+        assert_eq!(
+            state.db.get_prompts(app.as_str()).unwrap()["active"].content,
+            saved.content
+        );
+        assert!(PromptService::get_current_file_content(app.clone()).is_err());
 
         fs::remove_file(&path).unwrap();
         assert_eq!(
@@ -69,7 +90,7 @@ fn prompt_list_refreshes_external_edits_without_changing_inactive_templates() {
         fs::write(&path, "unmanaged instructions").unwrap();
         assert_eq!(
             PromptService::get_prompts(&state, app).unwrap()["active"].content,
-            ""
+            saved.content
         );
         assert_eq!(fs::read_to_string(path).unwrap(), "unmanaged instructions");
     }

--- a/src-tauri/tests/prompt_live_sync.rs
+++ b/src-tauri/tests/prompt_live_sync.rs
@@ -1,0 +1,76 @@
+mod support;
+
+use cc_switch_lib::{AppType, Prompt, PromptService};
+use std::fs;
+use support::{create_test_state, ensure_test_home, reset_test_fs, test_mutex};
+
+#[test]
+fn prompt_list_refreshes_external_edits_without_changing_inactive_templates() {
+    let _guard = test_mutex().lock().unwrap();
+    reset_test_fs();
+    let home = ensure_test_home();
+    let state = create_test_state().unwrap();
+
+    for (app, relative_path) in [
+        (AppType::Claude, ".claude/CLAUDE.md"),
+        (AppType::Codex, ".codex/AGENTS.md"),
+    ] {
+        let active = Prompt {
+            id: "active".into(),
+            name: "My instructions".into(),
+            content: "original".into(),
+            description: Some("Keep my metadata".into()),
+            enabled: true,
+            created_at: Some(1),
+            updated_at: Some(1),
+        };
+        let inactive = Prompt {
+            id: "inactive".into(),
+            enabled: false,
+            ..active.clone()
+        };
+        state.db.save_prompt(app.as_str(), &inactive).unwrap();
+        PromptService::upsert_prompt(&state, app.clone(), &active.id, active.clone()).unwrap();
+        let path = home.join(relative_path);
+
+        for content in ["externally edited\n", ""] {
+            fs::write(&path, content).unwrap();
+            let prompts = PromptService::get_prompts(&state, app.clone()).unwrap();
+            assert_eq!(prompts["active"].content, content);
+            assert_eq!(prompts["active"].name, active.name);
+            assert_eq!(prompts["active"].description, active.description);
+            assert_eq!(prompts["active"].created_at, active.created_at);
+            assert!(prompts["active"].enabled);
+            assert_eq!(prompts["inactive"].content, "original");
+            assert_eq!(fs::read_to_string(&path).unwrap(), content);
+            assert_eq!(
+                state.db.get_prompts(app.as_str()).unwrap()["active"].content,
+                content
+            );
+        }
+
+        let mut saved = state.db.get_prompts(app.as_str()).unwrap()["active"].clone();
+        saved.updated_at = Some(42);
+        state.db.save_prompt(app.as_str(), &saved).unwrap();
+        assert_eq!(
+            PromptService::get_prompts(&state, app.clone()).unwrap()["active"].updated_at,
+            Some(42)
+        );
+
+        fs::remove_file(&path).unwrap();
+        assert_eq!(
+            PromptService::get_prompts(&state, app.clone()).unwrap()["active"].updated_at,
+            Some(42)
+        );
+        assert!(!path.exists());
+
+        saved.enabled = false;
+        state.db.save_prompt(app.as_str(), &saved).unwrap();
+        fs::write(&path, "unmanaged instructions").unwrap();
+        assert_eq!(
+            PromptService::get_prompts(&state, app).unwrap()["active"].content,
+            ""
+        );
+        assert_eq!(fs::read_to_string(path).unwrap(), "unmanaged instructions");
+    }
+}

--- a/src/components/prompts/PromptPanel.tsx
+++ b/src/components/prompts/PromptPanel.tsx
@@ -133,6 +133,13 @@ const StandardPromptPanel = React.forwardRef<
     }, [appId, open, runExternalReload]);
 
     useEffect(() => {
+      if (!open) return;
+      const handleFocus = () => void runExternalReload();
+      window.addEventListener("focus", handleFocus);
+      return () => window.removeEventListener("focus", handleFocus);
+    }, [open, runExternalReload]);
+
+    useEffect(() => {
       setSearchQuery("");
       overlayOpenRef.current = false;
       setIsFormOpen(false);

--- a/tests/components/PromptPanel.test.tsx
+++ b/tests/components/PromptPanel.test.tsx
@@ -475,17 +475,27 @@ describe("PromptPanel", () => {
     expect(onNavigationBlockedChange).toHaveBeenLastCalledWith(false);
   });
 
+  it("refreshes on window focus and removes the listener on unmount", async () => {
+    const { unmount } = renderPanel();
+    await waitForPanelReady();
+    mocks.reload.mockClear();
+
+    fireEvent(window, new Event("focus"));
+    await waitFor(() => expect(mocks.reload).toHaveBeenCalledTimes(1));
+    await waitForPanelReady();
+    unmount();
+    mocks.reload.mockClear();
+    fireEvent(window, new Event("focus"));
+    expect(mocks.reload).not.toHaveBeenCalled();
+  });
+
   it("queues external reloads while an edit or confirmation is open", async () => {
     renderPanel();
     await waitForPanelReady();
     mocks.reload.mockClear();
 
     fireEvent.click(screen.getAllByTitle("common.edit")[0]);
-    act(() => {
-      window.dispatchEvent(
-        new CustomEvent("prompt-imported", { detail: { app: "claude" } }),
-      );
-    });
+    fireEvent(window, new Event("focus"));
     expect(mocks.reload).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("button", { name: "form-close" }));


### PR DESCRIPTION
## Summary / 概述

Editing the global `CLAUDE.md` or `AGENTS.md` outside CC Switch left the Prompts list showing the old database content. Loading the list now reads the live file back into the currently enabled prompt, and returning focus to the open Prompts panel refreshes the list. Refreshes remain queued while an edit, confirmation, or write is in progress.

Inactive templates and prompt metadata are preserved. Empty, whitespace-only, missing, and unreadable files leave the saved prompt intact. Unchanged content does not cause another database write. Pi retains its existing native-file activation behavior. Backfill uses the shared sync/restore mutex with `try_lock`; while it is occupied, list reads return persisted prompts without reading stale live content back into the database.

## Validation / 验证

Latest review fixes: updated empty/whitespace preservation coverage and parameterized edit-overlay queueing for both focus and prompt-imported events. Formatting and `git diff --check` completed. Tests were not run for this revision, as requested. The results below are from earlier revisions.

- Reproduced stale content and missing focus refresh with regression tests before implementing the fix.
- Added a Rust integration test covering external edits to both Claude and Codex files, persisted content, empty/missing files, unchanged timestamps, and inactive templates.
- Added focus-refresh and listener-cleanup coverage, and verified deferred refresh while editing.
- `pnpm test:unit`: 135 files, 1,088 tests passed.

- `cargo fmt --check` and `cargo test`: 2,946 tests passed, 5 ignored.

## Related Issue / 关联 Issue

Reported during local use; no GitHub issue filed.

## Checklist / 检查清单

- [x] `pnpm typecheck`
- [x] `pnpm format:check`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- [x] No user-facing text changes; i18n updates not needed.

