### PR TITLE
fix(provider): preserve child metadata during universal sync

### DIFF
--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -4058,6 +4058,111 @@ wire_api = "responses"
 
     #[test]
     #[serial]
+    fn sync_universal_to_apps_preserves_child_metadata() {
+        with_test_home(|state, _home| {
+            let mut universal = UniversalProvider::new(
+                "metadata".into(),
+                "Original".into(),
+                "custom".into(),
+                "https://old.example".into(),
+                "old-key".into(),
+            );
+            universal.apps.claude = true;
+            universal.apps.codex = true;
+            universal.apps.gemini = true;
+            universal.meta = Some(
+                serde_json::from_value(json!({
+                    "usage_script": {"enabled": false, "language": "javascript", "code": "parent"}
+                }))
+                .unwrap(),
+            );
+            state.db.save_universal_provider(&universal).unwrap();
+            ProviderService::sync_universal_to_apps(state, &universal.id).unwrap();
+
+            let mut expected = Vec::new();
+            for (index, app) in ["claude", "codex", "gemini"].iter().enumerate() {
+                let id = format!("universal-{app}-metadata");
+                let mut child = state.db.get_provider_by_id(&id, app).unwrap().unwrap();
+                assert_eq!(
+                    serde_json::to_value(&child.meta).unwrap(),
+                    serde_json::to_value(&universal.meta).unwrap()
+                );
+                child.meta = Some(
+                    serde_json::from_value(json!({
+                        "usage_script": {"enabled": true, "language": "javascript", "code": app,
+                            "apiKey": "usage-only-key", "autoQueryInterval": 15},
+                        "commonConfigEnabled": false,
+                        "endpointAutoSelect": true
+                    }))
+                    .unwrap(),
+                );
+                child.created_at = Some(123 + index as i64);
+                child.sort_index = Some(10 + index);
+                child.settings_config["local_setting"] = json!(app);
+                state.db.save_provider(app, &child).unwrap();
+                state
+                    .db
+                    .add_custom_endpoint(app, &id, "https://extra.example")
+                    .unwrap();
+                expected.push(child);
+            }
+
+            universal.name = "Updated".into();
+            universal.base_url = "https://new.example".into();
+            universal.api_key = "new-key".into();
+            universal.notes = Some("shared note".into());
+            universal.models = serde_json::from_value(json!({
+                "claude": {"model": "claude-new"},
+                "codex": {"model": "codex-new", "reasoningEffort": "low"},
+                "gemini": {"model": "gemini-new"}
+            }))
+            .unwrap();
+            // Both absent and present parent metadata must not overwrite child settings.
+            for parent_meta in [None, universal.meta.clone()] {
+                universal.meta = parent_meta;
+                state.db.save_universal_provider(&universal).unwrap();
+                ProviderService::sync_universal_to_apps(state, &universal.id).unwrap();
+                for (app, before) in ["claude", "codex", "gemini"].iter().zip(&expected) {
+                    let after = state
+                        .db
+                        .get_provider_by_id(&before.id, app)
+                        .unwrap()
+                        .unwrap();
+                    assert_eq!(
+                        serde_json::to_value(&after.meta).unwrap(),
+                        serde_json::to_value(&before.meta).unwrap(),
+                        "{app}"
+                    );
+                    assert_eq!(after.created_at, before.created_at, "{app}");
+                    assert_eq!(after.sort_index, before.sort_index, "{app}");
+                    assert_eq!(after.name, "Updated");
+                    assert_eq!(after.notes.as_deref(), Some("shared note"));
+                    assert_eq!(after.settings_config["local_setting"], json!(app));
+                    let generated = match *app {
+                        "claude" => universal.to_claude_provider(),
+                        "codex" => universal.to_codex_provider(),
+                        _ => universal.to_gemini_provider(),
+                    }
+                    .unwrap();
+                    let mut expected_settings = before.settings_config.clone();
+                    ProviderService::merge_json(&mut expected_settings, &generated.settings_config);
+                    assert_eq!(after.settings_config, expected_settings);
+                    assert_eq!(
+                        state.db.get_all_providers(app).unwrap()[&before.id]
+                            .meta
+                            .as_ref()
+                            .unwrap()
+                            .custom_endpoints
+                            .len(),
+                        1
+                    );
+                }
+            }
+        });
+    }
+
+    #[test]
+    #[serial]
     fn sync_universal_to_apps_reprojects_current_child_to_live() {
         with_test_home(|state, _home| {
             let mut universal = UniversalProvider::new(
@@ -6861,6 +6966,10 @@ impl ProviderService {
                 let mut merged = existing.settings_config.clone();
                 Self::merge_json(&mut merged, &claude_provider.settings_config);
                 claude_provider.settings_config = merged;
+                // 已有子供应商的应用专属配置与排序不属于统一供应商管理的字段。
+                claude_provider.meta = existing.meta;
+                claude_provider.created_at = existing.created_at;
+                claude_provider.sort_index = existing.sort_index;
             }
             state.db.save_provider("claude", &claude_provider)?;
             Self::project_universal_child_to_live(
@@ -6882,6 +6991,10 @@ impl ProviderService {
                 let mut merged = existing.settings_config.clone();
                 Self::merge_json(&mut merged, &codex_provider.settings_config);
                 codex_provider.settings_config = merged;
+                // 已有子供应商的应用专属配置与排序不属于统一供应商管理的字段。
+                codex_provider.meta = existing.meta;
+                codex_provider.created_at = existing.created_at;
+                codex_provider.sort_index = existing.sort_index;
             }
             state.db.save_provider("codex", &codex_provider)?;
             Self::project_universal_child_to_live(
@@ -6902,6 +7015,10 @@ impl ProviderService {
                 let mut merged = existing.settings_config.clone();
                 Self::merge_json(&mut merged, &gemini_provider.settings_config);
                 gemini_provider.settings_config = merged;
+                // 已有子供应商的应用专属配置与排序不属于统一供应商管理的字段。
+                gemini_provider.meta = existing.meta;
+                gemini_provider.created_at = existing.created_at;
+                gemini_provider.sort_index = existing.sort_index;
             }
             state.db.save_provider("gemini", &gemini_provider)?;
             Self::project_universal_child_to_live(


### PR DESCRIPTION
## Summary / 概述

修复统一供应商同步时覆盖已有子供应商元数据、导致用量查询等配置丢失的问题。

同步流程会生成新的子供应商对象，但此前仅合并 `settings_config`，随后 `save_provider` 会将生成对象的 `meta` 写入数据库。当统一供应商没有元数据时，已有的用量脚本及应用专属开关会被清空。

- 对已有 Claude、Codex、Gemini 子供应商保留 `meta`、`created_at` 和 `sort_index`。
- 名称、地址、密钥、模型、官网及备注等统一供应商管理的字段仍按原逻辑更新。
- 首次创建子供应商仍继承统一供应商的初始元数据。
- 不改动数据库层、禁用应用时的删除逻辑或当前供应商的 Live 重投影流程。

## Related Issue / 关联 Issue

Fixes #7134

## Verification / 验证

基于上游 main / v3.20.2 (`f3b18df`)，Windows 本地隔离测试。

新增回归测试覆盖三个应用：首次创建继承元数据；设置独立用量脚本、专用凭据、查询间隔、通用配置开关及排序后，分别在父供应商元数据缺失和存在时重复同步，检查这些配置与自定义端点保留，并确认共享字段与模型配置仍更新。

- 修复前：新增测试失败，Claude 子供应商元数据变为 `{}`。
- 修复后：新增回归测试和原有当前供应商 Live 重投影测试通过。
- `cargo test --manifest-path src-tauri/Cargo.toml --lib services::provider::tests -- --test-threads=1`：66 passed。
- `cargo test --manifest-path src-tauri/Cargo.toml --test provider_commands -- --test-threads=1`：10 passed。
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`：通过。
- `git diff --check`：通过。

未执行已安装桌面应用的 UI 测试。

## Screenshots / 截图

不适用，仅后端及测试变更。

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes — 未运行，无 TypeScript 变更。
- [ ] `pnpm format:check` passes — 未运行；Rust 格式检查通过。
- [ ] `cargo clippy` passes — 未运行。
- [x] 无需更新 i18n：未修改用户界面文案。
