### PR TITLE
fix(proxy): preserve per-app settings on shutdown and port allocation

### DIFF
--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -999,10 +999,15 @@ impl ProxyService {
             return Ok(());
         }
 
-        let mut resolved_config = config.clone();
+        // 端口是全局字段，不能通过旧接口回写各应用独立的重试和超时配置。
+        let mut resolved_config = self
+            .db
+            .get_global_proxy_config()
+            .await
+            .map_err(|e| format!("获取全局代理配置失败: {e}"))?;
         resolved_config.listen_port = actual_port;
         self.db
-            .update_proxy_config(resolved_config)
+            .update_global_proxy_config(resolved_config)
             .await
             .map_err(|e| format!("保存动态代理端口失败: {e}"))
     }
@@ -1803,20 +1808,16 @@ impl ProxyService {
         // 2. 恢复原始 Live 配置
         self.restore_live_configs().await?;
 
-        // 3. 更新 proxy_config 表中的 live_takeover_active 标志（兼容旧版）
-        //    注意：保留 proxy_config.enabled 状态，下次启动时自动恢复
-        if let Ok(mut config) = self.db.get_proxy_config().await {
-            config.live_takeover_active = false;
-            let _ = self.db.update_proxy_config(config).await;
-        }
+        // 保留各应用的 enabled 和故障转移配置，下次启动时自动恢复。
+        // live_takeover_active 已废弃，无需通过旧接口回写配置。
 
-        // 4. 删除备份（Live 配置已恢复，备份不再需要）
+        // 3. 删除备份（Live 配置已恢复，备份不再需要）
         self.db
             .delete_all_live_backups()
             .await
             .map_err(|e| format!("删除备份失败: {e}"))?;
 
-        // 5. 重置健康状态
+        // 4. 重置健康状态
         self.db
             .clear_all_provider_health()
             .await
@@ -4151,6 +4152,88 @@ mod tests {
         db.update_proxy_config(proxy_config)
             .await
             .expect("set test proxy config to an ephemeral port");
+    }
+
+    async fn seed_distinct_app_proxy_configs(db: &Database) -> Vec<Value> {
+        let mut configs = Vec::new();
+        for (app, retries) in [("claude", 6), ("codex", 0), ("gemini", 2), ("grokbuild", 3)] {
+            let mut config = db.get_proxy_config_for_app(app).await.unwrap();
+            config.enabled = retries % 2 == 0;
+            config.auto_failover_enabled = retries % 2 != 0;
+            config.max_retries = retries;
+            config.streaming_first_byte_timeout = 30 + retries;
+            config.streaming_idle_timeout = 90 + retries;
+            config.non_streaming_timeout = 300 + retries;
+            config.circuit_failure_threshold = 5 + retries;
+            configs.push(serde_json::to_value(&config).unwrap());
+            db.update_proxy_config_for_app(config).await.unwrap();
+        }
+        configs
+    }
+
+    async fn assert_app_proxy_configs_unchanged(db: &Database, configs: &[Value]) {
+        for expected in configs {
+            let app = expected["appType"].as_str().unwrap();
+            let actual = db.get_proxy_config_for_app(app).await.unwrap();
+            assert_eq!(serde_json::to_value(actual).unwrap(), *expected, "{app}");
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn shutdown_preserves_app_proxy_configs() {
+        let _home = TempHome::new();
+        crate::settings::reload_settings().unwrap();
+        let db = Arc::new(Database::memory().unwrap());
+        let configs = seed_distinct_app_proxy_configs(&db).await;
+        let service = ProxyService::new(db.clone());
+
+        let backup = json!({"env": {"ANTHROPIC_BASE_URL": "https://example.com"}});
+        db.save_live_backup("claude", &backup.to_string())
+            .await
+            .unwrap();
+
+        service.stop_with_restore_keep_state().await.unwrap();
+
+        assert_app_proxy_configs_unchanged(&db, &configs).await;
+        assert_eq!(
+            read_json_file::<Value>(&get_claude_settings_path()).unwrap(),
+            backup
+        );
+        assert!(db.get_live_backup("claude").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn ephemeral_port_preserves_app_proxy_configs() {
+        let db = Arc::new(Database::memory().unwrap());
+        let configs = seed_distinct_app_proxy_configs(&db).await;
+        let service = ProxyService::new(db.clone());
+        let mut config = db.get_proxy_config().await.unwrap();
+        config.listen_port = 0;
+        let mut expected_global = db.get_global_proxy_config().await.unwrap();
+        expected_global.listen_port = 23456;
+
+        service
+            .persist_ephemeral_listen_port_if_needed(&config, 23456)
+            .await
+            .unwrap();
+
+        assert_app_proxy_configs_unchanged(&db, &configs).await;
+        assert_eq!(
+            serde_json::to_value(db.get_global_proxy_config().await.unwrap()).unwrap(),
+            serde_json::to_value(expected_global).unwrap()
+        );
+
+        config.listen_port = 23456;
+        service
+            .persist_ephemeral_listen_port_if_needed(&config, 34567)
+            .await
+            .unwrap();
+        assert_eq!(
+            db.get_global_proxy_config().await.unwrap().listen_port,
+            23456
+        );
+        assert_app_proxy_configs_unchanged(&db, &configs).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary / 概述

修复正常退出 CC Switch 后，Codex 等应用的重试次数和超时配置被 Claude 配置覆盖的问题，同时修复动态监听端口保存路径上的相同问题。

- `stop_with_restore_keep_state()` 为已废弃的 `live_takeover_active` 字段调用旧的全局配置写入接口。该接口从 Claude 行读出配置，再把重试及超时字段更新到所有应用行。移除此无效回写，保留 Live 配置恢复、备份清理和健康状态重置。
- `persist_ephemeral_listen_port_if_needed()` 改用现有全局配置接口，仅更新全局字段，避免回写各应用独立的重试和超时配置。
- 保持旧配置接口及主动更新配置的现有语义，不涉及数据库迁移或前端改动。

## Related Issue / 关联 Issue

Fixes #7204

## Verification / 验证

基于上游 `main` / v3.20.2 (`f3b18df`)；Windows 本地验证。

新增两个回归测试，分别覆盖退出和动态端口保存。四个应用使用不同重试次数（Claude/Codex/Gemini/Grok Build：6/0/2/3）与超时配置，并比较全部应用级配置字段。另检查退出时配置备份仍能恢复并清理、动态端口正确持久化，以及固定端口不被改写。

- **修复前**：两个测试均失败，Codex 的重试次数从 0 被改成 6，三个超时字段也被覆盖。
- **修复后**：两个测试通过。
- `cargo test --manifest-path src-tauri/Cargo.toml --lib services::proxy::tests -- --test-threads=1`：96 passed。
- `cargo test --manifest-path src-tauri/Cargo.toml --lib database::dao::proxy::tests -- --test-threads=1`：3 passed。
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`：通过。
- `git diff --check`：通过。

测试使用内存数据库和隔离测试目录；未执行已安装应用的完整退出/重启 UI 测试。

## Screenshots / 截图

不适用：仅后端逻辑与测试变更。

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes — 未运行，无 TypeScript 变更。
- [ ] `pnpm format:check` passes — 未运行；Rust 格式检查已通过。
- [ ] `cargo clippy` passes — 未运行。
- [x] 无需更新 i18n：未修改用户界面文案。
