### PR TITLE
fix(pi): configure LongCat binary thinking

### DIFF
--- a/src/config/piModelCatalog.ts
+++ b/src/config/piModelCatalog.ts
@@ -212,7 +212,7 @@ export const piModelCatalog = {
       name: "LongCat 2.0",
       reasoning: true,
       input: ["text"],
-      contextWindow: 1_000_000,
+      contextWindow: 1_048_576,
       maxTokens: 131_072,
     },
   },

--- a/src/config/piProviderPresets.ts
+++ b/src/config/piProviderPresets.ts
@@ -1218,9 +1218,20 @@ const piProviderPresetDefinitions: PiProviderPreset[] = [
       api: "openai-completions",
       apiKey: "",
       models: [
-        piModel("longcat/longcat-2.0", {
-          id: "LongCat-2.0",
-        }),
+        {
+          ...piModel("longcat/longcat-2.0", {
+            id: "LongCat-2.0",
+            thinkingProfile: "offHighOnly",
+          }),
+          // LongCat supports a thinking.type toggle, not reasoning_effort.
+          compat: {
+            ...OPENAI_COMPLETIONS_COMPAT,
+            thinkingFormat: "deepseek",
+            supportsReasoningEffort: false,
+            supportsStrictMode: false,
+            supportsLongCacheRetention: false,
+          },
+        },
       ],
     },
     category: "cn_official",

--- a/src/config/piThinkingProfiles.ts
+++ b/src/config/piThinkingProfiles.ts
@@ -28,6 +28,17 @@ interface PiThinkingProfile {
  * defaults" choice.
  */
 export const piThinkingProfiles = {
+  offHighOnly: {
+    map: {
+      off: "none",
+      minimal: null,
+      low: null,
+      medium: null,
+      high: "high",
+      xhigh: null,
+      max: null,
+    },
+  },
   xhighAndMax: {
     map: {
       xhigh: "xhigh",

--- a/tests/config/longcatProviderPresets.test.ts
+++ b/tests/config/longcatProviderPresets.test.ts
@@ -5,6 +5,7 @@ import { codexProviderPresets } from "@/config/codexProviderPresets";
 import { hermesProviderPresets } from "@/config/hermesProviderPresets";
 import { openclawProviderPresets } from "@/config/openclawProviderPresets";
 import { opencodeProviderPresets } from "@/config/opencodeProviderPresets";
+import { piProviderPresets } from "@/config/piProviderPresets";
 
 const LONGCAT_MODEL = "LongCat-2.0";
 const LONGCAT_DISPLAY_NAME = "LongCat 2.0";
@@ -27,6 +28,32 @@ function findLongcatPreset<T extends { name: string }>(presets: T[]): T {
 }
 
 describe("Longcat provider presets", () => {
+  it("exports Pi's binary thinking protocol without OpenAI effort parameters", () => {
+    const preset = findLongcatPreset(piProviderPresets);
+    const exported = JSON.parse(JSON.stringify(preset.settingsConfig));
+    const model = exported.models[0];
+
+    expect(exported.api).toBe("openai-completions");
+    expect(exported.baseUrl).toBe(LONGCAT_OPENAI_BASE_URL);
+    expect(model.reasoning).toBe(true);
+    expect(model.compat).toMatchObject({
+      thinkingFormat: "deepseek",
+      supportsReasoningEffort: false,
+      maxTokensField: "max_tokens",
+      supportsDeveloperRole: false,
+      supportsStore: false,
+      supportsStrictMode: false,
+    });
+    expect(model.thinkingLevelMap.off).not.toBeNull();
+    expect(model.thinkingLevelMap.high).not.toBeNull();
+    for (const level of ["minimal", "low", "medium", "xhigh", "max"]) {
+      expect(model.thinkingLevelMap[level]).toBeNull();
+    }
+    expect(model.input).toEqual(["text"]);
+    expect(model.contextWindow).toBe(1048576);
+    expect(model.maxTokens).toBe(131072);
+  });
+
   it("uses the official LongCat 2.0 model for Claude Code", () => {
     const preset = findLongcatPreset(providerPresets);
     const env = (preset.settingsConfig as { env: Record<string, unknown> }).env;


### PR DESCRIPTION
## Summary / 概述

The LongCat Pi preset marks the model as reasoning-capable but omits its wire format, so Pi falls back to OpenAI effort parameters. Configure Pi's existing binary thinking format and expose off/high only, producing an explicit `thinking.type` for both states. Also use the documented 1,048,576-token context limit and disable unsupported optional OpenAI fields.

## Related Issue / 关联 Issue

Fixes #7200.

Follow-up to #4838; the current model name and endpoint are retained.

## Validation

- `pnpm typecheck` and `pnpm format:check` passed.
- `pnpm test:unit`: 135 files, 1,088 tests passed.
- The new exported-config regression fails without the fix.
- SDK request capture verifies the exact chat-completions URL, off/on `thinking.type`, `max_tokens`, and absence of `reasoning_effort`.
- Live API checks on 2026-09-08 using the exported preset and Pi SDK passed: thinking off/on, streamed tool calls, and continuation with real reasoning/tool-result history (HTTP 200). Tested on macOS; no Rust code changed.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `cargo clippy` — not applicable; no Rust changes
- [x] i18n — not applicable; no new user-facing strings

AI assistance: Codex helped implement, review, and test this focused change.
