### PR TITLE
fix(macOS): request local network permission for LAN APIs

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -14,6 +14,9 @@
       </array>
     </dict>
   </array>
+
+  <!-- macOS local-network privacy prompt for LAN API endpoints -->
+  <key>NSLocalNetworkUsageDescription</key>
+  <string>CC Switch needs access to your local network to connect to local API endpoints.</string>
 </dict>
 </plist>
-


### PR DESCRIPTION
## Summary / 概述

Add `NSLocalNetworkUsageDescription` to the macOS `Info.plist` so CC Switch can request Local Network permission before connecting to API endpoints on the LAN.

Without this usage description, macOS can block connections to private-network endpoints and CC Switch only surfaces a generic connection failure.

## Related Issue / 关联 Issue

Fixes #7109

## Changes / 修改

- add the macOS Local Network privacy usage description
- keep the change limited to packaging metadata; no proxy or request-routing behavior is changed

## Verification / 验证

- diff is limited to `src-tauri/Info.plist`
- plist remains well-formed XML
- expected macOS behavior: accessing a LAN endpoint can trigger the system Local Network permission prompt instead of being blocked without an authorization path

## Screenshots / 截图

Not applicable; this is a macOS permission metadata change.