### PR TITLE
fix(ui): align Alert icon with first text line via grid layout

### DIFF
--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
+  "relative grid w-full rounded-lg border px-4 py-3 text-sm [&>svg]:-mt-px [&>svg]:text-foreground [&>svg:has(+div)]:mt-0.5 [&:has(>svg)]:grid-cols-[auto_minmax(0,1fr)] [&:has(>svg)]:gap-x-3",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary / 概述

将 Alert 的图标和文字对齐，原来的样式图标明显矮于文字。

在diff，使用grid样式，同时 icon 的 margin-top 设定为 2，这样图案和第一行文字的中心线都在 10px 距离处。

## Related Issue / 关联 Issue

无

## Screenshots / 截图


修改前：

<img width="1262" height="786" alt="before-1" src="https://github.com/user-attachments/assets/251dec46-03b3-4ab7-8c24-b41d02e35799" />

<img width="1267" height="788" alt="before-2" src="https://github.com/user-attachments/assets/36f7cd0e-564d-4f9c-80f5-9e0c101722ea" />

修改后：
<img width="1396" height="788" alt="image" src="https://github.com/user-attachments/assets/bd6c8c7f-b791-4d6d-b713-7176c251c386" />

<img width="1462" height="903" alt="image" src="https://github.com/user-attachments/assets/f3aae3bb-3e88-4b3c-ad96-23548bb276db" />




## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [ ] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [ ] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
