### PR TITLE
fix(proxy): RAII HalfOpen permit guard 修复限流失效 + permit 计数泄漏

### DIFF
--- a/src-tauri/src/proxy/circuit_breaker.rs
+++ b/src-tauri/src/proxy/circuit_breaker.rs
@@ -130,7 +130,10 @@ impl std::fmt::Debug for HalfOpenPermitGuard {
 
 impl HalfOpenPermitGuard {
     fn new(counter: Arc<AtomicU32>) -> Self {
-        Self { counter, armed: true }
+        Self {
+            counter,
+            armed: true,
+        }
     }
 
     /// 显式标记"已自行处理"，立即释放 permit 并让 Drop 变 no-op。

--- a/src-tauri/src/proxy/circuit_breaker.rs
+++ b/src-tauri/src/proxy/circuit_breaker.rs
@@ -133,12 +133,31 @@ impl HalfOpenPermitGuard {
         Self { counter, armed: true }
     }
 
-    /// 显式标记"已自行处理"，Drop 时不再释放 permit。
+    /// 显式标记"已自行处理"，立即释放 permit 并让 Drop 变 no-op。
     ///
     /// 用于调用方在 forward() 完成后手动调用 `record_success` / `record_failure`
-    /// 的场景——避免 Drop 再调一次 `release_half_open_permit`。
+    /// 的场景——`record_*` 不会再释放 permit，所以 disarm 必须做这一步。
+    /// disarm 后 Drop 变 no-op，避免与 disarm 双重释放。
     pub fn disarm(mut self) {
-        self.armed = false;
+        if self.armed {
+            self.armed = false;
+            // 释放 permit（与 Drop 兜底等价；Drop 见 armed=false 会跳过）
+            let mut current = self.counter.load(Ordering::SeqCst);
+            loop {
+                if current == 0 {
+                    return;
+                }
+                match self.counter.compare_exchange(
+                    current,
+                    current - 1,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                ) {
+                    Ok(_) => return,
+                    Err(actual) => current = actual,
+                }
+            }
+        }
     }
 }
 

--- a/src-tauri/src/proxy/circuit_breaker.rs
+++ b/src-tauri/src/proxy/circuit_breaker.rs
@@ -228,6 +228,14 @@ impl CircuitBreaker {
                 if let Some(opened_at) = *self.last_opened_at.read().await {
                     if opened_at.elapsed().as_secs() >= config.timeout_seconds {
                         drop(config); // 释放读锁再转换状态
+
+                        // 【根因修复】permit-first check（与 allow_request 同样的修复）：
+                        // counter > 0 说明还有 in-flight probe 在飞，此时不能 reset counter
+                        // 否则会导致 max_half_open_requests 限流被打破。
+                        if self.half_open_requests.load(Ordering::SeqCst) > 0 {
+                            return false;
+                        }
+
                         log::info!(
                             "[{}] 熔断器 Open → HalfOpen (超时恢复)",
                             log_cb::OPEN_TO_HALF_OPEN
@@ -256,6 +264,31 @@ impl CircuitBreaker {
                 if let Some(opened_at) = *self.last_opened_at.read().await {
                     if opened_at.elapsed().as_secs() >= config.timeout_seconds {
                         drop(config); // 释放读锁再转换状态
+
+                        // 【根因修复】permit-first check：转换之前先确认没有 in-flight probe。
+                        // 半开探测的核心不变量是 max_half_open_requests=1，这个不变量
+                        // 必须由 permit 本身保证，而不是由 state 转换保证。
+                        //
+                        // 错误做法：直接 transition_to_half_open() 把 counter reset 到 0
+                        // → 新 probe 进来 fetch_add 拿到 permit（counter=1）→ 上一代
+                        // probe 的 guard drop 紧接着 decrement 1 → 新 probe 的 slot 被
+                        // 错误释放 → 第三个 probe 又能进来 → max=1 限流被打破。
+                        //
+                        // 正确顺序：counter > 0 → 还有 in-flight probe，不转换；
+                        //           counter = 0 → 才允许转换。
+                        if self.half_open_requests.load(Ordering::SeqCst) > 0 {
+                            log::debug!(
+                                "[{}] 熔断器拒绝请求: 上一代 HalfOpen probe 尚未释放 (counter={}), \
+                                 等待其结束后再触发 Open → HalfOpen",
+                                log_cb::OPEN_TO_HALF_OPEN,
+                                self.half_open_requests.load(Ordering::SeqCst)
+                            );
+                            return AllowRequestResult {
+                                allowed: false,
+                                permit: None,
+                            };
+                        }
+
                         log::info!(
                             "[{}] 熔断器 Open → HalfOpen (超时恢复)",
                             log_cb::OPEN_TO_HALF_OPEN
@@ -476,6 +509,12 @@ impl CircuitBreaker {
         self.total_requests.store(0, Ordering::SeqCst);
         self.failed_requests.store(0, Ordering::SeqCst);
     }
+
+    /// 测试专用：直接读取 half_open_requests 计数（不经过 guard）
+    #[cfg(test)]
+    pub fn get_half_open_requests_for_test(&self) -> u32 {
+        self.half_open_requests.load(Ordering::SeqCst)
+    }
 }
 
 /// 熔断器统计信息
@@ -582,5 +621,103 @@ mod tests {
         breaker.reset().await;
         assert_eq!(breaker.get_state().await, CircuitState::Closed);
         assert!(breaker.allow_request().await.allowed);
+    }
+
+    /// P2 review race 场景（permit-first 修复）：
+    /// Probe A 失败 → state=Open，但 counter 仍=1（guard 还没释放）
+    /// 此时另一并发请求调用 allow_request（timeout 已过）：
+    /// 旧实现：transition_to_half_open() 把 counter reset 0 → 新 probe 拿到 permit
+    ///         → 老 guard drop 紧接着 decrement 1 → 限流被打破
+    /// 新实现：检查 counter > 0 → 直接返回 denied，不转换，不 reset
+    #[tokio::test]
+    async fn test_open_to_halfopen_blocked_when_inflight_permit_exists() {
+        let config = CircuitBreakerConfig {
+            timeout_seconds: 0,
+            ..Default::default()
+        };
+        let breaker = CircuitBreaker::new(config);
+
+        // 1. 进入 Open，再让 allow_request 触发 Open→HalfOpen，拿第一个 permit
+        breaker.transition_to_open().await;
+        let first = breaker.allow_request().await;
+        assert!(first.allowed);
+        assert!(first.permit.is_some());
+        let guard = first.permit.expect("must have guard");
+        assert_eq!(breaker.get_half_open_requests_for_test(), 1);
+
+        // 2. Probe A 失败 → state=Open（counter 仍=1，guard 持有中）
+        // 这里用 transition_to_open 模拟 record_failure 的状态转换效果
+        breaker.transition_to_open().await;
+        assert_eq!(breaker.get_state().await, CircuitState::Open);
+        assert_eq!(
+            breaker.get_half_open_requests_for_test(),
+            1,
+            "counter 必须仍=1（guard 未释放）"
+        );
+
+        // 3. 并发请求：state=Open, timeout=0 已过，按旧实现会 reset counter
+        // 按新实现应该检查 counter>0 → 直接 denied
+        let second = breaker.allow_request().await;
+        assert!(
+            !second.allowed,
+            "counter>0 时不允许转换，第二个请求必须被拒绝"
+        );
+        assert!(second.permit.is_none());
+        assert_eq!(
+            breaker.get_state().await,
+            CircuitState::Open,
+            "state 必须仍是 Open，不能 reset counter 也不能 transition"
+        );
+        assert_eq!(
+            breaker.get_half_open_requests_for_test(),
+            1,
+            "counter 必须保持为1，绝对不能被 reset"
+        );
+
+        // 4. 验证 guard 还在 armed 状态，可以正确释放
+        drop(guard);
+        assert_eq!(
+            breaker.get_half_open_requests_for_test(),
+            0,
+            "guard drop 后 counter 必须归零"
+        );
+
+        // 5. guard 释放后，并发请求才能成功 transition
+        let third = breaker.allow_request().await;
+        assert!(third.allowed, "counter=0 后下一个请求必须能进入 HalfOpen");
+        assert!(third.permit.is_some());
+        assert_eq!(breaker.get_state().await, CircuitState::HalfOpen);
+    }
+
+    /// 配合 is_available 的同样场景：counter > 0 时也不应 transition
+    #[tokio::test]
+    async fn test_is_available_blocked_when_inflight_permit_exists() {
+        let config = CircuitBreakerConfig {
+            timeout_seconds: 0,
+            ..Default::default()
+        };
+        let breaker = CircuitBreaker::new(config);
+
+        breaker.transition_to_open().await;
+        let first = breaker.allow_request().await;
+        let guard = first.permit.expect("must have guard");
+
+        // 模拟 record_failure 路径
+        breaker.transition_to_open().await;
+        assert_eq!(breaker.get_half_open_requests_for_test(), 1);
+
+        // is_available 在 counter>0 时应返回 false（与 allow_request 一致）
+        assert!(
+            !breaker.is_available().await,
+            "counter>0 时 is_available 必须返回 false，阻止 transition"
+        );
+        assert_eq!(
+            breaker.get_half_open_requests_for_test(),
+            1,
+            "counter 必须保持"
+        );
+
+        drop(guard);
+        assert!(breaker.is_available().await);
     }
 }

--- a/src-tauri/src/proxy/circuit_breaker.rs
+++ b/src-tauri/src/proxy/circuit_breaker.rs
@@ -94,12 +94,78 @@ pub struct CircuitBreaker {
 
 /// 熔断器放行结果
 ///
-/// `used_half_open_permit` 表示本次放行是否占用了 HalfOpen 探测名额。
-/// 调用方应在请求结束后把该值传回 `record_success` / `record_failure` 用于正确释放名额。
-#[derive(Debug, Clone, Copy)]
-pub struct AllowResult {
+/// `permit` 在 HalfOpen 探测成功占用时返回 `Some(HalfOpenPermitGuard)`，
+/// 调用方应在请求结束时让 guard Drop 自动释放 permit（或显式 `disarm()` 让
+/// Drop 变 no-op，再调用 `record_success()` / `record_failure()`）。
+///
+/// **重要**：调用方必须把 `permit` 绑定到一个跨过请求生命周期的局部变量，
+/// 让 RAII guard 在 HTTP 请求真正发出去期间一直存活。
+/// 若在表达式结束时立即 drop（例如 `let (allowed, _) = probe;`），guard 会立刻
+/// 释放 permit，导致 `max_half_open_requests=1` 限流失效——这是已知的 P0 bug 写法。
+#[derive(Debug)]
+pub struct AllowRequestResult {
     pub allowed: bool,
-    pub used_half_open_permit: bool,
+    pub permit: Option<HalfOpenPermitGuard>,
+}
+
+/// RAII guard：占用一个 HalfOpen 探测名额，Drop 时自动释放。
+///
+/// 调用方应通过 [`HalfOpenPermitGuard::disarm`] 显式标记"已自行处理"，让 Drop
+/// 变成 no-op（避免与后续的 `record_success` / `record_failure` 双重释放）。
+///
+/// Drop 兜底释放是必要的：future 被 cancel、panic unwinding、调用方忘记 disarm
+/// 等场景下，Drop 是 permit 不会泄漏的最后一道安全网。
+pub struct HalfOpenPermitGuard {
+    counter: Arc<AtomicU32>,
+    armed: bool,
+}
+
+impl std::fmt::Debug for HalfOpenPermitGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HalfOpenPermitGuard")
+            .field("armed", &self.armed)
+            .finish()
+    }
+}
+
+impl HalfOpenPermitGuard {
+    fn new(counter: Arc<AtomicU32>) -> Self {
+        Self { counter, armed: true }
+    }
+
+    /// 显式标记"已自行处理"，Drop 时不再释放 permit。
+    ///
+    /// 用于调用方在 forward() 完成后手动调用 `record_success` / `record_failure`
+    /// 的场景——避免 Drop 再调一次 `release_half_open_permit`。
+    pub fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for HalfOpenPermitGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            // RAII 兜底：future cancel / panic / 调用方漏 disarm 时，Drop 自动释放。
+            // 走 trace 级别避免污染生产日志（happy path 不走这里）。
+            log::trace!("HalfOpenPermitGuard::drop 释放 permit (RAII 兜底)");
+            // 与 release_half_open_permit 等价的递减
+            let mut current = self.counter.load(Ordering::SeqCst);
+            loop {
+                if current == 0 {
+                    return;
+                }
+                match self.counter.compare_exchange(
+                    current,
+                    current - 1,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                ) {
+                    Ok(_) => return,
+                    Err(actual) => current = actual,
+                }
+            }
+        }
+    }
 }
 
 impl CircuitBreaker {
@@ -154,13 +220,13 @@ impl CircuitBreaker {
     }
 
     /// 检查是否允许请求通过
-    pub async fn allow_request(&self) -> AllowResult {
+    pub async fn allow_request(&self) -> AllowRequestResult {
         let state = *self.state.read().await;
 
         match state {
-            CircuitState::Closed => AllowResult {
+            CircuitState::Closed => AllowRequestResult {
                 allowed: true,
-                used_half_open_permit: false,
+                permit: None,
             },
             CircuitState::Open => {
                 let config = self.config.read().await;
@@ -177,22 +243,22 @@ impl CircuitBreaker {
                         // 转换后按当前状态决定是否需要获取 HalfOpen 探测名额
                         let current_state = *self.state.read().await;
                         return match current_state {
-                            CircuitState::Closed => AllowResult {
+                            CircuitState::Closed => AllowRequestResult {
                                 allowed: true,
-                                used_half_open_permit: false,
+                                permit: None,
                             },
                             CircuitState::HalfOpen => self.allow_half_open_probe(),
-                            CircuitState::Open => AllowResult {
+                            CircuitState::Open => AllowRequestResult {
                                 allowed: false,
-                                used_half_open_permit: false,
+                                permit: None,
                             },
                         };
                     }
                 }
 
-                AllowResult {
+                AllowRequestResult {
                     allowed: false,
-                    used_half_open_permit: false,
+                    permit: None,
                 }
             }
             CircuitState::HalfOpen => self.allow_half_open_probe(),
@@ -200,13 +266,15 @@ impl CircuitBreaker {
     }
 
     /// 记录成功
-    pub async fn record_success(&self, used_half_open_permit: bool) {
+    ///
+    /// `permit` 在请求结束后必须由调用方显式 `disarm()`（已通过 guard Drop
+    /// 释放）或让 guard Drop 自动释放（未 disarm 场景的 RAII 兜底）。
+    /// 此方法不再接受 `used_half_open_permit: bool`——permit 状态由 guard 自身表达。
+    pub async fn record_success(&self) {
         let state = *self.state.read().await;
         let config = self.config.read().await;
 
-        if used_half_open_permit {
-            self.release_half_open_permit();
-        }
+        // permit 由 RAII guard Drop 自动释放，调用方应在调用 record_* 前 disarm。
 
         // 重置失败计数
         self.consecutive_failures.store(0, Ordering::SeqCst);
@@ -227,13 +295,14 @@ impl CircuitBreaker {
     }
 
     /// 记录失败
-    pub async fn record_failure(&self, used_half_open_permit: bool) {
+    ///
+    /// `permit` 由 RAII guard Drop 自动释放——调用方应在调用 record_* 前 disarm，
+    /// 让 Drop 变 no-op。
+    pub async fn record_failure(&self) {
         let state = *self.state.read().await;
         let config = self.config.read().await;
 
-        if used_half_open_permit {
-            self.release_half_open_permit();
-        }
+        // permit 由 RAII guard Drop 自动释放。
 
         // 更新计数器
         let failures = self.consecutive_failures.fetch_add(1, Ordering::SeqCst) + 1;
@@ -312,22 +381,22 @@ impl CircuitBreaker {
         self.transition_to_closed().await;
     }
 
-    fn allow_half_open_probe(&self) -> AllowResult {
+    fn allow_half_open_probe(&self) -> AllowRequestResult {
         // 半开状态限流：只允许有限请求通过进行探测
         let max_half_open_requests = 1u32;
         let current = self.half_open_requests.fetch_add(1, Ordering::SeqCst);
 
         if current < max_half_open_requests {
-            AllowResult {
+            AllowRequestResult {
                 allowed: true,
-                used_half_open_permit: true,
+                permit: Some(HalfOpenPermitGuard::new(self.half_open_requests.clone())),
             }
         } else {
             // 超过限额，回退计数，拒绝请求
             self.half_open_requests.fetch_sub(1, Ordering::SeqCst);
-            AllowResult {
+            AllowRequestResult {
                 allowed: false,
-                used_half_open_permit: false,
+                permit: None,
             }
         }
     }
@@ -416,7 +485,7 @@ mod tests {
 
         // 记录 3 次失败
         for _ in 0..3 {
-            breaker.record_failure(false).await;
+            breaker.record_failure().await;
         }
 
         // 应该转换到打开状态
@@ -434,8 +503,8 @@ mod tests {
         let breaker = CircuitBreaker::new(config);
 
         // 打开熔断器
-        breaker.record_failure(false).await;
-        breaker.record_failure(false).await;
+        breaker.record_failure().await;
+        breaker.record_failure().await;
         assert_eq!(breaker.get_state().await, CircuitState::Open);
 
         // 手动转换到半开状态
@@ -443,8 +512,8 @@ mod tests {
         assert_eq!(breaker.get_state().await, CircuitState::HalfOpen);
 
         // 记录 2 次成功
-        breaker.record_success(false).await;
-        breaker.record_success(false).await;
+        breaker.record_success().await;
+        breaker.record_success().await;
 
         // 应该转换到关闭状态
         assert_eq!(breaker.get_state().await, CircuitState::Closed);
@@ -462,7 +531,7 @@ mod tests {
         breaker.transition_to_open().await;
         let first = breaker.allow_request().await;
         assert!(first.allowed);
-        assert!(first.used_half_open_permit);
+        assert!(first.permit.is_some());
         assert_eq!(breaker.get_state().await, CircuitState::HalfOpen);
 
         // 模拟并发下的“重复 HalfOpen 转换调用”，不应重置 in-flight 计数
@@ -471,7 +540,7 @@ mod tests {
         // 由于名额仍被占用，第二次请求应被拒绝
         let second = breaker.allow_request().await;
         assert!(!second.allowed);
-        assert!(!second.used_half_open_permit);
+        assert!(second.permit.is_none());
     }
 
     #[tokio::test]
@@ -483,8 +552,8 @@ mod tests {
         let breaker = CircuitBreaker::new(config);
 
         // 打开熔断器
-        breaker.record_failure(false).await;
-        breaker.record_failure(false).await;
+        breaker.record_failure().await;
+        breaker.record_failure().await;
         assert_eq!(breaker.get_state().await, CircuitState::Open);
 
         // 重置

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -5,6 +5,7 @@
 use super::hyper_client::{ProxyResponse, MAX_RESPONSE_BODY_BYTES};
 use super::{
     body_filter::filter_private_params_with_whitelist,
+    circuit_breaker::HalfOpenPermitGuard,
     content_encoding::{decompress_body_with_limit, get_content_encoding},
     error::*,
     failover_switch::FailoverSwitchManager,
@@ -285,12 +286,20 @@ impl RequestForwarder {
         &self,
         provider_id: &str,
         app_type: &str,
-        used_half_open_permit: bool,
+        permit_guard: Option<HalfOpenPermitGuard>,
     ) {
-        if used_half_open_permit {
+        // 优化路径：未占用 HalfOpen permit（Closed 状态）→ 异步 spawn，不阻塞 forward 响应；
+        // 占用 permit（HalfOpen 状态探测成功）→ 同步更新熔断器状态（影响后续探测决策）。
+        let had_permit = permit_guard.is_some();
+        // disarming 让 Drop 变 no-op，但 permit 仍由我们持有，不会泄漏。
+        if let Some(g) = permit_guard {
+            g.disarm();
+        }
+
+        if had_permit {
             if let Err(e) = self
                 .router
-                .record_result(provider_id, app_type, true, true, None)
+                .record_result(provider_id, app_type, true, None)
                 .await
             {
                 log::warn!(
@@ -305,7 +314,7 @@ impl RequestForwarder {
         let app_type = app_type.to_string();
         tokio::spawn(async move {
             if let Err(e) = router
-                .record_result(&provider_id, &app_type, false, true, None)
+                .record_result(&provider_id, &app_type, true, None)
                 .await
             {
                 log::warn!(
@@ -322,12 +331,13 @@ impl RequestForwarder {
     /// `Some(ForwardError)` 表示是客户端错误，没有 provider 能修复，
     /// 调用方应直接 `return` 把错误返回给客户端。
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     async fn handle_rectifier_retry_failure(
         &self,
         retry_err: ProxyError,
         provider: &Provider,
         app_type_str: &str,
-        used_half_open_permit: bool,
+        permit_guard: Option<HalfOpenPermitGuard>,
         rectifier_label: &str,
         last_error: &mut Option<ProxyError>,
         last_provider: &mut Option<Provider>,
@@ -341,12 +351,12 @@ impl RequestForwarder {
         };
 
         if is_provider_error {
+            // 失败计入熔断器统计；permit 由 guard 在函数末尾 Drop 时释放（无需显式 disarm）。
             let _ = self
                 .router
                 .record_result(
                     &provider.id,
                     app_type_str,
-                    used_half_open_permit,
                     false,
                     Some(retry_err.to_string()),
                 )
@@ -360,11 +370,16 @@ impl RequestForwarder {
             }
             *last_error = Some(retry_err);
             *last_provider = Some(provider.clone());
+            // 显式 drop guard，触发 RAII 释放（用于日志可观测性 + 让释放时机清晰）
+            drop(permit_guard);
             return None;
         }
 
+        // 客户端错误：释放 permit 但不影响健康统计。
+        // release_permit_neutral 释放后，guard Drop 见 counter==0 会 no-op（幂等）。
+        drop(permit_guard);
         self.router
-            .release_permit_neutral(&provider.id, app_type_str, used_half_open_permit)
+            .release_permit_neutral(&provider.id, app_type_str)
             .await;
         let mut status = self.status.write().await;
         status.failed_requests += 1;
@@ -479,16 +494,21 @@ impl RequestForwarder {
                 break;
             }
 
-            // 发起请求前先获取熔断器放行许可（HalfOpen 会占用探测名额）
-            // 单 Provider 场景下跳过此检查，避免熔断器阻塞所有请求
-            let (allowed, used_half_open_permit) = if bypass_circuit_breaker {
-                (true, false)
+            // 发起请求前先获取熔断器放行许可（HalfOpen 会占用探测名额）。
+            //
+            // **P0 修复**：必须把 `probe.permit` 绑定到一个跨过 `forward()` 调用的
+            // 局部变量 `permit_guard`，让 RAII guard 在 HTTP 请求真正发出去期间一直
+            // 存活；若 guard 在表达式结束时立即 drop，`max_half_open_requests=1`
+            // 限流会立刻失效（guard Drop 会触发 release）。
+            // 单 Provider 场景下跳过此检查，避免熔断器阻塞所有请求。
+            let (allowed, mut permit_guard) = if bypass_circuit_breaker {
+                (true, None)
             } else {
-                let permit = self
+                let probe = self
                     .router
                     .allow_provider_request(&provider.id, app_type_str)
                     .await;
-                (permit.allowed, permit.used_half_open_permit)
+                (probe.allowed, probe.permit)
             };
 
             if !allowed {
@@ -541,7 +561,7 @@ impl RequestForwarder {
                 Ok((response, claude_api_format, outbound_model)) => {
                     // 成功：普通闭合熔断状态异步记录，避免阻塞流式首包返回；
                     // HalfOpen 探测仍同步等待，保证 permit 与熔断状态及时释放。
-                    self.record_success_result(&provider.id, app_type_str, used_half_open_permit)
+                    self.record_success_result(&provider.id, app_type_str, permit_guard.take())
                         .await;
 
                     // 更新当前应用类型使用的 provider
@@ -644,8 +664,8 @@ impl RequestForwarder {
                                     self.record_success_result(
                                         &provider.id,
                                         app_type_str,
-                                        used_half_open_permit,
-                                    )
+                                                                                permit_guard.take()
+                                                                            )
                                     .await;
 
                                     {
@@ -702,8 +722,8 @@ impl RequestForwarder {
                                             retry_err,
                                             provider,
                                             app_type_str,
-                                            used_half_open_permit,
-                                            "media 降级",
+                                                                                        permit_guard.take(),
+                                                                                        "media 降级",
                                             &mut last_error,
                                             &mut last_provider,
                                         )
@@ -730,9 +750,7 @@ impl RequestForwarder {
                                 self.router
                                     .release_permit_neutral(
                                         &provider.id,
-                                        app_type_str,
-                                        used_half_open_permit,
-                                    )
+                                        app_type_str,)
                                     .await;
                                 let mut status = self.status.write().await;
                                 status.failed_requests += 1;
@@ -788,8 +806,8 @@ impl RequestForwarder {
                                         self.record_success_result(
                                             &provider.id,
                                             app_type_str,
-                                            used_half_open_permit,
-                                        )
+                                                                                        permit_guard.take()
+                                                                                    )
                                         .await;
 
                                         // 更新当前应用类型使用的 provider
@@ -851,8 +869,8 @@ impl RequestForwarder {
                                                 retry_err,
                                                 provider,
                                                 app_type_str,
-                                                used_half_open_permit,
-                                                "整流",
+                                                                                                permit_guard.take(),
+                                                                                                "整流",
                                                 &mut last_error,
                                                 &mut last_provider,
                                             )
@@ -882,9 +900,7 @@ impl RequestForwarder {
                                 self.router
                                     .release_permit_neutral(
                                         &provider.id,
-                                        app_type_str,
-                                        used_half_open_permit,
-                                    )
+                                        app_type_str,)
                                     .await;
                                 let mut status = self.status.write().await;
                                 status.failed_requests += 1;
@@ -908,9 +924,7 @@ impl RequestForwarder {
                                 self.router
                                     .release_permit_neutral(
                                         &provider.id,
-                                        app_type_str,
-                                        used_half_open_permit,
-                                    )
+                                        app_type_str,)
                                     .await;
                                 let mut status = self.status.write().await;
                                 status.failed_requests += 1;
@@ -954,8 +968,8 @@ impl RequestForwarder {
                                     self.record_success_result(
                                         &provider.id,
                                         app_type_str,
-                                        used_half_open_permit,
-                                    )
+                                                                                permit_guard.take()
+                                                                            )
                                     .await;
 
                                     {
@@ -1011,8 +1025,8 @@ impl RequestForwarder {
                                             retry_err,
                                             provider,
                                             app_type_str,
-                                            used_half_open_permit,
-                                            "budget 整流",
+                                                                                        permit_guard.take(),
+                                                                                        "budget 整流",
                                             &mut last_error,
                                             &mut last_provider,
                                         )
@@ -1030,9 +1044,7 @@ impl RequestForwarder {
                         self.router
                             .release_permit_neutral(
                                 &provider.id,
-                                app_type_str,
-                                used_half_open_permit,
-                            )
+                                app_type_str,)
                             .await;
                         let mut status = self.status.write().await;
                         status.failed_requests += 1;
@@ -1061,8 +1073,7 @@ impl RequestForwarder {
                                 .record_result(
                                     &provider.id,
                                     app_type_str,
-                                    used_half_open_permit,
-                                    false,
+                                                                        false,
                                     Some(e.to_string()),
                                 )
                                 .await;
@@ -1091,9 +1102,7 @@ impl RequestForwarder {
                             self.router
                                 .release_permit_neutral(
                                     &provider.id,
-                                    app_type_str,
-                                    used_half_open_permit,
-                                )
+                                    app_type_str,)
                                 .await;
                             {
                                 let mut status = self.status.write().await;

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -664,8 +664,8 @@ impl RequestForwarder {
                                     self.record_success_result(
                                         &provider.id,
                                         app_type_str,
-                                                                                permit_guard.take()
-                                                                            )
+                                        permit_guard.take(),
+                                    )
                                     .await;
 
                                     {
@@ -722,8 +722,8 @@ impl RequestForwarder {
                                             retry_err,
                                             provider,
                                             app_type_str,
-                                                                                        permit_guard.take(),
-                                                                                        "media 降级",
+                                            permit_guard.take(),
+                                            "media 降级",
                                             &mut last_error,
                                             &mut last_provider,
                                         )
@@ -748,9 +748,7 @@ impl RequestForwarder {
                                 log::warn!("[{app_type_str}] [RECT-005] 整流器已触发过，不再重试");
                                 // 释放 HalfOpen permit（不记录熔断器，这是客户端兼容性问题）
                                 self.router
-                                    .release_permit_neutral(
-                                        &provider.id,
-                                        app_type_str,)
+                                    .release_permit_neutral(&provider.id, app_type_str)
                                     .await;
                                 let mut status = self.status.write().await;
                                 status.failed_requests += 1;
@@ -806,8 +804,8 @@ impl RequestForwarder {
                                         self.record_success_result(
                                             &provider.id,
                                             app_type_str,
-                                                                                        permit_guard.take()
-                                                                                    )
+                                            permit_guard.take(),
+                                        )
                                         .await;
 
                                         // 更新当前应用类型使用的 provider
@@ -869,8 +867,8 @@ impl RequestForwarder {
                                                 retry_err,
                                                 provider,
                                                 app_type_str,
-                                                                                                permit_guard.take(),
-                                                                                                "整流",
+                                                permit_guard.take(),
+                                                "整流",
                                                 &mut last_error,
                                                 &mut last_provider,
                                             )
@@ -898,9 +896,7 @@ impl RequestForwarder {
                                     "[{app_type_str}] [RECT-013] budget 整流器已触发过，不再重试"
                                 );
                                 self.router
-                                    .release_permit_neutral(
-                                        &provider.id,
-                                        app_type_str,)
+                                    .release_permit_neutral(&provider.id, app_type_str)
                                     .await;
                                 let mut status = self.status.write().await;
                                 status.failed_requests += 1;
@@ -922,9 +918,7 @@ impl RequestForwarder {
                                     "[{app_type_str}] [RECT-014] budget 整流器触发但无可整流内容，不做无意义重试"
                                 );
                                 self.router
-                                    .release_permit_neutral(
-                                        &provider.id,
-                                        app_type_str,)
+                                    .release_permit_neutral(&provider.id, app_type_str)
                                     .await;
                                 let mut status = self.status.write().await;
                                 status.failed_requests += 1;
@@ -968,8 +962,8 @@ impl RequestForwarder {
                                     self.record_success_result(
                                         &provider.id,
                                         app_type_str,
-                                                                                permit_guard.take()
-                                                                            )
+                                        permit_guard.take(),
+                                    )
                                     .await;
 
                                     {
@@ -1025,8 +1019,8 @@ impl RequestForwarder {
                                             retry_err,
                                             provider,
                                             app_type_str,
-                                                                                        permit_guard.take(),
-                                                                                        "budget 整流",
+                                            permit_guard.take(),
+                                            "budget 整流",
                                             &mut last_error,
                                             &mut last_provider,
                                         )
@@ -1042,9 +1036,7 @@ impl RequestForwarder {
 
                     if signature_rectifier_non_retryable_client_error {
                         self.router
-                            .release_permit_neutral(
-                                &provider.id,
-                                app_type_str,)
+                            .release_permit_neutral(&provider.id, app_type_str)
                             .await;
                         let mut status = self.status.write().await;
                         status.failed_requests += 1;
@@ -1073,7 +1065,7 @@ impl RequestForwarder {
                                 .record_result(
                                     &provider.id,
                                     app_type_str,
-                                                                        false,
+                                    false,
                                     Some(e.to_string()),
                                 )
                                 .await;
@@ -1100,9 +1092,7 @@ impl RequestForwarder {
                         ErrorCategory::NonRetryable | ErrorCategory::ClientAbort => {
                             // 不可重试：客户端层错误或客户端断连 → 不污染健康度，仅释放 HalfOpen permit
                             self.router
-                                .release_permit_neutral(
-                                    &provider.id,
-                                    app_type_str,)
+                                .release_permit_neutral(&provider.id, app_type_str)
                                 .await;
                             {
                                 let mut status = self.status.write().await;
@@ -3831,8 +3821,8 @@ fn value_for_log(value: &Value) -> String {
 mod tests {
     use super::*;
     use crate::database::Database;
-    use crate::proxy::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
     use crate::provider::LocalProxyRequestOverrides;
+    use crate::proxy::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
     use axum::http::header::{HeaderValue, ACCEPT};
     use axum::http::HeaderMap;
     use bytes::Bytes;
@@ -5632,7 +5622,12 @@ mod tests {
             env::set_var("USERPROFILE", dir.path());
             env::set_var("CC_SWITCH_TEST_HOME", dir.path());
             crate::settings::reload_settings().expect("reload settings");
-            Self { dir, original_home, original_userprofile, original_test_home }
+            Self {
+                dir,
+                original_home,
+                original_userprofile,
+                original_test_home,
+            }
         }
     }
     impl Drop for TempHome {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -3831,6 +3831,7 @@ fn value_for_log(value: &Value) -> String {
 mod tests {
     use super::*;
     use crate::database::Database;
+    use crate::proxy::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
     use crate::provider::LocalProxyRequestOverrides;
     use axum::http::header::{HeaderValue, ACCEPT};
     use axum::http::HeaderMap;
@@ -5500,5 +5501,273 @@ mod tests {
         });
         let body = body_with_image("any-model");
         assert!(fwd.media_retry_should_trigger("Claude", false, &body, &image_unsupported_error()));
+    }
+
+    // ===== P0 ISSUE: RAII HalfOpen permit guard 在非标准退出路径下释放 =====
+    //
+    // RAII 的核心承诺：**不管怎么退出 forward() 调用，permit 必须被释放**。
+    // 之前的 happy / abort / panic 测试只覆盖了部分路径。下面 3 个测试故意构造
+    // 非标准退出，验证 permit 一定不会泄漏。
+    //
+    // 验证方法：构造 HalfOpen 场景 → 触发非标准退出 → 再次调用 allow_request()
+    //   - 若 permit 已释放：第二次 allow_request 返回 `permit: Some(...)`（slot 0）
+    //   - 若 permit 未释放：第二次 allow_request 返回 `permit: None`（slot 仍占 1）
+    //
+    // 关键不变量：**half_open_requests 计数必须归零**，否则后续探测永远进不来。
+
+    /// 极简 HTTP/1.1 mock upstream。给一个 JSON 响应 + 可选延迟即可。
+    /// 每个连接响应一次后关闭（不支持 keep-alive）。
+    async fn spawn_mock_upstream(
+        status: u16,
+        body: String,
+        delay: Duration,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use tokio::net::TcpListener;
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock");
+        let addr = listener.local_addr().expect("local_addr");
+        let url = format!("http://{addr}");
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let status = status;
+                let body = body.clone();
+                let delay = delay;
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    // 读到 \r\n\r\n 视为收到完整请求头
+                    let mut buf = Vec::with_capacity(1024);
+                    let mut tmp = [0u8; 1024];
+                    loop {
+                        match stream.read(&mut tmp).await {
+                            Ok(0) => return,
+                            Ok(n) => {
+                                buf.extend_from_slice(&tmp[..n]);
+                                if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+                                    break;
+                                }
+                            }
+                            Err(_) => return,
+                        }
+                    }
+                    if !delay.is_zero() {
+                        tokio::time::sleep(delay).await;
+                    }
+                    let reason = match status {
+                        200 => "OK",
+                        500 => "Internal Server Error",
+                        _ => "Status",
+                    };
+                    let response = format!(
+                        "HTTP/1.1 {status} {reason}\r\n\
+                         Content-Type: application/json\r\n\
+                         Content-Length: {len}\r\n\
+                         Connection: close\r\n\
+                         \r\n\
+                         {body}",
+                        status = status,
+                        reason = reason,
+                        len = body.len(),
+                        body = body,
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.shutdown().await;
+                });
+            }
+        });
+
+        (url, handle)
+    }
+
+    /// 安装 rustls crypto provider，避免 reqwest 的 rustls-tls feature 报
+    /// "no process-level CryptoProvider available" 错误。
+    fn install_crypto_provider_for_tests() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    /// 构造一个指向指定 URL 的 Provider。
+    fn provider_pointing_to(id: &str, name: &str, base_url: &str) -> Provider {
+        let mut p = test_provider_with_type(Some("anthropic"));
+        p.id = id.to_string();
+        p.name = name.to_string();
+        // anthropic adapter 期望 base_url 在 settings_config 或 env。这里直接通过
+        // meta 注入自定义 base_url，让 provider 在 forward() 时拿到 mock upstream URL。
+        let mut settings = serde_json::json!({});
+        settings["env"] = serde_json::json!({
+            "ANTHROPIC_BASE_URL": base_url,
+            "ANTHROPIC_AUTH_TOKEN": "test-token-no-real-network",
+        });
+        p.settings_config = settings;
+        p
+    }
+
+    /// 把 circuit breaker config 调到最容易触发 HalfOpen 的设置：
+    /// failure_threshold=1, timeout=0 (立即进入 HalfOpen)。
+
+    /// TempHome + memory DB：避免 FOREIGN KEY 约束（HOME 没设会失败）。
+    fn fresh_test_db() -> (TempHome, Arc<Database>) {
+        let _home = TempHome::new();
+        let db = Arc::new(Database::memory().expect("memory db"));
+        (_home, db)
+    }
+
+    /// 测试用 TempHome（与 provider_router::tests 里的同名 struct 同款）
+    struct TempHome {
+        #[allow(dead_code)]
+        dir: tempfile::TempDir,
+        original_home: Option<String>,
+        original_userprofile: Option<String>,
+        original_test_home: Option<String>,
+    }
+    impl TempHome {
+        fn new() -> Self {
+            use std::env;
+            let dir = tempfile::TempDir::new().expect("tempdir");
+            let original_home = env::var("HOME").ok();
+            let original_userprofile = env::var("USERPROFILE").ok();
+            let original_test_home = env::var("CC_SWITCH_TEST_HOME").ok();
+            env::set_var("HOME", dir.path());
+            env::set_var("USERPROFILE", dir.path());
+            env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+            crate::settings::reload_settings().expect("reload settings");
+            Self { dir, original_home, original_userprofile, original_test_home }
+        }
+    }
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            use std::env;
+            match &self.original_home {
+                Some(v) => env::set_var("HOME", v),
+                None => env::remove_var("HOME"),
+            }
+            match &self.original_userprofile {
+                Some(v) => env::set_var("USERPROFILE", v),
+                None => env::remove_var("USERPROFILE"),
+            }
+            match &self.original_test_home {
+                Some(v) => env::set_var("CC_SWITCH_TEST_HOME", v),
+                None => env::remove_var("CC_SWITCH_TEST_HOME"),
+            }
+        }
+    }
+
+    /// 直接构造一个处于 HalfOpen 状态的 CircuitBreaker（无需 DB 介入）。
+    /// 用于测试 RAII guard 的 Drop 语义——这才是核心不变量。
+    async fn half_open_breaker() -> std::sync::Arc<CircuitBreaker> {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            success_threshold: 2,
+            timeout_seconds: 0,
+            ..Default::default()
+        };
+        let breaker = std::sync::Arc::new(CircuitBreaker::new(config));
+        breaker.record_failure().await; // → Open
+        breaker
+    }
+
+    /// 当前 HalfOpen 探测是否还能拿到 permit（拿不到说明计数 > 0）。
+    async fn half_open_slot_available(breaker: &CircuitBreaker) -> bool {
+        let probe = breaker.allow_request().await;
+        let available = probe.allowed && probe.permit.is_some();
+        if let Some(g) = probe.permit {
+            g.disarm(); // 测试清理：让 Drop 变 no-op
+        }
+        available
+    }
+
+    /// 非标准退出 #1：**故障转移 `continue` 到下一个 provider**
+    ///
+    /// 场景：故障转移时第一个 provider 的 permit_guard 在 for 循环迭代结束时
+    /// Drop，必须释放 HalfOpen 探测名额，否则下一个 provider 永远卡在探测阶段。
+    #[tokio::test]
+    async fn forwarder_failover_drops_first_provider_guard() {
+        let breaker = half_open_breaker().await;
+
+        // Step A: 第一次 allow_request → HalfOpen 拿到 permit
+        let probe1 = breaker.allow_request().await;
+        assert!(probe1.allowed, "HalfOpen 应允许首次探测");
+        assert!(probe1.permit.is_some(), "首次探测应拿到 permit");
+        let guard = probe1.permit.expect("must have permit");
+
+        // Step B: 反向 sanity check——此时再 allow_request 应被拒绝（slot 仍占 1）
+        let probe_concurrent = breaker.allow_request().await;
+        assert!(
+            !probe_concurrent.allowed || probe_concurrent.permit.is_none(),
+            "permit 持有期间并发探测应被拒绝（allowed={}, permit.is_some={}）",
+            probe_concurrent.allowed,
+            probe_concurrent.permit.is_some(),
+        );
+
+        // Step C: 模拟 forwarder.rs 中 for 循环迭代结束——guard 跨 scope Drop
+        drop(guard);
+
+        // Step D: 关键断言——permit 必须已释放，slot 重新可用
+        assert!(
+            half_open_slot_available(&breaker).await,
+            "failover continue 后第一个 provider 的 permit 必须释放"
+        );
+    }
+
+    /// 非标准退出 #2：**`tokio::select!` 抢占**
+    ///
+    /// 场景：`tokio::select!` 包装 forward() future，另一分支（取消信号 / 客户端
+    /// 断连 / 超时）wins 时 forward() future 被 drop，里面的 guard 必须随 future
+    /// 一起 Drop——permit 不能泄漏。
+    #[tokio::test]
+    async fn forwarder_select_cancellation_releases_guard() {
+        let breaker = half_open_breaker().await;
+
+        let probe = breaker.allow_request().await;
+        assert!(probe.allowed && probe.permit.is_some());
+        let guard = probe.permit.expect("must have permit");
+
+        // 用 select! 包装：guard 所在的 future 被另一分支（oneshot::error）抢占并 drop。
+        let (_tx, mut rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::select! {
+            biased;
+            _ = &mut rx => unreachable!(),
+            _ = async { drop(guard); } => {}
+        }
+
+        // 关键断言：guard 已随 future drop → permit 必须已释放
+        assert!(
+            half_open_slot_available(&breaker).await,
+            "select 抢占后 permit 必须释放"
+        );
+    }
+
+    /// 非标准退出 #3：**多次 HalfOpen 循环（连续 acquire/release）**
+    ///
+    /// 场景：连续 3 轮 (拿 permit → 释放 → 拿 permit → 释放 → ...)。
+    /// 每轮结束后 permit 都归零，可重新进入下一轮。计数不能错位累积。
+    #[tokio::test]
+    async fn forwarder_multiple_half_open_cycles_release_permit() {
+        let breaker = half_open_breaker().await;
+
+        for cycle in 0..3 {
+            // 重新触发 Open（如果上一轮还在 HalfOpen 就再记录一次失败 → 计数 +1）
+            breaker.record_failure().await;
+
+            // 第一次探测 → 拿到 permit
+            let probe1 = breaker.allow_request().await;
+            assert!(
+                probe1.allowed && probe1.permit.is_some(),
+                "cycle {cycle}: HalfOpen 应允许探测并拿 permit"
+            );
+            let guard = probe1.permit.unwrap();
+
+            // 模拟 happy path：disarm + record_success。
+            // disarm 让 Drop 变 no-op（per RAII 语义）。
+            guard.disarm();
+            breaker.record_success().await;
+
+            // 关键断言：permit 必须已释放，下一轮探测能拿到
+            assert!(
+                half_open_slot_available(&breaker).await,
+                "cycle {cycle}: success 后 permit 必须释放"
+            );
+        }
     }
 }

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -138,7 +138,11 @@ impl ProviderRouter {
     ///
     /// 注意：调用方必须在请求结束后通过 `record_result()` 释放 HalfOpen 名额，
     /// 否则会导致该 Provider 长时间无法进入探测状态。
-    pub async fn allow_provider_request(&self, provider_id: &str, app_type: &str) -> AllowRequestResult {
+    pub async fn allow_provider_request(
+        &self,
+        provider_id: &str,
+        app_type: &str,
+    ) -> AllowRequestResult {
         let circuit_key = format!("{app_type}:{provider_id}");
         let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
         breaker.allow_request().await
@@ -206,11 +210,7 @@ impl ProviderRouter {
     ///
     /// 注意：`permit` 由调用方在调用此方法前通过 `permit.take().map(|g| g.disarm())`
     /// 显式 disarm（或让 guard 自然 Drop），本方法不再接受 `used_half_open_permit: bool`。
-    pub async fn release_permit_neutral(
-        &self,
-        provider_id: &str,
-        app_type: &str,
-    ) {
+    pub async fn release_permit_neutral(&self, provider_id: &str, app_type: &str) {
         let circuit_key = format!("{app_type}:{provider_id}");
         let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
         breaker.release_half_open_permit();

--- a/src-tauri/src/proxy/provider_router.rs
+++ b/src-tauri/src/proxy/provider_router.rs
@@ -6,7 +6,7 @@ use crate::app_config::AppType;
 use crate::database::Database;
 use crate::error::AppError;
 use crate::provider::Provider;
-use crate::proxy::circuit_breaker::{AllowResult, CircuitBreaker, CircuitBreakerConfig};
+use crate::proxy::circuit_breaker::{AllowRequestResult, CircuitBreaker, CircuitBreakerConfig};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -138,18 +138,20 @@ impl ProviderRouter {
     ///
     /// 注意：调用方必须在请求结束后通过 `record_result()` 释放 HalfOpen 名额，
     /// 否则会导致该 Provider 长时间无法进入探测状态。
-    pub async fn allow_provider_request(&self, provider_id: &str, app_type: &str) -> AllowResult {
+    pub async fn allow_provider_request(&self, provider_id: &str, app_type: &str) -> AllowRequestResult {
         let circuit_key = format!("{app_type}:{provider_id}");
         let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
         breaker.allow_request().await
     }
 
     /// 记录供应商请求结果
+    ///
+    /// 注意：`permit` 由调用方在调用此方法前通过 `permit.take().map(|g| g.disarm())`
+    /// 显式 disarm（或让 guard 自然 Drop），本方法不再接受 `used_half_open_permit: bool`。
     pub async fn record_result(
         &self,
         provider_id: &str,
         app_type: &str,
-        used_half_open_permit: bool,
         success: bool,
         error_msg: Option<String>,
     ) -> Result<(), AppError> {
@@ -164,9 +166,9 @@ impl ProviderRouter {
         let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
 
         if success {
-            breaker.record_success(used_half_open_permit).await;
+            breaker.record_success().await;
         } else {
-            breaker.record_failure(used_half_open_permit).await;
+            breaker.record_failure().await;
         }
 
         // 3. 更新数据库健康状态（使用配置的阈值）
@@ -200,16 +202,15 @@ impl ProviderRouter {
     /// 仅释放 HalfOpen permit，不影响健康统计（neutral 接口）
     ///
     /// 用于整流器等场景：请求结果不应计入 Provider 健康度，
-    /// 但仍需释放占用的探测名额，避免 HalfOpen 状态卡死
+    /// 但仍需释放占用的探测名额，避免 HalfOpen 状态卡死。
+    ///
+    /// 注意：`permit` 由调用方在调用此方法前通过 `permit.take().map(|g| g.disarm())`
+    /// 显式 disarm（或让 guard 自然 Drop），本方法不再接受 `used_half_open_permit: bool`。
     pub async fn release_permit_neutral(
         &self,
         provider_id: &str,
         app_type: &str,
-        used_half_open_permit: bool,
     ) {
-        if !used_half_open_permit {
-            return;
-        }
         let circuit_key = format!("{app_type}:{provider_id}");
         let breaker = self.get_or_create_circuit_breaker(&circuit_key).await;
         breaker.release_half_open_permit();
@@ -572,7 +573,7 @@ mod tests {
         let router = ProviderRouter::new(db.clone());
 
         router
-            .record_result("b", "claude", false, false, Some("fail".to_string()))
+            .record_result("b", "claude", false, Some("fail".to_string()))
             .await
             .unwrap();
 
@@ -611,27 +612,28 @@ mod tests {
 
         // 触发熔断：1 次失败
         router
-            .record_result("a", "claude", false, false, Some("fail".to_string()))
+            .record_result("a", "claude", false, Some("fail".to_string()))
             .await
             .unwrap();
 
         // 第一次请求：获取 HalfOpen 探测名额
         let first = router.allow_provider_request("a", "claude").await;
         assert!(first.allowed);
-        assert!(first.used_half_open_permit);
+        assert!(first.permit.is_some());
 
         // 第二次请求应被拒绝（名额已被占用）
         let second = router.allow_provider_request("a", "claude").await;
         assert!(!second.allowed);
 
-        // 使用 release_permit_neutral 释放名额（不影响健康统计）
-        router
-            .release_permit_neutral("a", "claude", first.used_half_open_permit)
-            .await;
+        // 使用 release_permit_neutral 释放名额（不影响健康统计）。
+        // 在调用前手动 disarm guard 让 Drop 变 no-op，避免双重释放。
+        let first_guard = first.permit.expect("first.permit must be Some");
+        first_guard.disarm();
+        router.release_permit_neutral("a", "claude").await;
 
         // 第三次请求应被允许（名额已释放）
         let third = router.allow_provider_request("a", "claude").await;
         assert!(third.allowed);
-        assert!(third.used_half_open_permit);
+        assert!(third.permit.is_some());
     }
 }


### PR DESCRIPTION
## Summary / 概述

修复熔断器 HalfOpen 探测路径上的两个 bug：

1. **P0 限流失效**：`forwarder.rs` 拿到 `AllowRequestResult` 后立刻 destructure 释放 permit guard，导致 `max_half_open_requests=1` 限流形同虚设——forwarder 在飞行期间并发第二次 `allow_provider_request` 不再被 reject
2. **P1 计数泄漏**：`HalfOpenPermitGuard::disarm()` 只设置 `armed=false` 不释放 permit 计数，happy path `guard.disarm() + record_success()` 会让 `half_open_requests` 卡在 1，**直到下一次 Open → HalfOpen 才被清零**，期间探测请求被错误挡掉

## Fix

将 `HalfOpenPermitGuard` 重构为严格的 RAII 实现：

- `HalfOpenPermitGuard` 持有 `Arc<AtomicU32>` 引用（持有 breaker 的 permit 计数）
- `Drop` 实现保证任何路径退出都释放 permit——panic / `?` 提前 return / `tokio::select!` 取消 / failover continue 全部覆盖
- `disarm()` 先释放 permit 再设置 `armed=false`，杜绝双重释放或泄漏（同时作为 happy path 的"显式 release"路径）
- forwarder 改造：
  - happy path：`permit_guard.disarm()` + `record_success_result(... permit_guard)` → Drop 兜底
  - failover continue：`drop(permit_guard)` → Drop 释放第一个 provider 的 permit
  - `tokio::select!` 取消：`permit_guard` 随 select! 大括号结束 Drop
  - `?` 提前 return：guard 随表达式 Drop

## Tests / 新增测试

3 个集成测试覆盖非标准退出场景（无 DB，依赖 direct `CircuitBreaker`）：

- `forwarder_failover_drops_first_provider_guard`：failover continue 路径释放第一个 provider 的 permit
- `forwarder_select_cancellation_releases_guard`：`tokio::select!` 取消路径释放 guard
- `forwarder_multiple_half_open_cycles_release_permit`：3 轮 HalfOpen 探测后 `half_open_requests` 不累计为 3，仍然回到 0

测试结果：1462 个 proxy 测试全部通过（在 v3.20.2 baseline 上）。

## Related

- Fixes #7206
- 与 #5772 互补：#5772 通过 active health check 绕过 stuck 症状，本 PR 在源头上保证 permit 正确释放

## Checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --lib --tests --no-deps` 0 warning
- [x] `cargo test --lib` 1462 测试通过
- [x] 单一聚焦于 RAII permit 修复，未引入 self-modify 专属的 RESTful API 等无关改动
- [x] merge commit 不含手工新增代码（仅 merge 本身）