### PR TITLE
fix(terminal): respect Windows Terminal default profile and isolate Claude session env

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5200,6 +5200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6600,6 +6606,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -76,7 +76,7 @@ base64 = "0.22"
 rusqlite = { version = "0.31", features = ["bundled", "backup", "hooks"] }
 indexmap = { version = "2", features = ["serde"] }
 rust_decimal = "1.33"
-uuid = { version = "1.11", features = ["v4"] }
+uuid = { version = "1.11", features = ["v4", "v5"] }
 sha2 = "0.10"
 hmac = "0.12"
 json5 = "0.4"
@@ -95,8 +95,12 @@ libc = "0.2"
 [target.'cfg(target_os = "windows")'.dependencies]
 winreg = "0.52"
 windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
     "Win32_Globalization",
+    "Win32_Security",
     "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_Ioctl",
     "Win32_UI_Shell",
 ] }
 

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -289,6 +289,45 @@ pub(crate) fn decode_command_output(bytes: &[u8]) -> String {
 }
 
 #[cfg(target_os = "windows")]
+fn decode_windows_codepage(bytes: &[u8], codepage: u32) -> Option<String> {
+    use windows_sys::Win32::Globalization::MultiByteToWideChar;
+
+    if codepage == 0 {
+        return None;
+    }
+
+    let input_len = i32::try_from(bytes.len()).ok()?;
+    unsafe {
+        let wide_len = MultiByteToWideChar(
+            codepage,
+            0,
+            bytes.as_ptr(),
+            input_len,
+            std::ptr::null_mut(),
+            0,
+        );
+        if wide_len <= 0 {
+            return None;
+        }
+
+        let mut wide = vec![0u16; wide_len as usize];
+        let written = MultiByteToWideChar(
+            codepage,
+            0,
+            bytes.as_ptr(),
+            input_len,
+            wide.as_mut_ptr(),
+            wide_len,
+        );
+        if written <= 0 {
+            return None;
+        }
+
+        Some(String::from_utf16_lossy(&wide[..written as usize]))
+    }
+}
+
+#[cfg(target_os = "windows")]
 fn decode_windows_command_output(bytes: &[u8]) -> String {
     if bytes.is_empty() {
         return String::new();
@@ -298,57 +337,39 @@ fn decode_windows_command_output(bytes: &[u8]) -> String {
         return text.to_string();
     }
 
-    use windows_sys::Win32::Globalization::{GetACP, GetOEMCP, MultiByteToWideChar};
-
-    fn decode_codepage(bytes: &[u8], codepage: u32) -> Option<String> {
-        if codepage == 0 {
-            return None;
-        }
-
-        let input_len = i32::try_from(bytes.len()).ok()?;
-        unsafe {
-            let wide_len = MultiByteToWideChar(
-                codepage,
-                0,
-                bytes.as_ptr(),
-                input_len,
-                std::ptr::null_mut(),
-                0,
-            );
-            if wide_len <= 0 {
-                return None;
-            }
-
-            let mut wide = vec![0u16; wide_len as usize];
-            let written = MultiByteToWideChar(
-                codepage,
-                0,
-                bytes.as_ptr(),
-                input_len,
-                wide.as_mut_ptr(),
-                wide_len,
-            );
-            if written <= 0 {
-                return None;
-            }
-
-            Some(String::from_utf16_lossy(&wide[..written as usize]))
-        }
-    }
+    use windows_sys::Win32::Globalization::{GetACP, GetOEMCP};
 
     let oem_cp = unsafe { GetOEMCP() };
-    if let Some(decoded) = decode_codepage(bytes, oem_cp) {
+    if let Some(decoded) = decode_windows_codepage(bytes, oem_cp) {
         return decoded;
     }
 
     let ansi_cp = unsafe { GetACP() };
     if ansi_cp != oem_cp {
-        if let Some(decoded) = decode_codepage(bytes, ansi_cp) {
+        if let Some(decoded) = decode_windows_codepage(bytes, ansi_cp) {
             return decoded;
         }
     }
 
     String::from_utf8_lossy(bytes).into_owned()
+}
+
+/// `where.exe` writes paths using the OEM code page. Decode that known protocol
+/// before considering UTF-8, because some OEM byte pairs are also valid UTF-8
+/// with a different meaning (for example CP936 C2 A1).
+#[cfg(target_os = "windows")]
+fn decode_windows_where_output_with_codepage(bytes: &[u8], codepage: u32) -> String {
+    if bytes.is_empty() {
+        return String::new();
+    }
+    decode_windows_codepage(bytes, codepage)
+        .unwrap_or_else(|| String::from_utf8_lossy(bytes).into_owned())
+}
+
+#[cfg(target_os = "windows")]
+fn decode_windows_where_output(bytes: &[u8]) -> String {
+    let oem_cp = unsafe { windows_sys::Win32::Globalization::GetOEMCP() };
+    decode_windows_where_output_with_codepage(bytes, oem_cp)
 }
 
 fn normalize_requested_tools(tools: &[String]) -> Vec<&'static str> {
@@ -2340,7 +2361,7 @@ fn resolve_path_default(
     if !out.status.success() {
         return Ok(None);
     }
-    let raw = decode_command_output(&out.stdout);
+    let raw = decode_windows_where_output(&out.stdout);
     // `where` lists every match on PATH in order; the first is what the user
     // actually runs. Skip App Execution Aliases (reparse points under
     // `Microsoft\WindowsApps`) — they launch the Store / a protocol handler,
@@ -4413,7 +4434,7 @@ fn which_command(cmd: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Windows: 根据用户首选终端启动
+/// Windows: launch the user's preferred terminal.
 #[cfg(target_os = "windows")]
 fn launch_windows_terminal(
     temp_dir: &std::path::Path,
@@ -4445,7 +4466,7 @@ del \"%~f0\" >nul 2>&1
     std::fs::write(&bat_file, &content).map_err(|e| format!("写入批处理文件失败: {e}"))?;
 
     let bat_path = bat_file.to_string_lossy();
-    let ps_cmd = format!("& '{}'", bat_path);
+    let ps_cmd = format!("& '{}'", bat_path.replace('\'', "''"));
 
     // Try the preferred terminal first
     let result = match terminal {
@@ -4453,7 +4474,7 @@ del \"%~f0\" >nul 2>&1
             &["powershell", "-NoExit", "-Command", &ps_cmd],
             "PowerShell",
         ),
-        "wt" => run_windows_start_command(&["wt", "cmd", "/K", &bat_path], "Windows Terminal"),
+        "wt" => launch_wt_terminal(&bat_path, &ps_cmd),
         _ => run_windows_start_command(&["cmd", "/K", &bat_path], "cmd"), // "cmd" or default
     };
 
@@ -4510,15 +4531,53 @@ fn escape_windows_batch_value(value: &str) -> String {
         .replace('(', "^(")
         .replace(')', "^)")
 }
-/// Windows: Run a start command with common error handling
+
+#[cfg(any(target_os = "windows", test))]
+fn build_windows_start_args<'a>(args: &[&'a str]) -> Vec<&'a str> {
+    let mut full_args = vec!["/C", "start", ""];
+    full_args.extend_from_slice(args);
+    full_args
+}
+
+#[cfg(target_os = "windows")]
+const PARENT_CLAUDE_SESSION_ENV_VARS: &[&str] = &[
+    "CLAUDE_CODE_CHILD_SESSION",
+    "CLAUDECODE",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDE_CODE_MESSAGING_SOCKET",
+    "CLAUDE_CODE_MESSAGING_TOKEN",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_EXECPATH",
+    "CLAUDE_CODE_SSE_PORT",
+    "CLAUDE_PID",
+    // Claude Code injects these into tool subprocesses so transcripts stay ANSI-free.
+    // A launched terminal is a real TTY; inheriting them greys out the new Claude TUI.
+    "NO_COLOR",
+    "NODE_DISABLE_COLORS",
+];
+
+/// Terminals opened by CC Switch are top-level sessions. They must not inherit the
+/// parent Claude session identity, IPC endpoints, or color-disable flags.
+/// Only runtime metadata is stripped; auth, proxy, PATH, and user Claude config stay.
+#[cfg(target_os = "windows")]
+fn detach_claude_parent_session_env(command: &mut std::process::Command) {
+    for name in PARENT_CLAUDE_SESSION_ENV_VARS {
+        command.env_remove(name);
+    }
+}
+
+/// Windows: launch a terminal via `cmd /C start`.
 #[cfg(target_os = "windows")]
 fn run_windows_start_command(args: &[&str], terminal_name: &str) -> Result<(), String> {
     use std::process::Command;
 
-    let mut full_args = vec!["/C", "start"];
-    full_args.extend(args);
+    // `start` treats the first quoted argument as a window title; the empty
+    // title keeps an absolute path as the command.
+    let full_args = build_windows_start_args(args);
 
-    let output = Command::new("cmd")
+    let mut command = Command::new("cmd");
+    detach_claude_parent_session_env(&mut command);
+    let output = command
         .args(&full_args)
         .creation_flags(CREATE_NO_WINDOW)
         .output()
@@ -4535,6 +4594,1084 @@ fn run_windows_start_command(args: &[&str], terminal_name: &str) -> Result<(), S
     }
 
     Ok(())
+}
+
+/// Shell family of Windows Terminal's default profile.
+#[cfg(any(target_os = "windows", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WtDefaultShell {
+    Pwsh,
+    PowerShell,
+    Cmd,
+}
+
+/// Keep the selector with the shell whose flags we append. Without `--profile`,
+/// WT can match the appended commandline against another profile instead of
+/// using defaultProfile, even when `--appendCommandLine` is set.
+#[cfg(any(target_os = "windows", test))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct WtDefaultProfile {
+    selector: String,
+    shell: WtDefaultShell,
+}
+
+#[cfg(any(target_os = "windows", test))]
+impl WtDefaultProfile {
+    pub(crate) fn build_wt_args<'a>(
+        &'a self,
+        wt_command: &'a str,
+        bat_path: &'a str,
+        ps_cmd: &'a str,
+    ) -> Vec<&'a str> {
+        let mut args = vec![
+            wt_command,
+            "new-tab",
+            "--profile",
+            self.selector.as_str(),
+            "--appendCommandLine",
+            "--",
+        ];
+        match self.shell {
+            WtDefaultShell::Pwsh | WtDefaultShell::PowerShell => {
+                args.extend(["-NoExit", "-Command", ps_cmd]);
+            }
+            WtDefaultShell::Cmd => args.extend(["/K", bat_path]),
+        }
+        args
+    }
+}
+
+/// When the default profile cannot be appended to safely, start cmd explicitly
+/// instead of appending `/K` to an unknown shell.
+#[cfg(any(target_os = "windows", test))]
+fn build_wt_cmd_fallback_args<'a>(wt_command: &'a str, bat_path: &'a str) -> Vec<&'a str> {
+    vec![wt_command, "new-tab", "cmd", "/K", bat_path]
+}
+
+/// `--appendCommandLine` exists from WT 1.19. Fall back to explicit cmd before spawn
+/// so an unsupported flag is not discovered only after the async launch.
+#[cfg(any(target_os = "windows", test))]
+fn select_wt_launch_args<'a>(
+    profile: Option<&'a WtDefaultProfile>,
+    supports_append: bool,
+    wt_command: &'a str,
+    bat_path: &'a str,
+    ps_cmd: &'a str,
+) -> Vec<&'a str> {
+    match (profile, supports_append) {
+        (Some(profile), true) => profile.build_wt_args(wt_command, bat_path, ps_cmd),
+        _ => build_wt_cmd_fallback_args(wt_command, bat_path),
+    }
+}
+
+/// Strip braces and lowercase GUID strings so they compare across configs.
+#[cfg(any(target_os = "windows", test))]
+fn normalize_wt_guid(guid: &str) -> String {
+    guid.trim()
+        .trim_matches(|c: char| c == '{' || c == '}')
+        .to_ascii_lowercase()
+}
+
+/// Split the first executable from the remaining arguments. WT still owns the
+/// original commandline quoting; this parser does not rebuild it.
+#[cfg(any(target_os = "windows", test))]
+fn split_wt_commandline(cmdline: &str) -> Option<(&str, &str)> {
+    let trimmed = cmdline.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(stripped) = trimmed.strip_prefix('"') {
+        let closing_quote = stripped.find('"')?;
+        let executable = &stripped[..closing_quote];
+        if executable.is_empty() {
+            return None;
+        }
+        return Some((executable, stripped[closing_quote + 1..].trim_start()));
+    }
+
+    let split_at = trimmed
+        .find(|character: char| character.is_whitespace())
+        .unwrap_or(trimmed.len());
+    Some((&trimmed[..split_at], trimmed[split_at..].trim_start()))
+}
+
+/// Tokenize arguments with Windows commandline quoting. Parse failure means
+/// appending extra arguments cannot be proven safe.
+#[cfg(any(target_os = "windows", test))]
+fn split_wt_arguments(arguments: &str) -> Option<Vec<String>> {
+    let characters: Vec<char> = arguments.chars().collect();
+    let mut result = Vec::new();
+    let mut index = 0usize;
+
+    while index < characters.len() {
+        while index < characters.len() && characters[index].is_whitespace() {
+            index += 1;
+        }
+        if index == characters.len() {
+            break;
+        }
+
+        let mut argument = String::new();
+        let mut in_quotes = false;
+        while index < characters.len() {
+            if !in_quotes && characters[index].is_whitespace() {
+                break;
+            }
+
+            if characters[index] == '\\' {
+                let slash_start = index;
+                while index < characters.len() && characters[index] == '\\' {
+                    index += 1;
+                }
+                let slash_count = index - slash_start;
+                if index < characters.len() && characters[index] == '"' {
+                    argument.extend(std::iter::repeat_n('\\', slash_count / 2));
+                    if slash_count % 2 == 0 {
+                        in_quotes = !in_quotes;
+                    } else {
+                        argument.push('"');
+                    }
+                    index += 1;
+                } else {
+                    argument.extend(std::iter::repeat_n('\\', slash_count));
+                }
+                continue;
+            }
+
+            if characters[index] == '"' {
+                in_quotes = !in_quotes;
+                index += 1;
+                continue;
+            }
+
+            argument.push(characters[index]);
+            index += 1;
+        }
+
+        if in_quotes {
+            return None;
+        }
+        result.push(argument);
+    }
+
+    Some(result)
+}
+
+/// PowerShell host CLI option arity. Unique prefixes match; mixed-kind
+/// prefixes are treated as unknown so append is refused.
+/// `pwsh` and Windows PowerShell 5.1 differ only in `-Version`'s kind and in
+/// shell-specific parameters, so each shell keeps its own table.
+#[cfg(any(target_os = "windows", test))]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PsHostOption {
+    Flag,
+    Value,
+    Terminal,
+}
+
+/// Host aliases and parameter names shared by `pwsh` and Windows PowerShell.
+/// Shell-specific differences remain separate so changes cannot silently drift.
+#[cfg(any(target_os = "windows", test))]
+const COMMON_POWERSHELL_HOST_OPTIONS: &[(&str, PsHostOption)] = &[
+    ("?", PsHostOption::Terminal),
+    ("c", PsHostOption::Terminal),
+    ("command", PsHostOption::Terminal),
+    ("config", PsHostOption::Value),
+    ("configurationname", PsHostOption::Value),
+    ("e", PsHostOption::Terminal),
+    ("ea", PsHostOption::Value),
+    ("ec", PsHostOption::Terminal),
+    ("encodedarguments", PsHostOption::Value),
+    ("encodedcommand", PsHostOption::Terminal),
+    ("ep", PsHostOption::Value),
+    ("ex", PsHostOption::Value),
+    ("executionpolicy", PsHostOption::Value),
+    ("f", PsHostOption::Terminal),
+    ("file", PsHostOption::Terminal),
+    ("h", PsHostOption::Terminal),
+    ("help", PsHostOption::Terminal),
+    ("if", PsHostOption::Value),
+    ("inp", PsHostOption::Value),
+    ("inputformat", PsHostOption::Value),
+    ("mta", PsHostOption::Flag),
+    ("noe", PsHostOption::Flag),
+    ("noexit", PsHostOption::Flag),
+    ("nol", PsHostOption::Flag),
+    ("nologo", PsHostOption::Flag),
+    ("noni", PsHostOption::Flag),
+    ("noninteractive", PsHostOption::Flag),
+    ("nop", PsHostOption::Flag),
+    ("noprofile", PsHostOption::Flag),
+    ("o", PsHostOption::Value),
+    ("of", PsHostOption::Value),
+    ("outputformat", PsHostOption::Value),
+    ("servermode", PsHostOption::Terminal),
+    ("sta", PsHostOption::Flag),
+    ("w", PsHostOption::Value),
+    ("wd", PsHostOption::Value),
+    ("windowstyle", PsHostOption::Value),
+    ("workingdirectory", PsHostOption::Value),
+];
+
+/// `pwsh`-only options. `-Version` exits instead of accepting a value.
+#[cfg(any(target_os = "windows", test))]
+const PWSH_HOST_OPTIONS: &[(&str, PsHostOption)] = &[
+    ("commandwithargs", PsHostOption::Terminal),
+    ("configurationfile", PsHostOption::Value),
+    ("custompipename", PsHostOption::Value),
+    ("cwa", PsHostOption::Terminal),
+    ("i", PsHostOption::Flag),
+    ("interactive", PsHostOption::Flag),
+    ("l", PsHostOption::Flag),
+    ("login", PsHostOption::Flag),
+    ("noprofileloadtime", PsHostOption::Flag),
+    ("settings", PsHostOption::Value),
+    ("settingsfile", PsHostOption::Value),
+    ("sshs", PsHostOption::Terminal),
+    ("sshservermode", PsHostOption::Terminal),
+    ("v", PsHostOption::Terminal),
+    ("version", PsHostOption::Terminal),
+    ("wo", PsHostOption::Value),
+];
+
+/// Windows PowerShell 5.1-only options and classifications. `-Version`
+/// accepts `2.0`/`3.0`, unlike `pwsh`.
+#[cfg(any(target_os = "windows", test))]
+const WINDOWS_POWERSHELL_HOST_OPTIONS: &[(&str, PsHostOption)] = &[
+    ("psconsolefile", PsHostOption::Value),
+    ("v", PsHostOption::Value),
+    ("version", PsHostOption::Value),
+];
+
+/// PowerShell host CLI option dashes: ASCII hyphen plus the Unicode dashes
+/// `pwsh`/`powershell.exe` accept (U+2013, U+2014, U+2015). Copied-from-docs
+/// commandlines often use these instead of ASCII `-`.
+#[cfg(any(target_os = "windows", test))]
+const PS_OPTION_DASHES: &[char] = &['-', '\u{2013}', '\u{2014}', '\u{2015}'];
+
+#[cfg(any(target_os = "windows", test))]
+fn ps_host_option_name(argument: &str) -> Option<&str> {
+    let mut chars = argument.chars();
+    let first = chars.next()?;
+    let rest = chars.as_str();
+    if first == '/' {
+        return (!rest.is_empty()).then_some(rest);
+    }
+    if !PS_OPTION_DASHES.contains(&first) {
+        return None;
+    }
+    // `--NoLogo` and `––NoLogo` (same dash twice) are long-option spellings.
+    // Mixed dashes (`-–NoLogo`) are not options; leave the second character.
+    let mut inner = rest.chars();
+    let rest = if inner.next() == Some(first) {
+        inner.as_str()
+    } else {
+        rest
+    };
+    (!rest.is_empty()).then_some(rest)
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn classify_ps_host_option(shell: WtDefaultShell, name: &str) -> Option<PsHostOption> {
+    let shell_options = match shell {
+        WtDefaultShell::Pwsh => PWSH_HOST_OPTIONS,
+        WtDefaultShell::PowerShell => WINDOWS_POWERSHELL_HOST_OPTIONS,
+        WtDefaultShell::Cmd => return None,
+    };
+    let name = name.to_ascii_lowercase();
+
+    let all_options = || {
+        COMMON_POWERSHELL_HOST_OPTIONS
+            .iter()
+            .chain(shell_options.iter())
+    };
+
+    // Exact alias or full parameter match wins immediately.
+    if let Some((_, option)) = all_options().find(|(alias, _)| *alias == name.as_str()) {
+        return Some(*option);
+    }
+
+    // Otherwise accept only a unique full-parameter prefix. Multiple
+    // candidates are ambiguous even when they have the same arity (`-no`
+    // matches NoExit, NoLogo, NonInteractive, and NoProfile).
+    let mut matches = all_options().filter(|(parameter, _)| parameter.starts_with(&name));
+    let (_, option) = matches.next()?;
+    matches.next().is_none().then_some(*option)
+}
+
+/// Walk host arguments with arity. A leftover positional is implicit `-File`.
+#[cfg(any(target_os = "windows", test))]
+fn pwsh_host_args_block_append(shell: WtDefaultShell, arguments: &[String]) -> bool {
+    let mut index = 0usize;
+    while index < arguments.len() {
+        let argument = &arguments[index];
+        if argument == "--" {
+            return true;
+        }
+        let Some(name) = ps_host_option_name(argument) else {
+            return true;
+        };
+        match classify_ps_host_option(shell, name) {
+            Some(PsHostOption::Flag) => index += 1,
+            Some(PsHostOption::Value) => {
+                if index + 1 >= arguments.len() {
+                    return true;
+                }
+                index += 2;
+            }
+            Some(PsHostOption::Terminal) | None => return true,
+        }
+    }
+    false
+}
+
+/// Existing terminal-action flags consume or reject extra arguments, so
+/// `--appendCommandLine` must not be used.
+#[cfg(any(target_os = "windows", test))]
+fn wt_commandline_has_terminal_action(shell: WtDefaultShell, arguments: &str) -> bool {
+    let Some(arguments) = split_wt_arguments(arguments) else {
+        return true;
+    };
+
+    match shell {
+        WtDefaultShell::Pwsh | WtDefaultShell::PowerShell => {
+            pwsh_host_args_block_append(shell, &arguments)
+        }
+        WtDefaultShell::Cmd => arguments.iter().any(|argument| {
+            let option = argument.to_ascii_lowercase();
+            // CMD allows glued switches such as /D/C and /D/K; a terminating action
+            // is not always the first whitespace-separated token.
+            option.contains("/c") || option.contains("/k")
+        }),
+    }
+}
+
+/// Classify a supported shell from the executable name. An explicit commandline
+/// is accepted only when extra arguments can be appended safely.
+#[cfg(any(target_os = "windows", test))]
+fn classify_wt_commandline(cmdline: &str) -> Option<WtDefaultShell> {
+    let (executable, arguments) = split_wt_commandline(cmdline)?;
+    let file_name = executable
+        .rsplit(['\\', '/'])
+        .next()
+        .unwrap_or(executable)
+        .to_ascii_lowercase();
+    let base_name = file_name.strip_suffix(".exe").unwrap_or(&file_name);
+
+    let shell = match base_name {
+        "pwsh" => WtDefaultShell::Pwsh,
+        "powershell" => WtDefaultShell::PowerShell,
+        "cmd" => WtDefaultShell::Cmd,
+        _ => return None,
+    };
+
+    (!wt_commandline_has_terminal_action(shell, arguments)).then_some(shell)
+}
+
+/// Callers filter defaults by WT version first, then classify the shell from an
+/// explicit command, inherited command, dynamic source, known GUID, or name.
+/// If a provided commandline cannot be appended to safely, refuse the profile
+/// instead of guessing from GUID or name.
+#[cfg(any(target_os = "windows", test))]
+fn classify_wt_profile(
+    profile: &serde_json::Value,
+    inherited_commandline: Option<&serde_json::Value>,
+) -> Option<WtDefaultShell> {
+    if let Some(commandline) = profile.get("commandline").or(inherited_commandline) {
+        return commandline.as_str().and_then(classify_wt_commandline);
+    }
+
+    // Dynamic profiles may omit an inspectable commandline; only known sources
+    // with a fixed meaning are accepted.
+    if let Some(source) = profile.get("source").and_then(|v| v.as_str()) {
+        if source == "Windows.Terminal.PowershellCore" {
+            return Some(WtDefaultShell::Pwsh);
+        }
+
+        // An unknown generator may already include a terminating action; do not
+        // fall back to GUID or name.
+        return None;
+    }
+
+    if let Some(guid) = profile.get("guid").and_then(|v| v.as_str()) {
+        match normalize_wt_guid(guid).as_str() {
+            "574e775e-4f2a-5b96-ac1e-a2962a402336" => return Some(WtDefaultShell::Pwsh),
+            "61c54bbd-c2c6-5271-96e7-009a87ff44bf" => return Some(WtDefaultShell::PowerShell),
+            "0caa0dad-35be-5f56-a8ff-afceeeaa6101" => return Some(WtDefaultShell::Cmd),
+            _ => {}
+        }
+    }
+
+    if let Some(name) = profile.get("name").and_then(|v| v.as_str()) {
+        let name_lower = name.to_ascii_lowercase();
+        if name_lower.contains("powershell 7") || name_lower.contains("pwsh") {
+            return Some(WtDefaultShell::Pwsh);
+        }
+        if name_lower.contains("powershell") {
+            return Some(WtDefaultShell::PowerShell);
+        }
+        if name_lower.contains("command prompt") || name_lower.contains("cmd") {
+            return Some(WtDefaultShell::Cmd);
+        }
+    }
+
+    None
+}
+
+// WT hashes Windows wide strings, not UTF-8: changing the encoding would select
+// a different profile even though the displayed name is identical.
+#[cfg(any(target_os = "windows", test))]
+fn wt_uuid_v5(namespace: uuid::Uuid, value: &str) -> uuid::Uuid {
+    let bytes: Vec<u8> = value.encode_utf16().flat_map(u16::to_le_bytes).collect();
+    uuid::Uuid::new_v5(&namespace, &bytes)
+}
+
+/// Mirror Profile::_GenerateGuidForProfile for entries in the local settings file.
+/// WT assigns these IDs before layering defaults. Fragment/generator profiles not
+/// present in this file cannot be reconstructed from names alone.
+/// https://github.com/microsoft/terminal/blob/v1.24.11911.0/src/cascadia/TerminalSettingsModel/Profile.cpp#L301-L319
+#[cfg(any(target_os = "windows", test))]
+fn wt_profile_guid(profile: &serde_json::Value) -> Option<uuid::Uuid> {
+    if let Some(guid) = profile.get("guid").filter(|value| !value.is_null()) {
+        return uuid::Uuid::parse_str(guid.as_str()?).ok();
+    }
+    let name = profile.get("name")?.as_str()?;
+    let source = match profile.get("source") {
+        None | Some(serde_json::Value::Null) => "",
+        Some(source) => source.as_str()?,
+    };
+    let namespace = uuid::Uuid::from_u128(0xf65ddb7e_706b_4499_8a50_40313caf510a);
+    let namespace = if source.is_empty() {
+        namespace
+    } else {
+        wt_uuid_v5(namespace, source)
+    };
+    Some(wt_uuid_v5(namespace, name))
+}
+
+/// Parse Windows Terminal settings.json and keep the default profile selector
+/// alongside its shell, so launch uses the same profile that was classified.
+#[cfg(any(target_os = "windows", test))]
+pub(crate) fn parse_wt_default_profile(
+    content: &str,
+    wt_version: Option<(u16, u16, u16, u16)>,
+) -> Option<WtDefaultProfile> {
+    // Windows Terminal settings.json commonly uses JSONC comments and trailing commas.
+    let json: serde_json::Value = match json5::from_str(content) {
+        Ok(v) => v,
+        Err(e) => {
+            log::debug!("Failed to parse Windows Terminal settings.json: {e}");
+            return None;
+        }
+    };
+
+    // WT profile names are case- and whitespace-sensitive; compare GUIDs as UUIDs below.
+    let default_profile = json.get("defaultProfile").and_then(|v| v.as_str())?;
+    if default_profile.is_empty() {
+        return None;
+    }
+
+    // Support modern `profiles.list` and the legacy flat `profiles` array.
+    let profiles = json.get("profiles");
+    // WT #19225 clears this field from 1.24; first public 1.24.2372.0 includes
+    // that rule, while 1.23 still inherits it.
+    let inherited_commandline = profiles
+        .and_then(|profiles| profiles.get("defaults"))
+        .and_then(|defaults| defaults.get("commandline"))
+        .filter(|_| wt_version.is_none_or(|version| version < (1, 24, 0, 0)));
+    let profile_list = profiles.and_then(|profiles| {
+        profiles
+            .get("list")
+            .and_then(|list| list.as_array())
+            .or_else(|| profiles.as_array())
+    });
+
+    let default_norm_guid = normalize_wt_guid(default_profile);
+    let default_guid = uuid::Uuid::parse_str(default_profile).ok();
+
+    if let Some(list) = profile_list {
+        // WT looks up GUID across the whole table first and only then searches
+        // by name, so an earlier same-name profile must not steal the match.
+        let matched = default_guid
+            .and_then(|expected| {
+                list.iter().find_map(|item| {
+                    let guid = wt_profile_guid(item)?;
+                    (guid == expected).then_some((item, guid))
+                })
+            })
+            .or_else(|| {
+                list.iter().find_map(|item| {
+                    let guid = wt_profile_guid(item)?;
+                    item.get("name")
+                        .and_then(|name| name.as_str())
+                        .is_some_and(|name| name == default_profile)
+                        .then_some((item, guid))
+                })
+            });
+
+        if let Some((item, guid)) = matched {
+            // When the load rule is unknown, only accept an explicit commandline;
+            // do not guess whether defaults would override the shell.
+            if wt_version.is_none()
+                && inherited_commandline.is_some()
+                && item.get("commandline").is_none()
+            {
+                log::debug!("Unknown WT version with inherited commandline; using explicit cmd");
+                return None;
+            }
+            return Some(WtDefaultProfile {
+                selector: format!("{{{guid}}}"),
+                shell: classify_wt_profile(item, inherited_commandline)?,
+            });
+        }
+    }
+
+    // Unlisted built-in profiles use the same version rule; an unknown version
+    // must not skip the ambiguity via GUID fallback.
+    let shell = if let Some(commandline) = inherited_commandline {
+        if wt_version.is_none() {
+            log::debug!("Unknown WT version with inherited commandline; using explicit cmd");
+            return None;
+        }
+        commandline.as_str().and_then(classify_wt_commandline)
+    } else {
+        // If the profile is not listed, fall back to well-known built-in GUIDs.
+        match default_norm_guid.as_str() {
+            "574e775e-4f2a-5b96-ac1e-a2962a402336" => Some(WtDefaultShell::Pwsh),
+            "61c54bbd-c2c6-5271-96e7-009a87ff44bf" => Some(WtDefaultShell::PowerShell),
+            "0caa0dad-35be-5f56-a8ff-afceeeaa6101" => Some(WtDefaultShell::Cmd),
+            _ => None,
+        }
+    }?;
+    Some(WtDefaultProfile {
+        selector: format!("{{{}}}", default_guid?),
+        shell,
+    })
+}
+
+#[cfg(any(target_os = "windows", test))]
+const APPEXECLINK_REPARSE_TAG: u32 = 0x8000_001b;
+
+/// Parse an APPEXECLINK buffer from `FSCTL_GET_REPARSE_POINT`.
+/// The payload starts with a string count; the third NUL-terminated UTF-16
+/// string is the real executable.
+#[cfg(any(target_os = "windows", test))]
+fn parse_app_execution_alias_target(buffer: &[u8]) -> Option<Vec<u16>> {
+    let tag = u32::from_le_bytes(buffer.get(0..4)?.try_into().ok()?);
+    if tag != APPEXECLINK_REPARSE_TAG {
+        return None;
+    }
+
+    let payload_length = u16::from_le_bytes(buffer.get(4..6)?.try_into().ok()?) as usize;
+    let payload_end = 8usize.checked_add(payload_length)?;
+    let payload = buffer.get(8..payload_end)?;
+    let string_count = u32::from_le_bytes(payload.get(0..4)?.try_into().ok()?);
+    if string_count < 3 || (payload.len() - 4) % 2 != 0 {
+        return None;
+    }
+
+    let strings: Vec<u16> = payload[4..]
+        .chunks_exact(2)
+        .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+        .collect();
+    let mut start = 0usize;
+    for index in 0..3 {
+        let end = start + strings.get(start..)?.iter().position(|value| *value == 0)?;
+        if index == 2 {
+            let target = strings.get(start..end)?.to_vec();
+            let drive = *target.first()?;
+            let is_ascii_drive = (drive >= b'A' as u16 && drive <= b'Z' as u16)
+                || (drive >= b'a' as u16 && drive <= b'z' as u16);
+            let is_absolute_drive_path = target.len() >= 3
+                && is_ascii_drive
+                && target[1] == b':' as u16
+                && target[2] == b'\\' as u16;
+            return is_absolute_drive_path.then_some(target);
+        }
+        start = end + 1;
+    }
+    None
+}
+
+#[cfg(target_os = "windows")]
+fn resolve_app_execution_alias_target(alias: &Path) -> Option<PathBuf> {
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+    use windows_sys::Win32::Foundation::{CloseHandle, GENERIC_READ, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+    use windows_sys::Win32::System::Ioctl::FSCTL_GET_REPARSE_POINT;
+    use windows_sys::Win32::System::IO::DeviceIoControl;
+
+    let wide_path: Vec<u16> = alias.as_os_str().encode_wide().chain(Some(0)).collect();
+    // SAFETY: pointer comes from a local NUL-terminated UTF-16 buffer; remaining
+    // arguments follow the CreateFileW contract.
+    // FSCTL_GET_REPARSE_POINT needs GENERIC_READ; access=0 can fail to return
+    // payload data on App Execution Aliases.
+    let handle = unsafe {
+        CreateFileW(
+            wide_path.as_ptr(),
+            GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return None;
+    }
+
+    let mut buffer = vec![0u8; 16 * 1024];
+    let mut returned = 0u32;
+    // SAFETY: handle is valid, the output buffer is writable for the call, and
+    // `returned` does not overlap the buffer.
+    let succeeded = unsafe {
+        DeviceIoControl(
+            handle,
+            FSCTL_GET_REPARSE_POINT,
+            std::ptr::null(),
+            0,
+            buffer.as_mut_ptr().cast(),
+            buffer.len() as u32,
+            &mut returned,
+            std::ptr::null_mut(),
+        )
+    };
+    // SAFETY: handle was created by the CreateFileW call above and is closed once.
+    let _ = unsafe { CloseHandle(handle) };
+    if succeeded == 0 {
+        return None;
+    }
+
+    let target = parse_app_execution_alias_target(buffer.get(..returned as usize)?)?;
+    Some(PathBuf::from(std::ffi::OsString::from_wide(&target)))
+}
+
+#[cfg(target_os = "windows")]
+struct ResolvedWtInstallation {
+    launcher: PathBuf,
+    settings_executable: Option<PathBuf>,
+}
+
+#[cfg(target_os = "windows")]
+const WT_LOOKUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Locate the first `wt` that PATH would launch, and keep launcher plus settings target.
+/// Uses the reconstructed GUI PATH; timeout falls through to the explicit cmd fallback.
+#[cfg(target_os = "windows")]
+fn resolve_wt_installation() -> Option<ResolvedWtInstallation> {
+    let effective_path = effective_path_os().unwrap_or_default();
+    let child = windows_path_lookup_command("wt", &effective_path)
+        .spawn()
+        .ok()?;
+    let output = wait_child_output(
+        child,
+        CommandDeadline::from_timeout(Some(WT_LOOKUP_TIMEOUT)),
+    )
+    .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = decode_windows_where_output(&output.stdout);
+    let launcher = stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(|line| PathBuf::from(line.trim_matches('"')))?;
+
+    let is_store_alias = launcher
+        .parent()
+        .is_some_and(is_windows_app_execution_alias_dir);
+    let settings_executable = if is_store_alias {
+        resolve_app_execution_alias_target(&launcher)
+    } else {
+        Some(
+            launcher
+                .parent()
+                .and_then(|parent| {
+                    launcher
+                        .file_stem()
+                        .map(|stem| parent.join(format!("{}.shim", stem.to_string_lossy())))
+                })
+                .filter(|shim| shim.is_file())
+                .and_then(|shim| parse_scoop_shim_target(&shim))
+                .unwrap_or_else(|| launcher.clone()),
+        )
+    };
+
+    Some(ResolvedWtInstallation {
+        launcher,
+        settings_executable,
+    })
+}
+
+/// Walk `path` upward for the nearest Windows Terminal Store package under
+/// `WindowsApps`; returns whether it is Preview and the lowercased package
+/// directory name (which embeds the version). Directory-name substrings
+/// elsewhere (GitHub zip extracts) must not match.
+#[cfg(any(target_os = "windows", test))]
+fn store_wt_package_dir(path: &Path) -> Option<(bool, String)> {
+    path.ancestors().find_map(|directory| {
+        let parent_name = directory.parent()?.file_name()?;
+        if !parent_name
+            .to_string_lossy()
+            .eq_ignore_ascii_case("WindowsApps")
+        {
+            return None;
+        }
+
+        let package = directory
+            .file_name()?
+            .to_string_lossy()
+            .to_ascii_lowercase();
+        let preview = package.starts_with("microsoft.windowsterminalpreview_");
+        if preview || package.starts_with("microsoft.windowsterminal_") {
+            Some((preview, package))
+        } else {
+            None
+        }
+    })
+}
+
+/// Return the Scoop root and package directory name so `apps/<package>/current/wt.exe`
+/// maps to the same install's `persist/<package>`, including custom Scoop roots.
+#[cfg(any(target_os = "windows", test))]
+fn scoop_wt_install_context(exe_path: &Path) -> Option<(PathBuf, String)> {
+    let apps_dir = exe_path.ancestors().find(|ancestor| {
+        ancestor
+            .file_name()
+            .is_some_and(|name| name.to_string_lossy().eq_ignore_ascii_case("apps"))
+    })?;
+    let package = exe_path
+        .strip_prefix(apps_dir)
+        .ok()?
+        .components()
+        .next()?
+        .as_os_str()
+        .to_string_lossy()
+        .into_owned();
+    if !package.eq_ignore_ascii_case("windows-terminal")
+        && !package.eq_ignore_ascii_case("windows-terminal-preview")
+    {
+        return None;
+    }
+
+    Some((apps_dir.parent()?.to_path_buf(), package))
+}
+
+/// Parse `major.minor.patch.revision` so Store package folders and Scoop
+/// versioned app directories can be compared against WT 1.19.
+#[cfg(any(target_os = "windows", test))]
+fn parse_wt_dotted_version(value: &str) -> Option<(u16, u16, u16, u16)> {
+    let mut parts = value.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    let revision = parts.next()?.parse().ok()?;
+    parts
+        .next()
+        .is_none()
+        .then_some((major, minor, patch, revision))
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn wt_version_supports_append(version: (u16, u16, u16, u16)) -> bool {
+    (version.0, version.1) >= (1, 19)
+}
+
+/// Store package folders and Scoop versioned directories embed the WT version.
+/// `current` shims and unpackaged layouts have to use the PE version instead.
+#[cfg(any(target_os = "windows", test))]
+fn wt_version_from_path(path: &Path) -> Option<(u16, u16, u16, u16)> {
+    if let Some((_, package)) = store_wt_package_dir(path) {
+        let rest = package
+            .strip_prefix("microsoft.windowsterminalpreview_")
+            .or_else(|| package.strip_prefix("microsoft.windowsterminal_"))?;
+        return parse_wt_dotted_version(rest.split('_').next()?);
+    }
+
+    // Scoop layout: `<root>/apps/<package>/<version>/…`; `current` is a shim
+    // whose version lives in the PE, not the directory name.
+    let (root, _) = scoop_wt_install_context(path)?;
+    let mut segments = path.strip_prefix(root.join("apps")).ok()?.components();
+    let version = segments.nth(1)?.as_os_str().to_string_lossy();
+    parse_wt_dotted_version(&version)
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn append_scoop_wt_settings_paths(paths: &mut Vec<PathBuf>, root: &Path, package: &str) {
+    let persist = root.join("persist").join(package);
+    // Scoop persists a settings subdirectory; files at the persist root are not
+    // the active WT config.
+    push_unique_path(paths, persist.join("settings").join("settings.json"));
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn store_wt_settings_path(local: &Path, preview: bool) -> PathBuf {
+    let package = if preview {
+        "Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe"
+    } else {
+        "Microsoft.WindowsTerminal_8wekyb3d8bbwe"
+    };
+    local
+        .join("Packages")
+        .join(package)
+        .join("LocalState")
+        .join("settings.json")
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn unpackaged_wt_settings_path(local: &Path) -> PathBuf {
+    local
+        .join("Microsoft")
+        .join("Windows Terminal")
+        .join("settings.json")
+}
+
+/// When WT places `.portable` beside the executable, only use sibling `settings/`
+/// and do not read LocalAppData.
+#[cfg(any(target_os = "windows", test))]
+fn is_wt_portable_install(exe_path: &Path) -> bool {
+    exe_path
+        .parent()
+        .is_some_and(|dir| dir.join(".portable").is_file())
+}
+
+/// Return settings paths for the resolved executable so leftover configs from
+/// other installs cannot participate in mtime ranking.
+/// Sibling and Scoop persist paths are only live while `.portable` exists;
+/// otherwise WT reads `%LOCALAPPDATA%\Microsoft\Windows Terminal`.
+#[cfg(any(target_os = "windows", test))]
+fn build_wt_settings_paths(
+    settings_executable: &Path,
+    local_appdata: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if is_wt_portable_install(settings_executable) {
+        if let Some(dir) = settings_executable.parent() {
+            // Portable mode only reads the settings subdirectory next to the
+            // module; leftover files at the root must not enter the sort.
+            push_unique_path(&mut paths, dir.join("settings").join("settings.json"));
+        }
+        if let Some((root, package)) = scoop_wt_install_context(settings_executable) {
+            append_scoop_wt_settings_paths(&mut paths, &root, &package);
+        }
+        return paths;
+    }
+
+    if let Some((preview, _)) = store_wt_package_dir(settings_executable) {
+        if let Some(local) = local_appdata {
+            push_unique_path(&mut paths, store_wt_settings_path(local, preview));
+        }
+    } else if let Some(local) = local_appdata {
+        push_unique_path(&mut paths, unpackaged_wt_settings_path(local));
+    }
+
+    paths
+}
+
+/// Parse the real executable path from a Scoop `.shim`.
+#[cfg(any(target_os = "windows", test))]
+fn parse_scoop_shim_target(shim_path: &Path) -> Option<PathBuf> {
+    let content = std::fs::read_to_string(shim_path).ok()?;
+    parse_scoop_shim_content(&content)
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn parse_scoop_shim_content(content: &str) -> Option<PathBuf> {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("path =") {
+            let path_str = rest.trim().trim_matches('"');
+            if !path_str.is_empty() {
+                return Some(PathBuf::from(path_str));
+            }
+        }
+    }
+    None
+}
+
+/// Candidates all belong to the same resolved install, so mtime can pick the
+/// active file. A parse failure continues to the next candidate of that install
+/// and never crosses Store/Scoop/Preview installs.
+#[cfg(any(target_os = "windows", test))]
+fn detect_wt_default_profile_from_paths(
+    paths: &[PathBuf],
+    wt_version: Option<(u16, u16, u16, u16)>,
+) -> Option<WtDefaultProfile> {
+    let mut existing = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for path in paths {
+        let normalized = path.canonicalize().unwrap_or_else(|_| path.clone());
+        if !seen.insert(normalized) || !path.is_file() {
+            continue;
+        }
+        let modified = std::fs::metadata(path)
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        existing.push((path, modified));
+    }
+    existing.sort_by_key(|(_, modified)| std::cmp::Reverse(*modified));
+
+    for (path, _) in existing {
+        if let Ok(content) = std::fs::read_to_string(path) {
+            if let Some(profile) = parse_wt_default_profile(&content, wt_version) {
+                return Some(profile);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "windows")]
+fn detect_wt_default_profile(
+    installation: &ResolvedWtInstallation,
+    wt_version: Option<(u16, u16, u16, u16)>,
+) -> Option<WtDefaultProfile> {
+    let settings_executable = installation.settings_executable.as_deref()?;
+    let local_appdata = std::env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .or_else(dirs::data_local_dir);
+    let paths = build_wt_settings_paths(settings_executable, local_appdata.as_deref());
+    let profile = detect_wt_default_profile_from_paths(&paths, wt_version);
+    if let Some(profile) = &profile {
+        log::debug!(
+            "Detected Windows Terminal default profile: {:?} (candidates: {:?})",
+            profile,
+            paths
+        );
+    }
+    profile
+}
+
+#[cfg(target_os = "windows")]
+fn wt_file_version(path: &Path) -> Option<(u16, u16, u16, u16)> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW,
+    };
+
+    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let mut dummy = 0u32;
+    // SAFETY: `wide` is a local NUL-terminated path buffer.
+    let size = unsafe { GetFileVersionInfoSizeW(wide.as_ptr(), &mut dummy) };
+    if size == 0 {
+        return None;
+    }
+
+    let mut buffer = vec![0u8; size as usize];
+    // SAFETY: `buffer` is writable for `size` bytes returned above.
+    let ok = unsafe { GetFileVersionInfoW(wide.as_ptr(), 0, size, buffer.as_mut_ptr().cast()) };
+    if ok == 0 {
+        return None;
+    }
+
+    let mut info: *mut core::ffi::c_void = core::ptr::null_mut();
+    let mut info_len = 0u32;
+    let subblock: Vec<u16> = "\\\0".encode_utf16().collect();
+    // SAFETY: `buffer` still owns the version block; `info`/`info_len` are out params.
+    let ok = unsafe {
+        VerQueryValueW(
+            buffer.as_ptr().cast(),
+            subblock.as_ptr(),
+            &mut info,
+            &mut info_len,
+        )
+    };
+    if ok == 0 || info.is_null() || (info_len as usize) < 16 {
+        return None;
+    }
+
+    // VS_FIXEDFILEINFO: signature, struct version, then fileVersionMS/LS.
+    let bytes = unsafe { std::slice::from_raw_parts(info as *const u8, info_len as usize) };
+    let ms = u32::from_le_bytes(bytes.get(8..12)?.try_into().ok()?);
+    let ls = u32::from_le_bytes(bytes.get(12..16)?.try_into().ok()?);
+    Some((
+        (ms >> 16) as u16,
+        (ms & 0xffff) as u16,
+        (ls >> 16) as u16,
+        (ls & 0xffff) as u16,
+    ))
+}
+
+#[cfg(target_os = "windows")]
+fn wt_version_from_executable(path: &Path) -> Option<(u16, u16, u16, u16)> {
+    wt_version_from_path(path)
+        .or_else(|| wt_file_version(path))
+        .or_else(|| {
+            let sibling = path.parent()?.join("WindowsTerminal.exe");
+            if sibling == path || !sibling.is_file() {
+                None
+            } else {
+                wt_file_version(&sibling)
+            }
+        })
+}
+
+/// Read the version from the same install's real target or launcher so config
+/// load rules and append support share one source.
+/// GUI WT help text is unreliable, so use path and PE version info instead of
+/// launching the terminal to probe.
+#[cfg(target_os = "windows")]
+fn wt_installation_version(installation: &ResolvedWtInstallation) -> Option<(u16, u16, u16, u16)> {
+    installation
+        .settings_executable
+        .as_deref()
+        .filter(|path| *path != installation.launcher.as_path())
+        .and_then(wt_version_from_executable)
+        .or_else(|| wt_version_from_executable(&installation.launcher))
+}
+
+/// The launcher path may contain cmd metacharacters, so spawn it directly
+/// instead of going through `cmd /C start`.
+/// WT may already be a resident GUI process, so report only spawn failure and
+/// return without waiting for the window to close.
+#[cfg(target_os = "windows")]
+fn run_wt_command(args: &[&str]) -> Result<(), String> {
+    let (launcher, arguments) = args
+        .split_first()
+        .ok_or_else(|| "缺少 Windows Terminal 启动程序".to_string())?;
+    let mut command = std::process::Command::new(launcher);
+    detach_claude_parent_session_env(&mut command);
+    command
+        .args(arguments)
+        .creation_flags(CREATE_NO_WINDOW)
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| format!("启动 Windows Terminal 失败: {e}"))
+}
+
+/// Launch the same resolved Windows Terminal, and fall back to an explicit cmd
+/// tab when the default profile cannot be recognized safely or WT is too old
+/// for `--appendCommandLine`.
+#[cfg(target_os = "windows")]
+fn launch_wt_terminal(bat_path: &str, ps_cmd: &str) -> Result<(), String> {
+    let installation = resolve_wt_installation();
+    let wt_command = installation
+        .as_ref()
+        .map(|installation| installation.launcher.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "wt".to_string());
+    let wt_version = installation.as_ref().and_then(wt_installation_version);
+    let profile = installation
+        .as_ref()
+        .and_then(|installation| detect_wt_default_profile(installation, wt_version));
+    // Keep the previous append policy for unknown versions; configs that depend
+    // on ambiguous defaults are refused by the parser.
+    let supports_append = profile.is_some() && wt_version.is_none_or(wt_version_supports_append);
+    let args = select_wt_launch_args(
+        profile.as_ref(),
+        supports_append,
+        &wt_command,
+        bat_path,
+        ps_cmd,
+    );
+    run_wt_command(&args)
 }
 
 /// 打开用户首选终端并在其中执行一段可信命令脚本。脚本尾部 `read -r` / `pause`
@@ -4685,14 +5822,14 @@ read -r _
         std::fs::write(&bat_file, &content).map_err(|e| format!("写入批处理文件失败: {e}"))?;
 
         let bat_path = bat_file.to_string_lossy();
-        let ps_cmd = format!("& '{}'", bat_path);
+        let ps_cmd = format!("& '{}'", bat_path.replace('\'', "''"));
 
         let result = match terminal {
             "powershell" => run_windows_start_command(
                 &["powershell", "-NoExit", "-Command", &ps_cmd],
                 "PowerShell",
             ),
-            "wt" => run_windows_start_command(&["wt", "cmd", "/K", &bat_path], "Windows Terminal"),
+            "wt" => launch_wt_terminal(&bat_path, &ps_cmd),
             _ => run_windows_start_command(&["cmd", "/K", &bat_path], "cmd"),
         };
 
@@ -6812,6 +7949,23 @@ mod tests {
 
     #[cfg(target_os = "windows")]
     #[test]
+    fn windows_where_output_prefers_oem_codepage_over_valid_utf8() {
+        let bytes = b"C:\\Temp\\\xC2\xA1\\wt.exe\r\n";
+
+        assert_eq!(
+            decode_windows_where_output_with_codepage(bytes, 936).trim(),
+            r"C:\Temp\隆\wt.exe"
+        );
+        assert_eq!(
+            std::str::from_utf8(bytes)
+                .expect("fixture is intentionally valid UTF-8")
+                .trim(),
+            r"C:\Temp\¡\wt.exe"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
     fn windows_path_lookup_ignores_same_named_file_in_current_directory() {
         let current_dir = tempfile::tempdir().expect("current directory should be created");
         let path_dir = tempfile::tempdir().expect("PATH directory should be created");
@@ -7189,6 +8343,1290 @@ mod tests {
         assert_eq!(
             command,
             "pushd \"\\\\server\\share\\100%%^&^(test^)\" || exit /b 1\r\n"
+        );
+    }
+
+    /// Cover JSONC, well-known GUIDs, quoted commandlines, and name matches.
+    #[test]
+    fn parse_wt_default_profile_recognizes_supported_profiles() {
+        // JSONC comments + PowerShell 7 well-known GUID
+        let jsonc_pwsh = r#"{
+            // Windows Terminal single line comment
+            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+            /* block comment */
+            "profiles": {
+                "list": [
+                    {
+                        "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                        "name": "PowerShell",
+                        "source": "Windows.Terminal.PowershellCore",
+                    },
+                ],
+            },
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(jsonc_pwsh, None).map(|profile| profile.shell),
+            Some(WtDefaultShell::Pwsh)
+        );
+
+        // Absolute commandline path for Windows PowerShell
+        let powershell_cmdline = r#"{
+            "defaultProfile": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+            "profiles": {
+                "list": [
+                    {
+                        "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+                        "name": "Windows PowerShell",
+                        "commandline": "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+                    }
+                ]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(powershell_cmdline, None).map(|profile| profile.shell),
+            Some(WtDefaultShell::PowerShell)
+        );
+
+        // Quoted custom pwsh path with arguments
+        let quoted_pwsh = r#"{
+            "defaultProfile": "{11111111-1111-4111-8111-111111111111}",
+            "profiles": [
+                {
+                    "guid": "{11111111-1111-4111-8111-111111111111}",
+                    "name": "Custom",
+                    "commandline": "\"C:\\Program Files\\PowerShell\\7\\pwsh.Exe\" -NoLogo"
+                }
+            ]
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(quoted_pwsh, None).map(|profile| profile.shell),
+            Some(WtDefaultShell::Pwsh)
+        );
+
+        // cmd.exe
+        let cmd_config = r#"{
+            "defaultProfile": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+            "profiles": {
+                "list": [
+                    {
+                        "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+                        "name": "Command Prompt",
+                        "commandline": "cmd.exe"
+                    }
+                ]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(cmd_config, None).map(|profile| profile.shell),
+            Some(WtDefaultShell::Cmd)
+        );
+
+        // Match by profile name instead of GUID
+        let name_config = r#"{
+            "defaultProfile": "PowerShell 7",
+            "profiles": {
+                "list": [
+                    {
+                        "guid": "{22222222-2222-4222-8222-222222222222}",
+                        "name": "PowerShell 7",
+                        "commandline": "pwsh.exe"
+                    }
+                ]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(name_config, None).map(|profile| profile.shell),
+            Some(WtDefaultShell::Pwsh)
+        );
+    }
+
+    #[test]
+    fn parse_wt_default_profile_returns_none_for_unsupported_or_malformed() {
+        let wsl = r#"{"defaultProfile": "{55555555-5555-4555-8555-555555555555}","profiles":{"list":[{"guid":"{55555555-5555-4555-8555-555555555555}","commandline":"wsl.exe"}]}}"#;
+        assert_eq!(parse_wt_default_profile(wsl, None), None);
+
+        let overridden_builtin = r#"{
+            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+            "profiles": {
+                "list": [{
+                    "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                    "name": "PowerShell",
+                    "source": "Windows.Terminal.PowershellCore",
+                    "commandline": "wsl.exe"
+                }]
+            }
+        }"#;
+        assert_eq!(parse_wt_default_profile(overridden_builtin, None), None);
+        assert_eq!(parse_wt_default_profile("not valid json", None), None);
+        assert_eq!(
+            parse_wt_default_profile(r#"{"defaultProfile": ""}"#, None),
+            None
+        );
+    }
+
+    #[test]
+    fn third_party_powershellcore_source_uses_explicit_fallback() {
+        let settings = serde_json::json!({
+            "defaultProfile": "{55555555-5555-4555-8555-555555555555}",
+            "profiles": {"list": [{
+                "guid": "{55555555-5555-4555-8555-555555555555}",
+                "source": "Contoso.PowerShellCore.Wsl"
+            }]}
+        });
+
+        let profile = parse_wt_default_profile(&settings.to_string(), None);
+        assert_eq!(
+            profile, None,
+            "third-party sources containing PowerShellCore must not be classified as pwsh"
+        );
+        assert_eq!(
+            select_wt_launch_args(profile.as_ref(), true, "wt", "probe.bat", "& 'probe.bat'"),
+            vec!["wt", "new-tab", "cmd", "/K", "probe.bat"],
+            "unknown dynamic profiles must use the explicit cmd fallback"
+        );
+    }
+
+    #[test]
+    fn visual_studio_dynamic_profiles_use_explicit_fallback() {
+        for (guid, name) in [
+            (
+                "{11111111-1111-4111-8111-111111111111}",
+                "Developer PowerShell for VS 2022",
+            ),
+            (
+                "{22222222-2222-4222-8222-222222222222}",
+                "Developer Command Prompt for VS 2022",
+            ),
+        ] {
+            let settings = serde_json::json!({
+                "defaultProfile": guid,
+                "profiles": {"list": [{
+                    "guid": guid,
+                    "name": name,
+                    "source": "Windows.Terminal.VisualStudio"
+                }]}
+            });
+
+            let profile = parse_wt_default_profile(&settings.to_string(), None);
+            assert_eq!(
+                profile, None,
+                "dynamic profile {name} must not be guessed by name"
+            );
+            assert_eq!(
+                select_wt_launch_args(profile.as_ref(), true, "wt", "probe.bat", "& 'probe.bat'",),
+                vec!["wt", "new-tab", "cmd", "/K", "probe.bat"],
+                "dynamic profile {name} must use the explicit cmd fallback"
+            );
+        }
+
+        let explicit_commandline = serde_json::json!({
+            "defaultProfile": "{33333333-3333-4333-8333-333333333333}",
+            "profiles": {"list": [{
+                "guid": "{33333333-3333-4333-8333-333333333333}",
+                "name": "Developer PowerShell for VS 2022",
+                "source": "Windows.Terminal.VisualStudio",
+                "commandline": "pwsh.exe -NoLogo"
+            }]}
+        });
+        assert_eq!(
+            parse_wt_default_profile(&explicit_commandline.to_string(), None)
+                .map(|profile| profile.shell),
+            Some(WtDefaultShell::Pwsh),
+            "an explicit safe commandline must take precedence over the dynamic source"
+        );
+    }
+
+    /// Server mode runs the remoting protocol and ignores `-Command`; leftover
+    /// positionals mean implicit `-File`. Append must be refused for all of
+    /// these, including the ServerMode prefixes `-s`/`-se` that PowerShell
+    /// resolves over `-Sta`/`-SettingsFile`.
+    #[test]
+    fn wt_commandline_classification_accepts_safe_and_refuses_unsafe() {
+        let refused: &[&str] = &[
+            r#"pwsh.exe -NoLogo -Fil "C:\init.ps1""#,
+            r#"cmd.exe /D /K C:\init.cmd"#,
+            r#"cmd.exe /cdir"#,
+            r#"cmd.exe /D/C echo ORIGINAL"#,
+            r#"cmd.exe /d/k echo ORIGINAL"#,
+            r#"cmd.exe /Q/D/CECHO ORIGINAL"#,
+            r#"cmd.exe /D/V:OFF/Kecho ORIGINAL"#,
+            r#"pwsh.exe -no"#,
+            r#"powershell.exe -no"#,
+            r#"pwsh.exe -SSHServerMode"#,
+            r#"pwsh.exe -s -NoProfile"#,
+            r#"pwsh.exe -se -NoProfile"#,
+            r#"pwsh.exe -ServerMode"#,
+            r#"powershell.exe -s -NoProfile"#,
+            r#"powershell.exe -se -NoProfile"#,
+            r#"powershell.exe -ServerMode"#,
+            r#"pwsh.exe C:\init.ps1"#,
+            r#"pwsh.exe -f C:\init.ps1"#,
+            r#"powershell.exe -c Get-Date"#,
+            r#"pwsh.exe -Version"#,
+            r#"powershell.exe -Version"#,
+            r#"pwsh.exe -WorkingDirectory "C:\missing"#,
+        ];
+        for cmdline in refused {
+            assert_eq!(classify_wt_commandline(cmdline), None, "{cmdline}");
+        }
+
+        let accepted: &[(&str, WtDefaultShell)] = &[
+            (r#"cmd.exe /D /T:0C"#, WtDefaultShell::Cmd),
+            (r#"cmd.exe /D/Q/V:OFF"#, WtDefaultShell::Cmd),
+            (r#"pwsh.exe -EncodedArguments ABC="#, WtDefaultShell::Pwsh),
+            (r#"pwsh.exe -ea ABC="#, WtDefaultShell::Pwsh),
+            (r#"pwsh.exe -encodeda ABC="#, WtDefaultShell::Pwsh),
+            (
+                r#"powershell.exe -EncodedArguments ABC="#,
+                WtDefaultShell::PowerShell,
+            ),
+            (r#"pwsh.exe -Login -NoLogo"#, WtDefaultShell::Pwsh),
+            (
+                r#"pwsh.exe -Interactive -NoProfileLoadTime"#,
+                WtDefaultShell::Pwsh,
+            ),
+            (
+                r#"pwsh.exe -SettingsFile C:\x.json -NoLogo"#,
+                WtDefaultShell::Pwsh,
+            ),
+            (r#"pwsh.exe -wd C:\Work -nol"#, WtDefaultShell::Pwsh),
+            (r#"pwsh.exe -i"#, WtDefaultShell::Pwsh),
+            (r#"powershell.exe -ep Bypass"#, WtDefaultShell::PowerShell),
+            (
+                r#"powershell.exe -if Text -of Text"#,
+                WtDefaultShell::PowerShell,
+            ),
+            (r#"powershell.exe -ea ABC="#, WtDefaultShell::PowerShell),
+            (
+                r#"pwsh.exe -ConfigurationFile C:\x.pssc"#,
+                WtDefaultShell::Pwsh,
+            ),
+            (
+                r#"powershell.exe -Version 2.0 -NoLogo"#,
+                WtDefaultShell::PowerShell,
+            ),
+            (r#"pwsh.exe -NoLogo -NoExit"#, WtDefaultShell::Pwsh),
+            (
+                r#"pwsh.exe -WorkingDirectory "C:\Work\My -File Project" -NoLogo"#,
+                WtDefaultShell::Pwsh,
+            ),
+            // Quoted executable with a space and no arguments appends safely.
+            (r#""C:\missing quote\pwsh.exe""#, WtDefaultShell::Pwsh),
+        ];
+        for (cmdline, expected) in accepted {
+            assert_eq!(
+                classify_wt_commandline(cmdline),
+                Some(*expected),
+                "{cmdline}"
+            );
+        }
+
+        // Copied-from-docs Unicode dashes (U+2013/2014/2015) and their
+        // doubled long-option spelling parse like ASCII `-`.
+        for dash in ['\u{2013}', '\u{2014}', '\u{2015}'] {
+            let doubled = format!("pwsh.exe {dash}{dash}NoLogo");
+            assert_eq!(
+                classify_wt_commandline(&format!("pwsh.exe {dash}NoLogo")),
+                Some(WtDefaultShell::Pwsh),
+                "dash {dash:?}"
+            );
+            assert_eq!(
+                classify_wt_commandline(&doubled),
+                Some(WtDefaultShell::Pwsh),
+                "doubled dash {dash:?}"
+            );
+            assert_eq!(
+                classify_wt_commandline(&format!("powershell.exe {dash}NoLogo")),
+                Some(WtDefaultShell::PowerShell),
+                "dash {dash:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn wt_cmd_concatenated_actions_use_explicit_fallback() {
+        let settings = serde_json::json!({
+            "defaultProfile": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+            "profiles": {"list": [{
+                "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+                "commandline": "cmd.exe /D/C echo ORIGINAL"
+            }]}
+        });
+        let profile = parse_wt_default_profile(&settings.to_string(), None);
+        assert_eq!(
+            select_wt_launch_args(profile.as_ref(), true, "wt", "probe.bat", "& 'probe.bat'"),
+            vec!["wt", "new-tab", "cmd", "/K", "probe.bat"]
+        );
+
+        #[cfg(target_os = "windows")]
+        {
+            // Pin CMD dialect with a real shell: a glued /K after /C is text of
+            // the original command and does not run a second batch.
+            let output = std::process::Command::new("cmd.exe")
+                .args(["/d/c", "echo", "ORIGINAL", "/K", "echo", "APPENDED"])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+                .expect("CMD concatenated switch probe should start");
+            assert!(output.status.success());
+            assert_eq!(
+                decode_command_output(&output.stdout).trim(),
+                "ORIGINAL /K echo APPENDED"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_wt_default_profile_inherits_profiles_defaults_commandline() {
+        let defaults_wsl = r#"{
+            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+            "profiles": {
+                "defaults": { "commandline": "wsl.exe" },
+                "list": [{
+                    "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                    "name": "PowerShell",
+                    "source": "Windows.Terminal.PowershellCore"
+                }]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(defaults_wsl, Some((1, 23, 20211, 0))),
+            None
+        );
+
+        let defaults_file = r#"{
+            "defaultProfile": "{44444444-4444-4444-8444-444444444444}",
+            "profiles": {
+                "defaults": { "commandline": "pwsh.exe -File C:\\init.ps1" },
+                "list": [{ "guid": "{44444444-4444-4444-8444-444444444444}", "name": "Custom" }]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(defaults_file, Some((1, 23, 20211, 0))),
+            None
+        );
+
+        let defaults_pwsh = r#"{
+            "defaultProfile": "{44444444-4444-4444-8444-444444444444}",
+            "profiles": {
+                "defaults": { "commandline": "pwsh.exe -NoLogo" },
+                "list": [{ "guid": "{44444444-4444-4444-8444-444444444444}", "name": "Custom" }]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(defaults_pwsh, Some((1, 23, 20211, 0)))
+                .map(|profile| profile.shell),
+            Some(WtDefaultShell::Pwsh)
+        );
+
+        let profile_overrides_defaults = r#"{
+            "defaultProfile": "{44444444-4444-4444-8444-444444444444}",
+            "profiles": {
+                "defaults": { "commandline": "wsl.exe" },
+                "list": [{
+                    "guid": "{44444444-4444-4444-8444-444444444444}",
+                    "name": "Custom",
+                    "commandline": "cmd.exe"
+                }]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(profile_overrides_defaults, Some((1, 23, 20211, 0)))
+                .map(|profile| profile.shell),
+            Some(WtDefaultShell::Cmd)
+        );
+
+        let unlisted_builtin_with_defaults = r#"{
+            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+            "profiles": {
+                "defaults": { "commandline": "wsl.exe" },
+                "list": []
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(unlisted_builtin_with_defaults, Some((1, 23, 20211, 0))),
+            None
+        );
+    }
+
+    #[test]
+    fn wt_default_profile_uses_versioned_defaults_commandline() {
+        let guid = "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}";
+        let temp = tempfile::tempdir().expect("settings directory should be created");
+        let path = temp.path().join("settings.json");
+        for (version, expected_shell) in [
+            (Some((1, 19, 10821, 0)), Some(WtDefaultShell::Pwsh)),
+            (Some((1, 22, 10352, 0)), Some(WtDefaultShell::Pwsh)),
+            (Some((1, 23, 20211, 0)), Some(WtDefaultShell::Pwsh)),
+            (Some((1, 24, 2372, 0)), Some(WtDefaultShell::Cmd)),
+            (Some((1, 24, 11911, 0)), Some(WtDefaultShell::Cmd)),
+            (Some((1, 25, 1912, 0)), Some(WtDefaultShell::Cmd)),
+            (None, None),
+        ] {
+            for listed in [true, false] {
+                let mut profiles = Vec::new();
+                if listed {
+                    profiles.push(serde_json::json!({"guid": guid, "name": "Command Prompt"}));
+                }
+                let settings = serde_json::json!({
+                    "defaultProfile": guid,
+                    "profiles": {"defaults": {"commandline": "pwsh.exe"}, "list": profiles}
+                });
+                std::fs::write(&path, settings.to_string()).expect("settings should be written");
+                let profile =
+                    detect_wt_default_profile_from_paths(std::slice::from_ref(&path), version);
+                assert_eq!(
+                    profile,
+                    expected_shell.map(|shell| WtDefaultProfile {
+                        selector: guid.to_string(),
+                        shell
+                    }),
+                    "version={version:?}, listed={listed}"
+                );
+                let mut expected_args = vec!["wt", "new-tab"];
+                if let Some(shell) = expected_shell {
+                    expected_args.extend(["--profile", guid, "--appendCommandLine", "--"]);
+                    match shell {
+                        WtDefaultShell::Cmd => expected_args.extend(["/K", "probe.bat"]),
+                        _ => expected_args.extend(["-NoExit", "-Command", "& 'probe.bat'"]),
+                    }
+                } else {
+                    expected_args.extend(["cmd", "/K", "probe.bat"]);
+                }
+                assert_eq!(
+                    select_wt_launch_args(
+                        profile.as_ref(),
+                        true,
+                        "wt",
+                        "probe.bat",
+                        "& 'probe.bat'"
+                    ),
+                    expected_args,
+                    "version={version:?}, listed={listed}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wt_defaults_version_does_not_override_explicit_commandline() {
+        let guid = "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}";
+        for version in [None, Some((1, 23, 20211, 0)), Some((1, 24, 11911, 0))] {
+            for defaults in ["pwsh.exe", "wsl.exe"] {
+                for explicit in ["cmd.exe", "wsl.exe"] {
+                    let settings = serde_json::json!({
+                        "defaultProfile": guid,
+                        "profiles": {
+                            "defaults": {"commandline": defaults},
+                            "list": [{"guid": guid, "commandline": explicit}]
+                        }
+                    });
+                    assert_eq!(
+                        parse_wt_default_profile(&settings.to_string(), version),
+                        (explicit == "cmd.exe").then(|| WtDefaultProfile {
+                            selector: guid.to_string(),
+                            shell: WtDefaultShell::Cmd,
+                        }),
+                        "version={version:?}, defaults={defaults}, explicit={explicit}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn wt_profile_guids_follow_wt_utf16_namespace_rules() {
+        // Fixed vector from WT's src/types/ut_types/UuidTests.cpp, not computed
+        // with the implementation under test. UTF-8 gives a different UUID.
+        let namespace = uuid::Uuid::parse_str("ad56de9e-5167-41b6-80eb-fb19f7927d1a").unwrap();
+        assert_eq!(
+            wt_uuid_v5(namespace, "testing").to_string(),
+            "e04fb1f7-739d-5d63-bb18-e0ea00b19ee8"
+        );
+        // Profile vectors independently calculated from WT's published algorithm.
+        for (profile, expected) in [
+            (
+                serde_json::json!({"name": "profile0"}),
+                "690955e2-dbc2-509c-b36d-ac466fdda656",
+            ),
+            (
+                serde_json::json!({"name": "profile0", "source": ""}),
+                "690955e2-dbc2-509c-b36d-ac466fdda656",
+            ),
+            (
+                serde_json::json!({"name": "profile0", "source": "Terminal.App.UnitTest.0"}),
+                "52b9372a-c1b1-57eb-a9ce-e2cdc8d52ceb",
+            ),
+            (
+                serde_json::json!({"name": "Profile0"}),
+                "6a2f325d-dd64-5214-ac09-ceac61244422",
+            ),
+            (
+                serde_json::json!({"name": "开发 🚀"}),
+                "513625d0-fe16-526d-b8b5-494277269c46",
+            ),
+            (
+                serde_json::json!({"name": "Dev&echo"}),
+                "f7143a97-a88e-5523-94a1-19c0c687e353",
+            ),
+            (
+                serde_json::json!({"name": "Dev%COMSPEC%"}),
+                "46d028dc-f2b0-526e-9427-7bf1d8c7070d",
+            ),
+            (
+                serde_json::json!({"name": "Dev;Test"}),
+                "c0bfcc63-c933-5d17-9a24-892f27f2f34c",
+            ),
+            (
+                serde_json::json!({"guid": "{574E775E-4F2A-5B96-AC1E-A2962A402336}", "name": "Dev&echo"}),
+                "574e775e-4f2a-5b96-ac1e-a2962a402336",
+            ),
+        ] {
+            assert_eq!(
+                wt_profile_guid(&profile)
+                    .map(|guid| guid.to_string())
+                    .as_deref(),
+                Some(expected),
+                "{profile}"
+            );
+        }
+        for profile in [
+            serde_json::json!({}),
+            serde_json::json!({"source": "Windows.Terminal.PowershellCore"}),
+            serde_json::json!({"name": "Dev", "guid": "Dev&echo"}),
+            serde_json::json!({"name": "Dev", "source": false}),
+        ] {
+            assert_eq!(wt_profile_guid(&profile), None, "{profile}");
+        }
+    }
+
+    #[test]
+    fn wt_default_profile_name_collisions_bind_the_exact_profile() {
+        // This fixture inherits defaults; use the legacy rule so selector matching
+        // is isolated from versioned default loading.
+        // Explicit GUIDs isolate selector matching from GUID generation.
+        let expected = "{22222222-2222-4222-8222-222222222222}";
+        let mut failures = Vec::new();
+        for (first_name, exact_name) in [
+            ("dev", "Dev"),
+            (" Dev", "Dev"),
+            ("Dev ", "Dev"),
+            ("Dev", " Dev"),
+            ("Dev", "Dev "),
+        ] {
+            for include_decoy in [false, true] {
+                let mut profiles = vec![serde_json::json!({"guid": expected, "name": exact_name})];
+                if include_decoy {
+                    profiles.insert(
+                        0,
+                        serde_json::json!({
+                            "guid": "{11111111-1111-4111-8111-111111111111}",
+                            "name": first_name
+                        }),
+                    );
+                }
+                let settings = serde_json::json!({
+                    "defaultProfile": exact_name,
+                    "profiles": {
+                        "defaults": {"commandline": "cmd.exe"},
+                        "list": profiles
+                    }
+                });
+                let profile =
+                    parse_wt_default_profile(&settings.to_string(), Some((1, 23, 20211, 0)));
+                let args = select_wt_launch_args(
+                    profile.as_ref(),
+                    true,
+                    "wt.exe",
+                    "probe.bat",
+                    "& 'probe.bat'",
+                );
+                let actual = args
+                    .windows(2)
+                    .find(|pair| pair[0] == "--profile")
+                    .map(|pair| pair[1]);
+                assert_eq!(
+                    actual,
+                    profile.as_ref().map(|profile| profile.selector.as_str()),
+                    "argument generation must preserve the parsed selector"
+                );
+                if actual != Some(expected) {
+                    failures.push(format!(
+                        "names={first_name:?}/{exact_name:?}, default={exact_name:?}, decoy={include_decoy}: expected {expected}, got {actual:?}"
+                    ));
+                }
+            }
+        }
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
+    }
+
+    #[test]
+    fn wt_default_profile_guid_precedes_name_collisions() {
+        let cmd_guid = "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}";
+        let pwsh_guid = "{574e775e-4f2a-5b96-ac1e-a2962a402336}";
+        for selector in [cmd_guid.to_string(), cmd_guid.to_ascii_uppercase()] {
+            for reverse in [false, true] {
+                for commandline in ["cmd.exe", "wsl.exe"] {
+                    let mut profiles = vec![
+                        serde_json::json!({"guid": pwsh_guid, "name": selector, "commandline": "pwsh.exe"}),
+                        serde_json::json!({"guid": cmd_guid, "name": "Command Prompt", "commandline": commandline}),
+                    ];
+                    if reverse {
+                        profiles.reverse();
+                    }
+                    let settings = serde_json::json!({
+                        "defaultProfile": selector,
+                        "profiles": {"list": profiles}
+                    });
+                    let expected = (commandline == "cmd.exe").then(|| WtDefaultProfile {
+                        selector: cmd_guid.to_string(),
+                        shell: WtDefaultShell::Cmd,
+                    });
+                    assert_eq!(
+                        parse_wt_default_profile(&settings.to_string(), None),
+                        expected,
+                        "selector={selector}, reverse={reverse}, commandline={commandline}"
+                    );
+                }
+            }
+        }
+
+        // Only when no GUID in the table matches may a GUID-shaped string be
+        // looked up as a name.
+        let name = "{11111111-1111-4111-8111-111111111111}";
+        let settings = serde_json::json!({
+            "defaultProfile": name,
+            "profiles": {"list": [{"guid": pwsh_guid, "name": name, "commandline": "pwsh.exe"}]}
+        });
+        assert_eq!(
+            parse_wt_default_profile(&settings.to_string(), None)
+                .unwrap()
+                .selector,
+            pwsh_guid
+        );
+    }
+
+    #[test]
+    fn parse_wt_default_profile_preserves_the_matched_selector() {
+        // This fixture inherits defaults; use the legacy rule so selector matching
+        // is isolated from versioned default loading.
+        for (content, selector) in [
+            (
+                r#"{"defaultProfile":"{33333333-3333-4333-8333-333333333333}","profiles":{"list":[{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
+                "{33333333-3333-4333-8333-333333333333}",
+            ),
+            (
+                r#"{"defaultProfile":"Custom shell","profiles":{"list":[{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
+                "{33333333-3333-4333-8333-333333333333}",
+            ),
+            (
+                r#"{"defaultProfile":"Custom shell","profiles":[{"name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}"#,
+                "{fa616ee5-b304-5217-8de0-4f1eb1e90d19}",
+            ),
+            (
+                r#"{"defaultProfile":"Profile0","profiles":{"list":[{"name":"profile0","commandline":"pwsh.exe"},{"name":"Profile0","commandline":"pwsh.exe"}]}}"#,
+                "{6a2f325d-dd64-5214-ac09-ceac61244422}",
+            ),
+            (
+                r#"{"defaultProfile":"{FA616EE5-B304-5217-8DE0-4F1EB1E90D19}","profiles":{"list":[{"name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
+                "{fa616ee5-b304-5217-8de0-4f1eb1e90d19}",
+            ),
+            (
+                r#"{"defaultProfile":"Custom shell","profiles":{"defaults":{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Other shell","source":"Other source","commandline":"pwsh.exe -NoLogo"},"list":[{"name":"Custom shell"}]}}"#,
+                "{fa616ee5-b304-5217-8de0-4f1eb1e90d19}",
+            ),
+            (
+                r#"{"defaultProfile":"{574e775e-4f2a-5b96-ac1e-a2962a402336}"}"#,
+                "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+            ),
+            (
+                r#"{"defaultProfile":"{33333333-3333-4333-8333-333333333333}","profiles":{"defaults":{"commandline":"pwsh.exe"},"list":[]}}"#,
+                "{33333333-3333-4333-8333-333333333333}",
+            ),
+        ] {
+            assert_eq!(
+                parse_wt_default_profile(content, Some((1, 23, 20211, 0))),
+                Some(WtDefaultProfile {
+                    selector: selector.to_string(),
+                    shell: WtDefaultShell::Pwsh,
+                }),
+                "{content}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_wt_default_profile_rejects_unresolvable_selectors() {
+        for content in [
+            r#"{"defaultProfile":"custom shell","profiles":{"list":[{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
+            r#"{"defaultProfile":"custom shell","profiles":[{"name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}"#,
+            r#"{"defaultProfile":" Custom shell","profiles":[{"name":"Custom shell","commandline":"pwsh.exe"}]}"#,
+            r#"{"defaultProfile":"Custom shell ","profiles":[{"name":"Custom shell","commandline":"pwsh.exe"}]}"#,
+            r#"{"defaultProfile":"Dev&echo","profiles":{"defaults":{"commandline":"pwsh.exe"},"list":[]}}"#,
+            r#"{"defaultProfile":"Dev&echo","profiles":{"list":[{"name":"Dev&echo","guid":"invalid","commandline":"pwsh.exe"}]}}"#,
+        ] {
+            assert_eq!(parse_wt_default_profile(content, None), None, "{content}");
+        }
+    }
+
+    #[test]
+    fn wt_launch_helpers_preserve_the_profile_and_use_explicit_fallback() {
+        let wt = r"C:\Program Files\Windows Terminal\wt.exe";
+        let bat = r"C:\Temp\test.bat";
+        let ps = r"& 'C:\Temp\test.bat'";
+
+        assert_eq!(
+            build_windows_start_args(&[wt, "new-tab"]),
+            vec!["/C", "start", "", wt, "new-tab"]
+        );
+        for shell in [
+            WtDefaultShell::Pwsh,
+            WtDefaultShell::PowerShell,
+            WtDefaultShell::Cmd,
+        ] {
+            let profile = WtDefaultProfile {
+                selector: "Custom profile with spaces".to_string(),
+                shell,
+            };
+            let mut expected = vec![
+                wt,
+                "new-tab",
+                "--profile",
+                "Custom profile with spaces",
+                "--appendCommandLine",
+                "--",
+            ];
+            if shell == WtDefaultShell::Cmd {
+                expected.extend(["/K", bat]);
+            } else {
+                expected.extend(["-NoExit", "-Command", ps]);
+            }
+            assert_eq!(
+                select_wt_launch_args(Some(&profile), true, wt, bat, ps),
+                expected
+            );
+            assert_eq!(
+                select_wt_launch_args(Some(&profile), false, wt, bat, ps),
+                vec![wt, "new-tab", "cmd", "/K", bat]
+            );
+        }
+        for supports_append in [false, true] {
+            assert_eq!(
+                select_wt_launch_args(None, supports_append, wt, bat, ps),
+                vec![wt, "new-tab", "cmd", "/K", bat]
+            );
+        }
+
+        let shim = "path = \"C:\\scoop\\apps\\windows-terminal\\current\\wt.exe\"\r\nargs = \r\n";
+        assert_eq!(
+            parse_scoop_shim_content(shim),
+            Some(PathBuf::from(
+                r"C:\scoop\apps\windows-terminal\current\wt.exe"
+            ))
+        );
+        assert_eq!(parse_scoop_shim_content("bad content"), None);
+    }
+
+    // Spawn a real argv probe so the launcher path and args are not re-parsed
+    // by an extra shell.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn wt_launch_preserves_special_character_paths_and_profile_args() {
+        let temp = tempfile::tempdir().expect("probe directory should be created");
+        let source = temp.path().join("argv_probe.rs");
+        let executable = temp.path().join("argv_probe.exe");
+        std::fs::write(
+            &source,
+            r#"#![windows_subsystem = "windows"]
+fn main() {
+    let path = std::env::current_exe().unwrap().with_extension("args");
+    let staging = path.with_extension("staging");
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    std::fs::write(&staging, format!("{args:?}")).unwrap();
+    std::fs::rename(staging, path).unwrap();
+}
+"#,
+        )
+        .expect("argv probe source should be written");
+        let compiled = std::process::Command::new("rustc")
+            .arg(&source)
+            .arg("-o")
+            .arg(&executable)
+            .output()
+            .expect("rustc should compile the argv probe");
+        assert!(
+            compiled.status.success(),
+            "{}",
+            String::from_utf8_lossy(&compiled.stderr)
+        );
+        let mut failures = Vec::new();
+        for directory in [
+            "Tools&echo",
+            "Tools%COMSPEC%",
+            "Tools^A",
+            "Tools(A)",
+            "Tools and O'Brien",
+            "工具🚀",
+        ] {
+            let launcher_dir = temp.path().join(directory);
+            std::fs::create_dir(&launcher_dir).expect("launcher directory should be created");
+            let launcher_executable = launcher_dir.join("wt.exe");
+            std::fs::copy(&executable, &launcher_executable)
+                .expect("probe should be copied to the launcher path");
+            let capture = launcher_executable.with_extension("args");
+            let launcher = launcher_executable.to_string_lossy();
+            for name in [
+                "Custom profile",
+                "Dev&echo",
+                "Dev%COMSPEC%",
+                "Dev;Test",
+                r"Dev\;Test",
+                r"Dev\\;Test",
+                "开发 🚀",
+                "Dev|echo",
+                "Dev^echo",
+            ] {
+                let settings = serde_json::json!({
+                    "defaultProfile": name,
+                    "profiles": {"list": [{"name": name, "commandline": "pwsh.exe -NoLogo"}]}
+                });
+                let profile = parse_wt_default_profile(&settings.to_string(), None)
+                    .expect("the profile should be recognized");
+                assert!(
+                    uuid::Uuid::parse_str(&profile.selector).is_ok(),
+                    "names must not reach cmd or WT as selectors: {name:?}"
+                );
+                let bat = r"C:\Temp\batch & %COMSPEC% ^ O'Brien\probe.bat";
+                let ps_cmd = format!("& '{}'", bat.replace('\'', "''"));
+                let args = select_wt_launch_args(Some(&profile), true, &launcher, bat, &ps_cmd);
+                let expected = format!("{:?}", &args[1..]);
+                run_wt_command(&args).expect("WT launcher should directly start the probe");
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+                while !capture.is_file() && std::time::Instant::now() < deadline {
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+                let observed =
+                    std::fs::read_to_string(&capture).expect("argv probe must write its result");
+                if observed != expected {
+                    failures.push(format!(
+                        "{name:?}: expected {expected}, received {observed}"
+                    ));
+                }
+                std::fs::remove_file(&capture)
+                    .expect("the completed probe result should be removed");
+            }
+        }
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
+        let missing_launcher = temp.path().join("missing.exe");
+        assert!(run_wt_command(&[&missing_launcher.to_string_lossy()]).is_err());
+        assert!(run_wt_command(&[]).is_err());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    #[serial_test::serial]
+    fn windows_terminal_launchers_do_not_inherit_parent_claude_session() {
+        struct EnvRestore(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+        impl Drop for EnvRestore {
+            fn drop(&mut self) {
+                for (name, value) in self.0.drain(..) {
+                    match value {
+                        Some(value) => std::env::set_var(name, value),
+                        None => std::env::remove_var(name),
+                    }
+                }
+            }
+        }
+
+        fn wait_for_probe(capture: &Path) -> String {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while !capture.is_file() && std::time::Instant::now() < deadline {
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+            std::fs::read_to_string(capture)
+                .expect("env probe must write its inherited variable names")
+        }
+
+        let restore = EnvRestore(
+            PARENT_CLAUDE_SESSION_ENV_VARS
+                .iter()
+                .map(|name| (*name, std::env::var_os(name)))
+                .collect(),
+        );
+        for name in PARENT_CLAUDE_SESSION_ENV_VARS {
+            std::env::set_var(name, "cc-switch-parent-session");
+        }
+
+        let temp = tempfile::tempdir().expect("probe directory should be created");
+        let source = temp.path().join("env_probe.rs");
+        let executable = temp.path().join("env_probe.exe");
+        std::fs::write(
+            &source,
+            r#"#![windows_subsystem = "windows"]
+fn main() {
+    let mut args = std::env::args_os().skip(1);
+    let capture = args.next().unwrap();
+    let inherited: Vec<String> = args
+        .filter(|name| std::env::var_os(name).is_some())
+        .map(|name| name.to_string_lossy().into_owned())
+        .collect();
+    std::fs::write(capture, inherited.join("\n")).unwrap();
+}
+"#,
+        )
+        .expect("env probe source should be written");
+        let compiled = std::process::Command::new("rustc")
+            .arg(&source)
+            .arg("-o")
+            .arg(&executable)
+            .output()
+            .expect("rustc should compile the env probe");
+        assert!(
+            compiled.status.success(),
+            "{}",
+            String::from_utf8_lossy(&compiled.stderr)
+        );
+
+        let launcher = executable.to_string_lossy();
+        for (label, capture, launch) in [
+            (
+                "direct Windows Terminal",
+                temp.path().join("direct.result"),
+                run_wt_command as fn(&[&str]) -> Result<(), String>,
+            ),
+            ("cmd start", temp.path().join("cmd-start.result"), |args| {
+                run_windows_start_command(args, "env probe")
+            }),
+        ] {
+            let capture_arg = capture.to_string_lossy();
+            let mut args = vec![launcher.as_ref(), capture_arg.as_ref()];
+            args.extend(PARENT_CLAUDE_SESSION_ENV_VARS.iter().copied());
+            launch(&args).unwrap_or_else(|error| panic!("{label} probe should launch: {error}"));
+            let inherited = wait_for_probe(&capture);
+            assert!(
+                inherited.is_empty(),
+                "{label} inherited parent Claude session variables:\n{inherited}"
+            );
+        }
+        drop(restore);
+    }
+
+    // Exercise the real WT profile selection, not only the generated argv.
+    // Opt in on a Windows desktop; this opens diagnostic tabs without changing settings.
+    #[cfg(target_os = "windows")]
+    #[test]
+    #[ignore = "requires desktop WT, a supported default profile GUID, and built-in PowerShell/cmd profiles"]
+    fn wt_launch_executes_batch_in_real_terminal() {
+        let installation = resolve_wt_installation().expect("Windows Terminal must be installed");
+        let default_profile =
+            detect_wt_default_profile(&installation, wt_installation_version(&installation))
+                .expect("the default WT profile must support batch execution");
+        let cases = [
+            (default_profile.clone(), true),
+            (
+                WtDefaultProfile {
+                    selector: "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}".to_string(),
+                    shell: WtDefaultShell::PowerShell,
+                },
+                true,
+            ),
+            (
+                WtDefaultProfile {
+                    selector: "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}".to_string(),
+                    shell: WtDefaultShell::Cmd,
+                },
+                true,
+            ),
+            (default_profile, false),
+        ];
+        let temp = tempfile::Builder::new()
+            .prefix("cc-switch-wt-smoke-")
+            .tempdir()
+            .expect("diagnostic directory should be created");
+        let fixture_dir = temp.path().join("space and O'Brien");
+        std::fs::create_dir(&fixture_dir).expect("quoted fixture directory should be created");
+        for (index, (profile, supports_append)) in cases.iter().enumerate() {
+            let marker = fixture_dir.join(format!("executed-{index}.txt"));
+            let batch = fixture_dir.join(format!("probe-{index}.bat"));
+            std::fs::write(
+                &batch,
+                format!(
+                    "@echo off\r\n> \"{}\" echo %WT_PROFILE_ID%\r\necho [cc-switch] WT launch diagnostic completed. This tab can be closed.\r\n",
+                    escape_windows_batch_value(&marker.to_string_lossy())
+                ),
+            )
+            .expect("diagnostic batch should be written");
+            let bat_path = batch.to_string_lossy();
+            let ps_cmd = format!("& '{}'", bat_path.replace('\'', "''"));
+            if index == 0 {
+                launch_wt_terminal(&bat_path, &ps_cmd).expect("WT launch should succeed");
+            } else {
+                let launcher = installation.launcher.to_string_lossy();
+                let args = select_wt_launch_args(
+                    Some(profile),
+                    *supports_append,
+                    &launcher,
+                    &bat_path,
+                    &ps_cmd,
+                );
+                run_wt_command(&args).expect("explicit-profile WT launch should succeed");
+            }
+
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+            while !marker.is_file() && std::time::Instant::now() < deadline {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            let profile_id = std::fs::read_to_string(&marker)
+                .unwrap_or_else(|error| panic!("case {index}: WT must execute the batch: {error}"));
+            if *supports_append {
+                assert_eq!(
+                    normalize_wt_guid(profile_id.trim()),
+                    normalize_wt_guid(&profile.selector),
+                    "case {index}: the batch must run in the same profile that was classified"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wt_settings_paths_stay_bound_to_the_resolved_installation() {
+        let local = Path::new("C:/Users/test/AppData/Local");
+        for exe in [
+            "C:/Users/test/scoop/apps/windows-terminal/current/WindowsTerminal.exe",
+            "C:/Program Files/Windows Terminal/wt.exe",
+            "C:/Tools/terminal/wt.exe",
+        ] {
+            assert_eq!(
+                build_wt_settings_paths(Path::new(exe), Some(local)),
+                vec![unpackaged_wt_settings_path(local)],
+                "{exe}"
+            );
+        }
+
+        // Do not depend on the local install type; classify stable vs Preview
+        // and bind each to its unique active settings path.
+        for (exe, expected_preview) in [
+            (
+                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminal_1.24.11911.0_x64__8wekyb3d8bbwe/wt.exe",
+                false,
+            ),
+            (
+                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminalPreview_1.0.0.0_x64__8wekyb3d8bbwe/wt.exe",
+                true,
+            ),
+        ] {
+            let exe = Path::new(exe);
+            let (preview, _) = store_wt_package_dir(exe)
+                .expect("Store executable must belong to a WT package");
+            assert_eq!(preview, expected_preview, "{exe:?}");
+            assert_eq!(
+                build_wt_settings_paths(exe, Some(local)),
+                vec![store_wt_settings_path(local, expected_preview)],
+                "{exe:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn wt_portable_install_uses_only_active_settings() {
+        let local = Path::new("C:/Users/test/AppData/Local");
+        for (layout, persist) in [
+            ("tools-wt", None),
+            (
+                "scoop/apps/windows-terminal/current",
+                Some("scoop/persist/windows-terminal"),
+            ),
+            (
+                "scoop/apps/windows-terminal-preview/1.24.0",
+                Some("scoop/persist/windows-terminal-preview"),
+            ),
+        ] {
+            let temp = tempfile::tempdir().expect("temp dir should be created");
+            let exe_dir = temp.path().join(layout);
+            std::fs::create_dir_all(&exe_dir).expect("portable dir should be created");
+            let exe = exe_dir.join("wt.exe");
+            std::fs::write(&exe, b"").expect("portable exe placeholder should be written");
+            std::fs::write(exe_dir.join(".portable"), b"")
+                .expect("portable marker should be written");
+
+            let active = r#"{
+                "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}"
+            }"#;
+            let stale = r#"{
+                "defaultProfile": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}"
+            }"#;
+            let mut expected = Vec::new();
+            for root in std::iter::once(exe_dir.clone())
+                .chain(persist.map(|persist| temp.path().join(persist)))
+            {
+                let settings_dir = root.join("settings");
+                std::fs::create_dir_all(&settings_dir).expect("settings dir should be created");
+                let active_path = settings_dir.join("settings.json");
+                std::fs::write(&active_path, active).expect("active settings should be written");
+                expected.push(active_path);
+                let stale_path = root.join("settings.json");
+                std::fs::write(&stale_path, stale).expect("stale settings should be written");
+                // A file at the root is not WT settings, even if its timestamp is
+                // newer than the active config.
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&stale_path)
+                    .expect("stale settings should open")
+                    .set_times(std::fs::FileTimes::new().set_modified(
+                        std::time::SystemTime::now() + std::time::Duration::from_secs(60),
+                    ))
+                    .expect("stale settings should have a newer timestamp");
+            }
+
+            let paths = build_wt_settings_paths(&exe, Some(local));
+            assert_eq!(
+                detect_wt_default_profile_from_paths(&paths, None),
+                parse_wt_default_profile(active, None),
+                "{layout}: root settings must not override the active PowerShell profile"
+            );
+            assert_eq!(
+                paths, expected,
+                "{layout}: only active settings are candidates"
+            );
+        }
+    }
+
+    #[test]
+    fn wt_version_and_path_detect_append_command_line_support() {
+        assert!(!wt_version_supports_append((1, 18, 3181, 0)));
+        assert!(wt_version_supports_append((1, 19, 0, 0)));
+        assert!(wt_version_supports_append((1, 24, 11911, 0)));
+        assert_eq!(
+            wt_version_from_path(Path::new(
+                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminal_1.18.3181.0_x64__8wekyb3d8bbwe/wt.exe"
+            )),
+            Some((1, 18, 3181, 0))
+        );
+        assert_eq!(
+            wt_version_from_path(Path::new(
+                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminal_1.24.11911.0_x64__8wekyb3d8bbwe/wt.exe"
+            )),
+            Some((1, 24, 11911, 0))
+        );
+        assert_eq!(
+            wt_version_from_path(Path::new(
+                "C:/Users/test/scoop/apps/windows-terminal/1.18.3181.0/wt.exe"
+            )),
+            Some((1, 18, 3181, 0))
+        );
+        assert_eq!(
+            wt_version_from_path(Path::new(
+                "C:/Users/test/scoop/apps/windows-terminal/current/wt.exe"
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn unpackaged_release_directory_is_not_misclassified_as_store() {
+        let local = Path::new("C:/Users/test/AppData/Local");
+        let exe = Path::new("C:/Tools/Microsoft.WindowsTerminal_1.23_x64/wt.exe");
+        let paths = build_wt_settings_paths(exe, Some(local));
+        assert!(paths.contains(&unpackaged_wt_settings_path(local)));
+        assert!(!paths.contains(&store_wt_settings_path(local, false)));
+        assert!(!paths.contains(&store_wt_settings_path(local, true)));
+    }
+
+    #[test]
+    fn app_execution_alias_parser_extracts_the_package_target() {
+        let build_buffer = |target: &str| {
+            let values = ["Package_Family", "Package_Family!App", target, "0"];
+            let mut payload = (values.len() as u32).to_le_bytes().to_vec();
+            for value in values {
+                for unit in value.encode_utf16().chain(Some(0)) {
+                    payload.extend_from_slice(&unit.to_le_bytes());
+                }
+            }
+
+            let mut buffer = APPEXECLINK_REPARSE_TAG.to_le_bytes().to_vec();
+            buffer.extend_from_slice(&(payload.len() as u16).to_le_bytes());
+            buffer.extend_from_slice(&0u16.to_le_bytes());
+            buffer.extend_from_slice(&payload);
+            buffer
+        };
+
+        let target = r"C:\Program Files\WindowsApps\Microsoft.WindowsTerminal_1.0.0.0_x64__8wekyb3d8bbwe\wt.exe";
+        let parsed = parse_app_execution_alias_target(&build_buffer(target))
+            .expect("App Execution Alias target should parse");
+        assert_eq!(String::from_utf16(&parsed).unwrap(), target);
+        assert_eq!(
+            parse_app_execution_alias_target(&build_buffer(r"relative\wt.exe")),
+            None
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn store_wt_alias_resolves_to_package_settings_not_scoop() {
+        let Some(local) = std::env::var_os("LOCALAPPDATA").map(PathBuf::from) else {
+            return;
+        };
+        let alias = local.join("Microsoft").join("WindowsApps").join("wt.exe");
+        if std::fs::symlink_metadata(&alias).is_err() {
+            return;
+        }
+
+        let target = resolve_app_execution_alias_target(&alias)
+            .expect("Store wt.exe App Execution Alias should resolve via APPEXECLINK");
+        // The wt.exe alias may belong to stable or Preview; settings paths must
+        // follow the actual target package.
+        let (preview, _) = store_wt_package_dir(&target)
+            .unwrap_or_else(|| panic!("Store alias must resolve to a WT package: {target:?}"));
+        assert_eq!(
+            build_wt_settings_paths(&target, Some(&local)),
+            vec![store_wt_settings_path(&local, preview)],
+            "Store settings should be bound to the resolved package: {target:?}"
+        );
+
+        // PATH lookup is a separate concern: GitHub-hosted Windows runners often
+        // have the Store alias file but no WindowsApps directory on PATH.
+        if let Some(installation) = resolve_wt_installation() {
+            assert_eq!(
+                installation
+                    .launcher
+                    .file_name()
+                    .map(|name| name.to_string_lossy().to_ascii_lowercase()),
+                Some("wt.exe".into()),
+                "launcher should stay the resolved wt.exe, got {:?}",
+                installation.launcher
+            );
+            if installation
+                .launcher
+                .parent()
+                .is_some_and(is_windows_app_execution_alias_dir)
+            {
+                assert_eq!(
+                    installation.settings_executable.as_ref(),
+                    Some(&target),
+                    "PATH-selected Store alias should bind settings to the same APPEXECLINK target"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wt_settings_detection_skips_malformed_candidates() {
+        let temp = tempfile::tempdir().expect("temp dir should be created");
+        let valid = temp.path().join("valid.json");
+        let malformed = temp.path().join("malformed.json");
+        let pwsh = r#"{
+            "defaultProfile": "PowerShell 7",
+            "profiles": [{"name": "PowerShell 7", "commandline": "pwsh.exe"}]
+        }"#;
+        std::fs::write(&valid, pwsh).expect("valid settings should be written");
+        std::fs::write(&malformed, "not json").expect("malformed settings should be written");
+
+        assert_eq!(
+            detect_wt_default_profile_from_paths(&[malformed, valid], None),
+            Some(WtDefaultProfile {
+                selector: "{8f7fc2c9-b084-5bc6-89f4-82fc0f5d1b6c}".to_string(),
+                shell: WtDefaultShell::Pwsh,
+            })
         );
     }
 }

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -16,6 +16,8 @@ use tauri_plugin_opener::OpenerExt;
 use std::os::windows::process::CommandExt;
 
 #[cfg(target_os = "windows")]
+const CREATE_NEW_CONSOLE: u32 = 0x00000010;
+#[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 /// 打开外部链接
@@ -367,7 +369,7 @@ fn decode_windows_where_output_with_codepage(bytes: &[u8], codepage: u32) -> Str
 }
 
 #[cfg(target_os = "windows")]
-fn decode_windows_where_output(bytes: &[u8]) -> String {
+pub(super) fn decode_windows_where_output(bytes: &[u8]) -> String {
     let oem_cp = unsafe { windows_sys::Win32::Globalization::GetOEMCP() };
     decode_windows_where_output_with_codepage(bytes, oem_cp)
 }
@@ -1411,7 +1413,7 @@ fn try_get_version_wsl(
     ShellProbe::NotFound("WSL check not supported on this platform".to_string())
 }
 
-fn push_unique_path(paths: &mut Vec<std::path::PathBuf>, path: std::path::PathBuf) {
+pub(super) fn push_unique_path(paths: &mut Vec<std::path::PathBuf>, path: std::path::PathBuf) {
     if path.as_os_str().is_empty() {
         return;
     }
@@ -1471,7 +1473,7 @@ fn should_skip_cli_path_env_dir(path: &Path) -> bool {
 }
 
 #[cfg(target_os = "windows")]
-fn is_windows_app_execution_alias_dir(path: &Path) -> bool {
+pub(super) fn is_windows_app_execution_alias_dir(path: &Path) -> bool {
     let normalized = path
         .to_string_lossy()
         .replace('/', "\\")
@@ -1675,7 +1677,7 @@ fn effective_path_string() -> String {
 /// Windows this is derived from `effective_path_string`; on other platforms the
 /// raw process value is returned unchanged (zero behaviour change).
 #[cfg(target_os = "windows")]
-fn effective_path_os() -> Option<std::ffi::OsString> {
+pub(super) fn effective_path_os() -> Option<std::ffi::OsString> {
     Some(std::ffi::OsString::from(effective_path_string()))
 }
 
@@ -2316,7 +2318,7 @@ fn resolve_path_default(
 }
 
 #[cfg(target_os = "windows")]
-fn windows_path_lookup_command(
+pub(super) fn windows_path_lookup_command(
     tool: &str,
     effective_path: &std::ffi::OsStr,
 ) -> std::process::Command {
@@ -3099,13 +3101,13 @@ fn locate_default_tool(
 }
 
 #[derive(Clone, Copy)]
-struct CommandDeadline {
+pub(super) struct CommandDeadline {
     expires_at: std::time::Instant,
     limit: std::time::Duration,
 }
 
 impl CommandDeadline {
-    fn from_timeout(timeout: Option<std::time::Duration>) -> Option<Self> {
+    pub(super) fn from_timeout(timeout: Option<std::time::Duration>) -> Option<Self> {
         timeout.map(|limit| Self {
             expires_at: std::time::Instant::now() + limit,
             limit,
@@ -3166,7 +3168,7 @@ fn isolate_child_process_group(cmd: &mut std::process::Command) {
     }
 }
 
-fn wait_child_output(
+pub(super) fn wait_child_output(
     mut child: std::process::Child,
     deadline: Option<CommandDeadline>,
 ) -> Result<std::process::Output, String> {
@@ -3784,8 +3786,8 @@ pub async fn open_provider_terminal(
     let config = &provider.settings_config;
     let env_vars = extract_env_vars_from_config(config, &app_type);
 
-    // 根据平台启动终端，传入提供商ID用于生成唯一的配置文件名
-    launch_terminal_with_env(env_vars, &providerId, launch_cwd.as_deref())
+    // 根据平台启动终端；每次调用使用独立的临时配置和启动脚本。
+    launch_terminal_with_env(env_vars, launch_cwd.as_deref())
         .map_err(|e| format!("启动终端失败: {e}"))?;
 
     Ok(true)
@@ -3866,50 +3868,70 @@ fn resolve_launch_cwd(cwd: Option<String>) -> Result<Option<PathBuf>, String> {
     Ok(Some(resolved))
 }
 
+fn write_unique_temp_artifact(
+    temp_dir: &Path,
+    prefix: &str,
+    suffix: &str,
+    content: &[u8],
+) -> Result<PathBuf, String> {
+    use std::io::Write;
+
+    let mut artifact = tempfile::Builder::new()
+        .prefix(prefix)
+        .suffix(suffix)
+        .tempfile_in(temp_dir)
+        .map_err(|e| format!("创建临时文件失败: {e}"))?;
+    artifact
+        .write_all(content)
+        .map_err(|e| format!("写入临时文件失败: {e}"))?;
+    let (file, path) = artifact
+        .keep()
+        .map_err(|e| format!("保留临时文件失败: {}", e.error))?;
+    drop(file);
+    Ok(path)
+}
+
 /// 创建临时配置文件并启动 claude 终端
 /// 使用 --settings 参数传入提供商特定的 API 配置
 fn launch_terminal_with_env(
     env_vars: Vec<(String, String)>,
-    provider_id: &str,
     cwd: Option<&Path>,
 ) -> Result<(), String> {
     let temp_dir = std::env::temp_dir();
-    let config_file = temp_dir.join(format!(
-        "claude_{}_{}.json",
-        provider_id,
-        std::process::id()
-    ));
 
-    // 创建并写入配置文件
-    write_claude_config(&config_file, &env_vars)?;
+    // 创建并写入每次调用独立的配置文件。
+    let config_file = write_claude_config(&temp_dir, &env_vars)?;
 
-    #[cfg(target_os = "macos")]
-    {
-        launch_macos_terminal(&config_file, cwd)?;
-        Ok(())
+    let result = {
+        #[cfg(target_os = "macos")]
+        {
+            launch_macos_terminal(&config_file, cwd)
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            launch_linux_terminal(&config_file, cwd)
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            launch_windows_terminal(&temp_dir, &config_file, cwd)
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+        {
+            Err("不支持的操作系统".to_string())
+        }
+    };
+
+    if result.is_err() {
+        let _ = std::fs::remove_file(&config_file);
     }
-
-    #[cfg(target_os = "linux")]
-    {
-        launch_linux_terminal(&config_file, cwd)?;
-        Ok(())
-    }
-
-    #[cfg(target_os = "windows")]
-    {
-        launch_windows_terminal(&temp_dir, &config_file, cwd)?;
-        Ok(())
-    }
-
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    Err("不支持的操作系统".to_string())
+    result
 }
 
 /// 写入 claude 配置文件
-fn write_claude_config(
-    config_file: &std::path::Path,
-    env_vars: &[(String, String)],
-) -> Result<(), String> {
+fn write_claude_config(temp_dir: &Path, env_vars: &[(String, String)]) -> Result<PathBuf, String> {
     let mut config_obj = serde_json::Map::new();
     let mut env_obj = serde_json::Map::new();
 
@@ -3922,7 +3944,7 @@ fn write_claude_config(
     let config_json =
         serde_json::to_string_pretty(&config_obj).map_err(|e| format!("序列化配置失败: {e}"))?;
 
-    std::fs::write(config_file, config_json).map_err(|e| format!("写入配置文件失败: {e}"))
+    write_unique_temp_artifact(temp_dir, "claude_", ".json", config_json.as_bytes())
 }
 
 /// macOS: 根据用户首选终端启动
@@ -4441,18 +4463,16 @@ fn launch_windows_terminal(
     config_file: &std::path::Path,
     cwd: Option<&Path>,
 ) -> Result<(), String> {
-    let preferred = crate::settings::get_preferred_terminal();
-    let terminal = preferred.as_deref().unwrap_or("cmd");
-
-    let bat_file = temp_dir.join(format!("cc_switch_claude_{}.bat", std::process::id()));
     let config_path_for_batch = escape_windows_batch_value(&config_file.to_string_lossy());
     let cwd_command = build_windows_cwd_command(cwd);
 
     let content = format!(
         "@echo off
+setlocal DisableDelayedExpansion
+set \"CC_SWITCH_INTERNAL_BATCH_PATH=\"
 {cwd_command}
 echo Using provider-specific claude config:
-echo {}
+echo \"{}\"
 claude --settings \"{}\"
 del \"{}\" >nul 2>&1
 del \"%~f0\" >nul 2>&1
@@ -4463,31 +4483,18 @@ del \"%~f0\" >nul 2>&1
         cwd_command = cwd_command,
     );
 
-    std::fs::write(&bat_file, &content).map_err(|e| format!("写入批处理文件失败: {e}"))?;
+    let bat_file =
+        write_unique_temp_artifact(temp_dir, "cc_switch_claude_", ".bat", content.as_bytes())?;
 
     let bat_path = bat_file.to_string_lossy();
-    let ps_cmd = format!("& '{}'", bat_path.replace('\'', "''"));
 
-    // Try the preferred terminal first
-    let result = match terminal {
-        "powershell" => run_windows_start_command(
-            &["powershell", "-NoExit", "-Command", &ps_cmd],
-            "PowerShell",
-        ),
-        "wt" => launch_wt_terminal(&bat_path, &ps_cmd),
-        _ => run_windows_start_command(&["cmd", "/K", &bat_path], "cmd"), // "cmd" or default
-    };
+    let result = launch_windows_batch_in_preferred_terminal(&bat_path);
 
-    // If preferred terminal fails and it's not the default, try cmd as fallback
-    if result.is_err() && terminal != "cmd" {
-        log::warn!(
-            "首选终端 {} 启动失败，回退到 cmd: {:?}",
-            terminal,
-            result.as_ref().err()
-        );
-        return run_windows_start_command(&["cmd", "/K", &bat_path], "cmd");
+    // The batch removes itself after it starts. If every spawn attempt failed,
+    // clean it here; the caller similarly removes the provider settings file.
+    if result.is_err() {
+        let _ = std::fs::remove_file(&bat_file);
     }
-
     result
 }
 
@@ -4519,28 +4526,28 @@ fn build_windows_cwd_command(cwd: Option<&Path>) -> String {
         .unwrap_or_default()
 }
 
-#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
-fn escape_windows_batch_value(value: &str) -> String {
-    value
-        .replace('^', "^^")
-        .replace('%', "%%")
-        .replace('&', "^&")
-        .replace('|', "^|")
-        .replace('<', "^<")
-        .replace('>', "^>")
-        .replace('(', "^(")
-        .replace(')', "^)")
-}
+#[cfg(any(target_os = "windows", test))]
+pub(super) const WINDOWS_BATCH_PATH_ENV: &str = "CC_SWITCH_INTERNAL_BATCH_PATH";
+#[cfg(any(target_os = "windows", test))]
+pub(super) const WINDOWS_BATCH_PATH_COMMAND: &str = "%CC_SWITCH_INTERNAL_BATCH_PATH%";
+#[cfg(any(target_os = "windows", test))]
+pub(super) const WINDOWS_POWERSHELL_BATCH_COMMAND: &str =
+    "& $env:ComSpec /D /V:OFF /C '%CC_SWITCH_INTERNAL_BATCH_PATH%'";
 
 #[cfg(any(target_os = "windows", test))]
-fn build_windows_start_args<'a>(args: &[&'a str]) -> Vec<&'a str> {
-    let mut full_args = vec!["/C", "start", ""];
-    full_args.extend_from_slice(args);
-    full_args
+pub(super) fn quote_windows_batch_path_for_env(path: &str) -> String {
+    format!("\"{path}\"")
+}
+
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(super) fn escape_windows_batch_value(value: &str) -> String {
+    // Every caller places the value inside double quotes. CMD keeps metacharacters
+    // literal there; only percent expansion still applies in a batch file.
+    value.replace('%', "%%")
 }
 
 #[cfg(target_os = "windows")]
-const PARENT_CLAUDE_SESSION_ENV_VARS: &[&str] = &[
+pub(super) const PARENT_CLAUDE_SESSION_ENV_VARS: &[&str] = &[
     "CLAUDE_CODE_CHILD_SESSION",
     "CLAUDECODE",
     "CLAUDE_CODE_SESSION_ID",
@@ -4566,1112 +4573,70 @@ fn detach_claude_parent_session_env(command: &mut std::process::Command) {
     }
 }
 
-/// Windows: launch a terminal via `cmd /C start`.
 #[cfg(target_os = "windows")]
-fn run_windows_start_command(args: &[&str], terminal_name: &str) -> Result<(), String> {
-    use std::process::Command;
+pub(super) fn configure_windows_batch_env(command: &mut std::process::Command, bat_path: &str) {
+    detach_claude_parent_session_env(command);
+    command.env(
+        WINDOWS_BATCH_PATH_ENV,
+        quote_windows_batch_path_for_env(bat_path),
+    );
+}
 
-    // `start` treats the first quoted argument as a window title; the empty
-    // title keeps an absolute path as the command.
-    let full_args = build_windows_start_args(args);
+#[cfg(target_os = "windows")]
+pub(super) fn configure_windows_cmd_batch(
+    command: &mut std::process::Command,
+    action: &str,
+    bat_path: &str,
+) {
+    configure_windows_batch_env(command, bat_path);
+    command.args(["/D", "/V:OFF", action, WINDOWS_BATCH_PATH_COMMAND]);
+}
 
-    let mut command = Command::new("cmd");
-    detach_claude_parent_session_env(&mut command);
-    let output = command
-        .args(&full_args)
-        .creation_flags(CREATE_NO_WINDOW)
-        .output()
-        .map_err(|e| format!("启动 {} 失败: {e}", terminal_name))?;
-
-    if !output.status.success() {
-        let stderr = decode_command_output(&output.stderr);
-        return Err(format!(
-            "{} 启动失败 (exit code: {:?}): {}",
-            terminal_name,
-            output.status.code(),
-            stderr
-        ));
-    }
-
+#[cfg(target_os = "windows")]
+fn run_windows_cmd_batch(bat_path: &str) -> Result<(), String> {
+    let mut command = std::process::Command::new("cmd");
+    configure_windows_cmd_batch(&mut command, "/K", bat_path);
+    command
+        .creation_flags(CREATE_NEW_CONSOLE)
+        .spawn()
+        .map_err(|e| format!("启动 cmd 失败: {e}"))?;
     Ok(())
 }
 
-/// Shell family of Windows Terminal's default profile.
-#[cfg(any(target_os = "windows", test))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum WtDefaultShell {
-    Pwsh,
-    PowerShell,
-    Cmd,
-}
-
-/// Keep the selector with the shell whose flags we append. Without `--profile`,
-/// WT can match the appended commandline against another profile instead of
-/// using defaultProfile, even when `--appendCommandLine` is set.
-#[cfg(any(target_os = "windows", test))]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct WtDefaultProfile {
-    selector: String,
-    shell: WtDefaultShell,
-}
-
-#[cfg(any(target_os = "windows", test))]
-impl WtDefaultProfile {
-    pub(crate) fn build_wt_args<'a>(
-        &'a self,
-        wt_command: &'a str,
-        bat_path: &'a str,
-        ps_cmd: &'a str,
-    ) -> Vec<&'a str> {
-        let mut args = vec![
-            wt_command,
-            "new-tab",
-            "--profile",
-            self.selector.as_str(),
-            "--appendCommandLine",
-            "--",
-        ];
-        match self.shell {
-            WtDefaultShell::Pwsh | WtDefaultShell::PowerShell => {
-                args.extend(["-NoExit", "-Command", ps_cmd]);
-            }
-            WtDefaultShell::Cmd => args.extend(["/K", bat_path]),
-        }
-        args
-    }
-}
-
-/// When the default profile cannot be appended to safely, start cmd explicitly
-/// instead of appending `/K` to an unknown shell.
-#[cfg(any(target_os = "windows", test))]
-fn build_wt_cmd_fallback_args<'a>(wt_command: &'a str, bat_path: &'a str) -> Vec<&'a str> {
-    vec![wt_command, "new-tab", "cmd", "/K", bat_path]
-}
-
-/// `--appendCommandLine` exists from WT 1.19. Fall back to explicit cmd before spawn
-/// so an unsupported flag is not discovered only after the async launch.
-#[cfg(any(target_os = "windows", test))]
-fn select_wt_launch_args<'a>(
-    profile: Option<&'a WtDefaultProfile>,
-    supports_append: bool,
-    wt_command: &'a str,
-    bat_path: &'a str,
-    ps_cmd: &'a str,
-) -> Vec<&'a str> {
-    match (profile, supports_append) {
-        (Some(profile), true) => profile.build_wt_args(wt_command, bat_path, ps_cmd),
-        _ => build_wt_cmd_fallback_args(wt_command, bat_path),
-    }
-}
-
-/// Strip braces and lowercase GUID strings so they compare across configs.
-#[cfg(any(target_os = "windows", test))]
-fn normalize_wt_guid(guid: &str) -> String {
-    guid.trim()
-        .trim_matches(|c: char| c == '{' || c == '}')
-        .to_ascii_lowercase()
-}
-
-/// Split the first executable from the remaining arguments. WT still owns the
-/// original commandline quoting; this parser does not rebuild it.
-#[cfg(any(target_os = "windows", test))]
-fn split_wt_commandline(cmdline: &str) -> Option<(&str, &str)> {
-    let trimmed = cmdline.trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    if let Some(stripped) = trimmed.strip_prefix('"') {
-        let closing_quote = stripped.find('"')?;
-        let executable = &stripped[..closing_quote];
-        if executable.is_empty() {
-            return None;
-        }
-        return Some((executable, stripped[closing_quote + 1..].trim_start()));
-    }
-
-    let split_at = trimmed
-        .find(|character: char| character.is_whitespace())
-        .unwrap_or(trimmed.len());
-    Some((&trimmed[..split_at], trimmed[split_at..].trim_start()))
-}
-
-/// Tokenize arguments with Windows commandline quoting. Parse failure means
-/// appending extra arguments cannot be proven safe.
-#[cfg(any(target_os = "windows", test))]
-fn split_wt_arguments(arguments: &str) -> Option<Vec<String>> {
-    let characters: Vec<char> = arguments.chars().collect();
-    let mut result = Vec::new();
-    let mut index = 0usize;
-
-    while index < characters.len() {
-        while index < characters.len() && characters[index].is_whitespace() {
-            index += 1;
-        }
-        if index == characters.len() {
-            break;
-        }
-
-        let mut argument = String::new();
-        let mut in_quotes = false;
-        while index < characters.len() {
-            if !in_quotes && characters[index].is_whitespace() {
-                break;
-            }
-
-            if characters[index] == '\\' {
-                let slash_start = index;
-                while index < characters.len() && characters[index] == '\\' {
-                    index += 1;
-                }
-                let slash_count = index - slash_start;
-                if index < characters.len() && characters[index] == '"' {
-                    argument.extend(std::iter::repeat_n('\\', slash_count / 2));
-                    if slash_count % 2 == 0 {
-                        in_quotes = !in_quotes;
-                    } else {
-                        argument.push('"');
-                    }
-                    index += 1;
-                } else {
-                    argument.extend(std::iter::repeat_n('\\', slash_count));
-                }
-                continue;
-            }
-
-            if characters[index] == '"' {
-                in_quotes = !in_quotes;
-                index += 1;
-                continue;
-            }
-
-            argument.push(characters[index]);
-            index += 1;
-        }
-
-        if in_quotes {
-            return None;
-        }
-        result.push(argument);
-    }
-
-    Some(result)
-}
-
-/// PowerShell host CLI option arity. Unique prefixes match; mixed-kind
-/// prefixes are treated as unknown so append is refused.
-/// `pwsh` and Windows PowerShell 5.1 differ only in `-Version`'s kind and in
-/// shell-specific parameters, so each shell keeps its own table.
-#[cfg(any(target_os = "windows", test))]
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum PsHostOption {
-    Flag,
-    Value,
-    Terminal,
-}
-
-/// Host aliases and parameter names shared by `pwsh` and Windows PowerShell.
-/// Shell-specific differences remain separate so changes cannot silently drift.
-#[cfg(any(target_os = "windows", test))]
-const COMMON_POWERSHELL_HOST_OPTIONS: &[(&str, PsHostOption)] = &[
-    ("?", PsHostOption::Terminal),
-    ("c", PsHostOption::Terminal),
-    ("command", PsHostOption::Terminal),
-    ("config", PsHostOption::Value),
-    ("configurationname", PsHostOption::Value),
-    ("e", PsHostOption::Terminal),
-    ("ea", PsHostOption::Value),
-    ("ec", PsHostOption::Terminal),
-    ("encodedarguments", PsHostOption::Value),
-    ("encodedcommand", PsHostOption::Terminal),
-    ("ep", PsHostOption::Value),
-    ("ex", PsHostOption::Value),
-    ("executionpolicy", PsHostOption::Value),
-    ("f", PsHostOption::Terminal),
-    ("file", PsHostOption::Terminal),
-    ("h", PsHostOption::Terminal),
-    ("help", PsHostOption::Terminal),
-    ("if", PsHostOption::Value),
-    ("inp", PsHostOption::Value),
-    ("inputformat", PsHostOption::Value),
-    ("mta", PsHostOption::Flag),
-    ("noe", PsHostOption::Flag),
-    ("noexit", PsHostOption::Flag),
-    ("nol", PsHostOption::Flag),
-    ("nologo", PsHostOption::Flag),
-    ("noni", PsHostOption::Flag),
-    ("noninteractive", PsHostOption::Flag),
-    ("nop", PsHostOption::Flag),
-    ("noprofile", PsHostOption::Flag),
-    ("o", PsHostOption::Value),
-    ("of", PsHostOption::Value),
-    ("outputformat", PsHostOption::Value),
-    ("servermode", PsHostOption::Terminal),
-    ("sta", PsHostOption::Flag),
-    ("w", PsHostOption::Value),
-    ("wd", PsHostOption::Value),
-    ("windowstyle", PsHostOption::Value),
-    ("workingdirectory", PsHostOption::Value),
-];
-
-/// `pwsh`-only options. `-Version` exits instead of accepting a value.
-#[cfg(any(target_os = "windows", test))]
-const PWSH_HOST_OPTIONS: &[(&str, PsHostOption)] = &[
-    ("commandwithargs", PsHostOption::Terminal),
-    ("configurationfile", PsHostOption::Value),
-    ("custompipename", PsHostOption::Value),
-    ("cwa", PsHostOption::Terminal),
-    ("i", PsHostOption::Flag),
-    ("interactive", PsHostOption::Flag),
-    ("l", PsHostOption::Flag),
-    ("login", PsHostOption::Flag),
-    ("noprofileloadtime", PsHostOption::Flag),
-    ("settings", PsHostOption::Value),
-    ("settingsfile", PsHostOption::Value),
-    ("sshs", PsHostOption::Terminal),
-    ("sshservermode", PsHostOption::Terminal),
-    ("v", PsHostOption::Terminal),
-    ("version", PsHostOption::Terminal),
-    ("wo", PsHostOption::Value),
-];
-
-/// Windows PowerShell 5.1-only options and classifications. `-Version`
-/// accepts `2.0`/`3.0`, unlike `pwsh`.
-#[cfg(any(target_os = "windows", test))]
-const WINDOWS_POWERSHELL_HOST_OPTIONS: &[(&str, PsHostOption)] = &[
-    ("psconsolefile", PsHostOption::Value),
-    ("v", PsHostOption::Value),
-    ("version", PsHostOption::Value),
-];
-
-/// PowerShell host CLI option dashes: ASCII hyphen plus the Unicode dashes
-/// `pwsh`/`powershell.exe` accept (U+2013, U+2014, U+2015). Copied-from-docs
-/// commandlines often use these instead of ASCII `-`.
-#[cfg(any(target_os = "windows", test))]
-const PS_OPTION_DASHES: &[char] = &['-', '\u{2013}', '\u{2014}', '\u{2015}'];
-
-#[cfg(any(target_os = "windows", test))]
-fn ps_host_option_name(argument: &str) -> Option<&str> {
-    let mut chars = argument.chars();
-    let first = chars.next()?;
-    let rest = chars.as_str();
-    if first == '/' {
-        return (!rest.is_empty()).then_some(rest);
-    }
-    if !PS_OPTION_DASHES.contains(&first) {
-        return None;
-    }
-    // `--NoLogo` and `––NoLogo` (same dash twice) are long-option spellings.
-    // Mixed dashes (`-–NoLogo`) are not options; leave the second character.
-    let mut inner = rest.chars();
-    let rest = if inner.next() == Some(first) {
-        inner.as_str()
-    } else {
-        rest
-    };
-    (!rest.is_empty()).then_some(rest)
-}
-
-#[cfg(any(target_os = "windows", test))]
-fn classify_ps_host_option(shell: WtDefaultShell, name: &str) -> Option<PsHostOption> {
-    let shell_options = match shell {
-        WtDefaultShell::Pwsh => PWSH_HOST_OPTIONS,
-        WtDefaultShell::PowerShell => WINDOWS_POWERSHELL_HOST_OPTIONS,
-        WtDefaultShell::Cmd => return None,
-    };
-    let name = name.to_ascii_lowercase();
-
-    let all_options = || {
-        COMMON_POWERSHELL_HOST_OPTIONS
-            .iter()
-            .chain(shell_options.iter())
-    };
-
-    // Exact alias or full parameter match wins immediately.
-    if let Some((_, option)) = all_options().find(|(alias, _)| *alias == name.as_str()) {
-        return Some(*option);
-    }
-
-    // Otherwise accept only a unique full-parameter prefix. Multiple
-    // candidates are ambiguous even when they have the same arity (`-no`
-    // matches NoExit, NoLogo, NonInteractive, and NoProfile).
-    let mut matches = all_options().filter(|(parameter, _)| parameter.starts_with(&name));
-    let (_, option) = matches.next()?;
-    matches.next().is_none().then_some(*option)
-}
-
-/// Walk host arguments with arity. A leftover positional is implicit `-File`.
-#[cfg(any(target_os = "windows", test))]
-fn pwsh_host_args_block_append(shell: WtDefaultShell, arguments: &[String]) -> bool {
-    let mut index = 0usize;
-    while index < arguments.len() {
-        let argument = &arguments[index];
-        if argument == "--" {
-            return true;
-        }
-        let Some(name) = ps_host_option_name(argument) else {
-            return true;
-        };
-        match classify_ps_host_option(shell, name) {
-            Some(PsHostOption::Flag) => index += 1,
-            Some(PsHostOption::Value) => {
-                if index + 1 >= arguments.len() {
-                    return true;
-                }
-                index += 2;
-            }
-            Some(PsHostOption::Terminal) | None => return true,
-        }
-    }
-    false
-}
-
-/// Existing terminal-action flags consume or reject extra arguments, so
-/// `--appendCommandLine` must not be used.
-#[cfg(any(target_os = "windows", test))]
-fn wt_commandline_has_terminal_action(shell: WtDefaultShell, arguments: &str) -> bool {
-    let Some(arguments) = split_wt_arguments(arguments) else {
-        return true;
-    };
-
-    match shell {
-        WtDefaultShell::Pwsh | WtDefaultShell::PowerShell => {
-            pwsh_host_args_block_append(shell, &arguments)
-        }
-        WtDefaultShell::Cmd => arguments.iter().any(|argument| {
-            let option = argument.to_ascii_lowercase();
-            // CMD allows glued switches such as /D/C and /D/K; a terminating action
-            // is not always the first whitespace-separated token.
-            option.contains("/c") || option.contains("/k")
-        }),
-    }
-}
-
-/// Classify a supported shell from the executable name. An explicit commandline
-/// is accepted only when extra arguments can be appended safely.
-#[cfg(any(target_os = "windows", test))]
-fn classify_wt_commandline(cmdline: &str) -> Option<WtDefaultShell> {
-    let (executable, arguments) = split_wt_commandline(cmdline)?;
-    let file_name = executable
-        .rsplit(['\\', '/'])
-        .next()
-        .unwrap_or(executable)
-        .to_ascii_lowercase();
-    let base_name = file_name.strip_suffix(".exe").unwrap_or(&file_name);
-
-    let shell = match base_name {
-        "pwsh" => WtDefaultShell::Pwsh,
-        "powershell" => WtDefaultShell::PowerShell,
-        "cmd" => WtDefaultShell::Cmd,
-        _ => return None,
-    };
-
-    (!wt_commandline_has_terminal_action(shell, arguments)).then_some(shell)
-}
-
-/// Callers filter defaults by WT version first, then classify the shell from an
-/// explicit command, inherited command, dynamic source, known GUID, or name.
-/// If a provided commandline cannot be appended to safely, refuse the profile
-/// instead of guessing from GUID or name.
-#[cfg(any(target_os = "windows", test))]
-fn classify_wt_profile(
-    profile: &serde_json::Value,
-    inherited_commandline: Option<&serde_json::Value>,
-) -> Option<WtDefaultShell> {
-    if let Some(commandline) = profile.get("commandline").or(inherited_commandline) {
-        return commandline.as_str().and_then(classify_wt_commandline);
-    }
-
-    // Dynamic profiles may omit an inspectable commandline; only known sources
-    // with a fixed meaning are accepted.
-    if let Some(source) = profile.get("source").and_then(|v| v.as_str()) {
-        if source == "Windows.Terminal.PowershellCore" {
-            return Some(WtDefaultShell::Pwsh);
-        }
-
-        // An unknown generator may already include a terminating action; do not
-        // fall back to GUID or name.
-        return None;
-    }
-
-    if let Some(guid) = profile.get("guid").and_then(|v| v.as_str()) {
-        match normalize_wt_guid(guid).as_str() {
-            "574e775e-4f2a-5b96-ac1e-a2962a402336" => return Some(WtDefaultShell::Pwsh),
-            "61c54bbd-c2c6-5271-96e7-009a87ff44bf" => return Some(WtDefaultShell::PowerShell),
-            "0caa0dad-35be-5f56-a8ff-afceeeaa6101" => return Some(WtDefaultShell::Cmd),
-            _ => {}
-        }
-    }
-
-    if let Some(name) = profile.get("name").and_then(|v| v.as_str()) {
-        let name_lower = name.to_ascii_lowercase();
-        if name_lower.contains("powershell 7") || name_lower.contains("pwsh") {
-            return Some(WtDefaultShell::Pwsh);
-        }
-        if name_lower.contains("powershell") {
-            return Some(WtDefaultShell::PowerShell);
-        }
-        if name_lower.contains("command prompt") || name_lower.contains("cmd") {
-            return Some(WtDefaultShell::Cmd);
-        }
-    }
-
-    None
-}
-
-// WT hashes Windows wide strings, not UTF-8: changing the encoding would select
-// a different profile even though the displayed name is identical.
-#[cfg(any(target_os = "windows", test))]
-fn wt_uuid_v5(namespace: uuid::Uuid, value: &str) -> uuid::Uuid {
-    let bytes: Vec<u8> = value.encode_utf16().flat_map(u16::to_le_bytes).collect();
-    uuid::Uuid::new_v5(&namespace, &bytes)
-}
-
-/// Mirror Profile::_GenerateGuidForProfile for entries in the local settings file.
-/// WT assigns these IDs before layering defaults. Fragment/generator profiles not
-/// present in this file cannot be reconstructed from names alone.
-/// https://github.com/microsoft/terminal/blob/v1.24.11911.0/src/cascadia/TerminalSettingsModel/Profile.cpp#L301-L319
-#[cfg(any(target_os = "windows", test))]
-fn wt_profile_guid(profile: &serde_json::Value) -> Option<uuid::Uuid> {
-    if let Some(guid) = profile.get("guid").filter(|value| !value.is_null()) {
-        return uuid::Uuid::parse_str(guid.as_str()?).ok();
-    }
-    let name = profile.get("name")?.as_str()?;
-    let source = match profile.get("source") {
-        None | Some(serde_json::Value::Null) => "",
-        Some(source) => source.as_str()?,
-    };
-    let namespace = uuid::Uuid::from_u128(0xf65ddb7e_706b_4499_8a50_40313caf510a);
-    let namespace = if source.is_empty() {
-        namespace
-    } else {
-        wt_uuid_v5(namespace, source)
-    };
-    Some(wt_uuid_v5(namespace, name))
-}
-
-/// Parse Windows Terminal settings.json and keep the default profile selector
-/// alongside its shell, so launch uses the same profile that was classified.
-#[cfg(any(target_os = "windows", test))]
-pub(crate) fn parse_wt_default_profile(
-    content: &str,
-    wt_version: Option<(u16, u16, u16, u16)>,
-) -> Option<WtDefaultProfile> {
-    // Windows Terminal settings.json commonly uses JSONC comments and trailing commas.
-    let json: serde_json::Value = match json5::from_str(content) {
-        Ok(v) => v,
-        Err(e) => {
-            log::debug!("Failed to parse Windows Terminal settings.json: {e}");
-            return None;
-        }
-    };
-
-    // WT profile names are case- and whitespace-sensitive; compare GUIDs as UUIDs below.
-    let default_profile = json.get("defaultProfile").and_then(|v| v.as_str())?;
-    if default_profile.is_empty() {
-        return None;
-    }
-
-    // Support modern `profiles.list` and the legacy flat `profiles` array.
-    let profiles = json.get("profiles");
-    // WT #19225 clears this field from 1.24; first public 1.24.2372.0 includes
-    // that rule, while 1.23 still inherits it.
-    let inherited_commandline = profiles
-        .and_then(|profiles| profiles.get("defaults"))
-        .and_then(|defaults| defaults.get("commandline"))
-        .filter(|_| wt_version.is_none_or(|version| version < (1, 24, 0, 0)));
-    let profile_list = profiles.and_then(|profiles| {
-        profiles
-            .get("list")
-            .and_then(|list| list.as_array())
-            .or_else(|| profiles.as_array())
-    });
-
-    let default_norm_guid = normalize_wt_guid(default_profile);
-    let default_guid = uuid::Uuid::parse_str(default_profile).ok();
-
-    if let Some(list) = profile_list {
-        // WT looks up GUID across the whole table first and only then searches
-        // by name, so an earlier same-name profile must not steal the match.
-        let matched = default_guid
-            .and_then(|expected| {
-                list.iter().find_map(|item| {
-                    let guid = wt_profile_guid(item)?;
-                    (guid == expected).then_some((item, guid))
-                })
-            })
-            .or_else(|| {
-                list.iter().find_map(|item| {
-                    let guid = wt_profile_guid(item)?;
-                    item.get("name")
-                        .and_then(|name| name.as_str())
-                        .is_some_and(|name| name == default_profile)
-                        .then_some((item, guid))
-                })
-            });
-
-        if let Some((item, guid)) = matched {
-            // When the load rule is unknown, only accept an explicit commandline;
-            // do not guess whether defaults would override the shell.
-            if wt_version.is_none()
-                && inherited_commandline.is_some()
-                && item.get("commandline").is_none()
-            {
-                log::debug!("Unknown WT version with inherited commandline; using explicit cmd");
-                return None;
-            }
-            return Some(WtDefaultProfile {
-                selector: format!("{{{guid}}}"),
-                shell: classify_wt_profile(item, inherited_commandline)?,
-            });
-        }
-    }
-
-    // Unlisted built-in profiles use the same version rule; an unknown version
-    // must not skip the ambiguity via GUID fallback.
-    let shell = if let Some(commandline) = inherited_commandline {
-        if wt_version.is_none() {
-            log::debug!("Unknown WT version with inherited commandline; using explicit cmd");
-            return None;
-        }
-        commandline.as_str().and_then(classify_wt_commandline)
-    } else {
-        // If the profile is not listed, fall back to well-known built-in GUIDs.
-        match default_norm_guid.as_str() {
-            "574e775e-4f2a-5b96-ac1e-a2962a402336" => Some(WtDefaultShell::Pwsh),
-            "61c54bbd-c2c6-5271-96e7-009a87ff44bf" => Some(WtDefaultShell::PowerShell),
-            "0caa0dad-35be-5f56-a8ff-afceeeaa6101" => Some(WtDefaultShell::Cmd),
-            _ => None,
-        }
-    }?;
-    Some(WtDefaultProfile {
-        selector: format!("{{{}}}", default_guid?),
-        shell,
-    })
-}
-
-#[cfg(any(target_os = "windows", test))]
-const APPEXECLINK_REPARSE_TAG: u32 = 0x8000_001b;
-
-/// Parse an APPEXECLINK buffer from `FSCTL_GET_REPARSE_POINT`.
-/// The payload starts with a string count; the third NUL-terminated UTF-16
-/// string is the real executable.
-#[cfg(any(target_os = "windows", test))]
-fn parse_app_execution_alias_target(buffer: &[u8]) -> Option<Vec<u16>> {
-    let tag = u32::from_le_bytes(buffer.get(0..4)?.try_into().ok()?);
-    if tag != APPEXECLINK_REPARSE_TAG {
-        return None;
-    }
-
-    let payload_length = u16::from_le_bytes(buffer.get(4..6)?.try_into().ok()?) as usize;
-    let payload_end = 8usize.checked_add(payload_length)?;
-    let payload = buffer.get(8..payload_end)?;
-    let string_count = u32::from_le_bytes(payload.get(0..4)?.try_into().ok()?);
-    if string_count < 3 || (payload.len() - 4) % 2 != 0 {
-        return None;
-    }
-
-    let strings: Vec<u16> = payload[4..]
-        .chunks_exact(2)
-        .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
-        .collect();
-    let mut start = 0usize;
-    for index in 0..3 {
-        let end = start + strings.get(start..)?.iter().position(|value| *value == 0)?;
-        if index == 2 {
-            let target = strings.get(start..end)?.to_vec();
-            let drive = *target.first()?;
-            let is_ascii_drive = (drive >= b'A' as u16 && drive <= b'Z' as u16)
-                || (drive >= b'a' as u16 && drive <= b'z' as u16);
-            let is_absolute_drive_path = target.len() >= 3
-                && is_ascii_drive
-                && target[1] == b':' as u16
-                && target[2] == b'\\' as u16;
-            return is_absolute_drive_path.then_some(target);
-        }
-        start = end + 1;
-    }
-    None
-}
-
 #[cfg(target_os = "windows")]
-fn resolve_app_execution_alias_target(alias: &Path) -> Option<PathBuf> {
-    use std::os::windows::ffi::{OsStrExt, OsStringExt};
-    use windows_sys::Win32::Foundation::{CloseHandle, GENERIC_READ, INVALID_HANDLE_VALUE};
-    use windows_sys::Win32::Storage::FileSystem::{
-        CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE,
-        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
-    };
-    use windows_sys::Win32::System::Ioctl::FSCTL_GET_REPARSE_POINT;
-    use windows_sys::Win32::System::IO::DeviceIoControl;
-
-    let wide_path: Vec<u16> = alias.as_os_str().encode_wide().chain(Some(0)).collect();
-    // SAFETY: pointer comes from a local NUL-terminated UTF-16 buffer; remaining
-    // arguments follow the CreateFileW contract.
-    // FSCTL_GET_REPARSE_POINT needs GENERIC_READ; access=0 can fail to return
-    // payload data on App Execution Aliases.
-    let handle = unsafe {
-        CreateFileW(
-            wide_path.as_ptr(),
-            GENERIC_READ,
-            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-            std::ptr::null(),
-            OPEN_EXISTING,
-            FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
-            std::ptr::null_mut(),
-        )
-    };
-    if handle == INVALID_HANDLE_VALUE {
-        return None;
-    }
-
-    let mut buffer = vec![0u8; 16 * 1024];
-    let mut returned = 0u32;
-    // SAFETY: handle is valid, the output buffer is writable for the call, and
-    // `returned` does not overlap the buffer.
-    let succeeded = unsafe {
-        DeviceIoControl(
-            handle,
-            FSCTL_GET_REPARSE_POINT,
-            std::ptr::null(),
-            0,
-            buffer.as_mut_ptr().cast(),
-            buffer.len() as u32,
-            &mut returned,
-            std::ptr::null_mut(),
-        )
-    };
-    // SAFETY: handle was created by the CreateFileW call above and is closed once.
-    let _ = unsafe { CloseHandle(handle) };
-    if succeeded == 0 {
-        return None;
-    }
-
-    let target = parse_app_execution_alias_target(buffer.get(..returned as usize)?)?;
-    Some(PathBuf::from(std::ffi::OsString::from_wide(&target)))
-}
-
-#[cfg(target_os = "windows")]
-struct ResolvedWtInstallation {
-    launcher: PathBuf,
-    settings_executable: Option<PathBuf>,
-}
-
-#[cfg(target_os = "windows")]
-const WT_LOOKUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
-
-/// Locate the first `wt` that PATH would launch, and keep launcher plus settings target.
-/// Uses the reconstructed GUI PATH; timeout falls through to the explicit cmd fallback.
-#[cfg(target_os = "windows")]
-fn resolve_wt_installation() -> Option<ResolvedWtInstallation> {
-    let effective_path = effective_path_os().unwrap_or_default();
-    let child = windows_path_lookup_command("wt", &effective_path)
-        .spawn()
-        .ok()?;
-    let output = wait_child_output(
-        child,
-        CommandDeadline::from_timeout(Some(WT_LOOKUP_TIMEOUT)),
-    )
-    .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    let stdout = decode_windows_where_output(&output.stdout);
-    let launcher = stdout
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
-        .map(|line| PathBuf::from(line.trim_matches('"')))?;
-
-    let is_store_alias = launcher
-        .parent()
-        .is_some_and(is_windows_app_execution_alias_dir);
-    let settings_executable = if is_store_alias {
-        resolve_app_execution_alias_target(&launcher)
-    } else {
-        Some(
-            launcher
-                .parent()
-                .and_then(|parent| {
-                    launcher
-                        .file_stem()
-                        .map(|stem| parent.join(format!("{}.shim", stem.to_string_lossy())))
-                })
-                .filter(|shim| shim.is_file())
-                .and_then(|shim| parse_scoop_shim_target(&shim))
-                .unwrap_or_else(|| launcher.clone()),
-        )
-    };
-
-    Some(ResolvedWtInstallation {
-        launcher,
-        settings_executable,
-    })
-}
-
-/// Walk `path` upward for the nearest Windows Terminal Store package under
-/// `WindowsApps`; returns whether it is Preview and the lowercased package
-/// directory name (which embeds the version). Directory-name substrings
-/// elsewhere (GitHub zip extracts) must not match.
-#[cfg(any(target_os = "windows", test))]
-fn store_wt_package_dir(path: &Path) -> Option<(bool, String)> {
-    path.ancestors().find_map(|directory| {
-        let parent_name = directory.parent()?.file_name()?;
-        if !parent_name
-            .to_string_lossy()
-            .eq_ignore_ascii_case("WindowsApps")
-        {
-            return None;
-        }
-
-        let package = directory
-            .file_name()?
-            .to_string_lossy()
-            .to_ascii_lowercase();
-        let preview = package.starts_with("microsoft.windowsterminalpreview_");
-        if preview || package.starts_with("microsoft.windowsterminal_") {
-            Some((preview, package))
-        } else {
-            None
-        }
-    })
-}
-
-/// Return the Scoop root and package directory name so `apps/<package>/current/wt.exe`
-/// maps to the same install's `persist/<package>`, including custom Scoop roots.
-#[cfg(any(target_os = "windows", test))]
-fn scoop_wt_install_context(exe_path: &Path) -> Option<(PathBuf, String)> {
-    let apps_dir = exe_path.ancestors().find(|ancestor| {
-        ancestor
-            .file_name()
-            .is_some_and(|name| name.to_string_lossy().eq_ignore_ascii_case("apps"))
-    })?;
-    let package = exe_path
-        .strip_prefix(apps_dir)
-        .ok()?
-        .components()
-        .next()?
-        .as_os_str()
-        .to_string_lossy()
-        .into_owned();
-    if !package.eq_ignore_ascii_case("windows-terminal")
-        && !package.eq_ignore_ascii_case("windows-terminal-preview")
-    {
-        return None;
-    }
-
-    Some((apps_dir.parent()?.to_path_buf(), package))
-}
-
-/// Parse `major.minor.patch.revision` so Store package folders and Scoop
-/// versioned app directories can be compared against WT 1.19.
-#[cfg(any(target_os = "windows", test))]
-fn parse_wt_dotted_version(value: &str) -> Option<(u16, u16, u16, u16)> {
-    let mut parts = value.split('.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts.next()?.parse().ok()?;
-    let revision = parts.next()?.parse().ok()?;
-    parts
-        .next()
-        .is_none()
-        .then_some((major, minor, patch, revision))
-}
-
-#[cfg(any(target_os = "windows", test))]
-fn wt_version_supports_append(version: (u16, u16, u16, u16)) -> bool {
-    (version.0, version.1) >= (1, 19)
-}
-
-/// Store package folders and Scoop versioned directories embed the WT version.
-/// `current` shims and unpackaged layouts have to use the PE version instead.
-#[cfg(any(target_os = "windows", test))]
-fn wt_version_from_path(path: &Path) -> Option<(u16, u16, u16, u16)> {
-    if let Some((_, package)) = store_wt_package_dir(path) {
-        let rest = package
-            .strip_prefix("microsoft.windowsterminalpreview_")
-            .or_else(|| package.strip_prefix("microsoft.windowsterminal_"))?;
-        return parse_wt_dotted_version(rest.split('_').next()?);
-    }
-
-    // Scoop layout: `<root>/apps/<package>/<version>/…`; `current` is a shim
-    // whose version lives in the PE, not the directory name.
-    let (root, _) = scoop_wt_install_context(path)?;
-    let mut segments = path.strip_prefix(root.join("apps")).ok()?.components();
-    let version = segments.nth(1)?.as_os_str().to_string_lossy();
-    parse_wt_dotted_version(&version)
-}
-
-#[cfg(any(target_os = "windows", test))]
-fn append_scoop_wt_settings_paths(paths: &mut Vec<PathBuf>, root: &Path, package: &str) {
-    let persist = root.join("persist").join(package);
-    // Scoop persists a settings subdirectory; files at the persist root are not
-    // the active WT config.
-    push_unique_path(paths, persist.join("settings").join("settings.json"));
-}
-
-#[cfg(any(target_os = "windows", test))]
-fn store_wt_settings_path(local: &Path, preview: bool) -> PathBuf {
-    let package = if preview {
-        "Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe"
-    } else {
-        "Microsoft.WindowsTerminal_8wekyb3d8bbwe"
-    };
-    local
-        .join("Packages")
-        .join(package)
-        .join("LocalState")
-        .join("settings.json")
-}
-
-#[cfg(any(target_os = "windows", test))]
-fn unpackaged_wt_settings_path(local: &Path) -> PathBuf {
-    local
-        .join("Microsoft")
-        .join("Windows Terminal")
-        .join("settings.json")
-}
-
-/// When WT places `.portable` beside the executable, only use sibling `settings/`
-/// and do not read LocalAppData.
-#[cfg(any(target_os = "windows", test))]
-fn is_wt_portable_install(exe_path: &Path) -> bool {
-    exe_path
-        .parent()
-        .is_some_and(|dir| dir.join(".portable").is_file())
-}
-
-/// Return settings paths for the resolved executable so leftover configs from
-/// other installs cannot participate in mtime ranking.
-/// Sibling and Scoop persist paths are only live while `.portable` exists;
-/// otherwise WT reads `%LOCALAPPDATA%\Microsoft\Windows Terminal`.
-#[cfg(any(target_os = "windows", test))]
-fn build_wt_settings_paths(
-    settings_executable: &Path,
-    local_appdata: Option<&Path>,
-) -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-
-    if is_wt_portable_install(settings_executable) {
-        if let Some(dir) = settings_executable.parent() {
-            // Portable mode only reads the settings subdirectory next to the
-            // module; leftover files at the root must not enter the sort.
-            push_unique_path(&mut paths, dir.join("settings").join("settings.json"));
-        }
-        if let Some((root, package)) = scoop_wt_install_context(settings_executable) {
-            append_scoop_wt_settings_paths(&mut paths, &root, &package);
-        }
-        return paths;
-    }
-
-    if let Some((preview, _)) = store_wt_package_dir(settings_executable) {
-        if let Some(local) = local_appdata {
-            push_unique_path(&mut paths, store_wt_settings_path(local, preview));
-        }
-    } else if let Some(local) = local_appdata {
-        push_unique_path(&mut paths, unpackaged_wt_settings_path(local));
-    }
-
-    paths
-}
-
-/// Parse the real executable path from a Scoop `.shim`.
-#[cfg(any(target_os = "windows", test))]
-fn parse_scoop_shim_target(shim_path: &Path) -> Option<PathBuf> {
-    let content = std::fs::read_to_string(shim_path).ok()?;
-    parse_scoop_shim_content(&content)
-}
-
-#[cfg(any(target_os = "windows", test))]
-fn parse_scoop_shim_content(content: &str) -> Option<PathBuf> {
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("path =") {
-            let path_str = rest.trim().trim_matches('"');
-            if !path_str.is_empty() {
-                return Some(PathBuf::from(path_str));
-            }
-        }
-    }
-    None
-}
-
-/// Candidates all belong to the same resolved install, so mtime can pick the
-/// active file. A parse failure continues to the next candidate of that install
-/// and never crosses Store/Scoop/Preview installs.
-#[cfg(any(target_os = "windows", test))]
-fn detect_wt_default_profile_from_paths(
-    paths: &[PathBuf],
-    wt_version: Option<(u16, u16, u16, u16)>,
-) -> Option<WtDefaultProfile> {
-    let mut existing = Vec::new();
-    let mut seen = std::collections::HashSet::new();
-    for path in paths {
-        let normalized = path.canonicalize().unwrap_or_else(|_| path.clone());
-        if !seen.insert(normalized) || !path.is_file() {
-            continue;
-        }
-        let modified = std::fs::metadata(path)
-            .and_then(|metadata| metadata.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-        existing.push((path, modified));
-    }
-    existing.sort_by_key(|(_, modified)| std::cmp::Reverse(*modified));
-
-    for (path, _) in existing {
-        if let Ok(content) = std::fs::read_to_string(path) {
-            if let Some(profile) = parse_wt_default_profile(&content, wt_version) {
-                return Some(profile);
-            }
-        }
-    }
-    None
-}
-
-#[cfg(target_os = "windows")]
-fn detect_wt_default_profile(
-    installation: &ResolvedWtInstallation,
-    wt_version: Option<(u16, u16, u16, u16)>,
-) -> Option<WtDefaultProfile> {
-    let settings_executable = installation.settings_executable.as_deref()?;
-    let local_appdata = std::env::var_os("LOCALAPPDATA")
-        .map(PathBuf::from)
-        .or_else(dirs::data_local_dir);
-    let paths = build_wt_settings_paths(settings_executable, local_appdata.as_deref());
-    let profile = detect_wt_default_profile_from_paths(&paths, wt_version);
-    if let Some(profile) = &profile {
-        log::debug!(
-            "Detected Windows Terminal default profile: {:?} (candidates: {:?})",
-            profile,
-            paths
-        );
-    }
-    profile
-}
-
-#[cfg(target_os = "windows")]
-fn wt_file_version(path: &Path) -> Option<(u16, u16, u16, u16)> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Storage::FileSystem::{
-        GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW,
-    };
-
-    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
-    let mut dummy = 0u32;
-    // SAFETY: `wide` is a local NUL-terminated path buffer.
-    let size = unsafe { GetFileVersionInfoSizeW(wide.as_ptr(), &mut dummy) };
-    if size == 0 {
-        return None;
-    }
-
-    let mut buffer = vec![0u8; size as usize];
-    // SAFETY: `buffer` is writable for `size` bytes returned above.
-    let ok = unsafe { GetFileVersionInfoW(wide.as_ptr(), 0, size, buffer.as_mut_ptr().cast()) };
-    if ok == 0 {
-        return None;
-    }
-
-    let mut info: *mut core::ffi::c_void = core::ptr::null_mut();
-    let mut info_len = 0u32;
-    let subblock: Vec<u16> = "\\\0".encode_utf16().collect();
-    // SAFETY: `buffer` still owns the version block; `info`/`info_len` are out params.
-    let ok = unsafe {
-        VerQueryValueW(
-            buffer.as_ptr().cast(),
-            subblock.as_ptr(),
-            &mut info,
-            &mut info_len,
-        )
-    };
-    if ok == 0 || info.is_null() || (info_len as usize) < 16 {
-        return None;
-    }
-
-    // VS_FIXEDFILEINFO: signature, struct version, then fileVersionMS/LS.
-    let bytes = unsafe { std::slice::from_raw_parts(info as *const u8, info_len as usize) };
-    let ms = u32::from_le_bytes(bytes.get(8..12)?.try_into().ok()?);
-    let ls = u32::from_le_bytes(bytes.get(12..16)?.try_into().ok()?);
-    Some((
-        (ms >> 16) as u16,
-        (ms & 0xffff) as u16,
-        (ls >> 16) as u16,
-        (ls & 0xffff) as u16,
-    ))
-}
-
-#[cfg(target_os = "windows")]
-fn wt_version_from_executable(path: &Path) -> Option<(u16, u16, u16, u16)> {
-    wt_version_from_path(path)
-        .or_else(|| wt_file_version(path))
-        .or_else(|| {
-            let sibling = path.parent()?.join("WindowsTerminal.exe");
-            if sibling == path || !sibling.is_file() {
-                None
-            } else {
-                wt_file_version(&sibling)
-            }
-        })
-}
-
-/// Read the version from the same install's real target or launcher so config
-/// load rules and append support share one source.
-/// GUI WT help text is unreliable, so use path and PE version info instead of
-/// launching the terminal to probe.
-#[cfg(target_os = "windows")]
-fn wt_installation_version(installation: &ResolvedWtInstallation) -> Option<(u16, u16, u16, u16)> {
-    installation
-        .settings_executable
-        .as_deref()
-        .filter(|path| *path != installation.launcher.as_path())
-        .and_then(wt_version_from_executable)
-        .or_else(|| wt_version_from_executable(&installation.launcher))
-}
-
-/// The launcher path may contain cmd metacharacters, so spawn it directly
-/// instead of going through `cmd /C start`.
-/// WT may already be a resident GUI process, so report only spawn failure and
-/// return without waiting for the window to close.
-#[cfg(target_os = "windows")]
-fn run_wt_command(args: &[&str]) -> Result<(), String> {
-    let (launcher, arguments) = args
-        .split_first()
-        .ok_or_else(|| "缺少 Windows Terminal 启动程序".to_string())?;
-    let mut command = std::process::Command::new(launcher);
-    detach_claude_parent_session_env(&mut command);
+fn run_windows_powershell_batch(bat_path: &str) -> Result<(), String> {
+    let mut command = std::process::Command::new("powershell");
+    configure_windows_batch_env(&mut command, bat_path);
+    command.args(["-NoExit", "-Command", WINDOWS_POWERSHELL_BATCH_COMMAND]);
     command
-        .args(arguments)
-        .creation_flags(CREATE_NO_WINDOW)
+        .creation_flags(CREATE_NEW_CONSOLE)
         .spawn()
-        .map(|_| ())
-        .map_err(|e| format!("启动 Windows Terminal 失败: {e}"))
+        .map_err(|e| format!("启动 PowerShell 失败: {e}"))?;
+    Ok(())
 }
 
-/// Launch the same resolved Windows Terminal, and fall back to an explicit cmd
-/// tab when the default profile cannot be recognized safely or WT is too old
-/// for `--appendCommandLine`.
 #[cfg(target_os = "windows")]
-fn launch_wt_terminal(bat_path: &str, ps_cmd: &str) -> Result<(), String> {
-    let installation = resolve_wt_installation();
-    let wt_command = installation
-        .as_ref()
-        .map(|installation| installation.launcher.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "wt".to_string());
-    let wt_version = installation.as_ref().and_then(wt_installation_version);
-    let profile = installation
-        .as_ref()
-        .and_then(|installation| detect_wt_default_profile(installation, wt_version));
-    // Keep the previous append policy for unknown versions; configs that depend
-    // on ambiguous defaults are refused by the parser.
-    let supports_append = profile.is_some() && wt_version.is_none_or(wt_version_supports_append);
-    let args = select_wt_launch_args(
-        profile.as_ref(),
-        supports_append,
-        &wt_command,
-        bat_path,
-        ps_cmd,
-    );
-    run_wt_command(&args)
+fn launch_windows_batch_in_preferred_terminal(bat_path: &str) -> Result<(), String> {
+    let preferred = crate::settings::get_preferred_terminal();
+    let terminal = preferred.as_deref().unwrap_or("cmd");
+    let result = match terminal {
+        "powershell" => run_windows_powershell_batch(bat_path),
+        "wt" => {
+            super::windows_terminal::launch_wt_terminal(bat_path, WINDOWS_POWERSHELL_BATCH_COMMAND)
+        }
+        _ => run_windows_cmd_batch(bat_path),
+    };
+
+    if result.is_err() && terminal != "cmd" {
+        log::warn!(
+            "首选终端 {} 启动失败，回退到 cmd: {:?}",
+            terminal,
+            result.as_ref().err()
+        );
+        run_windows_cmd_batch(bat_path)
+    } else {
+        result
+    }
 }
 
 /// 打开用户首选终端并在其中执行一段可信命令脚本。脚本尾部 `read -r` / `pause`
@@ -5682,6 +4647,8 @@ fn launch_wt_terminal(bat_path: &str, ps_cmd: &str) -> Result<(), String> {
 /// 保证它是可信字符串（当前只由后端硬编码调用）。
 pub(crate) fn launch_terminal_running(command_line: &str, label: &str) -> Result<(), String> {
     let temp_dir = std::env::temp_dir();
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     let pid = std::process::id();
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -5810,47 +4777,29 @@ read -r _
 
     #[cfg(target_os = "windows")]
     {
-        let preferred = crate::settings::get_preferred_terminal();
-        let terminal = preferred.as_deref().unwrap_or("cmd");
-
-        let bat_file = temp_dir.join(format!("cc_switch_{}_{}.bat", label, pid));
         let content = format!(
-            "@echo off\r\necho [cc-switch] Starting: {label}\r\necho.\r\n{cmd}\r\necho.\r\necho [cc-switch] Command exited. Press any key to close.\r\npause >nul\r\ndel \"%~f0\" >nul 2>&1\r\n",
+            "@echo off\r\nsetlocal DisableDelayedExpansion\r\nset \"CC_SWITCH_INTERNAL_BATCH_PATH=\"\r\necho [cc-switch] Starting: {label}\r\necho.\r\n{cmd}\r\necho.\r\necho [cc-switch] Command exited. Press any key to close.\r\npause >nul\r\ndel \"%~f0\" >nul 2>&1\r\n",
             label = label,
             cmd = command_line,
         );
-        std::fs::write(&bat_file, &content).map_err(|e| format!("写入批处理文件失败: {e}"))?;
+        let bat_file = write_unique_temp_artifact(
+            &temp_dir,
+            "cc_switch_command_",
+            ".bat",
+            content.as_bytes(),
+        )?;
 
         let bat_path = bat_file.to_string_lossy();
-        let ps_cmd = format!("& '{}'", bat_path.replace('\'', "''"));
 
-        let result = match terminal {
-            "powershell" => run_windows_start_command(
-                &["powershell", "-NoExit", "-Command", &ps_cmd],
-                "PowerShell",
-            ),
-            "wt" => launch_wt_terminal(&bat_path, &ps_cmd),
-            _ => run_windows_start_command(&["cmd", "/K", &bat_path], "cmd"),
-        };
-
-        let final_result = if result.is_err() && terminal != "cmd" {
-            log::warn!(
-                "首选终端 {} 启动失败，回退到 cmd: {:?}",
-                terminal,
-                result.as_ref().err()
-            );
-            run_windows_start_command(&["cmd", "/K", &bat_path], "cmd")
-        } else {
-            result
-        };
+        let result = launch_windows_batch_in_preferred_terminal(&bat_path);
 
         // The .bat self-deletes (`del "%~f0"`) after it runs, but that only
         // fires if *some* terminal actually launched it. If every attempt
         // failed, sweep the temp file ourselves to avoid pollution.
-        if final_result.is_err() {
+        if result.is_err() {
             let _ = std::fs::remove_file(&bat_file);
         }
-        final_result
+        result
     }
 
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
@@ -5879,6 +4828,29 @@ pub async fn set_window_theme(window: tauri::Window, theme: String) -> Result<()
 mod tests {
     use super::*;
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn temporary_launch_artifacts_are_unique_and_complete() {
+        let temp = tempfile::tempdir().expect("temporary directory should be created");
+        let first = write_unique_temp_artifact(temp.path(), "cc_switch_", ".bat", b"first")
+            .expect("first artifact should be written");
+        let second = write_unique_temp_artifact(temp.path(), "cc_switch_", ".bat", b"second")
+            .expect("second artifact should be written");
+
+        assert_ne!(first, second);
+        assert_eq!(first.parent(), Some(temp.path()));
+        assert_eq!(second.parent(), Some(temp.path()));
+        assert_eq!(
+            first.extension().and_then(|value| value.to_str()),
+            Some("bat")
+        );
+        assert_eq!(
+            second.extension().and_then(|value| value.to_str()),
+            Some("bat")
+        );
+        assert_eq!(std::fs::read(first).unwrap(), b"first");
+        assert_eq!(std::fs::read(second).unwrap(), b"second");
+    }
 
     /// 探测 helper 正常路径：spawn（含 pre_exec setsid）能启动、输出能捕获。
     /// `/bin/echo --version` 在 macOS/Linux 均即刻成功退出。
@@ -8327,6 +7299,17 @@ mod tests {
     }
 
     #[test]
+    fn build_windows_cwd_command_str_quotes_metacharacters_and_escapes_percent() {
+        let command =
+            build_windows_cwd_command_str(r"C:\space & %CC_SWITCH_CMD_EXPAND% ^ ! (test)\repo");
+
+        assert_eq!(
+            command,
+            "cd /d \"C:\\space & %%CC_SWITCH_CMD_EXPAND%% ^ ! (test)\\repo\" || exit /b 1\r\n"
+        );
+    }
+
+    #[test]
     fn build_windows_cwd_command_str_uses_pushd_for_unc_paths() {
         let command = build_windows_cwd_command_str(r"\\wsl$\Ubuntu\home\coder\repo");
 
@@ -8337,1296 +7320,12 @@ mod tests {
     }
 
     #[test]
-    fn build_windows_cwd_command_str_escapes_batch_metacharacters() {
+    fn build_windows_cwd_command_str_keeps_quoted_metacharacters_literal() {
         let command = build_windows_cwd_command_str(r"\\server\share\100%&(test)");
 
         assert_eq!(
             command,
-            "pushd \"\\\\server\\share\\100%%^&^(test^)\" || exit /b 1\r\n"
-        );
-    }
-
-    /// Cover JSONC, well-known GUIDs, quoted commandlines, and name matches.
-    #[test]
-    fn parse_wt_default_profile_recognizes_supported_profiles() {
-        // JSONC comments + PowerShell 7 well-known GUID
-        let jsonc_pwsh = r#"{
-            // Windows Terminal single line comment
-            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-            /* block comment */
-            "profiles": {
-                "list": [
-                    {
-                        "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-                        "name": "PowerShell",
-                        "source": "Windows.Terminal.PowershellCore",
-                    },
-                ],
-            },
-        }"#;
-        assert_eq!(
-            parse_wt_default_profile(jsonc_pwsh, None).map(|profile| profile.shell),
-            Some(WtDefaultShell::Pwsh)
-        );
-
-        // Absolute commandline path for Windows PowerShell
-        let powershell_cmdline = r#"{
-            "defaultProfile": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
-            "profiles": {
-                "list": [
-                    {
-                        "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
-                        "name": "Windows PowerShell",
-                        "commandline": "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
-                    }
-                ]
-            }
-        }"#;
-        assert_eq!(
-            parse_wt_default_profile(powershell_cmdline, None).map(|profile| profile.shell),
-            Some(WtDefaultShell::PowerShell)
-        );
-
-        // Quoted custom pwsh path with arguments
-        let quoted_pwsh = r#"{
-            "defaultProfile": "{11111111-1111-4111-8111-111111111111}",
-            "profiles": [
-                {
-                    "guid": "{11111111-1111-4111-8111-111111111111}",
-                    "name": "Custom",
-                    "commandline": "\"C:\\Program Files\\PowerShell\\7\\pwsh.Exe\" -NoLogo"
-                }
-            ]
-        }"#;
-        assert_eq!(
-            parse_wt_default_profile(quoted_pwsh, None).map(|profile| profile.shell),
-            Some(WtDefaultShell::Pwsh)
-        );
-
-        // cmd.exe
-        let cmd_config = r#"{
-            "defaultProfile": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
-            "profiles": {
-                "list": [
-                    {
-                        "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
-                        "name": "Command Prompt",
-                        "commandline": "cmd.exe"
-                    }
-                ]
-            }
-        }"#;
-        assert_eq!(
-            parse_wt_default_profile(cmd_config, None).map(|profile| profile.shell),
-            Some(WtDefaultShell::Cmd)
-        );
-
-        // Match by profile name instead of GUID
-        let name_config = r#"{
-            "defaultProfile": "PowerShell 7",
-            "profiles": {
-                "list": [
-                    {
-                        "guid": "{22222222-2222-4222-8222-222222222222}",
-                        "name": "PowerShell 7",
-                        "commandline": "pwsh.exe"
-                    }
-                ]
-            }
-        }"#;
-        assert_eq!(
-            parse_wt_default_profile(name_config, None).map(|profile| profile.shell),
-            Some(WtDefaultShell::Pwsh)
-        );
-    }
-
-    #[test]
-    fn parse_wt_default_profile_returns_none_for_unsupported_or_malformed() {
-        let wsl = r#"{"defaultProfile": "{55555555-5555-4555-8555-555555555555}","profiles":{"list":[{"guid":"{55555555-5555-4555-8555-555555555555}","commandline":"wsl.exe"}]}}"#;
-        assert_eq!(parse_wt_default_profile(wsl, None), None);
-
-        let overridden_builtin = r#"{
-            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-            "profiles": {
-                "list": [{
-                    "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-                    "name": "PowerShell",
-                    "source": "Windows.Terminal.PowershellCore",
-                    "commandline": "wsl.exe"
-                }]
-            }
-        }"#;
-        assert_eq!(parse_wt_default_profile(overridden_builtin, None), None);
-        assert_eq!(parse_wt_default_profile("not valid json", None), None);
-        assert_eq!(
-            parse_wt_default_profile(r#"{"defaultProfile": ""}"#, None),
-            None
-        );
-    }
-
-    #[test]
-    fn third_party_powershellcore_source_uses_explicit_fallback() {
-        let settings = serde_json::json!({
-            "defaultProfile": "{55555555-5555-4555-8555-555555555555}",
-            "profiles": {"list": [{
-                "guid": "{55555555-5555-4555-8555-555555555555}",
-                "source": "Contoso.PowerShellCore.Wsl"
-            }]}
-        });
-
-        let profile = parse_wt_default_profile(&settings.to_string(), None);
-        assert_eq!(
-            profile, None,
-            "third-party sources containing PowerShellCore must not be classified as pwsh"
-        );
-        assert_eq!(
-            select_wt_launch_args(profile.as_ref(), true, "wt", "probe.bat", "& 'probe.bat'"),
-            vec!["wt", "new-tab", "cmd", "/K", "probe.bat"],
-            "unknown dynamic profiles must use the explicit cmd fallback"
-        );
-    }
-
-    #[test]
-    fn visual_studio_dynamic_profiles_use_explicit_fallback() {
-        for (guid, name) in [
-            (
-                "{11111111-1111-4111-8111-111111111111}",
-                "Developer PowerShell for VS 2022",
-            ),
-            (
-                "{22222222-2222-4222-8222-222222222222}",
-                "Developer Command Prompt for VS 2022",
-            ),
-        ] {
-            let settings = serde_json::json!({
-                "defaultProfile": guid,
-                "profiles": {"list": [{
-                    "guid": guid,
-                    "name": name,
-                    "source": "Windows.Terminal.VisualStudio"
-                }]}
-            });
-
-            let profile = parse_wt_default_profile(&settings.to_string(), None);
-            assert_eq!(
-                profile, None,
-                "dynamic profile {name} must not be guessed by name"
-            );
-            assert_eq!(
-                select_wt_launch_args(profile.as_ref(), true, "wt", "probe.bat", "& 'probe.bat'",),
-                vec!["wt", "new-tab", "cmd", "/K", "probe.bat"],
-                "dynamic profile {name} must use the explicit cmd fallback"
-            );
-        }
-
-        let explicit_commandline = serde_json::json!({
-            "defaultProfile": "{33333333-3333-4333-8333-333333333333}",
-            "profiles": {"list": [{
-                "guid": "{33333333-3333-4333-8333-333333333333}",
-                "name": "Developer PowerShell for VS 2022",
-                "source": "Windows.Terminal.VisualStudio",
-                "commandline": "pwsh.exe -NoLogo"
-            }]}
-        });
-        assert_eq!(
-            parse_wt_default_profile(&explicit_commandline.to_string(), None)
-                .map(|profile| profile.shell),
-            Some(WtDefaultShell::Pwsh),
-            "an explicit safe commandline must take precedence over the dynamic source"
-        );
-    }
-
-    /// Server mode runs the remoting protocol and ignores `-Command`; leftover
-    /// positionals mean implicit `-File`. Append must be refused for all of
-    /// these, including the ServerMode prefixes `-s`/`-se` that PowerShell
-    /// resolves over `-Sta`/`-SettingsFile`.
-    #[test]
-    fn wt_commandline_classification_accepts_safe_and_refuses_unsafe() {
-        let refused: &[&str] = &[
-            r#"pwsh.exe -NoLogo -Fil "C:\init.ps1""#,
-            r#"cmd.exe /D /K C:\init.cmd"#,
-            r#"cmd.exe /cdir"#,
-            r#"cmd.exe /D/C echo ORIGINAL"#,
-            r#"cmd.exe /d/k echo ORIGINAL"#,
-            r#"cmd.exe /Q/D/CECHO ORIGINAL"#,
-            r#"cmd.exe /D/V:OFF/Kecho ORIGINAL"#,
-            r#"pwsh.exe -no"#,
-            r#"powershell.exe -no"#,
-            r#"pwsh.exe -SSHServerMode"#,
-            r#"pwsh.exe -s -NoProfile"#,
-            r#"pwsh.exe -se -NoProfile"#,
-            r#"pwsh.exe -ServerMode"#,
-            r#"powershell.exe -s -NoProfile"#,
-            r#"powershell.exe -se -NoProfile"#,
-            r#"powershell.exe -ServerMode"#,
-            r#"pwsh.exe C:\init.ps1"#,
-            r#"pwsh.exe -f C:\init.ps1"#,
-            r#"powershell.exe -c Get-Date"#,
-            r#"pwsh.exe -Version"#,
-            r#"powershell.exe -Version"#,
-            r#"pwsh.exe -WorkingDirectory "C:\missing"#,
-        ];
-        for cmdline in refused {
-            assert_eq!(classify_wt_commandline(cmdline), None, "{cmdline}");
-        }
-
-        let accepted: &[(&str, WtDefaultShell)] = &[
-            (r#"cmd.exe /D /T:0C"#, WtDefaultShell::Cmd),
-            (r#"cmd.exe /D/Q/V:OFF"#, WtDefaultShell::Cmd),
-            (r#"pwsh.exe -EncodedArguments ABC="#, WtDefaultShell::Pwsh),
-            (r#"pwsh.exe -ea ABC="#, WtDefaultShell::Pwsh),
-            (r#"pwsh.exe -encodeda ABC="#, WtDefaultShell::Pwsh),
-            (
-                r#"powershell.exe -EncodedArguments ABC="#,
-                WtDefaultShell::PowerShell,
-            ),
-            (r#"pwsh.exe -Login -NoLogo"#, WtDefaultShell::Pwsh),
-            (
-                r#"pwsh.exe -Interactive -NoProfileLoadTime"#,
-                WtDefaultShell::Pwsh,
-            ),
-            (
-                r#"pwsh.exe -SettingsFile C:\x.json -NoLogo"#,
-                WtDefaultShell::Pwsh,
-            ),
-            (r#"pwsh.exe -wd C:\Work -nol"#, WtDefaultShell::Pwsh),
-            (r#"pwsh.exe -i"#, WtDefaultShell::Pwsh),
-            (r#"powershell.exe -ep Bypass"#, WtDefaultShell::PowerShell),
-            (
-                r#"powershell.exe -if Text -of Text"#,
-                WtDefaultShell::PowerShell,
-            ),
-            (r#"powershell.exe -ea ABC="#, WtDefaultShell::PowerShell),
-            (
-                r#"pwsh.exe -ConfigurationFile C:\x.pssc"#,
-                WtDefaultShell::Pwsh,
-            ),
-            (
-                r#"powershell.exe -Version 2.0 -NoLogo"#,
-                WtDefaultShell::PowerShell,
-            ),
-            (r#"pwsh.exe -NoLogo -NoExit"#, WtDefaultShell::Pwsh),
-            (
-                r#"pwsh.exe -WorkingDirectory "C:\Work\My -File Project" -NoLogo"#,
-                WtDefaultShell::Pwsh,
-            ),
-            // Quoted executable with a space and no arguments appends safely.
-            (r#""C:\missing quote\pwsh.exe""#, WtDefaultShell::Pwsh),
-        ];
-        for (cmdline, expected) in accepted {
-            assert_eq!(
-                classify_wt_commandline(cmdline),
-                Some(*expected),
-                "{cmdline}"
-            );
-        }
-
-        // Copied-from-docs Unicode dashes (U+2013/2014/2015) and their
-        // doubled long-option spelling parse like ASCII `-`.
-        for dash in ['\u{2013}', '\u{2014}', '\u{2015}'] {
-            let doubled = format!("pwsh.exe {dash}{dash}NoLogo");
-            assert_eq!(
-                classify_wt_commandline(&format!("pwsh.exe {dash}NoLogo")),
-                Some(WtDefaultShell::Pwsh),
-                "dash {dash:?}"
-            );
-            assert_eq!(
-                classify_wt_commandline(&doubled),
-                Some(WtDefaultShell::Pwsh),
-                "doubled dash {dash:?}"
-            );
-            assert_eq!(
-                classify_wt_commandline(&format!("powershell.exe {dash}NoLogo")),
-                Some(WtDefaultShell::PowerShell),
-                "dash {dash:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn wt_cmd_concatenated_actions_use_explicit_fallback() {
-        let settings = serde_json::json!({
-            "defaultProfile": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
-            "profiles": {"list": [{
-                "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
-                "commandline": "cmd.exe /D/C echo ORIGINAL"
-            }]}
-        });
-        let profile = parse_wt_default_profile(&settings.to_string(), None);
-        assert_eq!(
-            select_wt_launch_args(profile.as_ref(), true, "wt", "probe.bat", "& 'probe.bat'"),
-            vec!["wt", "new-tab", "cmd", "/K", "probe.bat"]
-        );
-
-        #[cfg(target_os = "windows")]
-        {
-            // Pin CMD dialect with a real shell: a glued /K after /C is text of
-            // the original command and does not run a second batch.
-            let output = std::process::Command::new("cmd.exe")
-                .args(["/d/c", "echo", "ORIGINAL", "/K", "echo", "APPENDED"])
-                .creation_flags(CREATE_NO_WINDOW)
-                .output()
-                .expect("CMD concatenated switch probe should start");
-            assert!(output.status.success());
-            assert_eq!(
-                decode_command_output(&output.stdout).trim(),
-                "ORIGINAL /K echo APPENDED"
-            );
-        }
-    }
-
-    #[test]
-    fn parse_wt_default_profile_inherits_profiles_defaults_commandline() {
-        let defaults_wsl = r#"{
-            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-            "profiles": {
-                "defaults": { "commandline": "wsl.exe" },
-                "list": [{
-                    "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-                    "name": "PowerShell",
-                    "source": "Windows.Terminal.PowershellCore"
-                }]
-            }
-        }"#;
-        assert_eq!(
-            parse_wt_default_profile(defaults_wsl, Some((1, 23, 20211, 0))),
-            None
-        );
-
-        let defaults_file = r#"{
-            "defaultProfile": "{44444444-4444-4444-8444-444444444444}",
-            "profiles": {
-                "defaults": { "commandline": "pwsh.exe -File C:\\init.ps1" },
-                "list": [{ "guid": "{44444444-4444-4444-8444-444444444444}", "name": "Custom" }]
-            }
-        }"#;
-        assert_eq!(
-            parse_wt_default_profile(defaults_file, Some((1, 23, 20211, 0))),
-            None
-        );
-
-        let defaults_pwsh = r#"{
-            "defaultProfile": "{44444444-4444-4444-8444-444444444444}",
-            "profiles": {
-                "defaults": { "commandline": "pwsh.exe -NoLogo" },
-                "list": [{ "guid": "{44444444-4444-4444-8444-444444444444}", "name": "Custom" }]
-            }
-        }"#;
-        assert_eq!(
-            parse_wt_default_profile(defaults_pwsh, Some((1, 23, 20211, 0)))
-                .map(|profile| profile.shell),
-            Some(WtDefaultShell::Pwsh)
-        );
-
-        let profile_overrides_defaults = r#"{
-            "defaultProfile": "{44444444-4444-4444-8444-444444444444}",
-            "profiles": {
-                "defaults": { "commandline": "wsl.exe" },
-                "list": [{
-                    "guid": "{44444444-4444-4444-8444-444444444444}",
-                    "name": "Custom",
-                    "commandline": "cmd.exe"
-                }]
-            }
-        }"#;
-        assert_eq!(
-            parse_wt_default_profile(profile_overrides_defaults, Some((1, 23, 20211, 0)))
-                .map(|profile| profile.shell),
-            Some(WtDefaultShell::Cmd)
-        );
-
-        let unlisted_builtin_with_defaults = r#"{
-            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-            "profiles": {
-                "defaults": { "commandline": "wsl.exe" },
-                "list": []
-            }
-        }"#;
-        assert_eq!(
-            parse_wt_default_profile(unlisted_builtin_with_defaults, Some((1, 23, 20211, 0))),
-            None
-        );
-    }
-
-    #[test]
-    fn wt_default_profile_uses_versioned_defaults_commandline() {
-        let guid = "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}";
-        let temp = tempfile::tempdir().expect("settings directory should be created");
-        let path = temp.path().join("settings.json");
-        for (version, expected_shell) in [
-            (Some((1, 19, 10821, 0)), Some(WtDefaultShell::Pwsh)),
-            (Some((1, 22, 10352, 0)), Some(WtDefaultShell::Pwsh)),
-            (Some((1, 23, 20211, 0)), Some(WtDefaultShell::Pwsh)),
-            (Some((1, 24, 2372, 0)), Some(WtDefaultShell::Cmd)),
-            (Some((1, 24, 11911, 0)), Some(WtDefaultShell::Cmd)),
-            (Some((1, 25, 1912, 0)), Some(WtDefaultShell::Cmd)),
-            (None, None),
-        ] {
-            for listed in [true, false] {
-                let mut profiles = Vec::new();
-                if listed {
-                    profiles.push(serde_json::json!({"guid": guid, "name": "Command Prompt"}));
-                }
-                let settings = serde_json::json!({
-                    "defaultProfile": guid,
-                    "profiles": {"defaults": {"commandline": "pwsh.exe"}, "list": profiles}
-                });
-                std::fs::write(&path, settings.to_string()).expect("settings should be written");
-                let profile =
-                    detect_wt_default_profile_from_paths(std::slice::from_ref(&path), version);
-                assert_eq!(
-                    profile,
-                    expected_shell.map(|shell| WtDefaultProfile {
-                        selector: guid.to_string(),
-                        shell
-                    }),
-                    "version={version:?}, listed={listed}"
-                );
-                let mut expected_args = vec!["wt", "new-tab"];
-                if let Some(shell) = expected_shell {
-                    expected_args.extend(["--profile", guid, "--appendCommandLine", "--"]);
-                    match shell {
-                        WtDefaultShell::Cmd => expected_args.extend(["/K", "probe.bat"]),
-                        _ => expected_args.extend(["-NoExit", "-Command", "& 'probe.bat'"]),
-                    }
-                } else {
-                    expected_args.extend(["cmd", "/K", "probe.bat"]);
-                }
-                assert_eq!(
-                    select_wt_launch_args(
-                        profile.as_ref(),
-                        true,
-                        "wt",
-                        "probe.bat",
-                        "& 'probe.bat'"
-                    ),
-                    expected_args,
-                    "version={version:?}, listed={listed}"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn wt_defaults_version_does_not_override_explicit_commandline() {
-        let guid = "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}";
-        for version in [None, Some((1, 23, 20211, 0)), Some((1, 24, 11911, 0))] {
-            for defaults in ["pwsh.exe", "wsl.exe"] {
-                for explicit in ["cmd.exe", "wsl.exe"] {
-                    let settings = serde_json::json!({
-                        "defaultProfile": guid,
-                        "profiles": {
-                            "defaults": {"commandline": defaults},
-                            "list": [{"guid": guid, "commandline": explicit}]
-                        }
-                    });
-                    assert_eq!(
-                        parse_wt_default_profile(&settings.to_string(), version),
-                        (explicit == "cmd.exe").then(|| WtDefaultProfile {
-                            selector: guid.to_string(),
-                            shell: WtDefaultShell::Cmd,
-                        }),
-                        "version={version:?}, defaults={defaults}, explicit={explicit}"
-                    );
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn wt_profile_guids_follow_wt_utf16_namespace_rules() {
-        // Fixed vector from WT's src/types/ut_types/UuidTests.cpp, not computed
-        // with the implementation under test. UTF-8 gives a different UUID.
-        let namespace = uuid::Uuid::parse_str("ad56de9e-5167-41b6-80eb-fb19f7927d1a").unwrap();
-        assert_eq!(
-            wt_uuid_v5(namespace, "testing").to_string(),
-            "e04fb1f7-739d-5d63-bb18-e0ea00b19ee8"
-        );
-        // Profile vectors independently calculated from WT's published algorithm.
-        for (profile, expected) in [
-            (
-                serde_json::json!({"name": "profile0"}),
-                "690955e2-dbc2-509c-b36d-ac466fdda656",
-            ),
-            (
-                serde_json::json!({"name": "profile0", "source": ""}),
-                "690955e2-dbc2-509c-b36d-ac466fdda656",
-            ),
-            (
-                serde_json::json!({"name": "profile0", "source": "Terminal.App.UnitTest.0"}),
-                "52b9372a-c1b1-57eb-a9ce-e2cdc8d52ceb",
-            ),
-            (
-                serde_json::json!({"name": "Profile0"}),
-                "6a2f325d-dd64-5214-ac09-ceac61244422",
-            ),
-            (
-                serde_json::json!({"name": "开发 🚀"}),
-                "513625d0-fe16-526d-b8b5-494277269c46",
-            ),
-            (
-                serde_json::json!({"name": "Dev&echo"}),
-                "f7143a97-a88e-5523-94a1-19c0c687e353",
-            ),
-            (
-                serde_json::json!({"name": "Dev%COMSPEC%"}),
-                "46d028dc-f2b0-526e-9427-7bf1d8c7070d",
-            ),
-            (
-                serde_json::json!({"name": "Dev;Test"}),
-                "c0bfcc63-c933-5d17-9a24-892f27f2f34c",
-            ),
-            (
-                serde_json::json!({"guid": "{574E775E-4F2A-5B96-AC1E-A2962A402336}", "name": "Dev&echo"}),
-                "574e775e-4f2a-5b96-ac1e-a2962a402336",
-            ),
-        ] {
-            assert_eq!(
-                wt_profile_guid(&profile)
-                    .map(|guid| guid.to_string())
-                    .as_deref(),
-                Some(expected),
-                "{profile}"
-            );
-        }
-        for profile in [
-            serde_json::json!({}),
-            serde_json::json!({"source": "Windows.Terminal.PowershellCore"}),
-            serde_json::json!({"name": "Dev", "guid": "Dev&echo"}),
-            serde_json::json!({"name": "Dev", "source": false}),
-        ] {
-            assert_eq!(wt_profile_guid(&profile), None, "{profile}");
-        }
-    }
-
-    #[test]
-    fn wt_default_profile_name_collisions_bind_the_exact_profile() {
-        // This fixture inherits defaults; use the legacy rule so selector matching
-        // is isolated from versioned default loading.
-        // Explicit GUIDs isolate selector matching from GUID generation.
-        let expected = "{22222222-2222-4222-8222-222222222222}";
-        let mut failures = Vec::new();
-        for (first_name, exact_name) in [
-            ("dev", "Dev"),
-            (" Dev", "Dev"),
-            ("Dev ", "Dev"),
-            ("Dev", " Dev"),
-            ("Dev", "Dev "),
-        ] {
-            for include_decoy in [false, true] {
-                let mut profiles = vec![serde_json::json!({"guid": expected, "name": exact_name})];
-                if include_decoy {
-                    profiles.insert(
-                        0,
-                        serde_json::json!({
-                            "guid": "{11111111-1111-4111-8111-111111111111}",
-                            "name": first_name
-                        }),
-                    );
-                }
-                let settings = serde_json::json!({
-                    "defaultProfile": exact_name,
-                    "profiles": {
-                        "defaults": {"commandline": "cmd.exe"},
-                        "list": profiles
-                    }
-                });
-                let profile =
-                    parse_wt_default_profile(&settings.to_string(), Some((1, 23, 20211, 0)));
-                let args = select_wt_launch_args(
-                    profile.as_ref(),
-                    true,
-                    "wt.exe",
-                    "probe.bat",
-                    "& 'probe.bat'",
-                );
-                let actual = args
-                    .windows(2)
-                    .find(|pair| pair[0] == "--profile")
-                    .map(|pair| pair[1]);
-                assert_eq!(
-                    actual,
-                    profile.as_ref().map(|profile| profile.selector.as_str()),
-                    "argument generation must preserve the parsed selector"
-                );
-                if actual != Some(expected) {
-                    failures.push(format!(
-                        "names={first_name:?}/{exact_name:?}, default={exact_name:?}, decoy={include_decoy}: expected {expected}, got {actual:?}"
-                    ));
-                }
-            }
-        }
-        assert!(failures.is_empty(), "{}", failures.join("\n"));
-    }
-
-    #[test]
-    fn wt_default_profile_guid_precedes_name_collisions() {
-        let cmd_guid = "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}";
-        let pwsh_guid = "{574e775e-4f2a-5b96-ac1e-a2962a402336}";
-        for selector in [cmd_guid.to_string(), cmd_guid.to_ascii_uppercase()] {
-            for reverse in [false, true] {
-                for commandline in ["cmd.exe", "wsl.exe"] {
-                    let mut profiles = vec![
-                        serde_json::json!({"guid": pwsh_guid, "name": selector, "commandline": "pwsh.exe"}),
-                        serde_json::json!({"guid": cmd_guid, "name": "Command Prompt", "commandline": commandline}),
-                    ];
-                    if reverse {
-                        profiles.reverse();
-                    }
-                    let settings = serde_json::json!({
-                        "defaultProfile": selector,
-                        "profiles": {"list": profiles}
-                    });
-                    let expected = (commandline == "cmd.exe").then(|| WtDefaultProfile {
-                        selector: cmd_guid.to_string(),
-                        shell: WtDefaultShell::Cmd,
-                    });
-                    assert_eq!(
-                        parse_wt_default_profile(&settings.to_string(), None),
-                        expected,
-                        "selector={selector}, reverse={reverse}, commandline={commandline}"
-                    );
-                }
-            }
-        }
-
-        // Only when no GUID in the table matches may a GUID-shaped string be
-        // looked up as a name.
-        let name = "{11111111-1111-4111-8111-111111111111}";
-        let settings = serde_json::json!({
-            "defaultProfile": name,
-            "profiles": {"list": [{"guid": pwsh_guid, "name": name, "commandline": "pwsh.exe"}]}
-        });
-        assert_eq!(
-            parse_wt_default_profile(&settings.to_string(), None)
-                .unwrap()
-                .selector,
-            pwsh_guid
-        );
-    }
-
-    #[test]
-    fn parse_wt_default_profile_preserves_the_matched_selector() {
-        // This fixture inherits defaults; use the legacy rule so selector matching
-        // is isolated from versioned default loading.
-        for (content, selector) in [
-            (
-                r#"{"defaultProfile":"{33333333-3333-4333-8333-333333333333}","profiles":{"list":[{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
-                "{33333333-3333-4333-8333-333333333333}",
-            ),
-            (
-                r#"{"defaultProfile":"Custom shell","profiles":{"list":[{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
-                "{33333333-3333-4333-8333-333333333333}",
-            ),
-            (
-                r#"{"defaultProfile":"Custom shell","profiles":[{"name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}"#,
-                "{fa616ee5-b304-5217-8de0-4f1eb1e90d19}",
-            ),
-            (
-                r#"{"defaultProfile":"Profile0","profiles":{"list":[{"name":"profile0","commandline":"pwsh.exe"},{"name":"Profile0","commandline":"pwsh.exe"}]}}"#,
-                "{6a2f325d-dd64-5214-ac09-ceac61244422}",
-            ),
-            (
-                r#"{"defaultProfile":"{FA616EE5-B304-5217-8DE0-4F1EB1E90D19}","profiles":{"list":[{"name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
-                "{fa616ee5-b304-5217-8de0-4f1eb1e90d19}",
-            ),
-            (
-                r#"{"defaultProfile":"Custom shell","profiles":{"defaults":{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Other shell","source":"Other source","commandline":"pwsh.exe -NoLogo"},"list":[{"name":"Custom shell"}]}}"#,
-                "{fa616ee5-b304-5217-8de0-4f1eb1e90d19}",
-            ),
-            (
-                r#"{"defaultProfile":"{574e775e-4f2a-5b96-ac1e-a2962a402336}"}"#,
-                "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
-            ),
-            (
-                r#"{"defaultProfile":"{33333333-3333-4333-8333-333333333333}","profiles":{"defaults":{"commandline":"pwsh.exe"},"list":[]}}"#,
-                "{33333333-3333-4333-8333-333333333333}",
-            ),
-        ] {
-            assert_eq!(
-                parse_wt_default_profile(content, Some((1, 23, 20211, 0))),
-                Some(WtDefaultProfile {
-                    selector: selector.to_string(),
-                    shell: WtDefaultShell::Pwsh,
-                }),
-                "{content}"
-            );
-        }
-    }
-
-    #[test]
-    fn parse_wt_default_profile_rejects_unresolvable_selectors() {
-        for content in [
-            r#"{"defaultProfile":"custom shell","profiles":{"list":[{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
-            r#"{"defaultProfile":"custom shell","profiles":[{"name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}"#,
-            r#"{"defaultProfile":" Custom shell","profiles":[{"name":"Custom shell","commandline":"pwsh.exe"}]}"#,
-            r#"{"defaultProfile":"Custom shell ","profiles":[{"name":"Custom shell","commandline":"pwsh.exe"}]}"#,
-            r#"{"defaultProfile":"Dev&echo","profiles":{"defaults":{"commandline":"pwsh.exe"},"list":[]}}"#,
-            r#"{"defaultProfile":"Dev&echo","profiles":{"list":[{"name":"Dev&echo","guid":"invalid","commandline":"pwsh.exe"}]}}"#,
-        ] {
-            assert_eq!(parse_wt_default_profile(content, None), None, "{content}");
-        }
-    }
-
-    #[test]
-    fn wt_launch_helpers_preserve_the_profile_and_use_explicit_fallback() {
-        let wt = r"C:\Program Files\Windows Terminal\wt.exe";
-        let bat = r"C:\Temp\test.bat";
-        let ps = r"& 'C:\Temp\test.bat'";
-
-        assert_eq!(
-            build_windows_start_args(&[wt, "new-tab"]),
-            vec!["/C", "start", "", wt, "new-tab"]
-        );
-        for shell in [
-            WtDefaultShell::Pwsh,
-            WtDefaultShell::PowerShell,
-            WtDefaultShell::Cmd,
-        ] {
-            let profile = WtDefaultProfile {
-                selector: "Custom profile with spaces".to_string(),
-                shell,
-            };
-            let mut expected = vec![
-                wt,
-                "new-tab",
-                "--profile",
-                "Custom profile with spaces",
-                "--appendCommandLine",
-                "--",
-            ];
-            if shell == WtDefaultShell::Cmd {
-                expected.extend(["/K", bat]);
-            } else {
-                expected.extend(["-NoExit", "-Command", ps]);
-            }
-            assert_eq!(
-                select_wt_launch_args(Some(&profile), true, wt, bat, ps),
-                expected
-            );
-            assert_eq!(
-                select_wt_launch_args(Some(&profile), false, wt, bat, ps),
-                vec![wt, "new-tab", "cmd", "/K", bat]
-            );
-        }
-        for supports_append in [false, true] {
-            assert_eq!(
-                select_wt_launch_args(None, supports_append, wt, bat, ps),
-                vec![wt, "new-tab", "cmd", "/K", bat]
-            );
-        }
-
-        let shim = "path = \"C:\\scoop\\apps\\windows-terminal\\current\\wt.exe\"\r\nargs = \r\n";
-        assert_eq!(
-            parse_scoop_shim_content(shim),
-            Some(PathBuf::from(
-                r"C:\scoop\apps\windows-terminal\current\wt.exe"
-            ))
-        );
-        assert_eq!(parse_scoop_shim_content("bad content"), None);
-    }
-
-    // Spawn a real argv probe so the launcher path and args are not re-parsed
-    // by an extra shell.
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn wt_launch_preserves_special_character_paths_and_profile_args() {
-        let temp = tempfile::tempdir().expect("probe directory should be created");
-        let source = temp.path().join("argv_probe.rs");
-        let executable = temp.path().join("argv_probe.exe");
-        std::fs::write(
-            &source,
-            r#"#![windows_subsystem = "windows"]
-fn main() {
-    let path = std::env::current_exe().unwrap().with_extension("args");
-    let staging = path.with_extension("staging");
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    std::fs::write(&staging, format!("{args:?}")).unwrap();
-    std::fs::rename(staging, path).unwrap();
-}
-"#,
-        )
-        .expect("argv probe source should be written");
-        let compiled = std::process::Command::new("rustc")
-            .arg(&source)
-            .arg("-o")
-            .arg(&executable)
-            .output()
-            .expect("rustc should compile the argv probe");
-        assert!(
-            compiled.status.success(),
-            "{}",
-            String::from_utf8_lossy(&compiled.stderr)
-        );
-        let mut failures = Vec::new();
-        for directory in [
-            "Tools&echo",
-            "Tools%COMSPEC%",
-            "Tools^A",
-            "Tools(A)",
-            "Tools and O'Brien",
-            "工具🚀",
-        ] {
-            let launcher_dir = temp.path().join(directory);
-            std::fs::create_dir(&launcher_dir).expect("launcher directory should be created");
-            let launcher_executable = launcher_dir.join("wt.exe");
-            std::fs::copy(&executable, &launcher_executable)
-                .expect("probe should be copied to the launcher path");
-            let capture = launcher_executable.with_extension("args");
-            let launcher = launcher_executable.to_string_lossy();
-            for name in [
-                "Custom profile",
-                "Dev&echo",
-                "Dev%COMSPEC%",
-                "Dev;Test",
-                r"Dev\;Test",
-                r"Dev\\;Test",
-                "开发 🚀",
-                "Dev|echo",
-                "Dev^echo",
-            ] {
-                let settings = serde_json::json!({
-                    "defaultProfile": name,
-                    "profiles": {"list": [{"name": name, "commandline": "pwsh.exe -NoLogo"}]}
-                });
-                let profile = parse_wt_default_profile(&settings.to_string(), None)
-                    .expect("the profile should be recognized");
-                assert!(
-                    uuid::Uuid::parse_str(&profile.selector).is_ok(),
-                    "names must not reach cmd or WT as selectors: {name:?}"
-                );
-                let bat = r"C:\Temp\batch & %COMSPEC% ^ O'Brien\probe.bat";
-                let ps_cmd = format!("& '{}'", bat.replace('\'', "''"));
-                let args = select_wt_launch_args(Some(&profile), true, &launcher, bat, &ps_cmd);
-                let expected = format!("{:?}", &args[1..]);
-                run_wt_command(&args).expect("WT launcher should directly start the probe");
-                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-                while !capture.is_file() && std::time::Instant::now() < deadline {
-                    std::thread::sleep(std::time::Duration::from_millis(20));
-                }
-                let observed =
-                    std::fs::read_to_string(&capture).expect("argv probe must write its result");
-                if observed != expected {
-                    failures.push(format!(
-                        "{name:?}: expected {expected}, received {observed}"
-                    ));
-                }
-                std::fs::remove_file(&capture)
-                    .expect("the completed probe result should be removed");
-            }
-        }
-        assert!(failures.is_empty(), "{}", failures.join("\n"));
-        let missing_launcher = temp.path().join("missing.exe");
-        assert!(run_wt_command(&[&missing_launcher.to_string_lossy()]).is_err());
-        assert!(run_wt_command(&[]).is_err());
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test]
-    #[serial_test::serial]
-    fn windows_terminal_launchers_do_not_inherit_parent_claude_session() {
-        struct EnvRestore(Vec<(&'static str, Option<std::ffi::OsString>)>);
-
-        impl Drop for EnvRestore {
-            fn drop(&mut self) {
-                for (name, value) in self.0.drain(..) {
-                    match value {
-                        Some(value) => std::env::set_var(name, value),
-                        None => std::env::remove_var(name),
-                    }
-                }
-            }
-        }
-
-        fn wait_for_probe(capture: &Path) -> String {
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-            while !capture.is_file() && std::time::Instant::now() < deadline {
-                std::thread::sleep(std::time::Duration::from_millis(20));
-            }
-            std::fs::read_to_string(capture)
-                .expect("env probe must write its inherited variable names")
-        }
-
-        let restore = EnvRestore(
-            PARENT_CLAUDE_SESSION_ENV_VARS
-                .iter()
-                .map(|name| (*name, std::env::var_os(name)))
-                .collect(),
-        );
-        for name in PARENT_CLAUDE_SESSION_ENV_VARS {
-            std::env::set_var(name, "cc-switch-parent-session");
-        }
-
-        let temp = tempfile::tempdir().expect("probe directory should be created");
-        let source = temp.path().join("env_probe.rs");
-        let executable = temp.path().join("env_probe.exe");
-        std::fs::write(
-            &source,
-            r#"#![windows_subsystem = "windows"]
-fn main() {
-    let mut args = std::env::args_os().skip(1);
-    let capture = args.next().unwrap();
-    let inherited: Vec<String> = args
-        .filter(|name| std::env::var_os(name).is_some())
-        .map(|name| name.to_string_lossy().into_owned())
-        .collect();
-    std::fs::write(capture, inherited.join("\n")).unwrap();
-}
-"#,
-        )
-        .expect("env probe source should be written");
-        let compiled = std::process::Command::new("rustc")
-            .arg(&source)
-            .arg("-o")
-            .arg(&executable)
-            .output()
-            .expect("rustc should compile the env probe");
-        assert!(
-            compiled.status.success(),
-            "{}",
-            String::from_utf8_lossy(&compiled.stderr)
-        );
-
-        let launcher = executable.to_string_lossy();
-        for (label, capture, launch) in [
-            (
-                "direct Windows Terminal",
-                temp.path().join("direct.result"),
-                run_wt_command as fn(&[&str]) -> Result<(), String>,
-            ),
-            ("cmd start", temp.path().join("cmd-start.result"), |args| {
-                run_windows_start_command(args, "env probe")
-            }),
-        ] {
-            let capture_arg = capture.to_string_lossy();
-            let mut args = vec![launcher.as_ref(), capture_arg.as_ref()];
-            args.extend(PARENT_CLAUDE_SESSION_ENV_VARS.iter().copied());
-            launch(&args).unwrap_or_else(|error| panic!("{label} probe should launch: {error}"));
-            let inherited = wait_for_probe(&capture);
-            assert!(
-                inherited.is_empty(),
-                "{label} inherited parent Claude session variables:\n{inherited}"
-            );
-        }
-        drop(restore);
-    }
-
-    // Exercise the real WT profile selection, not only the generated argv.
-    // Opt in on a Windows desktop; this opens diagnostic tabs without changing settings.
-    #[cfg(target_os = "windows")]
-    #[test]
-    #[ignore = "requires desktop WT, a supported default profile GUID, and built-in PowerShell/cmd profiles"]
-    fn wt_launch_executes_batch_in_real_terminal() {
-        let installation = resolve_wt_installation().expect("Windows Terminal must be installed");
-        let default_profile =
-            detect_wt_default_profile(&installation, wt_installation_version(&installation))
-                .expect("the default WT profile must support batch execution");
-        let cases = [
-            (default_profile.clone(), true),
-            (
-                WtDefaultProfile {
-                    selector: "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}".to_string(),
-                    shell: WtDefaultShell::PowerShell,
-                },
-                true,
-            ),
-            (
-                WtDefaultProfile {
-                    selector: "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}".to_string(),
-                    shell: WtDefaultShell::Cmd,
-                },
-                true,
-            ),
-            (default_profile, false),
-        ];
-        let temp = tempfile::Builder::new()
-            .prefix("cc-switch-wt-smoke-")
-            .tempdir()
-            .expect("diagnostic directory should be created");
-        let fixture_dir = temp.path().join("space and O'Brien");
-        std::fs::create_dir(&fixture_dir).expect("quoted fixture directory should be created");
-        for (index, (profile, supports_append)) in cases.iter().enumerate() {
-            let marker = fixture_dir.join(format!("executed-{index}.txt"));
-            let batch = fixture_dir.join(format!("probe-{index}.bat"));
-            std::fs::write(
-                &batch,
-                format!(
-                    "@echo off\r\n> \"{}\" echo %WT_PROFILE_ID%\r\necho [cc-switch] WT launch diagnostic completed. This tab can be closed.\r\n",
-                    escape_windows_batch_value(&marker.to_string_lossy())
-                ),
-            )
-            .expect("diagnostic batch should be written");
-            let bat_path = batch.to_string_lossy();
-            let ps_cmd = format!("& '{}'", bat_path.replace('\'', "''"));
-            if index == 0 {
-                launch_wt_terminal(&bat_path, &ps_cmd).expect("WT launch should succeed");
-            } else {
-                let launcher = installation.launcher.to_string_lossy();
-                let args = select_wt_launch_args(
-                    Some(profile),
-                    *supports_append,
-                    &launcher,
-                    &bat_path,
-                    &ps_cmd,
-                );
-                run_wt_command(&args).expect("explicit-profile WT launch should succeed");
-            }
-
-            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
-            while !marker.is_file() && std::time::Instant::now() < deadline {
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-            let profile_id = std::fs::read_to_string(&marker)
-                .unwrap_or_else(|error| panic!("case {index}: WT must execute the batch: {error}"));
-            if *supports_append {
-                assert_eq!(
-                    normalize_wt_guid(profile_id.trim()),
-                    normalize_wt_guid(&profile.selector),
-                    "case {index}: the batch must run in the same profile that was classified"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn wt_settings_paths_stay_bound_to_the_resolved_installation() {
-        let local = Path::new("C:/Users/test/AppData/Local");
-        for exe in [
-            "C:/Users/test/scoop/apps/windows-terminal/current/WindowsTerminal.exe",
-            "C:/Program Files/Windows Terminal/wt.exe",
-            "C:/Tools/terminal/wt.exe",
-        ] {
-            assert_eq!(
-                build_wt_settings_paths(Path::new(exe), Some(local)),
-                vec![unpackaged_wt_settings_path(local)],
-                "{exe}"
-            );
-        }
-
-        // Do not depend on the local install type; classify stable vs Preview
-        // and bind each to its unique active settings path.
-        for (exe, expected_preview) in [
-            (
-                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminal_1.24.11911.0_x64__8wekyb3d8bbwe/wt.exe",
-                false,
-            ),
-            (
-                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminalPreview_1.0.0.0_x64__8wekyb3d8bbwe/wt.exe",
-                true,
-            ),
-        ] {
-            let exe = Path::new(exe);
-            let (preview, _) = store_wt_package_dir(exe)
-                .expect("Store executable must belong to a WT package");
-            assert_eq!(preview, expected_preview, "{exe:?}");
-            assert_eq!(
-                build_wt_settings_paths(exe, Some(local)),
-                vec![store_wt_settings_path(local, expected_preview)],
-                "{exe:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn wt_portable_install_uses_only_active_settings() {
-        let local = Path::new("C:/Users/test/AppData/Local");
-        for (layout, persist) in [
-            ("tools-wt", None),
-            (
-                "scoop/apps/windows-terminal/current",
-                Some("scoop/persist/windows-terminal"),
-            ),
-            (
-                "scoop/apps/windows-terminal-preview/1.24.0",
-                Some("scoop/persist/windows-terminal-preview"),
-            ),
-        ] {
-            let temp = tempfile::tempdir().expect("temp dir should be created");
-            let exe_dir = temp.path().join(layout);
-            std::fs::create_dir_all(&exe_dir).expect("portable dir should be created");
-            let exe = exe_dir.join("wt.exe");
-            std::fs::write(&exe, b"").expect("portable exe placeholder should be written");
-            std::fs::write(exe_dir.join(".portable"), b"")
-                .expect("portable marker should be written");
-
-            let active = r#"{
-                "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}"
-            }"#;
-            let stale = r#"{
-                "defaultProfile": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}"
-            }"#;
-            let mut expected = Vec::new();
-            for root in std::iter::once(exe_dir.clone())
-                .chain(persist.map(|persist| temp.path().join(persist)))
-            {
-                let settings_dir = root.join("settings");
-                std::fs::create_dir_all(&settings_dir).expect("settings dir should be created");
-                let active_path = settings_dir.join("settings.json");
-                std::fs::write(&active_path, active).expect("active settings should be written");
-                expected.push(active_path);
-                let stale_path = root.join("settings.json");
-                std::fs::write(&stale_path, stale).expect("stale settings should be written");
-                // A file at the root is not WT settings, even if its timestamp is
-                // newer than the active config.
-                std::fs::OpenOptions::new()
-                    .write(true)
-                    .open(&stale_path)
-                    .expect("stale settings should open")
-                    .set_times(std::fs::FileTimes::new().set_modified(
-                        std::time::SystemTime::now() + std::time::Duration::from_secs(60),
-                    ))
-                    .expect("stale settings should have a newer timestamp");
-            }
-
-            let paths = build_wt_settings_paths(&exe, Some(local));
-            assert_eq!(
-                detect_wt_default_profile_from_paths(&paths, None),
-                parse_wt_default_profile(active, None),
-                "{layout}: root settings must not override the active PowerShell profile"
-            );
-            assert_eq!(
-                paths, expected,
-                "{layout}: only active settings are candidates"
-            );
-        }
-    }
-
-    #[test]
-    fn wt_version_and_path_detect_append_command_line_support() {
-        assert!(!wt_version_supports_append((1, 18, 3181, 0)));
-        assert!(wt_version_supports_append((1, 19, 0, 0)));
-        assert!(wt_version_supports_append((1, 24, 11911, 0)));
-        assert_eq!(
-            wt_version_from_path(Path::new(
-                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminal_1.18.3181.0_x64__8wekyb3d8bbwe/wt.exe"
-            )),
-            Some((1, 18, 3181, 0))
-        );
-        assert_eq!(
-            wt_version_from_path(Path::new(
-                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminal_1.24.11911.0_x64__8wekyb3d8bbwe/wt.exe"
-            )),
-            Some((1, 24, 11911, 0))
-        );
-        assert_eq!(
-            wt_version_from_path(Path::new(
-                "C:/Users/test/scoop/apps/windows-terminal/1.18.3181.0/wt.exe"
-            )),
-            Some((1, 18, 3181, 0))
-        );
-        assert_eq!(
-            wt_version_from_path(Path::new(
-                "C:/Users/test/scoop/apps/windows-terminal/current/wt.exe"
-            )),
-            None
-        );
-    }
-
-    #[test]
-    fn unpackaged_release_directory_is_not_misclassified_as_store() {
-        let local = Path::new("C:/Users/test/AppData/Local");
-        let exe = Path::new("C:/Tools/Microsoft.WindowsTerminal_1.23_x64/wt.exe");
-        let paths = build_wt_settings_paths(exe, Some(local));
-        assert!(paths.contains(&unpackaged_wt_settings_path(local)));
-        assert!(!paths.contains(&store_wt_settings_path(local, false)));
-        assert!(!paths.contains(&store_wt_settings_path(local, true)));
-    }
-
-    #[test]
-    fn app_execution_alias_parser_extracts_the_package_target() {
-        let build_buffer = |target: &str| {
-            let values = ["Package_Family", "Package_Family!App", target, "0"];
-            let mut payload = (values.len() as u32).to_le_bytes().to_vec();
-            for value in values {
-                for unit in value.encode_utf16().chain(Some(0)) {
-                    payload.extend_from_slice(&unit.to_le_bytes());
-                }
-            }
-
-            let mut buffer = APPEXECLINK_REPARSE_TAG.to_le_bytes().to_vec();
-            buffer.extend_from_slice(&(payload.len() as u16).to_le_bytes());
-            buffer.extend_from_slice(&0u16.to_le_bytes());
-            buffer.extend_from_slice(&payload);
-            buffer
-        };
-
-        let target = r"C:\Program Files\WindowsApps\Microsoft.WindowsTerminal_1.0.0.0_x64__8wekyb3d8bbwe\wt.exe";
-        let parsed = parse_app_execution_alias_target(&build_buffer(target))
-            .expect("App Execution Alias target should parse");
-        assert_eq!(String::from_utf16(&parsed).unwrap(), target);
-        assert_eq!(
-            parse_app_execution_alias_target(&build_buffer(r"relative\wt.exe")),
-            None
-        );
-    }
-
-    #[cfg(target_os = "windows")]
-    #[test]
-    fn store_wt_alias_resolves_to_package_settings_not_scoop() {
-        let Some(local) = std::env::var_os("LOCALAPPDATA").map(PathBuf::from) else {
-            return;
-        };
-        let alias = local.join("Microsoft").join("WindowsApps").join("wt.exe");
-        if std::fs::symlink_metadata(&alias).is_err() {
-            return;
-        }
-
-        let target = resolve_app_execution_alias_target(&alias)
-            .expect("Store wt.exe App Execution Alias should resolve via APPEXECLINK");
-        // The wt.exe alias may belong to stable or Preview; settings paths must
-        // follow the actual target package.
-        let (preview, _) = store_wt_package_dir(&target)
-            .unwrap_or_else(|| panic!("Store alias must resolve to a WT package: {target:?}"));
-        assert_eq!(
-            build_wt_settings_paths(&target, Some(&local)),
-            vec![store_wt_settings_path(&local, preview)],
-            "Store settings should be bound to the resolved package: {target:?}"
-        );
-
-        // PATH lookup is a separate concern: GitHub-hosted Windows runners often
-        // have the Store alias file but no WindowsApps directory on PATH.
-        if let Some(installation) = resolve_wt_installation() {
-            assert_eq!(
-                installation
-                    .launcher
-                    .file_name()
-                    .map(|name| name.to_string_lossy().to_ascii_lowercase()),
-                Some("wt.exe".into()),
-                "launcher should stay the resolved wt.exe, got {:?}",
-                installation.launcher
-            );
-            if installation
-                .launcher
-                .parent()
-                .is_some_and(is_windows_app_execution_alias_dir)
-            {
-                assert_eq!(
-                    installation.settings_executable.as_ref(),
-                    Some(&target),
-                    "PATH-selected Store alias should bind settings to the same APPEXECLINK target"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn wt_settings_detection_skips_malformed_candidates() {
-        let temp = tempfile::tempdir().expect("temp dir should be created");
-        let valid = temp.path().join("valid.json");
-        let malformed = temp.path().join("malformed.json");
-        let pwsh = r#"{
-            "defaultProfile": "PowerShell 7",
-            "profiles": [{"name": "PowerShell 7", "commandline": "pwsh.exe"}]
-        }"#;
-        std::fs::write(&valid, pwsh).expect("valid settings should be written");
-        std::fs::write(&malformed, "not json").expect("malformed settings should be written");
-
-        assert_eq!(
-            detect_wt_default_profile_from_paths(&[malformed, valid], None),
-            Some(WtDefaultProfile {
-                selector: "{8f7fc2c9-b084-5bc6-89f4-82fc0f5d1b6c}".to_string(),
-                shell: WtDefaultShell::Pwsh,
-            })
+            "pushd \"\\\\server\\share\\100%%&(test)\" || exit /b 1\r\n"
         );
     }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -35,6 +35,8 @@ mod lightweight;
 mod s3_sync;
 mod usage;
 mod webdav_sync;
+#[cfg(any(target_os = "windows", test))]
+mod windows_terminal;
 mod workspace;
 
 pub use auth::*;

--- a/src-tauri/src/commands/windows_terminal.rs
+++ b/src-tauri/src/commands/windows_terminal.rs
@@ -1,0 +1,2605 @@
+#[cfg(target_os = "windows")]
+use super::misc::{
+    configure_windows_batch_env, decode_windows_where_output, effective_path_os,
+    is_windows_app_execution_alias_dir, wait_child_output, windows_path_lookup_command,
+    CommandDeadline,
+};
+#[cfg(any(target_os = "windows", test))]
+use super::misc::{push_unique_path, WINDOWS_BATCH_PATH_COMMAND};
+use std::path::{Path, PathBuf};
+
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+/// Shell family of Windows Terminal's default profile.
+#[cfg(any(target_os = "windows", test))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WtDefaultShell {
+    Pwsh,
+    PowerShell,
+    Cmd,
+}
+
+/// Keep the selector with the shell whose flags we append. Without `--profile`,
+/// WT can match the appended commandline against another profile instead of
+/// using defaultProfile, even when `--appendCommandLine` is set.
+#[cfg(any(target_os = "windows", test))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WtDefaultProfile {
+    selector: String,
+    shell: WtDefaultShell,
+}
+
+#[cfg(any(target_os = "windows", test))]
+impl WtDefaultProfile {
+    fn build_wt_args<'a>(&'a self, ps_cmd: &'a str) -> Vec<&'a str> {
+        let mut args = vec![
+            "new-tab",
+            "--profile",
+            self.selector.as_str(),
+            "--appendCommandLine",
+            "--",
+        ];
+        match self.shell {
+            WtDefaultShell::Pwsh | WtDefaultShell::PowerShell => {
+                args.extend(["-NoExit", "-Command", ps_cmd]);
+            }
+            WtDefaultShell::Cmd => {
+                args.extend(["/D", "/V:OFF", "/K", WINDOWS_BATCH_PATH_COMMAND]);
+            }
+        }
+        args
+    }
+}
+
+/// When the default profile cannot be appended to safely, start cmd explicitly
+/// instead of appending `/K` to an unknown shell.
+#[cfg(any(target_os = "windows", test))]
+fn build_wt_cmd_fallback_args() -> Vec<&'static str> {
+    vec![
+        "new-tab",
+        "cmd",
+        "/D",
+        "/V:OFF",
+        "/K",
+        WINDOWS_BATCH_PATH_COMMAND,
+    ]
+}
+
+/// `--appendCommandLine` exists from WT 1.19. Fall back to explicit cmd before spawn
+/// so an unsupported flag is not discovered only after the async launch.
+#[cfg(any(target_os = "windows", test))]
+fn select_wt_launch_args<'a>(
+    profile: Option<&'a WtDefaultProfile>,
+    supports_append: bool,
+    ps_cmd: &'a str,
+) -> Vec<&'a str> {
+    match (profile, supports_append) {
+        (Some(profile), true) => profile.build_wt_args(ps_cmd),
+        _ => build_wt_cmd_fallback_args(),
+    }
+}
+
+/// Strip braces and lowercase GUID strings so they compare across configs.
+#[cfg(any(target_os = "windows", test))]
+fn normalize_wt_guid(guid: &str) -> String {
+    guid.trim()
+        .trim_matches(|c: char| c == '{' || c == '}')
+        .to_ascii_lowercase()
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn known_wt_shell_from_normalized_guid(guid: &str) -> Option<WtDefaultShell> {
+    match guid {
+        "574e775e-4f2a-5b96-ac1e-a2962a402336" => Some(WtDefaultShell::Pwsh),
+        "61c54bbd-c2c6-5271-96e7-009a87ff44bf" => Some(WtDefaultShell::PowerShell),
+        "0caa0dad-35be-5f56-a8ff-afceeeaa6101" => Some(WtDefaultShell::Cmd),
+        _ => None,
+    }
+}
+
+/// Split the first executable from the remaining arguments. WT still owns the
+/// original commandline quoting; this parser does not rebuild it.
+#[cfg(any(target_os = "windows", test))]
+fn split_wt_commandline(cmdline: &str) -> Option<(&str, &str)> {
+    let trimmed = cmdline.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some(stripped) = trimmed.strip_prefix('"') {
+        let closing_quote = stripped.find('"')?;
+        let executable = &stripped[..closing_quote];
+        if executable.is_empty() {
+            return None;
+        }
+        return Some((executable, stripped[closing_quote + 1..].trim_start()));
+    }
+
+    let split_at = trimmed
+        .find(|character: char| character.is_whitespace())
+        .unwrap_or(trimmed.len());
+    Some((&trimmed[..split_at], trimmed[split_at..].trim_start()))
+}
+
+/// Tokenize arguments with Windows commandline quoting. Parse failure means
+/// appending extra arguments cannot be proven safe.
+#[cfg(any(target_os = "windows", test))]
+fn split_wt_arguments(arguments: &str) -> Option<Vec<String>> {
+    let characters: Vec<char> = arguments.chars().collect();
+    let mut result = Vec::new();
+    let mut index = 0usize;
+
+    while index < characters.len() {
+        while index < characters.len() && characters[index].is_whitespace() {
+            index += 1;
+        }
+        if index == characters.len() {
+            break;
+        }
+
+        let mut argument = String::new();
+        let mut in_quotes = false;
+        while index < characters.len() {
+            if !in_quotes && characters[index].is_whitespace() {
+                break;
+            }
+
+            if characters[index] == '\\' {
+                let slash_start = index;
+                while index < characters.len() && characters[index] == '\\' {
+                    index += 1;
+                }
+                let slash_count = index - slash_start;
+                if index < characters.len() && characters[index] == '"' {
+                    argument.extend(std::iter::repeat_n('\\', slash_count / 2));
+                    if slash_count % 2 == 0 {
+                        in_quotes = !in_quotes;
+                    } else {
+                        argument.push('"');
+                    }
+                    index += 1;
+                } else {
+                    argument.extend(std::iter::repeat_n('\\', slash_count));
+                }
+                continue;
+            }
+
+            if characters[index] == '"' {
+                in_quotes = !in_quotes;
+                index += 1;
+                continue;
+            }
+
+            argument.push(characters[index]);
+            index += 1;
+        }
+
+        if in_quotes {
+            return None;
+        }
+        result.push(argument);
+    }
+
+    Some(result)
+}
+
+/// PowerShell host CLI option arity. Unique prefixes match; mixed-kind
+/// prefixes are treated as unknown so append is refused.
+/// `pwsh` and Windows PowerShell 5.1 differ only in `-Version`'s kind and in
+/// shell-specific parameters, so each shell keeps its own table.
+#[cfg(any(target_os = "windows", test))]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PsHostOption {
+    Flag,
+    Value,
+    Terminal,
+}
+
+/// Host aliases and parameter names shared by `pwsh` and Windows PowerShell.
+/// Shell-specific differences remain separate so changes cannot silently drift.
+#[cfg(any(target_os = "windows", test))]
+const COMMON_POWERSHELL_HOST_OPTIONS: &[(&str, PsHostOption)] = &[
+    ("?", PsHostOption::Terminal),
+    ("c", PsHostOption::Terminal),
+    ("command", PsHostOption::Terminal),
+    ("config", PsHostOption::Value),
+    ("configurationname", PsHostOption::Value),
+    ("e", PsHostOption::Terminal),
+    ("ea", PsHostOption::Value),
+    ("ec", PsHostOption::Terminal),
+    ("encodedarguments", PsHostOption::Value),
+    ("encodedcommand", PsHostOption::Terminal),
+    ("ep", PsHostOption::Value),
+    ("ex", PsHostOption::Value),
+    ("executionpolicy", PsHostOption::Value),
+    ("f", PsHostOption::Terminal),
+    ("file", PsHostOption::Terminal),
+    ("h", PsHostOption::Terminal),
+    ("help", PsHostOption::Terminal),
+    ("if", PsHostOption::Value),
+    ("inp", PsHostOption::Value),
+    ("inputformat", PsHostOption::Value),
+    ("mta", PsHostOption::Flag),
+    ("noe", PsHostOption::Flag),
+    ("noexit", PsHostOption::Flag),
+    ("nol", PsHostOption::Flag),
+    ("nologo", PsHostOption::Flag),
+    ("noni", PsHostOption::Flag),
+    ("noninteractive", PsHostOption::Flag),
+    ("nop", PsHostOption::Flag),
+    ("noprofile", PsHostOption::Flag),
+    ("o", PsHostOption::Value),
+    ("of", PsHostOption::Value),
+    ("outputformat", PsHostOption::Value),
+    ("servermode", PsHostOption::Terminal),
+    ("sta", PsHostOption::Flag),
+    ("w", PsHostOption::Value),
+    ("wd", PsHostOption::Value),
+    ("windowstyle", PsHostOption::Value),
+    ("workingdirectory", PsHostOption::Value),
+];
+
+/// `pwsh`-only options. `-Version` exits instead of accepting a value.
+#[cfg(any(target_os = "windows", test))]
+const PWSH_HOST_OPTIONS: &[(&str, PsHostOption)] = &[
+    ("commandwithargs", PsHostOption::Terminal),
+    ("configurationfile", PsHostOption::Value),
+    ("custompipename", PsHostOption::Value),
+    ("cwa", PsHostOption::Terminal),
+    ("i", PsHostOption::Flag),
+    ("interactive", PsHostOption::Flag),
+    ("l", PsHostOption::Flag),
+    ("login", PsHostOption::Flag),
+    ("noprofileloadtime", PsHostOption::Flag),
+    ("settings", PsHostOption::Value),
+    ("settingsfile", PsHostOption::Value),
+    ("sshs", PsHostOption::Terminal),
+    ("sshservermode", PsHostOption::Terminal),
+    ("v", PsHostOption::Terminal),
+    ("version", PsHostOption::Terminal),
+    ("wo", PsHostOption::Value),
+];
+
+/// Windows PowerShell 5.1-only options and classifications. `-Version`
+/// accepts `2.0`/`3.0`, unlike `pwsh`.
+#[cfg(any(target_os = "windows", test))]
+const WINDOWS_POWERSHELL_HOST_OPTIONS: &[(&str, PsHostOption)] = &[
+    ("psconsolefile", PsHostOption::Value),
+    ("v", PsHostOption::Value),
+    ("version", PsHostOption::Value),
+];
+
+/// PowerShell host CLI option dashes: ASCII hyphen plus the Unicode dashes
+/// `pwsh`/`powershell.exe` accept (U+2013, U+2014, U+2015). Copied-from-docs
+/// commandlines often use these instead of ASCII `-`.
+#[cfg(any(target_os = "windows", test))]
+const PS_OPTION_DASHES: &[char] = &['-', '\u{2013}', '\u{2014}', '\u{2015}'];
+
+#[cfg(any(target_os = "windows", test))]
+fn ps_host_option_name(argument: &str) -> Option<&str> {
+    let mut chars = argument.chars();
+    let first = chars.next()?;
+    let rest = chars.as_str();
+    if first == '/' {
+        return (!rest.is_empty()).then_some(rest);
+    }
+    if !PS_OPTION_DASHES.contains(&first) {
+        return None;
+    }
+    // `--NoLogo` and `––NoLogo` (same dash twice) are long-option spellings.
+    // Mixed dashes (`-–NoLogo`) are not options; leave the second character.
+    let mut inner = rest.chars();
+    let rest = if inner.next() == Some(first) {
+        inner.as_str()
+    } else {
+        rest
+    };
+    (!rest.is_empty()).then_some(rest)
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn classify_ps_host_option(shell: WtDefaultShell, name: &str) -> Option<PsHostOption> {
+    let shell_options = match shell {
+        WtDefaultShell::Pwsh => PWSH_HOST_OPTIONS,
+        WtDefaultShell::PowerShell => WINDOWS_POWERSHELL_HOST_OPTIONS,
+        WtDefaultShell::Cmd => return None,
+    };
+    let name = name.to_ascii_lowercase();
+
+    let all_options = || {
+        COMMON_POWERSHELL_HOST_OPTIONS
+            .iter()
+            .chain(shell_options.iter())
+    };
+
+    // Exact alias or full parameter match wins immediately.
+    if let Some((_, option)) = all_options().find(|(alias, _)| *alias == name.as_str()) {
+        return Some(*option);
+    }
+
+    // Otherwise accept only a unique full-parameter prefix. Multiple
+    // candidates are ambiguous even when they have the same arity (`-no`
+    // matches NoExit, NoLogo, NonInteractive, and NoProfile).
+    let mut matches = all_options().filter(|(parameter, _)| parameter.starts_with(&name));
+    let (_, option) = matches.next()?;
+    matches.next().is_none().then_some(*option)
+}
+
+/// Walk host arguments with arity. A leftover positional is implicit `-File`.
+#[cfg(any(target_os = "windows", test))]
+fn pwsh_host_args_block_append(shell: WtDefaultShell, arguments: &[String]) -> bool {
+    let mut index = 0usize;
+    while index < arguments.len() {
+        let argument = &arguments[index];
+        if argument == "--" {
+            return true;
+        }
+        let Some(name) = ps_host_option_name(argument) else {
+            return true;
+        };
+        match classify_ps_host_option(shell, name) {
+            Some(PsHostOption::Flag) => index += 1,
+            Some(PsHostOption::Value) => {
+                if index + 1 >= arguments.len() {
+                    return true;
+                }
+                index += 2;
+            }
+            Some(PsHostOption::Terminal) | None => return true,
+        }
+    }
+    false
+}
+
+/// Existing terminal-action flags consume or reject extra arguments, so
+/// `--appendCommandLine` must not be used.
+#[cfg(any(target_os = "windows", test))]
+fn wt_commandline_has_terminal_action(shell: WtDefaultShell, arguments: &str) -> bool {
+    let Some(arguments) = split_wt_arguments(arguments) else {
+        return true;
+    };
+
+    match shell {
+        WtDefaultShell::Pwsh | WtDefaultShell::PowerShell => {
+            pwsh_host_args_block_append(shell, &arguments)
+        }
+        WtDefaultShell::Cmd => arguments.iter().any(|argument| {
+            let option = argument.to_ascii_lowercase();
+            // CMD allows glued switches such as /D/C and /D/K; `/R` is an
+            // undocumented alias for terminating `/C`. An action is not always
+            // the first whitespace-separated token.
+            option.contains("/c") || option.contains("/k") || option.contains("/r")
+        }),
+    }
+}
+
+/// Classify a supported shell from the executable name. An explicit commandline
+/// is accepted only when extra arguments can be appended safely.
+#[cfg(any(target_os = "windows", test))]
+fn classify_wt_commandline(cmdline: &str) -> Option<WtDefaultShell> {
+    let (executable, arguments) = split_wt_commandline(cmdline)?;
+    let file_name = executable
+        .rsplit(['\\', '/'])
+        .next()
+        .unwrap_or(executable)
+        .to_ascii_lowercase();
+    let base_name = file_name.strip_suffix(".exe").unwrap_or(&file_name);
+
+    let shell = match base_name {
+        "pwsh" => WtDefaultShell::Pwsh,
+        "powershell" => WtDefaultShell::PowerShell,
+        "cmd" => WtDefaultShell::Cmd,
+        _ => return None,
+    };
+
+    (!wt_commandline_has_terminal_action(shell, arguments)).then_some(shell)
+}
+
+/// Callers filter defaults by WT version first, then classify the shell from an
+/// explicit command, inherited command, dynamic source, or known GUID.
+/// If a provided commandline cannot be appended to safely, refuse the profile
+/// instead of guessing from GUID or name.
+#[cfg(any(target_os = "windows", test))]
+fn classify_wt_profile(
+    profile: &serde_json::Value,
+    inherited_commandline: Option<&serde_json::Value>,
+) -> Option<WtDefaultShell> {
+    if let Some(commandline) = profile.get("commandline").or(inherited_commandline) {
+        return commandline.as_str().and_then(classify_wt_commandline);
+    }
+
+    // Dynamic profiles may omit an inspectable commandline; only known sources
+    // with a fixed meaning are accepted.
+    if let Some(source) = profile.get("source").and_then(|v| v.as_str()) {
+        if source == "Windows.Terminal.PowershellCore" {
+            return Some(WtDefaultShell::Pwsh);
+        }
+
+        // An unknown generator may already include a terminating action; do not
+        // fall back to GUID metadata.
+        return None;
+    }
+
+    if let Some(shell) = profile
+        .get("guid")
+        .and_then(|value| value.as_str())
+        .and_then(|guid| known_wt_shell_from_normalized_guid(&normalize_wt_guid(guid)))
+    {
+        return Some(shell);
+    }
+
+    // Without a commandline, a known generator source, or a built-in GUID,
+    // the display name is not evidence of the shell. WT's built-in profile
+    // commandline defaults to cmd.exe, while a sparse user override may still
+    // inherit an unknown dynamic/fragment commandline. Refuse to guess so the
+    // caller uses the explicit cmd fallback.
+    None
+}
+
+// WT hashes Windows wide strings, not UTF-8: changing the encoding would select
+// a different profile even though the displayed name is identical.
+#[cfg(any(target_os = "windows", test))]
+fn wt_uuid_v5(namespace: uuid::Uuid, value: &str) -> uuid::Uuid {
+    let bytes: Vec<u8> = value.encode_utf16().flat_map(u16::to_le_bytes).collect();
+    uuid::Uuid::new_v5(&namespace, &bytes)
+}
+
+/// Mirror Profile::_GenerateGuidForProfile for entries in the local settings file.
+/// WT assigns these IDs before layering defaults. Fragment/generator profiles not
+/// present in this file cannot be reconstructed from names alone.
+/// https://github.com/microsoft/terminal/blob/v1.24.11911.0/src/cascadia/TerminalSettingsModel/Profile.cpp#L301-L319
+#[cfg(any(target_os = "windows", test))]
+fn wt_profile_guid(profile: &serde_json::Value) -> Option<uuid::Uuid> {
+    if let Some(guid) = profile.get("guid").filter(|value| !value.is_null()) {
+        return uuid::Uuid::parse_str(guid.as_str()?).ok();
+    }
+    let name = profile.get("name")?.as_str()?;
+    let source = match profile.get("source") {
+        None | Some(serde_json::Value::Null) => "",
+        Some(source) => source.as_str()?,
+    };
+    let namespace = uuid::Uuid::from_u128(0xf65ddb7e_706b_4499_8a50_40313caf510a);
+    let namespace = if source.is_empty() {
+        namespace
+    } else {
+        wt_uuid_v5(namespace, source)
+    };
+    Some(wt_uuid_v5(namespace, name))
+}
+
+/// Parse Windows Terminal settings.json and keep the default profile selector
+/// alongside its shell, so launch uses the same profile that was classified.
+#[cfg(any(target_os = "windows", test))]
+fn parse_wt_default_profile(
+    content: &str,
+    wt_version: Option<(u16, u16, u16, u16)>,
+) -> Option<WtDefaultProfile> {
+    // Windows Terminal settings.json commonly uses JSONC comments and trailing commas.
+    let json: serde_json::Value = match json5::from_str(content) {
+        Ok(v) => v,
+        Err(e) => {
+            log::debug!("Failed to parse Windows Terminal settings.json: {e}");
+            return None;
+        }
+    };
+
+    // WT profile names are case- and whitespace-sensitive; compare GUIDs as UUIDs below.
+    let default_profile = json.get("defaultProfile").and_then(|v| v.as_str())?;
+    if default_profile.is_empty() {
+        return None;
+    }
+
+    // Support modern `profiles.list` and the legacy flat `profiles` array.
+    let profiles = json.get("profiles");
+    // WT #19225 clears this field from 1.24; first public 1.24.2372.0 includes
+    // that rule, while 1.23 still inherits it.
+    let inherited_commandline = profiles
+        .and_then(|profiles| profiles.get("defaults"))
+        .and_then(|defaults| defaults.get("commandline"))
+        .filter(|_| wt_version.is_none_or(|version| version < (1, 24, 0, 0)));
+    let profile_list = profiles.and_then(|profiles| {
+        profiles
+            .get("list")
+            .and_then(|list| list.as_array())
+            .or_else(|| profiles.as_array())
+    });
+
+    // WT only attempts GUID lookup for the canonical braced form. An unbraced
+    // UUID-shaped value is a profile name and must stay on the exact-name path.
+    let is_braced_guid = default_profile.len() == 38
+        && default_profile.starts_with('{')
+        && default_profile.ends_with('}');
+    let default_guid = is_braced_guid
+        .then(|| uuid::Uuid::parse_str(default_profile).ok())
+        .flatten();
+    let default_norm_guid = default_guid
+        .as_ref()
+        .map(uuid::Uuid::to_string)
+        .unwrap_or_default();
+
+    if let Some(list) = profile_list {
+        // WT looks up GUID across the whole table first and only then searches
+        // by name, so an earlier same-name profile must not steal the match.
+        let matched = default_guid
+            .and_then(|expected| {
+                list.iter().find_map(|item| {
+                    let guid = wt_profile_guid(item)?;
+                    (guid == expected).then_some((item, guid))
+                })
+            })
+            .or_else(|| {
+                list.iter().find_map(|item| {
+                    let guid = wt_profile_guid(item)?;
+                    item.get("name")
+                        .and_then(|name| name.as_str())
+                        .is_some_and(|name| name == default_profile)
+                        .then_some((item, guid))
+                })
+            });
+
+        if let Some((item, guid)) = matched {
+            // When the load rule is unknown, only accept an explicit commandline;
+            // do not guess whether defaults would override the shell.
+            if wt_version.is_none()
+                && inherited_commandline.is_some()
+                && item.get("commandline").is_none()
+            {
+                log::debug!("Unknown WT version with inherited commandline; using explicit cmd");
+                return None;
+            }
+            return Some(WtDefaultProfile {
+                selector: format!("{{{guid}}}"),
+                shell: classify_wt_profile(item, inherited_commandline)?,
+            });
+        }
+    }
+
+    // Unlisted built-in profiles use the same version rule; an unknown version
+    // must not skip the ambiguity via GUID fallback.
+    let shell = if let Some(commandline) = inherited_commandline {
+        if wt_version.is_none() {
+            log::debug!("Unknown WT version with inherited commandline; using explicit cmd");
+            return None;
+        }
+        commandline.as_str().and_then(classify_wt_commandline)
+    } else {
+        // If the profile is not listed, fall back to well-known built-in GUIDs.
+        known_wt_shell_from_normalized_guid(&default_norm_guid)
+    }?;
+    Some(WtDefaultProfile {
+        selector: format!("{{{}}}", default_guid?),
+        shell,
+    })
+}
+
+#[cfg(any(target_os = "windows", test))]
+const APPEXECLINK_REPARSE_TAG: u32 = 0x8000_001b;
+
+/// Parse an APPEXECLINK buffer from `FSCTL_GET_REPARSE_POINT`.
+/// The payload starts with a string count; the third NUL-terminated UTF-16
+/// string is the real executable.
+#[cfg(any(target_os = "windows", test))]
+fn parse_app_execution_alias_target(buffer: &[u8]) -> Option<Vec<u16>> {
+    let tag = u32::from_le_bytes(buffer.get(0..4)?.try_into().ok()?);
+    if tag != APPEXECLINK_REPARSE_TAG {
+        return None;
+    }
+
+    let payload_length = u16::from_le_bytes(buffer.get(4..6)?.try_into().ok()?) as usize;
+    let payload_end = 8usize.checked_add(payload_length)?;
+    let payload = buffer.get(8..payload_end)?;
+    let string_count = u32::from_le_bytes(payload.get(0..4)?.try_into().ok()?);
+    if string_count < 3 || (payload.len() - 4) % 2 != 0 {
+        return None;
+    }
+
+    let strings: Vec<u16> = payload[4..]
+        .chunks_exact(2)
+        .map(|bytes| u16::from_le_bytes([bytes[0], bytes[1]]))
+        .collect();
+    let mut start = 0usize;
+    for index in 0..3 {
+        let end = start + strings.get(start..)?.iter().position(|value| *value == 0)?;
+        if index == 2 {
+            let target = strings.get(start..end)?.to_vec();
+            let drive = *target.first()?;
+            let is_ascii_drive = (drive >= b'A' as u16 && drive <= b'Z' as u16)
+                || (drive >= b'a' as u16 && drive <= b'z' as u16);
+            let is_absolute_drive_path = target.len() >= 3
+                && is_ascii_drive
+                && target[1] == b':' as u16
+                && target[2] == b'\\' as u16;
+            return is_absolute_drive_path.then_some(target);
+        }
+        start = end + 1;
+    }
+    None
+}
+
+#[cfg(target_os = "windows")]
+fn resolve_app_execution_alias_target(alias: &Path) -> Option<PathBuf> {
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+    use windows_sys::Win32::Foundation::{CloseHandle, GENERIC_READ, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+    use windows_sys::Win32::System::Ioctl::FSCTL_GET_REPARSE_POINT;
+    use windows_sys::Win32::System::IO::DeviceIoControl;
+
+    let wide_path: Vec<u16> = alias.as_os_str().encode_wide().chain(Some(0)).collect();
+    // SAFETY: pointer comes from a local NUL-terminated UTF-16 buffer; remaining
+    // arguments follow the CreateFileW contract.
+    // FSCTL_GET_REPARSE_POINT needs GENERIC_READ; access=0 can fail to return
+    // payload data on App Execution Aliases.
+    let handle = unsafe {
+        CreateFileW(
+            wide_path.as_ptr(),
+            GENERIC_READ,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            std::ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return None;
+    }
+
+    let mut buffer = vec![0u8; 16 * 1024];
+    let mut returned = 0u32;
+    // SAFETY: handle is valid, the output buffer is writable for the call, and
+    // `returned` does not overlap the buffer.
+    let succeeded = unsafe {
+        DeviceIoControl(
+            handle,
+            FSCTL_GET_REPARSE_POINT,
+            std::ptr::null(),
+            0,
+            buffer.as_mut_ptr().cast(),
+            buffer.len() as u32,
+            &mut returned,
+            std::ptr::null_mut(),
+        )
+    };
+    // SAFETY: handle was created by the CreateFileW call above and is closed once.
+    let _ = unsafe { CloseHandle(handle) };
+    if succeeded == 0 {
+        return None;
+    }
+
+    let target = parse_app_execution_alias_target(buffer.get(..returned as usize)?)?;
+    Some(PathBuf::from(std::ffi::OsString::from_wide(&target)))
+}
+
+#[cfg(target_os = "windows")]
+struct ResolvedWtInstallation {
+    launcher: PathBuf,
+    settings_executable: Option<PathBuf>,
+}
+
+#[cfg(target_os = "windows")]
+const WT_LOOKUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// Locate the first `wt` that PATH would launch, and keep launcher plus settings target.
+/// Uses the reconstructed GUI PATH; timeout falls through to the explicit cmd fallback.
+#[cfg(target_os = "windows")]
+fn resolve_wt_installation() -> Option<ResolvedWtInstallation> {
+    let effective_path = effective_path_os().unwrap_or_default();
+    let child = windows_path_lookup_command("wt", &effective_path)
+        .spawn()
+        .ok()?;
+    let output = wait_child_output(
+        child,
+        CommandDeadline::from_timeout(Some(WT_LOOKUP_TIMEOUT)),
+    )
+    .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = decode_windows_where_output(&output.stdout);
+    let launcher = stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(|line| PathBuf::from(line.trim_matches('"')))?;
+
+    let is_store_alias = launcher
+        .parent()
+        .is_some_and(is_windows_app_execution_alias_dir);
+    let settings_executable = if is_store_alias {
+        resolve_app_execution_alias_target(&launcher)
+    } else {
+        Some(
+            launcher
+                .parent()
+                .and_then(|parent| {
+                    launcher
+                        .file_stem()
+                        .map(|stem| parent.join(format!("{}.shim", stem.to_string_lossy())))
+                })
+                .filter(|shim| shim.is_file())
+                .and_then(|shim| parse_scoop_shim_target(&shim))
+                .unwrap_or_else(|| launcher.clone()),
+        )
+    };
+
+    Some(ResolvedWtInstallation {
+        launcher,
+        settings_executable,
+    })
+}
+
+/// Walk `path` upward for the nearest Windows Terminal Store package under
+/// `WindowsApps`; returns whether it is Preview and the lowercased package
+/// directory name (which embeds the version). Directory-name substrings
+/// elsewhere (GitHub zip extracts) must not match.
+#[cfg(any(target_os = "windows", test))]
+fn store_wt_package_dir(path: &Path) -> Option<(bool, String)> {
+    path.ancestors().find_map(|directory| {
+        let parent_name = directory.parent()?.file_name()?;
+        if !parent_name
+            .to_string_lossy()
+            .eq_ignore_ascii_case("WindowsApps")
+        {
+            return None;
+        }
+
+        let package = directory
+            .file_name()?
+            .to_string_lossy()
+            .to_ascii_lowercase();
+        let preview = package.starts_with("microsoft.windowsterminalpreview_");
+        if preview || package.starts_with("microsoft.windowsterminal_") {
+            Some((preview, package))
+        } else {
+            None
+        }
+    })
+}
+
+/// Return the Scoop root and package directory name so `apps/<package>/current/wt.exe`
+/// maps to the same install's `persist/<package>`, including custom Scoop roots.
+#[cfg(any(target_os = "windows", test))]
+fn scoop_wt_install_context(exe_path: &Path) -> Option<(PathBuf, String)> {
+    let apps_dir = exe_path.ancestors().find(|ancestor| {
+        ancestor
+            .file_name()
+            .is_some_and(|name| name.to_string_lossy().eq_ignore_ascii_case("apps"))
+    })?;
+    let package = exe_path
+        .strip_prefix(apps_dir)
+        .ok()?
+        .components()
+        .next()?
+        .as_os_str()
+        .to_string_lossy()
+        .into_owned();
+    if !package.eq_ignore_ascii_case("windows-terminal")
+        && !package.eq_ignore_ascii_case("windows-terminal-preview")
+    {
+        return None;
+    }
+
+    Some((apps_dir.parent()?.to_path_buf(), package))
+}
+
+/// Parse `major.minor.patch.revision` so Store package folders and Scoop
+/// versioned app directories can be compared against WT 1.19.
+#[cfg(any(target_os = "windows", test))]
+fn parse_wt_dotted_version(value: &str) -> Option<(u16, u16, u16, u16)> {
+    let mut parts = value.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    let revision = parts.next()?.parse().ok()?;
+    parts
+        .next()
+        .is_none()
+        .then_some((major, minor, patch, revision))
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn wt_version_supports_append(version: (u16, u16, u16, u16)) -> bool {
+    (version.0, version.1) >= (1, 19)
+}
+
+/// Store package folders and Scoop versioned directories embed the WT version.
+/// `current` shims and unpackaged layouts have to use the PE version instead.
+#[cfg(any(target_os = "windows", test))]
+fn wt_version_from_path(path: &Path) -> Option<(u16, u16, u16, u16)> {
+    if let Some((_, package)) = store_wt_package_dir(path) {
+        let rest = package
+            .strip_prefix("microsoft.windowsterminalpreview_")
+            .or_else(|| package.strip_prefix("microsoft.windowsterminal_"))?;
+        return parse_wt_dotted_version(rest.split('_').next()?);
+    }
+
+    // Scoop layout: `<root>/apps/<package>/<version>/…`; `current` is a shim
+    // whose version lives in the PE, not the directory name.
+    let (root, _) = scoop_wt_install_context(path)?;
+    let mut segments = path.strip_prefix(root.join("apps")).ok()?.components();
+    let version = segments.nth(1)?.as_os_str().to_string_lossy();
+    parse_wt_dotted_version(&version)
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn append_scoop_wt_settings_paths(paths: &mut Vec<PathBuf>, root: &Path, package: &str) {
+    let persist = root.join("persist").join(package);
+    // Scoop persists a settings subdirectory; files at the persist root are not
+    // the active WT config.
+    push_unique_path(paths, persist.join("settings").join("settings.json"));
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn store_wt_settings_path(local: &Path, preview: bool) -> PathBuf {
+    let package = if preview {
+        "Microsoft.WindowsTerminalPreview_8wekyb3d8bbwe"
+    } else {
+        "Microsoft.WindowsTerminal_8wekyb3d8bbwe"
+    };
+    local
+        .join("Packages")
+        .join(package)
+        .join("LocalState")
+        .join("settings.json")
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn unpackaged_wt_settings_path(local: &Path) -> PathBuf {
+    local
+        .join("Microsoft")
+        .join("Windows Terminal")
+        .join("settings.json")
+}
+
+/// When WT places `.portable` beside the executable, only use sibling `settings/`
+/// and do not read LocalAppData.
+#[cfg(any(target_os = "windows", test))]
+fn is_wt_portable_install(exe_path: &Path) -> bool {
+    exe_path
+        .parent()
+        .is_some_and(|dir| dir.join(".portable").is_file())
+}
+
+/// Return settings paths for the resolved executable so leftover configs from
+/// other installs cannot participate in mtime ranking.
+/// Sibling and Scoop persist paths are only live while `.portable` exists;
+/// otherwise WT reads `%LOCALAPPDATA%\Microsoft\Windows Terminal`.
+#[cfg(any(target_os = "windows", test))]
+fn build_wt_settings_paths(
+    settings_executable: &Path,
+    local_appdata: Option<&Path>,
+) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if is_wt_portable_install(settings_executable) {
+        if let Some(dir) = settings_executable.parent() {
+            // Portable mode only reads the settings subdirectory next to the
+            // module; leftover files at the root must not enter the sort.
+            push_unique_path(&mut paths, dir.join("settings").join("settings.json"));
+        }
+        if let Some((root, package)) = scoop_wt_install_context(settings_executable) {
+            append_scoop_wt_settings_paths(&mut paths, &root, &package);
+        }
+        return paths;
+    }
+
+    if let Some((preview, _)) = store_wt_package_dir(settings_executable) {
+        if let Some(local) = local_appdata {
+            push_unique_path(&mut paths, store_wt_settings_path(local, preview));
+        }
+    } else if let Some(local) = local_appdata {
+        push_unique_path(&mut paths, unpackaged_wt_settings_path(local));
+    }
+
+    paths
+}
+
+/// Parse the real executable path from a Scoop `.shim`.
+#[cfg(any(target_os = "windows", test))]
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+fn parse_scoop_shim_target(shim_path: &Path) -> Option<PathBuf> {
+    let content = std::fs::read_to_string(shim_path).ok()?;
+    parse_scoop_shim_content(&content)
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn parse_scoop_shim_content(content: &str) -> Option<PathBuf> {
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("path =") {
+            let path_str = rest.trim().trim_matches('"');
+            if !path_str.is_empty() {
+                return Some(PathBuf::from(path_str));
+            }
+        }
+    }
+    None
+}
+
+/// Candidates all belong to the same resolved install, so mtime can pick the
+/// active file. A parse failure continues to the next candidate of that install
+/// and never crosses Store/Scoop/Preview installs.
+#[cfg(any(target_os = "windows", test))]
+fn detect_wt_default_profile_from_paths(
+    paths: &[PathBuf],
+    wt_version: Option<(u16, u16, u16, u16)>,
+) -> Option<WtDefaultProfile> {
+    let mut existing = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for path in paths {
+        let normalized = path.canonicalize().unwrap_or_else(|_| path.clone());
+        if !seen.insert(normalized) || !path.is_file() {
+            continue;
+        }
+        let modified = std::fs::metadata(path)
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        existing.push((path, modified));
+    }
+    existing.sort_by_key(|(_, modified)| std::cmp::Reverse(*modified));
+
+    for (path, _) in existing {
+        if let Ok(content) = std::fs::read_to_string(path) {
+            if let Some(profile) = parse_wt_default_profile(&content, wt_version) {
+                return Some(profile);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "windows")]
+fn detect_wt_default_profile(
+    installation: &ResolvedWtInstallation,
+    wt_version: Option<(u16, u16, u16, u16)>,
+) -> Option<WtDefaultProfile> {
+    let settings_executable = installation.settings_executable.as_deref()?;
+    let local_appdata = std::env::var_os("LOCALAPPDATA")
+        .map(PathBuf::from)
+        .or_else(dirs::data_local_dir);
+    let paths = build_wt_settings_paths(settings_executable, local_appdata.as_deref());
+    let profile = detect_wt_default_profile_from_paths(&paths, wt_version);
+    if let Some(profile) = &profile {
+        log::debug!(
+            "Detected Windows Terminal default profile: {:?} (candidates: {:?})",
+            profile,
+            paths
+        );
+    }
+    profile
+}
+
+#[cfg(target_os = "windows")]
+fn wt_file_version(path: &Path) -> Option<(u16, u16, u16, u16)> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Storage::FileSystem::{
+        GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW,
+    };
+
+    let wide: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+    let mut dummy = 0u32;
+    // SAFETY: `wide` is a local NUL-terminated path buffer.
+    let size = unsafe { GetFileVersionInfoSizeW(wide.as_ptr(), &mut dummy) };
+    if size == 0 {
+        return None;
+    }
+
+    let mut buffer = vec![0u8; size as usize];
+    // SAFETY: `buffer` is writable for `size` bytes returned above.
+    let ok = unsafe { GetFileVersionInfoW(wide.as_ptr(), 0, size, buffer.as_mut_ptr().cast()) };
+    if ok == 0 {
+        return None;
+    }
+
+    let mut info: *mut core::ffi::c_void = core::ptr::null_mut();
+    let mut info_len = 0u32;
+    let subblock: Vec<u16> = "\\\0".encode_utf16().collect();
+    // SAFETY: `buffer` still owns the version block; `info`/`info_len` are out params.
+    let ok = unsafe {
+        VerQueryValueW(
+            buffer.as_ptr().cast(),
+            subblock.as_ptr(),
+            &mut info,
+            &mut info_len,
+        )
+    };
+    if ok == 0 || info.is_null() || (info_len as usize) < 16 {
+        return None;
+    }
+
+    // VS_FIXEDFILEINFO: signature, struct version, then fileVersionMS/LS.
+    let bytes = unsafe { std::slice::from_raw_parts(info as *const u8, info_len as usize) };
+    let ms = u32::from_le_bytes(bytes.get(8..12)?.try_into().ok()?);
+    let ls = u32::from_le_bytes(bytes.get(12..16)?.try_into().ok()?);
+    Some((
+        (ms >> 16) as u16,
+        (ms & 0xffff) as u16,
+        (ls >> 16) as u16,
+        (ls & 0xffff) as u16,
+    ))
+}
+
+#[cfg(target_os = "windows")]
+fn wt_version_from_executable(path: &Path) -> Option<(u16, u16, u16, u16)> {
+    wt_version_from_path(path)
+        .or_else(|| wt_file_version(path))
+        .or_else(|| {
+            let sibling = path.parent()?.join("WindowsTerminal.exe");
+            if sibling == path || !sibling.is_file() {
+                None
+            } else {
+                wt_file_version(&sibling)
+            }
+        })
+}
+
+/// Read the version from the same install's real target or launcher so config
+/// load rules and append support share one source.
+/// GUI WT help text is unreliable, so use path and PE version info instead of
+/// launching the terminal to probe.
+#[cfg(target_os = "windows")]
+fn wt_installation_version(installation: &ResolvedWtInstallation) -> Option<(u16, u16, u16, u16)> {
+    installation
+        .settings_executable
+        .as_deref()
+        .filter(|path| *path != installation.launcher.as_path())
+        .and_then(wt_version_from_executable)
+        .or_else(|| wt_version_from_executable(&installation.launcher))
+}
+
+/// The launcher path may contain cmd metacharacters, so spawn it directly
+/// instead of going through `cmd /C start`.
+/// WT may already be a resident GUI process, so report only spawn failure and
+/// return without waiting for the window to close.
+#[cfg(target_os = "windows")]
+fn run_wt_command(launcher: &str, args: &[&str], bat_path: &str) -> Result<(), String> {
+    let mut command = std::process::Command::new(launcher);
+    configure_windows_batch_env(&mut command, bat_path);
+    command
+        .args(args)
+        .creation_flags(CREATE_NO_WINDOW)
+        .spawn()
+        .map(|_| ())
+        .map_err(|e| format!("启动 Windows Terminal 失败: {e}"))
+}
+
+/// Launch the same resolved Windows Terminal, and fall back to an explicit cmd
+/// tab when the default profile cannot be recognized safely or WT is too old
+/// for `--appendCommandLine`.
+#[cfg(target_os = "windows")]
+pub(super) fn launch_wt_terminal(bat_path: &str, ps_cmd: &str) -> Result<(), String> {
+    let installation = resolve_wt_installation();
+    let wt_command = installation
+        .as_ref()
+        .map(|installation| installation.launcher.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "wt".to_string());
+    let wt_version = installation.as_ref().and_then(wt_installation_version);
+    let profile = installation
+        .as_ref()
+        .and_then(|installation| detect_wt_default_profile(installation, wt_version));
+    // Keep the previous append policy for unknown versions; configs that depend
+    // on ambiguous defaults are refused by the parser.
+    let supports_append = profile.is_some() && wt_version.is_none_or(wt_version_supports_append);
+    let args = select_wt_launch_args(profile.as_ref(), supports_append, ps_cmd);
+    run_wt_command(&wt_command, &args, bat_path)
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_os = "windows")]
+    use super::super::misc::{
+        configure_windows_batch_env, configure_windows_cmd_batch, quote_windows_batch_path_for_env,
+        PARENT_CLAUDE_SESSION_ENV_VARS, WINDOWS_BATCH_PATH_ENV, WINDOWS_POWERSHELL_BATCH_COMMAND,
+    };
+    use super::super::misc::{decode_command_output, escape_windows_batch_value};
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    #[cfg(target_os = "windows")]
+    struct EnvRestore(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+    #[cfg(target_os = "windows")]
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            for (name, value) in self.0.drain(..) {
+                match value {
+                    Some(value) => std::env::set_var(name, value),
+                    None => std::env::remove_var(name),
+                }
+            }
+        }
+    }
+
+    fn extend_expected_cmd_batch_args(args: &mut Vec<&str>) {
+        args.extend(["/D", "/V:OFF", "/K", WINDOWS_BATCH_PATH_COMMAND]);
+    }
+
+    /// Cover JSONC, well-known GUIDs, quoted commandlines, and name matches.
+    #[test]
+    fn parse_wt_default_profile_recognizes_supported_profiles() {
+        // JSONC comments + PowerShell 7 well-known GUID
+        let jsonc_pwsh = r#"{
+            // Windows Terminal single line comment
+            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+            /* block comment */
+            "profiles": {
+                "list": [
+                    {
+                        "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                        "name": "PowerShell",
+                        "source": "Windows.Terminal.PowershellCore",
+                    },
+                ],
+            },
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(jsonc_pwsh, None).map(|profile| profile.shell),
+            Some(WtDefaultShell::Pwsh)
+        );
+
+        // Absolute commandline path for Windows PowerShell
+        let powershell_cmdline = r#"{
+            "defaultProfile": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+            "profiles": {
+                "list": [
+                    {
+                        "guid": "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}",
+                        "name": "Windows PowerShell",
+                        "commandline": "%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+                    }
+                ]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(powershell_cmdline, None).map(|profile| profile.shell),
+            Some(WtDefaultShell::PowerShell)
+        );
+
+        // Quoted custom pwsh path with arguments
+        let quoted_pwsh = r#"{
+            "defaultProfile": "{11111111-1111-4111-8111-111111111111}",
+            "profiles": [
+                {
+                    "guid": "{11111111-1111-4111-8111-111111111111}",
+                    "name": "Custom",
+                    "commandline": "\"C:\\Program Files\\PowerShell\\7\\pwsh.Exe\" -NoLogo"
+                }
+            ]
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(quoted_pwsh, None).map(|profile| profile.shell),
+            Some(WtDefaultShell::Pwsh)
+        );
+
+        // cmd.exe
+        let cmd_config = r#"{
+            "defaultProfile": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+            "profiles": {
+                "list": [
+                    {
+                        "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+                        "name": "Command Prompt",
+                        "commandline": "cmd.exe"
+                    }
+                ]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(cmd_config, None).map(|profile| profile.shell),
+            Some(WtDefaultShell::Cmd)
+        );
+
+        // Match by profile name instead of GUID
+        let name_config = r#"{
+            "defaultProfile": "PowerShell 7",
+            "profiles": {
+                "list": [
+                    {
+                        "guid": "{22222222-2222-4222-8222-222222222222}",
+                        "name": "PowerShell 7",
+                        "commandline": "pwsh.exe"
+                    }
+                ]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(name_config, None).map(|profile| profile.shell),
+            Some(WtDefaultShell::Pwsh)
+        );
+    }
+
+    #[test]
+    fn name_only_profiles_do_not_imply_a_shell() {
+        for name in [
+            "pwsh custom",
+            "PowerShell 7 custom",
+            "Windows PowerShell custom",
+            "Command Prompt custom",
+        ] {
+            for version in [
+                None,
+                Some((1, 18, 0, 0)),
+                Some((1, 19, 0, 0)),
+                Some((1, 23, 0, 0)),
+                Some((1, 24, 0, 0)),
+            ] {
+                let settings = serde_json::json!({
+                    "defaultProfile": "{77777777-7777-4777-8777-777777777777}",
+                    "profiles": {"list": [{
+                        "guid": "{77777777-7777-4777-8777-777777777777}",
+                        "name": name
+                    }]}
+                });
+                let profile = parse_wt_default_profile(&settings.to_string(), version);
+                assert_eq!(
+                    profile, None,
+                    "a display name is not shell evidence: {name:?}, version {version:?}"
+                );
+                assert_eq!(
+                    select_wt_launch_args(
+                        profile.as_ref(),
+                        version.is_some_and(wt_version_supports_append),
+                        "& 'probe.bat'",
+                    ),
+                    build_wt_cmd_fallback_args(),
+                    "an ambiguous profile must use the explicit cmd fallback"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn unbraced_default_profile_uuid_is_a_name_not_a_guid() {
+        let uuid_name = "574e775e-4f2a-5b96-ac1e-a2962a402336";
+        let named_profile_guid = "{77777777-7777-4777-8777-777777777777}";
+        let settings = serde_json::json!({
+            "defaultProfile": uuid_name,
+            "profiles": {"list": [
+                {
+                    "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                    "name": "Actual PowerShell profile",
+                    "source": "Windows.Terminal.PowershellCore"
+                },
+                {
+                    "guid": named_profile_guid,
+                    "name": uuid_name,
+                    "commandline": "cmd.exe"
+                }
+            ]}
+        });
+
+        let profile = parse_wt_default_profile(&settings.to_string(), Some((1, 24, 0, 0)))
+            .expect("the UUID-shaped profile name should be resolved");
+        assert_eq!(profile.selector, named_profile_guid);
+        assert_eq!(profile.shell, WtDefaultShell::Cmd);
+
+        let unlisted = serde_json::json!({"defaultProfile": uuid_name});
+        assert_eq!(
+            parse_wt_default_profile(&unlisted.to_string(), Some((1, 24, 0, 0))),
+            None,
+            "an unbraced UUID-shaped name must not enter the built-in GUID fallback"
+        );
+    }
+
+    #[test]
+    fn parse_wt_default_profile_returns_none_for_unsupported_or_malformed() {
+        let wsl = r#"{"defaultProfile": "{55555555-5555-4555-8555-555555555555}","profiles":{"list":[{"guid":"{55555555-5555-4555-8555-555555555555}","commandline":"wsl.exe"}]}}"#;
+        assert_eq!(parse_wt_default_profile(wsl, None), None);
+
+        let overridden_builtin = r#"{
+            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+            "profiles": {
+                "list": [{
+                    "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                    "name": "PowerShell",
+                    "source": "Windows.Terminal.PowershellCore",
+                    "commandline": "wsl.exe"
+                }]
+            }
+        }"#;
+        assert_eq!(parse_wt_default_profile(overridden_builtin, None), None);
+        assert_eq!(parse_wt_default_profile("not valid json", None), None);
+        assert_eq!(
+            parse_wt_default_profile(r#"{"defaultProfile": ""}"#, None),
+            None
+        );
+    }
+
+    #[test]
+    fn third_party_powershellcore_source_uses_explicit_fallback() {
+        let settings = serde_json::json!({
+            "defaultProfile": "{55555555-5555-4555-8555-555555555555}",
+            "profiles": {"list": [{
+                "guid": "{55555555-5555-4555-8555-555555555555}",
+                "source": "Contoso.PowerShellCore.Wsl"
+            }]}
+        });
+
+        let profile = parse_wt_default_profile(&settings.to_string(), None);
+        assert_eq!(
+            profile, None,
+            "third-party sources containing PowerShellCore must not be classified as pwsh"
+        );
+        assert_eq!(
+            select_wt_launch_args(profile.as_ref(), true, "& 'probe.bat'"),
+            build_wt_cmd_fallback_args(),
+            "unknown dynamic profiles must use the explicit cmd fallback"
+        );
+    }
+
+    #[test]
+    fn visual_studio_dynamic_profiles_use_explicit_fallback() {
+        for (guid, name) in [
+            (
+                "{11111111-1111-4111-8111-111111111111}",
+                "Developer PowerShell for VS 2022",
+            ),
+            (
+                "{22222222-2222-4222-8222-222222222222}",
+                "Developer Command Prompt for VS 2022",
+            ),
+        ] {
+            let settings = serde_json::json!({
+                "defaultProfile": guid,
+                "profiles": {"list": [{
+                    "guid": guid,
+                    "name": name,
+                    "source": "Windows.Terminal.VisualStudio"
+                }]}
+            });
+
+            let profile = parse_wt_default_profile(&settings.to_string(), None);
+            assert_eq!(
+                profile, None,
+                "dynamic profile {name} must not be guessed by name"
+            );
+            assert_eq!(
+                select_wt_launch_args(profile.as_ref(), true, "& 'probe.bat'"),
+                build_wt_cmd_fallback_args(),
+                "dynamic profile {name} must use the explicit cmd fallback"
+            );
+        }
+
+        let explicit_commandline = serde_json::json!({
+            "defaultProfile": "{33333333-3333-4333-8333-333333333333}",
+            "profiles": {"list": [{
+                "guid": "{33333333-3333-4333-8333-333333333333}",
+                "name": "Developer PowerShell for VS 2022",
+                "source": "Windows.Terminal.VisualStudio",
+                "commandline": "pwsh.exe -NoLogo"
+            }]}
+        });
+        assert_eq!(
+            parse_wt_default_profile(&explicit_commandline.to_string(), None)
+                .map(|profile| profile.shell),
+            Some(WtDefaultShell::Pwsh),
+            "an explicit safe commandline must take precedence over the dynamic source"
+        );
+    }
+
+    /// Server mode runs the remoting protocol and ignores `-Command`; leftover
+    /// positionals mean implicit `-File`. Append must be refused for all of
+    /// these, including the ServerMode prefixes `-s`/`-se` that PowerShell
+    /// resolves over `-Sta`/`-SettingsFile`.
+    #[test]
+    fn wt_commandline_classification_accepts_safe_and_refuses_unsafe() {
+        let refused: &[&str] = &[
+            r#"pwsh.exe -NoLogo -Fil "C:\init.ps1""#,
+            r#"cmd.exe /D /K C:\init.cmd"#,
+            r#"cmd.exe /R echo ORIGINAL"#,
+            r#"cmd.exe /D/R echo ORIGINAL"#,
+            r#"cmd.exe /cdir"#,
+            r#"cmd.exe /D/C echo ORIGINAL"#,
+            r#"cmd.exe /d/k echo ORIGINAL"#,
+            r#"cmd.exe /Q/D/CECHO ORIGINAL"#,
+            r#"cmd.exe /D/V:OFF/Kecho ORIGINAL"#,
+            r#"pwsh.exe -no"#,
+            r#"powershell.exe -no"#,
+            r#"pwsh.exe -SSHServerMode"#,
+            r#"pwsh.exe -s -NoProfile"#,
+            r#"pwsh.exe -se -NoProfile"#,
+            r#"pwsh.exe -ServerMode"#,
+            r#"powershell.exe -s -NoProfile"#,
+            r#"powershell.exe -se -NoProfile"#,
+            r#"powershell.exe -ServerMode"#,
+            r#"pwsh.exe C:\init.ps1"#,
+            r#"pwsh.exe -f C:\init.ps1"#,
+            r#"powershell.exe -c Get-Date"#,
+            r#"pwsh.exe -Version"#,
+            r#"powershell.exe -Version"#,
+            r#"pwsh.exe -WorkingDirectory "C:\missing"#,
+        ];
+        for cmdline in refused {
+            assert_eq!(classify_wt_commandline(cmdline), None, "{cmdline}");
+        }
+
+        let accepted: &[(&str, WtDefaultShell)] = &[
+            (r#"cmd.exe /D /T:0C"#, WtDefaultShell::Cmd),
+            (r#"cmd.exe /D/Q/V:OFF"#, WtDefaultShell::Cmd),
+            (r#"pwsh.exe -EncodedArguments ABC="#, WtDefaultShell::Pwsh),
+            (r#"pwsh.exe -ea ABC="#, WtDefaultShell::Pwsh),
+            (r#"pwsh.exe -encodeda ABC="#, WtDefaultShell::Pwsh),
+            (
+                r#"powershell.exe -EncodedArguments ABC="#,
+                WtDefaultShell::PowerShell,
+            ),
+            (r#"pwsh.exe -Login -NoLogo"#, WtDefaultShell::Pwsh),
+            (
+                r#"pwsh.exe -Interactive -NoProfileLoadTime"#,
+                WtDefaultShell::Pwsh,
+            ),
+            (
+                r#"pwsh.exe -SettingsFile C:\x.json -NoLogo"#,
+                WtDefaultShell::Pwsh,
+            ),
+            (r#"pwsh.exe -wd C:\Work -nol"#, WtDefaultShell::Pwsh),
+            (r#"pwsh.exe -i"#, WtDefaultShell::Pwsh),
+            (r#"powershell.exe -ep Bypass"#, WtDefaultShell::PowerShell),
+            (
+                r#"powershell.exe -if Text -of Text"#,
+                WtDefaultShell::PowerShell,
+            ),
+            (r#"powershell.exe -ea ABC="#, WtDefaultShell::PowerShell),
+            (
+                r#"pwsh.exe -ConfigurationFile C:\x.pssc"#,
+                WtDefaultShell::Pwsh,
+            ),
+            (
+                r#"powershell.exe -Version 2.0 -NoLogo"#,
+                WtDefaultShell::PowerShell,
+            ),
+            (r#"pwsh.exe -NoLogo -NoExit"#, WtDefaultShell::Pwsh),
+            (
+                r#"pwsh.exe -WorkingDirectory "C:\Work\My -File Project" -NoLogo"#,
+                WtDefaultShell::Pwsh,
+            ),
+            // Quoted executable with a space and no arguments appends safely.
+            (r#""C:\missing quote\pwsh.exe""#, WtDefaultShell::Pwsh),
+        ];
+        for (cmdline, expected) in accepted {
+            assert_eq!(
+                classify_wt_commandline(cmdline),
+                Some(*expected),
+                "{cmdline}"
+            );
+        }
+
+        // Copied-from-docs Unicode dashes (U+2013/2014/2015) and their
+        // doubled long-option spelling parse like ASCII `-`.
+        for dash in ['\u{2013}', '\u{2014}', '\u{2015}'] {
+            let doubled = format!("pwsh.exe {dash}{dash}NoLogo");
+            assert_eq!(
+                classify_wt_commandline(&format!("pwsh.exe {dash}NoLogo")),
+                Some(WtDefaultShell::Pwsh),
+                "dash {dash:?}"
+            );
+            assert_eq!(
+                classify_wt_commandline(&doubled),
+                Some(WtDefaultShell::Pwsh),
+                "doubled dash {dash:?}"
+            );
+            assert_eq!(
+                classify_wt_commandline(&format!("powershell.exe {dash}NoLogo")),
+                Some(WtDefaultShell::PowerShell),
+                "dash {dash:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn wt_cmd_concatenated_actions_use_explicit_fallback() {
+        let settings = serde_json::json!({
+            "defaultProfile": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+            "profiles": {"list": [{
+                "guid": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}",
+                "commandline": "cmd.exe /D/C echo ORIGINAL"
+            }]}
+        });
+        let profile = parse_wt_default_profile(&settings.to_string(), None);
+        assert_eq!(
+            select_wt_launch_args(profile.as_ref(), true, "& 'probe.bat'"),
+            build_wt_cmd_fallback_args()
+        );
+
+        #[cfg(target_os = "windows")]
+        {
+            // Pin CMD dialect with a real shell: a glued /K after /C is text of
+            // the original command and does not run a second batch.
+            let output = std::process::Command::new("cmd.exe")
+                .args(["/d/c", "echo", "ORIGINAL", "/K", "echo", "APPENDED"])
+                .creation_flags(CREATE_NO_WINDOW)
+                .output()
+                .expect("CMD concatenated switch probe should start");
+            assert!(output.status.success());
+            assert_eq!(
+                decode_command_output(&output.stdout).trim(),
+                "ORIGINAL /K echo APPENDED"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_wt_default_profile_inherits_profiles_defaults_commandline() {
+        let defaults_wsl = r#"{
+            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+            "profiles": {
+                "defaults": { "commandline": "wsl.exe" },
+                "list": [{
+                    "guid": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+                    "name": "PowerShell",
+                    "source": "Windows.Terminal.PowershellCore"
+                }]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(defaults_wsl, Some((1, 23, 20211, 0))),
+            None
+        );
+
+        let defaults_file = r#"{
+            "defaultProfile": "{44444444-4444-4444-8444-444444444444}",
+            "profiles": {
+                "defaults": { "commandline": "pwsh.exe -File C:\\init.ps1" },
+                "list": [{ "guid": "{44444444-4444-4444-8444-444444444444}", "name": "Custom" }]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(defaults_file, Some((1, 23, 20211, 0))),
+            None
+        );
+
+        let defaults_pwsh = r#"{
+            "defaultProfile": "{44444444-4444-4444-8444-444444444444}",
+            "profiles": {
+                "defaults": { "commandline": "pwsh.exe -NoLogo" },
+                "list": [{ "guid": "{44444444-4444-4444-8444-444444444444}", "name": "Custom" }]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(defaults_pwsh, Some((1, 23, 20211, 0)))
+                .map(|profile| profile.shell),
+            Some(WtDefaultShell::Pwsh)
+        );
+
+        let profile_overrides_defaults = r#"{
+            "defaultProfile": "{44444444-4444-4444-8444-444444444444}",
+            "profiles": {
+                "defaults": { "commandline": "wsl.exe" },
+                "list": [{
+                    "guid": "{44444444-4444-4444-8444-444444444444}",
+                    "name": "Custom",
+                    "commandline": "cmd.exe"
+                }]
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(profile_overrides_defaults, Some((1, 23, 20211, 0)))
+                .map(|profile| profile.shell),
+            Some(WtDefaultShell::Cmd)
+        );
+
+        let unlisted_builtin_with_defaults = r#"{
+            "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+            "profiles": {
+                "defaults": { "commandline": "wsl.exe" },
+                "list": []
+            }
+        }"#;
+        assert_eq!(
+            parse_wt_default_profile(unlisted_builtin_with_defaults, Some((1, 23, 20211, 0))),
+            None
+        );
+    }
+
+    #[test]
+    fn wt_default_profile_uses_versioned_defaults_commandline() {
+        let guid = "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}";
+        let temp = tempfile::tempdir().expect("settings directory should be created");
+        let path = temp.path().join("settings.json");
+        for (version, expected_shell) in [
+            (Some((1, 19, 10821, 0)), Some(WtDefaultShell::Pwsh)),
+            (Some((1, 22, 10352, 0)), Some(WtDefaultShell::Pwsh)),
+            (Some((1, 23, 20211, 0)), Some(WtDefaultShell::Pwsh)),
+            (Some((1, 24, 2372, 0)), Some(WtDefaultShell::Cmd)),
+            (Some((1, 24, 11911, 0)), Some(WtDefaultShell::Cmd)),
+            (Some((1, 25, 1912, 0)), Some(WtDefaultShell::Cmd)),
+            (None, None),
+        ] {
+            for listed in [true, false] {
+                let mut profiles = Vec::new();
+                if listed {
+                    profiles.push(serde_json::json!({"guid": guid, "name": "Command Prompt"}));
+                }
+                let settings = serde_json::json!({
+                    "defaultProfile": guid,
+                    "profiles": {"defaults": {"commandline": "pwsh.exe"}, "list": profiles}
+                });
+                std::fs::write(&path, settings.to_string()).expect("settings should be written");
+                let profile =
+                    detect_wt_default_profile_from_paths(std::slice::from_ref(&path), version);
+                assert_eq!(
+                    profile,
+                    expected_shell.map(|shell| WtDefaultProfile {
+                        selector: guid.to_string(),
+                        shell
+                    }),
+                    "version={version:?}, listed={listed}"
+                );
+                let mut expected_args = vec!["new-tab"];
+                if let Some(shell) = expected_shell {
+                    expected_args.extend(["--profile", guid, "--appendCommandLine", "--"]);
+                    match shell {
+                        WtDefaultShell::Cmd => extend_expected_cmd_batch_args(&mut expected_args),
+                        _ => expected_args.extend(["-NoExit", "-Command", "& 'probe.bat'"]),
+                    }
+                } else {
+                    expected_args.push("cmd");
+                    extend_expected_cmd_batch_args(&mut expected_args);
+                }
+                assert_eq!(
+                    select_wt_launch_args(profile.as_ref(), true, "& 'probe.bat'"),
+                    expected_args,
+                    "version={version:?}, listed={listed}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wt_defaults_version_does_not_override_explicit_commandline() {
+        let guid = "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}";
+        for version in [None, Some((1, 23, 20211, 0)), Some((1, 24, 11911, 0))] {
+            for defaults in ["pwsh.exe", "wsl.exe"] {
+                for explicit in ["cmd.exe", "wsl.exe"] {
+                    let settings = serde_json::json!({
+                        "defaultProfile": guid,
+                        "profiles": {
+                            "defaults": {"commandline": defaults},
+                            "list": [{"guid": guid, "commandline": explicit}]
+                        }
+                    });
+                    assert_eq!(
+                        parse_wt_default_profile(&settings.to_string(), version),
+                        (explicit == "cmd.exe").then(|| WtDefaultProfile {
+                            selector: guid.to_string(),
+                            shell: WtDefaultShell::Cmd,
+                        }),
+                        "version={version:?}, defaults={defaults}, explicit={explicit}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn wt_profile_guids_follow_wt_utf16_namespace_rules() {
+        // Fixed vector from WT's src/types/ut_types/UuidTests.cpp, not computed
+        // with the implementation under test. UTF-8 gives a different UUID.
+        let namespace = uuid::Uuid::parse_str("ad56de9e-5167-41b6-80eb-fb19f7927d1a").unwrap();
+        assert_eq!(
+            wt_uuid_v5(namespace, "testing").to_string(),
+            "e04fb1f7-739d-5d63-bb18-e0ea00b19ee8"
+        );
+        // Profile vectors independently calculated from WT's published algorithm.
+        for (profile, expected) in [
+            (
+                serde_json::json!({"name": "profile0"}),
+                "690955e2-dbc2-509c-b36d-ac466fdda656",
+            ),
+            (
+                serde_json::json!({"name": "profile0", "source": ""}),
+                "690955e2-dbc2-509c-b36d-ac466fdda656",
+            ),
+            (
+                serde_json::json!({"name": "profile0", "source": "Terminal.App.UnitTest.0"}),
+                "52b9372a-c1b1-57eb-a9ce-e2cdc8d52ceb",
+            ),
+            (
+                serde_json::json!({"name": "Profile0"}),
+                "6a2f325d-dd64-5214-ac09-ceac61244422",
+            ),
+            (
+                serde_json::json!({"name": "开发 🚀"}),
+                "513625d0-fe16-526d-b8b5-494277269c46",
+            ),
+            (
+                serde_json::json!({"name": "Dev&echo"}),
+                "f7143a97-a88e-5523-94a1-19c0c687e353",
+            ),
+            (
+                serde_json::json!({"name": "Dev%COMSPEC%"}),
+                "46d028dc-f2b0-526e-9427-7bf1d8c7070d",
+            ),
+            (
+                serde_json::json!({"name": "Dev;Test"}),
+                "c0bfcc63-c933-5d17-9a24-892f27f2f34c",
+            ),
+            (
+                serde_json::json!({"guid": "{574E775E-4F2A-5B96-AC1E-A2962A402336}", "name": "Dev&echo"}),
+                "574e775e-4f2a-5b96-ac1e-a2962a402336",
+            ),
+        ] {
+            assert_eq!(
+                wt_profile_guid(&profile)
+                    .map(|guid| guid.to_string())
+                    .as_deref(),
+                Some(expected),
+                "{profile}"
+            );
+        }
+        for profile in [
+            serde_json::json!({}),
+            serde_json::json!({"source": "Windows.Terminal.PowershellCore"}),
+            serde_json::json!({"name": "Dev", "guid": "Dev&echo"}),
+            serde_json::json!({"name": "Dev", "source": false}),
+        ] {
+            assert_eq!(wt_profile_guid(&profile), None, "{profile}");
+        }
+    }
+
+    #[test]
+    fn wt_default_profile_name_collisions_bind_the_exact_profile() {
+        // This fixture inherits defaults; use the legacy rule so selector matching
+        // is isolated from versioned default loading.
+        // Explicit GUIDs isolate selector matching from GUID generation.
+        let expected = "{22222222-2222-4222-8222-222222222222}";
+        let mut failures = Vec::new();
+        for (first_name, exact_name) in [
+            ("dev", "Dev"),
+            (" Dev", "Dev"),
+            ("Dev ", "Dev"),
+            ("Dev", " Dev"),
+            ("Dev", "Dev "),
+        ] {
+            for include_decoy in [false, true] {
+                let mut profiles = vec![serde_json::json!({"guid": expected, "name": exact_name})];
+                if include_decoy {
+                    profiles.insert(
+                        0,
+                        serde_json::json!({
+                            "guid": "{11111111-1111-4111-8111-111111111111}",
+                            "name": first_name
+                        }),
+                    );
+                }
+                let settings = serde_json::json!({
+                    "defaultProfile": exact_name,
+                    "profiles": {
+                        "defaults": {"commandline": "cmd.exe"},
+                        "list": profiles
+                    }
+                });
+                let profile =
+                    parse_wt_default_profile(&settings.to_string(), Some((1, 23, 20211, 0)));
+                let args = select_wt_launch_args(profile.as_ref(), true, "& 'probe.bat'");
+                let actual = args
+                    .windows(2)
+                    .find(|pair| pair[0] == "--profile")
+                    .map(|pair| pair[1]);
+                assert_eq!(
+                    actual,
+                    profile.as_ref().map(|profile| profile.selector.as_str()),
+                    "argument generation must preserve the parsed selector"
+                );
+                if actual != Some(expected) {
+                    failures.push(format!(
+                        "names={first_name:?}/{exact_name:?}, default={exact_name:?}, decoy={include_decoy}: expected {expected}, got {actual:?}"
+                    ));
+                }
+            }
+        }
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
+    }
+
+    #[test]
+    fn wt_default_profile_guid_precedes_name_collisions() {
+        let cmd_guid = "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}";
+        let pwsh_guid = "{574e775e-4f2a-5b96-ac1e-a2962a402336}";
+        for selector in [cmd_guid.to_string(), cmd_guid.to_ascii_uppercase()] {
+            for reverse in [false, true] {
+                for commandline in ["cmd.exe", "wsl.exe"] {
+                    let mut profiles = vec![
+                        serde_json::json!({"guid": pwsh_guid, "name": selector, "commandline": "pwsh.exe"}),
+                        serde_json::json!({"guid": cmd_guid, "name": "Command Prompt", "commandline": commandline}),
+                    ];
+                    if reverse {
+                        profiles.reverse();
+                    }
+                    let settings = serde_json::json!({
+                        "defaultProfile": selector,
+                        "profiles": {"list": profiles}
+                    });
+                    let expected = (commandline == "cmd.exe").then(|| WtDefaultProfile {
+                        selector: cmd_guid.to_string(),
+                        shell: WtDefaultShell::Cmd,
+                    });
+                    assert_eq!(
+                        parse_wt_default_profile(&settings.to_string(), None),
+                        expected,
+                        "selector={selector}, reverse={reverse}, commandline={commandline}"
+                    );
+                }
+            }
+        }
+
+        // Only when no GUID in the table matches may a GUID-shaped string be
+        // looked up as a name.
+        let name = "{11111111-1111-4111-8111-111111111111}";
+        let settings = serde_json::json!({
+            "defaultProfile": name,
+            "profiles": {"list": [{"guid": pwsh_guid, "name": name, "commandline": "pwsh.exe"}]}
+        });
+        assert_eq!(
+            parse_wt_default_profile(&settings.to_string(), None)
+                .unwrap()
+                .selector,
+            pwsh_guid
+        );
+    }
+
+    #[test]
+    fn parse_wt_default_profile_preserves_the_matched_selector() {
+        // This fixture inherits defaults; use the legacy rule so selector matching
+        // is isolated from versioned default loading.
+        for (content, selector) in [
+            (
+                r#"{"defaultProfile":"{33333333-3333-4333-8333-333333333333}","profiles":{"list":[{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
+                "{33333333-3333-4333-8333-333333333333}",
+            ),
+            (
+                r#"{"defaultProfile":"Custom shell","profiles":{"list":[{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
+                "{33333333-3333-4333-8333-333333333333}",
+            ),
+            (
+                r#"{"defaultProfile":"Custom shell","profiles":[{"name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}"#,
+                "{fa616ee5-b304-5217-8de0-4f1eb1e90d19}",
+            ),
+            (
+                r#"{"defaultProfile":"Profile0","profiles":{"list":[{"name":"profile0","commandline":"pwsh.exe"},{"name":"Profile0","commandline":"pwsh.exe"}]}}"#,
+                "{6a2f325d-dd64-5214-ac09-ceac61244422}",
+            ),
+            (
+                r#"{"defaultProfile":"{FA616EE5-B304-5217-8DE0-4F1EB1E90D19}","profiles":{"list":[{"name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
+                "{fa616ee5-b304-5217-8de0-4f1eb1e90d19}",
+            ),
+            (
+                r#"{"defaultProfile":"Custom shell","profiles":{"defaults":{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Other shell","source":"Other source","commandline":"pwsh.exe -NoLogo"},"list":[{"name":"Custom shell"}]}}"#,
+                "{fa616ee5-b304-5217-8de0-4f1eb1e90d19}",
+            ),
+            (
+                r#"{"defaultProfile":"{574e775e-4f2a-5b96-ac1e-a2962a402336}"}"#,
+                "{574e775e-4f2a-5b96-ac1e-a2962a402336}",
+            ),
+            (
+                r#"{"defaultProfile":"{33333333-3333-4333-8333-333333333333}","profiles":{"defaults":{"commandline":"pwsh.exe"},"list":[]}}"#,
+                "{33333333-3333-4333-8333-333333333333}",
+            ),
+        ] {
+            assert_eq!(
+                parse_wt_default_profile(content, Some((1, 23, 20211, 0))),
+                Some(WtDefaultProfile {
+                    selector: selector.to_string(),
+                    shell: WtDefaultShell::Pwsh,
+                }),
+                "{content}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_wt_default_profile_rejects_unresolvable_selectors() {
+        for content in [
+            r#"{"defaultProfile":"custom shell","profiles":{"list":[{"guid":"{33333333-3333-4333-8333-333333333333}","name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}}"#,
+            r#"{"defaultProfile":"custom shell","profiles":[{"name":"Custom shell","commandline":"pwsh.exe -NoLogo"}]}"#,
+            r#"{"defaultProfile":" Custom shell","profiles":[{"name":"Custom shell","commandline":"pwsh.exe"}]}"#,
+            r#"{"defaultProfile":"Custom shell ","profiles":[{"name":"Custom shell","commandline":"pwsh.exe"}]}"#,
+            r#"{"defaultProfile":"Dev&echo","profiles":{"defaults":{"commandline":"pwsh.exe"},"list":[]}}"#,
+            r#"{"defaultProfile":"Dev&echo","profiles":{"list":[{"name":"Dev&echo","guid":"invalid","commandline":"pwsh.exe"}]}}"#,
+        ] {
+            assert_eq!(parse_wt_default_profile(content, None), None, "{content}");
+        }
+    }
+
+    #[test]
+    fn wt_launch_helpers_preserve_the_profile_and_use_explicit_fallback() {
+        let ps = r"& 'C:\Temp\test.bat'";
+        let expected_fallback = vec![
+            "new-tab",
+            "cmd",
+            "/D",
+            "/V:OFF",
+            "/K",
+            "%CC_SWITCH_INTERNAL_BATCH_PATH%",
+        ];
+
+        for shell in [
+            WtDefaultShell::Pwsh,
+            WtDefaultShell::PowerShell,
+            WtDefaultShell::Cmd,
+        ] {
+            let profile = WtDefaultProfile {
+                selector: "Custom profile with spaces".to_string(),
+                shell,
+            };
+            let mut expected = vec![
+                "new-tab",
+                "--profile",
+                "Custom profile with spaces",
+                "--appendCommandLine",
+                "--",
+            ];
+            if shell == WtDefaultShell::Cmd {
+                expected.extend(["/D", "/V:OFF", "/K", "%CC_SWITCH_INTERNAL_BATCH_PATH%"]);
+            } else {
+                expected.extend(["-NoExit", "-Command", ps]);
+            }
+            assert_eq!(select_wt_launch_args(Some(&profile), true, ps), expected);
+            assert_eq!(
+                select_wt_launch_args(Some(&profile), false, ps),
+                expected_fallback
+            );
+        }
+        for supports_append in [false, true] {
+            assert_eq!(
+                select_wt_launch_args(None, supports_append, ps),
+                expected_fallback
+            );
+        }
+
+        let shim = "path = \"C:\\scoop\\apps\\windows-terminal\\current\\wt.exe\"\r\nargs = \r\n";
+        assert_eq!(
+            parse_scoop_shim_content(shim),
+            Some(PathBuf::from(
+                r"C:\scoop\apps\windows-terminal\current\wt.exe"
+            ))
+        );
+        assert_eq!(parse_scoop_shim_content("bad content"), None);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn cmd_batch_env_reference_executes_special_character_path() {
+        let temp = tempfile::tempdir().expect("probe directory should be created");
+        let hostile_dir = temp
+            .path()
+            .join("space & %CC_SWITCH_CMD_EXPAND% ^ ! (test)");
+        std::fs::create_dir(&hostile_dir).expect("hostile directory should be created");
+        let batch = hostile_dir.join("probe.bat");
+        let marker = temp.path().join("executed.txt");
+        std::fs::write(
+            &batch,
+            format!(
+                "@echo off\r\nsetlocal DisableDelayedExpansion\r\nset \"CC_SWITCH_INTERNAL_BATCH_PATH=\"\r\n> \"{}\" echo ok\r\n",
+                escape_windows_batch_value(&marker.to_string_lossy())
+            ),
+        )
+        .expect("probe batch should be written");
+
+        let mut command = std::process::Command::new("cmd");
+        command.env("CC_SWITCH_CMD_EXPAND", "wrong");
+        configure_windows_cmd_batch(&mut command, "/C", &batch.to_string_lossy());
+        let output = command.output().expect("cmd probe should start");
+
+        assert!(
+            output.status.success(),
+            "stdout: {}\nstderr: {}",
+            decode_command_output(&output.stdout),
+            decode_command_output(&output.stderr)
+        );
+        assert_eq!(
+            std::fs::read_to_string(marker).unwrap().trim(),
+            "ok",
+            "the literal hostile path must execute without variable expansion"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn powershell_batch_command_executes_special_character_path() {
+        let temp = tempfile::tempdir().expect("probe directory should be created");
+        let hostile_dir = temp
+            .path()
+            .join("space & %CC_SWITCH_CMD_EXPAND% ^ ! (test) and O'Brien");
+        std::fs::create_dir(&hostile_dir).expect("hostile directory should be created");
+        let batch = hostile_dir.join("probe.bat");
+        let marker = hostile_dir.join("executed.txt");
+        std::fs::write(
+            &batch,
+            format!(
+                "@echo off\r\nsetlocal DisableDelayedExpansion\r\n> \"{}\" echo ok\r\n",
+                escape_windows_batch_value(&marker.to_string_lossy())
+            ),
+        )
+        .expect("probe batch should be written");
+
+        let bat_path = batch.to_string_lossy();
+        let output = std::process::Command::new("pwsh")
+            .args([
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                WINDOWS_POWERSHELL_BATCH_COMMAND,
+            ])
+            .env(
+                WINDOWS_BATCH_PATH_ENV,
+                quote_windows_batch_path_for_env(&bat_path),
+            )
+            .env("CC_SWITCH_CMD_EXPAND", "wrong")
+            .output()
+            .expect("PowerShell probe should start");
+
+        assert!(
+            output.status.success(),
+            "stdout: {}\nstderr: {}",
+            decode_command_output(&output.stdout),
+            decode_command_output(&output.stderr)
+        );
+        assert_eq!(
+            std::fs::read_to_string(marker).unwrap().trim(),
+            "ok",
+            "PowerShell must execute the literal hostile batch path"
+        );
+    }
+
+    // Spawn a real argv probe so the launcher path and args are not re-parsed
+    // by an extra shell.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn wt_launch_preserves_special_character_paths_and_profile_args() {
+        let temp = tempfile::tempdir().expect("probe directory should be created");
+        let source = temp.path().join("argv_probe.rs");
+        let executable = temp.path().join("argv_probe.exe");
+        std::fs::write(
+            &source,
+            r#"#![windows_subsystem = "windows"]
+fn main() {
+    let path = std::env::current_exe().unwrap().with_extension("args");
+    let staging = path.with_extension("staging");
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let batch_path = std::env::var("CC_SWITCH_INTERNAL_BATCH_PATH").unwrap_or_default();
+    std::fs::write(&staging, format!("{args:?}\n{batch_path}")).unwrap();
+    std::fs::rename(staging, path).unwrap();
+}
+"#,
+        )
+        .expect("argv probe source should be written");
+        let compiled =
+            std::process::Command::new(std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into()))
+                .arg(&source)
+                .arg("-o")
+                .arg(&executable)
+                .output()
+                .expect("rustc should compile the argv probe");
+        assert!(
+            compiled.status.success(),
+            "{}",
+            String::from_utf8_lossy(&compiled.stderr)
+        );
+        let mut failures = Vec::new();
+        for directory in [
+            "Tools&echo",
+            "Tools%COMSPEC%",
+            "Tools^A",
+            "Tools(A)",
+            "Tools and O'Brien",
+            "工具🚀",
+        ] {
+            let launcher_dir = temp.path().join(directory);
+            std::fs::create_dir(&launcher_dir).expect("launcher directory should be created");
+            let launcher_executable = launcher_dir.join("wt.exe");
+            std::fs::copy(&executable, &launcher_executable)
+                .expect("probe should be copied to the launcher path");
+            let capture = launcher_executable.with_extension("args");
+            let launcher = launcher_executable.to_string_lossy();
+            for name in [
+                "Custom profile",
+                "Dev&echo",
+                "Dev%COMSPEC%",
+                "Dev;Test",
+                r"Dev\;Test",
+                r"Dev\\;Test",
+                "开发 🚀",
+                "Dev|echo",
+                "Dev^echo",
+            ] {
+                let settings = serde_json::json!({
+                    "defaultProfile": name,
+                    "profiles": {"list": [{"name": name, "commandline": "pwsh.exe -NoLogo"}]}
+                });
+                let profile = parse_wt_default_profile(&settings.to_string(), None)
+                    .expect("the profile should be recognized");
+                assert!(
+                    uuid::Uuid::parse_str(&profile.selector).is_ok(),
+                    "names must not reach cmd or WT as selectors: {name:?}"
+                );
+                let bat = r"C:\Temp\batch & %COMSPEC% ^ O'Brien\probe.bat";
+                let ps_cmd = format!("& '{}'", bat.replace('\'', "''"));
+                let args = select_wt_launch_args(Some(&profile), true, &ps_cmd);
+                let expected = format!("{args:?}\n{}", quote_windows_batch_path_for_env(bat));
+                run_wt_command(&launcher, &args, bat)
+                    .expect("WT launcher should directly start the probe");
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+                while !capture.is_file() && std::time::Instant::now() < deadline {
+                    std::thread::sleep(std::time::Duration::from_millis(20));
+                }
+                let observed =
+                    std::fs::read_to_string(&capture).expect("argv probe must write its result");
+                if observed != expected {
+                    failures.push(format!(
+                        "{name:?}: expected {expected}, received {observed}"
+                    ));
+                }
+                std::fs::remove_file(&capture)
+                    .expect("the completed probe result should be removed");
+            }
+        }
+        assert!(failures.is_empty(), "{}", failures.join("\n"));
+        let missing_launcher = temp.path().join("missing.exe");
+        assert!(run_wt_command(&missing_launcher.to_string_lossy(), &[], "probe.bat").is_err());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    #[serial_test::serial]
+    fn windows_terminal_launchers_do_not_inherit_parent_claude_session() {
+        fn wait_for_probe(capture: &Path) -> String {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            while !capture.is_file() && std::time::Instant::now() < deadline {
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+            std::fs::read_to_string(capture)
+                .expect("env probe must write its inherited variable names")
+        }
+
+        let restore = EnvRestore(
+            PARENT_CLAUDE_SESSION_ENV_VARS
+                .iter()
+                .map(|name| (*name, std::env::var_os(name)))
+                .collect(),
+        );
+        for name in PARENT_CLAUDE_SESSION_ENV_VARS {
+            std::env::set_var(name, "cc-switch-parent-session");
+        }
+
+        let temp = tempfile::tempdir().expect("probe directory should be created");
+        let source = temp.path().join("env_probe.rs");
+        let executable = temp.path().join("env_probe.exe");
+        std::fs::write(
+            &source,
+            r#"#![windows_subsystem = "windows"]
+fn main() {
+    let mut args = std::env::args_os().skip(1);
+    let capture = args.next().unwrap();
+    let inherited: Vec<String> = args
+        .filter(|name| std::env::var_os(name).is_some())
+        .map(|name| name.to_string_lossy().into_owned())
+        .collect();
+    std::fs::write(capture, inherited.join("\n")).unwrap();
+}
+"#,
+        )
+        .expect("env probe source should be written");
+        let compiled =
+            std::process::Command::new(std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into()))
+                .arg(&source)
+                .arg("-o")
+                .arg(&executable)
+                .output()
+                .expect("rustc should compile the env probe");
+        assert!(
+            compiled.status.success(),
+            "{}",
+            String::from_utf8_lossy(&compiled.stderr)
+        );
+
+        fn run_wt_probe(args: &[&str]) -> Result<(), String> {
+            let (launcher, arguments) = args
+                .split_first()
+                .ok_or_else(|| "missing env probe executable".to_string())?;
+            run_wt_command(launcher, arguments, r"C:\Temp\cc-switch-env-probe.bat")
+        }
+
+        fn run_configured_batch_probe(args: &[&str]) -> Result<(), String> {
+            let (launcher, arguments) = args
+                .split_first()
+                .ok_or_else(|| "missing env probe executable".to_string())?;
+            let mut command = std::process::Command::new(launcher);
+            configure_windows_batch_env(&mut command, r"C:\Temp\cc-switch-env-probe.bat");
+            command
+                .args(arguments)
+                .creation_flags(CREATE_NO_WINDOW)
+                .spawn()
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+        }
+
+        let launcher = executable.to_string_lossy();
+        for (label, capture, launch) in [
+            (
+                "Windows Terminal",
+                temp.path().join("wt.result"),
+                run_wt_probe as fn(&[&str]) -> Result<(), String>,
+            ),
+            (
+                "configured batch process",
+                temp.path().join("batch.result"),
+                run_configured_batch_probe as fn(&[&str]) -> Result<(), String>,
+            ),
+        ] {
+            let capture_arg = capture.to_string_lossy();
+            let mut args = vec![launcher.as_ref(), capture_arg.as_ref()];
+            args.extend(PARENT_CLAUDE_SESSION_ENV_VARS.iter().copied());
+            launch(&args).unwrap_or_else(|error| panic!("{label} probe should launch: {error}"));
+            let inherited = wait_for_probe(&capture);
+            assert!(
+                inherited.is_empty(),
+                "{label} inherited parent Claude session variables:\n{inherited}"
+            );
+        }
+        drop(restore);
+    }
+
+    // Exercise the real WT profile selection, not only the generated argv.
+    // Opt in on a Windows desktop; this opens diagnostic tabs without changing settings.
+    #[cfg(target_os = "windows")]
+    #[test]
+    #[serial_test::serial]
+    #[ignore = "requires desktop WT, a supported default profile GUID, and built-in PowerShell/cmd profiles"]
+    fn wt_launch_executes_batch_in_real_terminal() {
+        const SENTINEL: &str = "CC_SWITCH_WT_ENV_SENTINEL";
+        const CMD_EXPANSION_SENTINEL: &str = "CC_SWITCH_CMD_EXPAND";
+        let restore = EnvRestore(
+            PARENT_CLAUDE_SESSION_ENV_VARS
+                .iter()
+                .copied()
+                .chain([SENTINEL, CMD_EXPANSION_SENTINEL])
+                .map(|name| (name, std::env::var_os(name)))
+                .collect(),
+        );
+        for name in PARENT_CLAUDE_SESSION_ENV_VARS {
+            std::env::set_var(name, "cc-switch-parent-session");
+        }
+        std::env::set_var(SENTINEL, "preserved");
+        std::env::set_var(CMD_EXPANSION_SENTINEL, "wrong");
+
+        let installation = resolve_wt_installation().expect("Windows Terminal must be installed");
+        let wt_version = wt_installation_version(&installation);
+        let supports_append = wt_version.is_none_or(wt_version_supports_append);
+        let default_profile = detect_wt_default_profile(&installation, wt_version)
+            .expect("the default WT profile must support batch execution");
+        let cases = [
+            (default_profile.clone(), supports_append),
+            (
+                WtDefaultProfile {
+                    selector: "{61c54bbd-c2c6-5271-96e7-009a87ff44bf}".to_string(),
+                    shell: WtDefaultShell::PowerShell,
+                },
+                supports_append,
+            ),
+            (
+                WtDefaultProfile {
+                    selector: "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}".to_string(),
+                    shell: WtDefaultShell::Cmd,
+                },
+                supports_append,
+            ),
+            (default_profile, false),
+        ];
+        let temp = tempfile::Builder::new()
+            .prefix("cc-switch-wt-smoke-")
+            .tempdir()
+            .expect("diagnostic directory should be created");
+        let fixture_dir = temp
+            .path()
+            .join("space & %CC_SWITCH_CMD_EXPAND% ^ ! (test) and O'Brien");
+        std::fs::create_dir(&fixture_dir).expect("quoted fixture directory should be created");
+        for (index, (profile, supports_append)) in cases.iter().enumerate() {
+            let marker = fixture_dir.join(format!("executed-{index}.txt"));
+            let batch = fixture_dir.join(format!("probe-{index}.bat"));
+            std::fs::write(
+                &batch,
+                format!(
+                    "@echo off\r\nsetlocal DisableDelayedExpansion\r\nset \"CC_SWITCH_INTERNAL_BATCH_PATH=\"\r\n> \"{marker}\" echo profile=%WT_PROFILE_ID%\r\n>> \"{marker}\" echo NO_COLOR=%NO_COLOR%\r\n>> \"{marker}\" echo NODE_DISABLE_COLORS=%NODE_DISABLE_COLORS%\r\n>> \"{marker}\" echo CLAUDE_CODE_CHILD_SESSION=%CLAUDE_CODE_CHILD_SESSION%\r\n>> \"{marker}\" echo CLAUDE_CODE_SESSION_ID=%CLAUDE_CODE_SESSION_ID%\r\n>> \"{marker}\" echo sentinel=%CC_SWITCH_WT_ENV_SENTINEL%\r\nexit\r\n",
+                    marker = escape_windows_batch_value(&marker.to_string_lossy())
+                ),
+            )
+            .expect("diagnostic batch should be written");
+            let bat_path = batch.to_string_lossy();
+            let ps_cmd = format!("{WINDOWS_POWERSHELL_BATCH_COMMAND}; exit");
+            if index == 0 {
+                launch_wt_terminal(&bat_path, &ps_cmd).expect("WT launch should succeed");
+            } else {
+                let launcher = installation.launcher.to_string_lossy();
+                let args = select_wt_launch_args(Some(profile), *supports_append, &ps_cmd);
+                run_wt_command(&launcher, &args, &bat_path)
+                    .expect("explicit-profile WT launch should succeed");
+            }
+
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+            while !marker.is_file() && std::time::Instant::now() < deadline {
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            let captured = std::fs::read_to_string(&marker)
+                .unwrap_or_else(|error| panic!("case {index}: WT must execute the batch: {error}"));
+            let values: std::collections::HashMap<_, _> = captured
+                .lines()
+                .filter_map(|line| line.split_once('='))
+                .collect();
+            for name in [
+                "NO_COLOR",
+                "NODE_DISABLE_COLORS",
+                "CLAUDE_CODE_CHILD_SESSION",
+                "CLAUDE_CODE_SESSION_ID",
+            ] {
+                assert_eq!(
+                    values.get(name),
+                    Some(&""),
+                    "case {index}: {name} must not cross the WT spawn boundary"
+                );
+            }
+            assert_eq!(
+                values.get("sentinel"),
+                Some(&"preserved"),
+                "case {index}: unrelated environment must be preserved"
+            );
+            if *supports_append {
+                assert_eq!(
+                    normalize_wt_guid(values.get("profile").copied().unwrap_or_default()),
+                    normalize_wt_guid(&profile.selector),
+                    "case {index}: the batch must run in the same profile that was classified"
+                );
+            }
+        }
+        drop(restore);
+    }
+
+    #[test]
+    fn wt_settings_paths_stay_bound_to_the_resolved_installation() {
+        let local = Path::new("C:/Users/test/AppData/Local");
+        for exe in [
+            "C:/Users/test/scoop/apps/windows-terminal/current/WindowsTerminal.exe",
+            "C:/Program Files/Windows Terminal/wt.exe",
+            "C:/Tools/terminal/wt.exe",
+        ] {
+            assert_eq!(
+                build_wt_settings_paths(Path::new(exe), Some(local)),
+                vec![unpackaged_wt_settings_path(local)],
+                "{exe}"
+            );
+        }
+
+        // Do not depend on the local install type; classify stable vs Preview
+        // and bind each to its unique active settings path.
+        for (exe, expected_preview) in [
+            (
+                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminal_1.24.11911.0_x64__8wekyb3d8bbwe/wt.exe",
+                false,
+            ),
+            (
+                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminalPreview_1.0.0.0_x64__8wekyb3d8bbwe/wt.exe",
+                true,
+            ),
+        ] {
+            let exe = Path::new(exe);
+            let (preview, _) = store_wt_package_dir(exe)
+                .expect("Store executable must belong to a WT package");
+            assert_eq!(preview, expected_preview, "{exe:?}");
+            assert_eq!(
+                build_wt_settings_paths(exe, Some(local)),
+                vec![store_wt_settings_path(local, expected_preview)],
+                "{exe:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn wt_portable_install_uses_only_active_settings() {
+        let local = Path::new("C:/Users/test/AppData/Local");
+        for (layout, persist) in [
+            ("tools-wt", None),
+            (
+                "scoop/apps/windows-terminal/current",
+                Some("scoop/persist/windows-terminal"),
+            ),
+            (
+                "scoop/apps/windows-terminal-preview/1.24.0",
+                Some("scoop/persist/windows-terminal-preview"),
+            ),
+        ] {
+            let temp = tempfile::tempdir().expect("temp dir should be created");
+            let exe_dir = temp.path().join(layout);
+            std::fs::create_dir_all(&exe_dir).expect("portable dir should be created");
+            let exe = exe_dir.join("wt.exe");
+            std::fs::write(&exe, b"").expect("portable exe placeholder should be written");
+            std::fs::write(exe_dir.join(".portable"), b"")
+                .expect("portable marker should be written");
+
+            let active = r#"{
+                "defaultProfile": "{574e775e-4f2a-5b96-ac1e-a2962a402336}"
+            }"#;
+            let stale = r#"{
+                "defaultProfile": "{0caa0dad-35be-5f56-a8ff-afceeeaa6101}"
+            }"#;
+            let mut expected = Vec::new();
+            for root in std::iter::once(exe_dir.clone())
+                .chain(persist.map(|persist| temp.path().join(persist)))
+            {
+                let settings_dir = root.join("settings");
+                std::fs::create_dir_all(&settings_dir).expect("settings dir should be created");
+                let active_path = settings_dir.join("settings.json");
+                std::fs::write(&active_path, active).expect("active settings should be written");
+                expected.push(active_path);
+                let stale_path = root.join("settings.json");
+                std::fs::write(&stale_path, stale).expect("stale settings should be written");
+                // A file at the root is not WT settings, even if its timestamp is
+                // newer than the active config.
+                std::fs::OpenOptions::new()
+                    .write(true)
+                    .open(&stale_path)
+                    .expect("stale settings should open")
+                    .set_times(std::fs::FileTimes::new().set_modified(
+                        std::time::SystemTime::now() + std::time::Duration::from_secs(60),
+                    ))
+                    .expect("stale settings should have a newer timestamp");
+            }
+
+            let paths = build_wt_settings_paths(&exe, Some(local));
+            assert_eq!(
+                detect_wt_default_profile_from_paths(&paths, None),
+                parse_wt_default_profile(active, None),
+                "{layout}: root settings must not override the active PowerShell profile"
+            );
+            assert_eq!(
+                paths, expected,
+                "{layout}: only active settings are candidates"
+            );
+        }
+    }
+
+    #[test]
+    fn wt_version_and_path_detect_append_command_line_support() {
+        assert!(!wt_version_supports_append((1, 18, 3181, 0)));
+        assert!(wt_version_supports_append((1, 19, 0, 0)));
+        assert!(wt_version_supports_append((1, 24, 11911, 0)));
+        assert_eq!(
+            wt_version_from_path(Path::new(
+                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminal_1.18.3181.0_x64__8wekyb3d8bbwe/wt.exe"
+            )),
+            Some((1, 18, 3181, 0))
+        );
+        assert_eq!(
+            wt_version_from_path(Path::new(
+                "C:/Program Files/WindowsApps/Microsoft.WindowsTerminal_1.24.11911.0_x64__8wekyb3d8bbwe/wt.exe"
+            )),
+            Some((1, 24, 11911, 0))
+        );
+        assert_eq!(
+            wt_version_from_path(Path::new(
+                "C:/Users/test/scoop/apps/windows-terminal/1.18.3181.0/wt.exe"
+            )),
+            Some((1, 18, 3181, 0))
+        );
+        assert_eq!(
+            wt_version_from_path(Path::new(
+                "C:/Users/test/scoop/apps/windows-terminal/current/wt.exe"
+            )),
+            None
+        );
+    }
+
+    #[test]
+    fn unpackaged_release_directory_is_not_misclassified_as_store() {
+        let local = Path::new("C:/Users/test/AppData/Local");
+        let exe = Path::new("C:/Tools/Microsoft.WindowsTerminal_1.23_x64/wt.exe");
+        let paths = build_wt_settings_paths(exe, Some(local));
+        assert!(paths.contains(&unpackaged_wt_settings_path(local)));
+        assert!(!paths.contains(&store_wt_settings_path(local, false)));
+        assert!(!paths.contains(&store_wt_settings_path(local, true)));
+    }
+
+    #[test]
+    fn app_execution_alias_parser_extracts_the_package_target() {
+        let build_buffer = |target: &str| {
+            let values = ["Package_Family", "Package_Family!App", target, "0"];
+            let mut payload = (values.len() as u32).to_le_bytes().to_vec();
+            for value in values {
+                for unit in value.encode_utf16().chain(Some(0)) {
+                    payload.extend_from_slice(&unit.to_le_bytes());
+                }
+            }
+
+            let mut buffer = APPEXECLINK_REPARSE_TAG.to_le_bytes().to_vec();
+            buffer.extend_from_slice(&(payload.len() as u16).to_le_bytes());
+            buffer.extend_from_slice(&0u16.to_le_bytes());
+            buffer.extend_from_slice(&payload);
+            buffer
+        };
+
+        let target = r"C:\Program Files\WindowsApps\Microsoft.WindowsTerminal_1.0.0.0_x64__8wekyb3d8bbwe\wt.exe";
+        let parsed = parse_app_execution_alias_target(&build_buffer(target))
+            .expect("App Execution Alias target should parse");
+        assert_eq!(String::from_utf16(&parsed).unwrap(), target);
+        assert_eq!(
+            parse_app_execution_alias_target(&build_buffer(r"relative\wt.exe")),
+            None
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn store_wt_alias_resolves_to_package_settings_not_scoop() {
+        let Some(local) = std::env::var_os("LOCALAPPDATA").map(PathBuf::from) else {
+            return;
+        };
+        let alias = local.join("Microsoft").join("WindowsApps").join("wt.exe");
+        if std::fs::symlink_metadata(&alias).is_err() {
+            return;
+        }
+
+        let target = resolve_app_execution_alias_target(&alias)
+            .expect("Store wt.exe App Execution Alias should resolve via APPEXECLINK");
+        // The wt.exe alias may belong to stable or Preview; settings paths must
+        // follow the actual target package.
+        let (preview, _) = store_wt_package_dir(&target)
+            .unwrap_or_else(|| panic!("Store alias must resolve to a WT package: {target:?}"));
+        assert_eq!(
+            build_wt_settings_paths(&target, Some(&local)),
+            vec![store_wt_settings_path(&local, preview)],
+            "Store settings should be bound to the resolved package: {target:?}"
+        );
+
+        // PATH lookup is a separate concern: GitHub-hosted Windows runners often
+        // have the Store alias file but no WindowsApps directory on PATH.
+        if let Some(installation) = resolve_wt_installation() {
+            assert_eq!(
+                installation
+                    .launcher
+                    .file_name()
+                    .map(|name| name.to_string_lossy().to_ascii_lowercase()),
+                Some("wt.exe".into()),
+                "launcher should stay the resolved wt.exe, got {:?}",
+                installation.launcher
+            );
+            if installation
+                .launcher
+                .parent()
+                .is_some_and(is_windows_app_execution_alias_dir)
+            {
+                assert_eq!(
+                    installation.settings_executable.as_ref(),
+                    Some(&target),
+                    "PATH-selected Store alias should bind settings to the same APPEXECLINK target"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn wt_settings_detection_skips_malformed_candidates() {
+        let temp = tempfile::tempdir().expect("temp dir should be created");
+        let valid = temp.path().join("valid.json");
+        let malformed = temp.path().join("malformed.json");
+        let pwsh = r#"{
+            "defaultProfile": "PowerShell 7",
+            "profiles": [{"name": "PowerShell 7", "commandline": "pwsh.exe"}]
+        }"#;
+        std::fs::write(&valid, pwsh).expect("valid settings should be written");
+        std::fs::write(&malformed, "not json").expect("malformed settings should be written");
+
+        assert_eq!(
+            detect_wt_default_profile_from_paths(&[malformed, valid], None),
+            Some(WtDefaultProfile {
+                selector: "{8f7fc2c9-b084-5bc6-89f4-82fc0f5d1b6c}".to_string(),
+                shell: WtDefaultShell::Pwsh,
+            })
+        );
+    }
+}


### PR DESCRIPTION
## Summary

When Windows Terminal is selected as the preferred terminal on Windows, CC Switch currently launches `wt cmd /K ...`. This overrides the user's Windows Terminal `defaultProfile` (for example PowerShell 7), while a provider-specific Claude session launched from CC Switch can also inherit parent Claude runtime/IPC identity and color-disable variables.

This PR keeps Windows Terminal in control of the user's configured profile, appearance, initialization, and command line, while safely launching Claude with the selected provider's temporary settings.

## What changed

### Windows Terminal profile handling

- Resolves the actual `wt.exe` installation being launched and binds settings discovery to that installation, including Store, unpackaged, Scoop, Portable Mode, and App Execution Alias cases.
- Reads Windows Terminal's `defaultProfile` and passes its exact selector through `--profile` so supplying a command line cannot make WT select another profile or generic `ProfileDefaults()`.
- Uses `--appendCommandLine` where supported so the selected profile retains its own executable and initialization arguments.
- Classifies a shell only from an explicit profile `commandline`, the known `Windows.Terminal.PowershellCore` generator source, or a built-in profile GUID. **Profile display names are never treated as shell evidence.**
- Matches WT's `defaultProfile` resolution rule: only a canonical 38-character `{...}` value is treated as a GUID; an unbraced UUID-shaped value remains a profile name.
- Refuses unsafe append cases, including existing PowerShell server/terminating actions and CMD `/C`, `/K`, or `/R`, and falls back on WT versions before `--appendCommandLine` support.
- Uses an explicit CMD tab for WSL, Git Bash, unknown profiles, or any profile whose command line cannot be safely extended rather than guessing its shell.

### Provider launch and session isolation

- Creates unique provider settings JSON and BAT files atomically for every launch, preventing concurrent launches from the same CC Switch process from overwriting one another.
- Passes the quoted BAT path through `CC_SWITCH_INTERNAL_BATCH_PATH` and executes it with delayed expansion disabled. This preserves paths containing spaces, `&`, `%`, `^`, `!`, parentheses, and apostrophes across CMD, PowerShell, and Windows Terminal.
- Cleans up the settings JSON and BAT when terminal launch ultimately fails, avoiding stale files that may contain provider credentials.
- Clears inherited Claude runtime/session/IPC variables at every Windows batch-launch boundary while preserving auth, proxy, PATH, and user Claude configuration.
- Continues to remove `NO_COLOR` and `NODE_DISABLE_COLORS` **unconditionally** at that Windows top-level terminal boundary, preserving the existing colored Claude TUI behavior.

For PowerShell profiles, the deliberate process chain is:

```text
WindowsTerminal.exe -> pwsh.exe / powershell.exe -> cmd.exe (BAT) -> claude.exe --settings <provider-settings>
```

The tab is still the user's selected profile and its `$PROFILE` initialization runs. The environment isolation in this PR remains Windows-only; non-Windows terminal launch behavior is unchanged.

### Structure and shared Windows detection

- Moves approximately 2,600 lines of Windows Terminal parsing, discovery, version probing, launch code, and tests out of the already-large `misc.rs` into `commands/windows_terminal.rs`.
- Reuses the shared Windows path and process helpers instead of duplicating them.
- Documents the OEM-first decoding change for `where.exe`: this intentionally affects every Windows PATH tool probe (`claude`, `codex`, `gemini`, `wt`, etc.), because hidden-console `where.exe` output uses the OEM code page. UTF-8 remains the fallback.
- Keeps the Scoop shim parser warning-free on non-Windows test builds and makes probe tests honor the `RUSTC` environment variable.

## Review feedback addressed

This update addresses all requested items from the maintainer review:

- removed name-based profile shell inference;
- disclosed the shared OEM-first `where.exe` decoding behavior;
- moved Windows Terminal code into its own module;
- aligned braced GUID detection with Windows Terminal;
- documented the PowerShell-to-BAT process chain, unsupported-profile fallback, and Windows-only isolation boundary;
- fixed the non-Windows dead-code nit and `RUSTC` handling.

It also adds hardening found during follow-up testing: unique concurrent launch artifacts, hostile BAT-path handling, CMD `/R` detection, and cleanup of sensitive temporary files after launch failure.

## Validation

- `cargo fmt --check`: passed
- `cargo clippy --all-targets -- -D warnings`: passed
- Full Rust suite: **2,952 passed, 0 failed, 7 ignored**
- Windows Terminal targeted suite: **28 passed, 0 failed, 1 ignored**
- Real ignored Windows Terminal launch smoke: **1 passed**
- Frontend type checking, formatting, unit tests, and production renderer build: passed
- GitHub CI on Windows, Windows + WSL2, Ubuntu, and macOS: passed
- GitHub-hosted `windows-2022` Tauri production build: passed
- The downloaded cloud-built production EXE was tested through the real UI and provider-specific Windows Terminal launch flow: passed

## Related issue

Fixes #5322

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `cargo clippy` passes
- [x] Updated i18n files if user-facing text changed (N/A — backend only)
