### PR TITLE
fix(settings): localize tool-probe error display in About section

### DIFF
--- a/src/components/settings/AboutSection.tsx
+++ b/src/components/settings/AboutSection.tsx
@@ -647,7 +647,9 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
             // 命令退出码为 0、但刷新后仍探不到版本：多半是"装上了却跑不起来"
             // （如 openclaw 要求更高的 Node 版本）。refreshToolVersions 的 merge 已把
             // version 置空并写入后端 error，这里只需归类为软失败并展示原因。
-            const detail = tool?.error?.trim() || t("settings.toolNotRunnable");
+            const detail = tool?.installed_but_broken
+              ? tool?.error?.trim() || t("settings.toolNotRunnable")
+              : t("common.notInstalled");
             failures.push({
               toolName,
               detail,
@@ -1078,7 +1080,11 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
                     ? "update"
                     : null;
             const runningAction = toolActions[toolName];
-            const title = tool?.version || tool?.error || t("common.unknown");
+            const title =
+              tool?.version ||
+              (installedButBroken
+                ? tool?.error || t("settings.installedNotRunnable")
+                : t("common.notInstalled"));
             const conflicts = toolDiagnostics[toolName];
 
             return (
@@ -1151,11 +1157,13 @@ export function AboutSection({ isPortable }: AboutSectionProps) {
                         : tool?.latest_version || t("common.unknown")}
                     </span>
                   </div>
-                  {!isToolVersionLoading && !tool?.version && tool?.error && (
-                    <div className="truncate text-[11px] text-muted-foreground">
-                      {tool.error}
-                    </div>
-                  )}
+                  {!isToolVersionLoading &&
+                    installedButBroken &&
+                    tool?.error && (
+                      <div className="truncate text-[11px] text-muted-foreground">
+                        {tool.error}
+                      </div>
+                    )}
                 </div>
 
                 {tool?.env_type === "wsl" && (


### PR DESCRIPTION
## Summary / 概述

「关于」页的工具卡片和安装失败 toast 会把后端返回的原始英文探测错误
（"not installed or not executable"）直接渲染给用户，共三处：
1. 悬停「当前版本」值的 tooltip
2. 版本行下方的错误详情行
3. 安装/升级后仍探测不到版本时的 toast 描述

其他地方都走了 i18n 文案，但是这三个地方绕过了。导致原来的 i18n 文案没有用上。

## Related Issue / 关联 Issue

无

## Screenshots / 截图

修改前：

<img width="1399" height="986" alt="image" src="https://github.com/user-attachments/assets/d179c737-d2a8-4ab9-86fc-cce06ecb4859" />


修改后：

<img width="1406" height="980" alt="edited" src="https://github.com/user-attachments/assets/cea71d6f-630d-4d63-bc61-eb8b27ee65ec" />

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
