### PR TITLE
fix(proxy): skip empty reasoning_content placeholders in Anthropic SSE streaming

### DIFF
--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -267,7 +267,17 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                         }
 
                                         // 处理 reasoning（thinking）
-                                        if let Some(reasoning) = &choice.delta.reasoning {
+                                        // 某些上游始终填充 reasoning_content，输出正文时也带上空字符串。空值会匹配
+                                        // Some("") 进入本分支，与下方 content 分支轮流改写 current_non_tool_block_type，
+                                        // 导致单个 chunk 内 text/thinking 块被反复关闭重开，正文碎片化。
+                                        // 非流式路径 openai_to_anthropic 已对 reasoning_content 做同样的空值过滤，
+                                        // 此处与之保持一致（也与下方 content 分支的 !content.is_empty() 对称）。
+                                        if let Some(reasoning) = choice
+                                            .delta
+                                            .reasoning
+                                            .as_ref()
+                                            .filter(|r| !r.is_empty())
+                                        {
                                             if current_non_tool_block_type != Some("thinking") {
                                                 if let Some(index) = current_non_tool_block_index.take() {
                                                     let event = json!({
@@ -746,6 +756,24 @@ mod tests {
 
     fn event_type(event: &Value) -> Option<&str> {
         event.get("type").and_then(|v| v.as_str())
+    }
+
+    /// 收集某一类 content_block_delta 的文本字段并拼接，用于断言流式增量的最终内容。
+    fn collect_delta_text(events: &[Value], delta_type: &str, field: &str) -> String {
+        events
+            .iter()
+            .filter(|event| {
+                event_type(event) == Some("content_block_delta")
+                    && event.pointer("/delta/type").and_then(|v| v.as_str()) == Some(delta_type)
+            })
+            .map(|event| {
+                event
+                    .pointer(field)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string()
+            })
+            .collect()
     }
 
     #[test]
@@ -1244,5 +1272,99 @@ mod tests {
         assert!(!events
             .iter()
             .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
+    }
+
+    #[tokio::test]
+    async fn test_empty_reasoning_alongside_content_does_not_fragment_blocks() {
+        // 回归：某些上游输出正文时仍会填充 reasoning_content 字段（值为空字符串）。
+        // 修复前 reasoning 分支无空值保护，空字符串会进入分支并与 content 分支轮流
+        // 改写 current_non_tool_block_type，使 text/thinking 块被反复关闭重开，正文
+        // 被切成多个碎片且夹带空 thinking 块。修复后应只有一个 text 块，且不产生
+        // 任何 thinking 块。
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_frag\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"某个历史\",\"reasoning_content\":\"\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_frag\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"？\",\"reasoning_content\":\"\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_frag\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+
+        // 锁死块的 index、类型与顺序：整条流只应有一个 text 块，位于 index 0。
+        let block_starts: Vec<(Option<u64>, &str)> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_start"))
+            .map(|event| {
+                (
+                    event.get("index").and_then(|v| v.as_u64()),
+                    event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            block_starts,
+            vec![(Some(0), "text")],
+            "empty reasoning_content must not open any thinking block, and all content \
+             chunks must append to a single text block"
+        );
+
+        // 不应产生任何 thinking_delta（包括空的）
+        let thinking: String = collect_delta_text(&events, "thinking_delta", "/delta/thinking");
+        assert!(
+            thinking.is_empty(),
+            "no thinking_delta should be emitted, got: {:?}",
+            thinking
+        );
+
+        // 所有 text_delta 应落在同一个块上，拼接后是完整句子
+        assert_eq!(
+            collect_delta_text(&events, "text_delta", "/delta/text"),
+            "某个历史？"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_non_empty_reasoning_still_creates_thinking_block() {
+        // 保护性测试：确保上面的修复没有误伤——真正带内容的 reasoning 仍应产出
+        // thinking 块。断言同时锁死块的 index、类型、顺序与 thinking 内容。
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_think\",\"model\":\"glm-5.1\",\"choices\":[{\"delta\":{\"reasoning_content\":\"让我想想\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_think\",\"model\":\"glm-5.1\",\"choices\":[{\"delta\":{\"content\":\"答案是 42\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_think\",\"model\":\"glm-5.1\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+
+        let block_starts: Vec<(Option<u64>, &str)> = events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_start"))
+            .map(|event| {
+                (
+                    event.get("index").and_then(|v| v.as_u64()),
+                    event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            block_starts,
+            vec![(Some(0), "thinking"), (Some(1), "text")],
+            "real reasoning must yield exactly one thinking block followed by one text block"
+        );
+
+        assert_eq!(
+            collect_delta_text(&events, "thinking_delta", "/delta/thinking"),
+            "让我想想"
+        );
+        assert_eq!(
+            collect_delta_text(&events, "text_delta", "/delta/text"),
+            "答案是 42"
+        );
     }
 }


### PR DESCRIPTION
## Summary / 概述

修复 OpenAI Chat Completions → Anthropic Messages 流式转换中，上游 chunk 携带**空串占位** `reasoning_content` 时，转换器每个 chunk 都关闭 text block 并新开一个空 thinking block 的问题。

Fixes streaming block churn: upstreams that send an empty-string `reasoning_content` placeholder in every chunk caused the converter to close and reopen content blocks on every chunk, flooding the Anthropic SSE stream with empty `thinking` blocks.

### Symptom / 现象

With a Chat Completions provider routed through the local proxy into Claude Code, the session JSONL shows:

使用 Chat Completions 供应商经本地路由接入 Claude Code 时，会话 JSONL 呈现：

```jsonc
// apiBlockIndex 511
"content": [{"type":"text","text":"某个历史"}]
// apiBlockIndex 512
"content": [{"type":"thinking","thinking":"","signature":""}]
// apiBlockIndex 519
"content": [{"type":"text","text":"？"}]
// apiBlockIndex 520
"content": [{"type":"thinking","thinking":"","signature":""}]
```

Three things stand out / 三个异常特征:

- `apiBlockIndex` reaches **520** for a reply with `output_tokens: 1226` — roughly two blocks per token-chunk / 单条回复的块编号涨到 520，约为每个 token chunk 两个块
- `text` and `thinking` blocks **strictly alternate** / text 与 thinking 块严格交替
- Every `thinking` block is **empty** / 每个 thinking 块都是空的

Claude Code renders this as fragmented output, and the blocks are written into the session JSONL, so they accumulate across the conversation.

They are *not* replayed upstream, though — at least not through `transform.rs`: `convert_message_to_openai` there skips `thinking` blocks whose text is empty (called from `anthropic_to_openai`), and `signature` appears nowhere in that file, since the upstream speaks OpenAI format. I have only verified that one file, not the whole request path. The observable damage is rendering breakage and transcript bloat.

畸形块不会回传上游（至少 `transform.rs` 这一层不会）：该文件的 `convert_message_to_openai` 会跳过文本为空的 `thinking` 块，且 `signature` 在该文件中零出现——上游说的是 OpenAI 格式，没有这个字段。我只核实了这一个文件，未验证整条请求路径。可观察到的损害是渲染错乱与转录膨胀。

### Root cause / 根因

`src-tauri/src/proxy/providers/streaming.rs`, `create_anthropic_sse_stream`.

The converter is stateful — it tracks which content block is currently open / 转换器是有状态的，跟踪当前打开的 content block:

```rust
let mut current_non_tool_block_type: Option<&'static str> = None;  // None / "thinking" / "text"
let mut current_non_tool_block_index: Option<u32> = None;
```

Both branches use the same "close the old block, open a new one" rule, and **both run sequentially within a single chunk** — reasoning first, content second / 两个分支共用同一套「关旧块、开新块」规则，且在同一个 chunk 内顺序执行——reasoning 在前，content 在后:

| Branch / 分支 | Guard / 守卫 | Block-switch condition / 换块条件 |
|---|---|---|
| reasoning | `if let Some(reasoning) = &choice.delta.reasoning` — **no empty check / 无空值检查** | `current_non_tool_block_type != Some("thinking")` |
| content | `if let Some(content) = ... { if !content.is_empty() {` | `current_non_tool_block_type != Some("text")` |

Given an upstream chunk of the form / 给定这样一个上游 chunk:

```json
{"delta": {"content": "某个历史", "reasoning_content": ""}}
```

the state variable flips **twice** in one pass / 状态变量在单次遍历中翻转**两次**:

```
① reasoning branch / reasoning 分支
   Some("") is not None → branch entered (no empty guard) / 非 None，进入分支（无空值守卫）
   current type is "text" (left over from previous chunk) ≠ "thinking"
   → content_block_stop   (close text)
   → content_block_start  (open thinking)
   → content_block_delta  thinking_delta ""   ← empty / 空
   state := "thinking"

② content branch / content 分支
   "某个历史" is non-empty → branch entered / 非空，进入分支
   current type is "thinking" (just set by ①) ≠ "text"
   → content_block_stop   (close thinking)
   → content_block_start  (open text)
   → content_block_delta  text_delta "某个历史"
   state := "text"
```

One chunk → two state flips → **6 SSE events and 2 block indices consumed**. The next chunk repeats it exactly / 单个 chunk 消耗 6 个 SSE 事件与 2 个块编号，下一个 chunk 完全重演:

```
N text chunks  →  2N content blocks   (N of them pure garbage / 其中 N 个是纯垃圾)
```

The mechanism: `current_non_tool_block_type` is shared by both branches, and each branch treats whatever the other one left behind as a stale block that must be closed. An empty reasoning string is enough to enter the reasoning branch and trip that condition, so every text chunk pays for a thinking block it never needed.

机理在于 `current_non_tool_block_type` 被两个分支共享，各自把对方留下的块当成过期状态而关闭。一个空串就足以进入 reasoning 分支并触发换块，于是每个正文 chunk 都要为一个它根本不需要的 thinking 块付代价。

**Why the empty `thinking` blocks are conclusive / 为什么空 thinking 块是决定性证据**

The converter can only emit an *empty* thinking block when `reasoning == Some("")` / 转换器只有在 `reasoning == Some("")` 时才可能产出*空* thinking 块:

- `reasoning` is `null` → `if let Some(...)` doesn't match, branch skipped, no block opened / 不匹配，跳过分支，不开块
- `reasoning` is non-empty → block opened, but it carries content / 开块，但带有内容

So the presence of empty thinking blocks in the transcript proves the upstream is sending `reasoning_content: ""`. The strict text/thinking alternation is the fingerprint of the double flip described above.

因此转录中出现空 thinking 块，即证明上游在发送 `reasoning_content: ""`；严格的 text/thinking 交替则是上述双重翻转的指纹。

### Fix / 修复

Filter empty reasoning **before** entering the branch. This makes the streaming path consistent with `openai_to_anthropic`, and symmetric with the content branch's own `!content.is_empty()` guard / 在进入分支**之前**过滤空 reasoning，使流式路径与非流式的 `openai_to_anthropic` 一致，也与 content 分支自身的守卫对称:

```rust
if let Some(reasoning) = choice
    .delta
    .reasoning
    .as_ref()
    .filter(|r| !r.is_empty())
{
```

The non-streaming converter already had this guard — `openai_to_anthropic` in `transform.rs` checks `!reasoning_content.is_empty()` before emitting a thinking block. The streaming path was the only one missing it.

非流式转换器早已有此守卫——`transform.rs` 的 `openai_to_anthropic` 在产出 thinking 块前会检查 `!reasoning_content.is_empty()`。流式路径是唯一漏掉的一处。

With empty reasoning filtered out, `if let` doesn't match → the reasoning branch is skipped entirely → `current_non_tool_block_type` is left alone → the content branch sees it still equal to `"text"`, its condition is false, and it emits a plain `text_delta` on the existing block.

过滤掉空 reasoning 后，`if let` 不匹配 → reasoning 分支整体跳过 → `current_non_tool_block_type` 不被改动 → content 分支看到它仍是 `"text"`，条件为假，于是在既有块上发出普通 `text_delta`。

Result / 结果: `N` chunks aggregate into **1 text block + N deltas**, the shape the Anthropic protocol expects / N 个 chunk 汇聚为 1 个 text 块 + N 个 delta，即 Anthropic 协议要求的形状。

### Tests / 测试

Two regression tests added / 新增两个回归测试:

**`test_empty_reasoning_alongside_content_does_not_fragment_blocks`** — reproduces the reported stream (each chunk carries `reasoning_content: ""` plus real text) and asserts / 复现所报告的流形态（每个 chunk 都带空串 `reasoning_content` 与真实正文），断言:

- exactly one block is created: `vec![(Some(0), "text")]` / 只产生一个块
- no `thinking_delta` is emitted at all, not even an empty one / 完全不产出 thinking_delta，空的也不产出
- the concatenated `text_delta`s equal the original sentence (`"某个历史？"`) / 拼接后的文本等于原句

**`test_non_empty_reasoning_still_creates_thinking_block`** — guards against over-correction: genuine reasoning content must still produce exactly one `thinking` block (index 0) followed by one `text` block (index 1), with both deltas' text matching the input / 防止矫枉过正：真实 reasoning 仍须产出恰好一个 thinking 块（index 0）后接一个 text 块（index 1），且两者 delta 文本与输入一致。

Both tests pin block `index`, type and order via `assert_eq!` on the collected `content_block_start` list, so a regression that reorders, duplicates or fragments blocks fails. A shared `collect_delta_text` helper concatenates the deltas of a given type.

两个测试都用 `assert_eq!` 对收集到的 `content_block_start` 列表锁死块的 `index`、类型与顺序，因此任何导致重排、重复或碎片化的回归都会失败；并抽出共用的 `collect_delta_text` 辅助函数拼接指定类型的 delta。

Verified locally against upstream `main` at `f3b18df` (v3.20.2) / 已在上游 main `f3b18df`（v3.20.2）上本地验证:

```
cargo test --lib proxy::providers::streaming   → 160 passed, 0 failed   (baseline 158 / 基线 158)
cargo clippy --lib --all-features -- -D warnings → no warnings / 零告警
cargo fmt --check                                → clean / 通过
```

## Related Issue / 关联 Issue

Not using `Fixes #` deliberately — see below / 有意不使用 `Fixes #`，原因见下。

#3092 and #4785 both report OpenAI Chat streaming being split into multiple Claude assistant messages. #4785 was closed as a duplicate of #3092, with the note that it should be reopened if the SSE shape differs.

#3092 与 #4785 都报告了 OpenAI Chat 流式响应被拆成多条 Claude assistant message。#4785 已作为 #3092 的重复被关闭，并注明若 SSE 形态不同可重新打开。

The symptom in #4785 — `"Hey!"` / `" That"` / `"'s a"` each becoming its own block under a single `chatcmpl-*` id — matches the fragmentation this PR fixes. I have not confirmed the two share a root cause: that report shows only `text` blocks, and I don't know whether its upstream was sending `reasoning_content: ""`.

#4785 的现象（同一 `chatcmpl-*` id 下 `"Hey!"` / `" That"` / `"'s a"` 各自成块）与本 PR 修复的碎片化一致。但我**未确认**二者同源：那份报告只出现 `text` 块，我无法判断其上游是否在发送 `reasoning_content: ""`。

Two other open PRs apply the same fix to the same file: #4869 (2026-07-01, @AdJIa) and #6421 (2026-08-13, @U1traTC). Both guard with a nested `if !reasoning.is_empty()`, and #4869 also carries a regression test; this one filters in the `if let` binding instead. Three PRs on one bug is two too many — happy to close this in favour of whichever the maintainers prefer, or to rebase onto it.

另有两个 OPEN PR 对同一文件施加了同样的修复：#4869（2026-07-01，@AdJIa）与 #6421（2026-08-13，@U1traTC）。两者都用嵌套的 `if !reasoning.is_empty()` 守卫，其中 #4869 同样带有回归测试；本 PR 改为在 `if let` 绑定处过滤。同一个 bug 上出现三个 PR 已经多了两个——维护者若倾向其中任一个，我可以关闭本 PR，或改为 rebase 到该分支上。

## Screenshots / 截图

No UI change. Before/after evidence is the emitted SSE event sequence, measured on the same input / 无界面改动。前后对比证据为同一输入下产出的 SSE 事件序列:

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| `content_block_start` count ≈ chunk count; `text` / `thinking` strictly alternating; every `thinking` block empty (`apiBlockIndex` exceeded 500 on one reply) / 块数约等于 chunk 数，text 与 thinking 严格交替，thinking 块全空（单条回复块编号超过 500） | `message_start` → 1 × `thinking` block → 1 × `text` block → `message_delta` → `message_stop`; zero empty `thinking_delta` / 结构标准，零空 thinking_delta |

Unit-test assertions, both passing / 单元测试断言（均通过）:

```
// empty placeholder + text
assert_eq!(block_starts, vec![(Some(0), "text")]);

// real reasoning + text
assert_eq!(block_starts, vec![(Some(0), "thinking"), (Some(1), "text")]);
```

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes / 通过 TypeScript 类型检查 — **N/A**, Rust only / 仅 Rust 改动
- [ ] `pnpm format:check` passes / 通过代码格式检查 — **N/A**, Rust only / 仅 Rust 改动
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码） — `--lib --all-features -- -D warnings`, zero warnings / 零告警
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件 — no user-facing text changed / 未修改用户可见文本

Additionally verified / 另外验证:

- [x] `cargo test --lib proxy::providers::streaming` — 160 passed, 0 failed
- [x] `cargo fmt --check` — clean
