### PR TITLE
fix(proxy): skip empty reasoning_content placeholders in Anthropic SSE streaming

### DIFF
--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -266,8 +266,16 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                             has_sent_message_start = true;
                                         }
 
-                                        // 处理 reasoning（thinking）
-                                        if let Some(reasoning) = &choice.delta.reasoning {
+                                        // 处理 reasoning（thinking）。DeepSeek/Qwen 系上游可能每个 chunk
+                                        // 都带空串占位的 reasoning_content，空串必须跳过，否则会反复关闭
+                                        // text block 并新开空 thinking block；与下方 content 分支及非流式
+                                        // transform.rs 的 is_empty 过滤保持一致。
+                                        if let Some(reasoning) = choice
+                                            .delta
+                                            .reasoning
+                                            .as_ref()
+                                            .filter(|s| !s.is_empty())
+                                        {
                                             if current_non_tool_block_type != Some("thinking") {
                                                 if let Some(index) = current_non_tool_block_index.take() {
                                                     let event = json!({
@@ -1244,5 +1252,61 @@ mod tests {
         assert!(!events
             .iter()
             .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_skips_empty_reasoning_content_placeholder_chunks() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_empty_reasoning\",\"model\":\"deepseek-v4-pro\",\"choices\":[{\"delta\":{\"role\":\"assistant\",\"reasoning_content\":\"\",\"content\":\"\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_empty_reasoning\",\"model\":\"deepseek-v4-pro\",\"choices\":[{\"delta\":{\"reasoning_content\":\"think a\",\"content\":\"\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_empty_reasoning\",\"model\":\"deepseek-v4-pro\",\"choices\":[{\"delta\":{\"reasoning_content\":\"think b\",\"content\":\"\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_empty_reasoning\",\"model\":\"deepseek-v4-pro\",\"choices\":[{\"delta\":{\"reasoning_content\":\"\",\"content\":\"ans\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_empty_reasoning\",\"model\":\"deepseek-v4-pro\",\"choices\":[{\"delta\":{\"reasoning_content\":\"\",\"content\":\"wer\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_empty_reasoning\",\"model\":\"deepseek-v4-pro\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":4}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+
+        let block_starts: Vec<(Option<u64>, &str)> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_start"))
+            .map(|event| {
+                (
+                    event.get("index").and_then(|v| v.as_u64()),
+                    event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            block_starts,
+            vec![(Some(0), "thinking"), (Some(1), "text")],
+            "empty reasoning_content placeholder chunks must not churn content blocks"
+        );
+
+        let collect_deltas = |delta_type: &str, field: &str| -> String {
+            events
+                .iter()
+                .filter(|event| {
+                    event_type(event) == Some("content_block_delta")
+                        && event.pointer("/delta/type").and_then(|v| v.as_str()) == Some(delta_type)
+                })
+                .map(|event| {
+                    event
+                        .pointer(field)
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string()
+                })
+                .collect()
+        };
+        assert_eq!(
+            collect_deltas("thinking_delta", "/delta/thinking"),
+            "think athink b"
+        );
+        assert_eq!(collect_deltas("text_delta", "/delta/text"), "answer");
     }
 }


### PR DESCRIPTION
## Summary / 概述

修复 OpenAI Chat Completions → Anthropic Messages 流式转换中，上游 chunk 携带**空串占位**的 `reasoning_content` 时，转换器每个 chunk 都关闭 text block 并新开一个空 thinking block 的问题。

Fix streaming conversion churn: upstreams that send empty-string `reasoning_content` placeholder fields in every chunk caused the converter to close/reopen content blocks on every chunk, flooding the Anthropic SSE stream with empty thinking blocks.

### 背景 / Background

部分 DeepSeek / Qwen 系兼容上游在**每个**流式 chunk 里同时携带 `reasoning_content` 和 `content` 两个字段，不活跃的那个填空串而非省略（实测某 LiteLLM 网关后的 deepseek 模型）：

```json
{"delta": {"reasoning_content": "思考中", "content": ""}}
{"delta": {"reasoning_content": "", "content": "回答"}}
```

`streaming.rs` 的 reasoning 分支只判断了字段存在性（`Some("")` 也会命中），而 content 分支有 `is_empty` 过滤。于是每个 content chunk 都会触发：**关 text block → 开空 thinking block → 发空 thinking_delta → 关 thinking block → 再开 text block**。

在 Claude Code 中的实际症状（deepseek 模型，格式路由开启）：

- 一次回复产生数百个交替的 `content_block_start/stop` 事件
- transcript JSONL 按 content block 逐条落盘，单条回复膨胀成数百条碎片 assistant 记录（实测 `apiBlockIndex` 超过 500），每条重复完整 usage，且夹带大量 `{"type":"thinking","thinking":"","signature":""}` 空块
- 污染会话历史，影响 resume / compact，浪费存储与 token 估算

### 修复 / Fix

一行过滤，与代码库既有模式对齐：

- 同文件下方 content 分支：`if !content.is_empty()`
- 非流式 `transform.rs::openai_to_anthropic`：`if !reasoning_content.is_empty()`

新增回归测试 `test_streaming_skips_empty_reasoning_content_placeholder_chunks`，输入为真实上游 chunk 形态，断言整条流只产生 1 个 thinking block + 1 个 text block，且无空 thinking_delta。

## Related Issue / 关联 Issue

N/A

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| 每 chunk 交替产生空 thinking 块与 text 块（单次回复数百个 content_block 事件，transcript 碎片化） | `message_start → thinking block(12 deltas) → text block → message_delta → message_stop`，结构标准 |

实测事件统计（经代理端到端，DeepSeek 模型流式，修复前后对比）：

```
修复前: content_block_start × N（N ≈ chunk 数，thinking/text 交替，空 thinking_delta 大量出现）
修复后: 1 个 thinking 块 + 1 个 text 块，空 thinking_delta = 0
```

## Checklist / 检查清单

- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（`--lib --all-features -- -D warnings` 零告警）
- [x] `cargo test proxy::providers::streaming` passes / 流式转换测试全部通过（159/159，含新增回归测试）
- [ ] `pnpm typecheck` / `pnpm format:check` — 不涉及前端改动 / not applicable (Rust only)
- [x] 未修改用户可见文本，无需更新 i18n / no user-facing text changes
