### PR TITLE
fix(usage): widen provider filter to w-48 to match ModelsDevAutoSyncPanel

### DIFF
--- a/src/components/usage/ModelsDevPickerDialog.tsx
+++ b/src/components/usage/ModelsDevPickerDialog.tsx
@@ -217,7 +217,7 @@ export function ModelsDevPickerDialog({
                   value={providerFilter}
                   onValueChange={setProviderFilter}
                 >
-                  <SelectTrigger className="w-44 shrink-0">
+                  <SelectTrigger className="w-48 shrink-0">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent className="z-[120] max-h-[min(24rem,var(--radix-select-content-available-height))]">


### PR DESCRIPTION
The w-44 SelectTrigger left the Japanese label すべてのプロバイダー nearly touching the edges; align with the w-48 used by ModelsDevAutoSyncPanel.tsx for the same filter.

## Summary / 概述

对齐供应商筛选宽度 w-44→w-48，与 AutoSyncPanel 一致，接续  #6980 

## Related Issue / 关联 Issue

无

Fixes #

## Screenshots / 截图
修改前：
<img width="1122" height="744" alt="image" src="https://github.com/user-attachments/assets/0056c14a-f86e-49f5-b4e0-9aa5f0400e85" />


修改后：
<img width="1118" height="754" alt="Screenshot 2026-09-08 140503" src="https://github.com/user-attachments/assets/309b9fcc-c2e0-4a47-9b53-a4d47410fedf" />

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
