### PR TITLE
feat(dsh): add DeepSeek Harness as an AppType target

### DIFF
--- a/src-tauri/src/app_config.rs
+++ b/src-tauri/src/app_config.rs
@@ -32,7 +32,8 @@ impl McpApps {
             AppType::OpenCode => self.opencode,
             AppType::OpenClaw => false, // OpenClaw doesn't support MCP
             AppType::Hermes => self.hermes,
-            AppType::Pi => false, // Pi core has no native MCP registry.
+            AppType::Dsh => false, // DSH mounts MCP via profile cordis patches; no native config-file sync yet.
+            AppType::Pi => false,  // Pi core has no native MCP registry.
             AppType::ClaudeDesktop => false,
         }
     }
@@ -47,7 +48,8 @@ impl McpApps {
             AppType::OpenCode => self.opencode = enabled,
             AppType::OpenClaw => {} // OpenClaw doesn't support MCP, ignore
             AppType::Hermes => self.hermes = enabled,
-            AppType::Pi => {}            // Pi core has no native MCP registry.
+            AppType::Dsh => {} // DSH mounts MCP via profile cordis patches; no native sync yet.
+            AppType::Pi => {}  // Pi core has no native MCP registry.
             AppType::ClaudeDesktop => {} // Claude Desktop 3P provider config doesn't support MCP here
         }
     }
@@ -116,6 +118,7 @@ impl SkillApps {
             AppType::GrokBuild => self.grokbuild,
             AppType::OpenCode => self.opencode,
             AppType::Hermes => self.hermes,
+            AppType::Dsh => false, // DSH skills are package-managed (dsh-architect-skills); no file sync.
             AppType::Pi => self.pi,
             AppType::OpenClaw => false, // OpenClaw doesn't support Skills
             AppType::ClaudeDesktop => false,
@@ -131,6 +134,7 @@ impl SkillApps {
             AppType::GrokBuild => self.grokbuild = enabled,
             AppType::OpenCode => self.opencode = enabled,
             AppType::Hermes => self.hermes = enabled,
+            AppType::Dsh => {} // DSH skills are package-managed; no file sync.
             AppType::Pi => self.pi = enabled,
             AppType::OpenClaw => {} // OpenClaw doesn't support Skills, ignore
             AppType::ClaudeDesktop => {} // Claude Desktop 3P profiles don't use CC Switch skill sync
@@ -391,6 +395,7 @@ pub enum AppType {
     OpenCode,
     OpenClaw,
     Hermes,
+    Dsh,
     Pi,
 }
 
@@ -405,6 +410,7 @@ impl AppType {
             AppType::OpenCode => "opencode",
             AppType::OpenClaw => "openclaw",
             AppType::Hermes => "hermes",
+            AppType::Dsh => "dsh",
             AppType::Pi => "pi",
         }
     }
@@ -413,11 +419,11 @@ impl AppType {
     ///
     /// - Switch mode (false): Only the current provider is written to live config (Claude, Codex, Gemini)
     /// - Additive mode (true): Providers coexist in native config and can be enabled independently
-    ///   (OpenCode, OpenClaw, Hermes, Pi)
+    ///   (OpenCode, OpenClaw, Hermes, DSH, Pi)
     pub fn is_additive_mode(&self) -> bool {
         matches!(
             self,
-            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Pi
+            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Dsh | AppType::Pi
         )
     }
 
@@ -439,6 +445,7 @@ impl AppType {
             AppType::OpenCode,
             AppType::OpenClaw,
             AppType::Hermes,
+            AppType::Dsh,
             AppType::Pi,
         ]
         .into_iter()
@@ -459,11 +466,12 @@ impl FromStr for AppType {
             "opencode" => Ok(AppType::OpenCode),
             "openclaw" => Ok(AppType::OpenClaw),
             "hermes" => Ok(AppType::Hermes),
+            "dsh" | "deepseek-harness" | "deepseek_harness" => Ok(AppType::Dsh),
             "pi" => Ok(AppType::Pi),
             other => Err(AppError::localized(
                 "unsupported_app",
-                format!("不支持的应用标识: '{other}'。可选值: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, pi。"),
-                format!("Unsupported app id: '{other}'. Allowed: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, pi."),
+                format!("不支持的应用标识: '{other}'。可选值: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, dsh, pi。"),
+                format!("Unsupported app id: '{other}'. Allowed: claude, claude-desktop, codex, gemini, grokbuild, opencode, openclaw, hermes, dsh, pi."),
             )),
         }
     }
@@ -503,6 +511,7 @@ impl CommonConfigSnippets {
             AppType::OpenCode => self.opencode.as_ref(),
             AppType::OpenClaw => self.openclaw.as_ref(),
             AppType::Hermes => self.hermes.as_ref(),
+            AppType::Dsh => None, // DSH has no per-app common-config snippet surface yet.
             AppType::Pi => None,
         }
     }
@@ -518,6 +527,7 @@ impl CommonConfigSnippets {
             AppType::OpenCode => self.opencode = snippet,
             AppType::OpenClaw => self.openclaw = snippet,
             AppType::Hermes => self.hermes = snippet,
+            AppType::Dsh => {} // DSH has no per-app common-config snippet surface yet.
             AppType::Pi => {}
         }
     }
@@ -842,6 +852,9 @@ impl MultiAppConfig {
             AppType::OpenCode => &mut config.prompts.opencode.prompts,
             AppType::OpenClaw => &mut config.prompts.openclaw.prompts,
             AppType::Hermes => &mut config.prompts.hermes.prompts,
+            // DSH prompts target ~/.dsh/AGENTS.md; auto-import is disabled
+            // until the portable kernel (P1) defines its content contract.
+            AppType::Dsh => return Ok(false),
             // Pi was added after prompts moved to SQLite. Keeping it out of
             // this legacy config avoids a second, unused prompt state.
             AppType::Pi => return Ok(false),
@@ -888,6 +901,7 @@ impl MultiAppConfig {
                 AppType::OpenCode => &self.mcp.opencode.servers,
                 AppType::OpenClaw => continue, // OpenClaw MCP is still in development, skip
                 AppType::Hermes => continue,   // Hermes didn't exist in v3.6.x, skip
+                AppType::Dsh => continue,      // DSH didn't exist in v3.6.x, skip
                 AppType::Pi => continue,       // Pi didn't exist in v3.6.x, skip
             };
 

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -135,6 +135,15 @@ pub async fn get_config_status(
 
             Ok(ConfigStatus { exists, path })
         }
+        AppType::Dsh => {
+            let config_path = crate::dsh_config::get_dsh_settings_path();
+            let exists = config_path.exists();
+            let path = crate::dsh_config::get_dsh_dir()
+                .to_string_lossy()
+                .to_string();
+
+            Ok(ConfigStatus { exists, path })
+        }
         AppType::Pi => {
             let config_path = crate::pi_config::get_pi_models_path().map_err(|e| e.to_string())?;
             let path = crate::pi_config::get_pi_agent_dir()
@@ -167,6 +176,7 @@ pub async fn get_config_dir(app: String) -> Result<String, String> {
         AppType::OpenCode => crate::opencode_config::get_opencode_dir(),
         AppType::OpenClaw => crate::openclaw_config::get_openclaw_dir(),
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
+        AppType::Dsh => crate::dsh_config::get_dsh_dir(),
         AppType::Pi => crate::pi_config::get_pi_agent_dir().map_err(|e| e.to_string())?,
     };
 
@@ -186,6 +196,7 @@ pub async fn open_config_folder(handle: AppHandle, app: String) -> Result<bool, 
         AppType::OpenCode => crate::opencode_config::get_opencode_dir(),
         AppType::OpenClaw => crate::openclaw_config::get_openclaw_dir(),
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
+        AppType::Dsh => crate::dsh_config::get_dsh_dir(),
         AppType::Pi => crate::pi_config::get_pi_agent_dir().map_err(|e| e.to_string())?,
     };
 

--- a/src-tauri/src/database/dao/mcp.rs
+++ b/src-tauri/src/database/dao/mcp.rs
@@ -91,7 +91,7 @@ impl Database {
             AppType::OpenCode => Some("enabled_opencode"),
             AppType::Hermes => Some("enabled_hermes"),
             // These applications intentionally have no MCP flag in the SSOT.
-            AppType::ClaudeDesktop | AppType::OpenClaw | AppType::Pi => None,
+            AppType::ClaudeDesktop | AppType::OpenClaw | AppType::Dsh | AppType::Pi => None,
         };
 
         if let Some(column) = column {

--- a/src-tauri/src/deeplink/provider.rs
+++ b/src-tauri/src/deeplink/provider.rs
@@ -152,6 +152,7 @@ pub(crate) fn build_provider_from_request(
         AppType::OpenCode => build_opencode_settings(request),
         AppType::OpenClaw => build_additive_app_settings(request),
         AppType::Hermes => build_hermes_settings(request),
+        AppType::Dsh => build_dsh_settings(request),
         AppType::Pi => {
             return Err(AppError::InvalidInput(
                 "Pi providers must be added from the Pi provider page".to_string(),
@@ -559,6 +560,44 @@ fn build_additive_app_settings(request: &DeepLinkImportRequest) -> serde_json::V
 /// protocol) and let the user adjust via the UI after import. We never rely
 /// on Hermes' built-in URL heuristics, which only recognize a handful of
 /// official endpoints.
+/// Build a DSH provider settings object from a deep link request.
+///
+/// DSH provider blocks use camelCase fields (`baseURL`, `apiKeyEnv`,
+/// `reasoningEfforts`) and resolve credentials per request through the
+/// environment. A deep link has no env-var name to reference, so the key
+/// (when present) is placed in `apiKey` for the user to migrate into an
+/// `apiKeyEnv` reference via the UI; cc-switch never writes that field to
+/// the live settings.yaml — `dsh_config::set_provider` consumers are
+/// expected to keep secrets behind references.
+fn build_dsh_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
+    let endpoint = get_primary_endpoint(request);
+
+    let mut config = serde_json::Map::new();
+
+    if let Some(name) = request.name.as_deref().filter(|s| !s.is_empty()) {
+        config.insert("displayName".to_string(), json!(name));
+    }
+
+    if !endpoint.is_empty() {
+        config.insert("baseURL".to_string(), json!(endpoint));
+    }
+
+    config.insert("api".to_string(), json!("openai-completions"));
+
+    if let Some(api_key) = &request.api_key {
+        config.insert("apiKey".to_string(), json!(api_key));
+    }
+
+    if let Some(model) = &request.model {
+        config.insert(
+            "models".to_string(),
+            json!([{ "id": model, "reasoningEfforts": { "off": null, "low": "low", "high": "high" } }]),
+        );
+    }
+
+    json!(config)
+}
+
 fn build_hermes_settings(request: &DeepLinkImportRequest) -> serde_json::Value {
     let endpoint = get_primary_endpoint(request);
 

--- a/src-tauri/src/dsh_config.rs
+++ b/src-tauri/src/dsh_config.rs
@@ -722,7 +722,11 @@ fn cleanup_dsh_backups(dir: &Path) -> Result<(), AppError> {
 /// 写入（upsert）一个 DSH provider 到指定 settings 文件。
 ///
 /// 区块级替换 + 备份 + 原子写；不触碰 `agent-default-model`。
-fn set_provider_at(path: &Path, id: &str, config: &JsonValue) -> Result<DshWriteOutcome, AppError> {
+pub fn set_provider_at(
+    path: &Path,
+    id: &str,
+    config: &JsonValue,
+) -> Result<DshWriteOutcome, AppError> {
     let _guard = dsh_write_lock()
         .lock()
         .map_err(|e| AppError::Config(format!("DSH write lock poisoned: {e}")))?;
@@ -779,7 +783,7 @@ pub fn set_provider(id: &str, config: JsonValue) -> Result<DshWriteOutcome, AppE
 }
 
 /// 从指定 settings 文件删除一个 DSH provider。
-fn remove_provider_at(path: &Path, id: &str) -> Result<DshWriteOutcome, AppError> {
+pub fn remove_provider_at(path: &Path, id: &str) -> Result<DshWriteOutcome, AppError> {
     let _guard = dsh_write_lock()
         .lock()
         .map_err(|e| AppError::Config(format!("DSH write lock poisoned: {e}")))?;
@@ -823,7 +827,7 @@ pub fn remove_provider(id: &str) -> Result<DshWriteOutcome, AppError> {
 /// 覆写顶层 `agent-default-model` 小节（切换当前路由）。
 ///
 /// 只重写该顶层小节，保留其余内容。
-fn set_default_model_at(
+pub fn set_default_model_at(
     path: &Path,
     default_model: &DshDefaultModel,
 ) -> Result<DshWriteOutcome, AppError> {

--- a/src-tauri/src/dsh_config.rs
+++ b/src-tauri/src/dsh_config.rs
@@ -1,0 +1,1130 @@
+//! DeepSeek Harness (DSH) 配置文件读写模块
+//!
+//! DeepSeek Harness (DSH) configuration read/write module.
+//!
+//! 处理 `~/.dsh/settings.yaml` 的读写操作（YAML 格式）。DSH 使用累加式
+//! 供应商管理：所有 provider profiles 共存于 `llm-pi-ai.providers.<id>`
+//! 之下，当前激活路由存于顶层 `agent-default-model` 小节。
+//!
+//! ## 配置结构示例
+//!
+//! ```yaml
+//! llm-pi-ai:
+//!   providers:
+//!     a6api-under-0.1-cny:
+//!       displayName: A6API ≤¥0.1
+//!       apiKeyEnv: A6API_UNDER_0_1_CNY_API_KEY
+//!       api: openai-completions
+//!       baseURL: https://api.a6api.com/v1
+//!       models:
+//!         - id: glm-5.3
+//!           reasoningEfforts:
+//!             off: null
+//!             low: low
+//!
+//! agent-default-model:
+//!   provider: a6api-under-0.1-cny
+//!   model: glm-5.3
+//!   reasoningEffort: low
+//! ```
+//!
+//! ## 写入策略
+//!
+//! 与 Hermes 模块一致，采用「区块级替换」而非整文件 serde 往返：
+//! - `agent-default-model` 是顶层小节，复用顶层小节定位/替换算法；
+//! - `llm-pi-ai.providers.<id>` 是嵌套块，使用本模块的嵌套块扫描器，
+//!   只替换目标 provider 的块，保留文件其余部分的注释与格式；
+//! - 每次写入前先备份到 `~/.cc-switch/backups/dsh/`，再原子写回。
+//!
+//! DSH 的 settings.yaml 由 dsh-settings-file 以跨进程写锁 + 原子重命名
+//! 维护，本模块无法参与其锁协议，因此仅在单次读-改-写内保持一致性，
+//! 并通过备份支持人工回滚。
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use chrono::Local;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use serde_yaml::Value as YamlValue;
+
+use crate::config::{atomic_write, get_app_config_dir};
+use crate::error::AppError;
+use crate::settings::effective_backup_retain_count;
+
+// ============================================================================
+// Path Functions
+// ============================================================================
+
+/// 获取 DSH 配置目录
+///
+/// 解析顺序：
+///   1. CCS 设置 `dsh_config_dir`（显式覆盖）
+///   2. `DSH_HOME` 环境变量（trim 后非空）
+///   3. 平台默认 `~/.dsh`
+pub fn get_dsh_dir() -> PathBuf {
+    if let Some(override_dir) = crate::settings::get_dsh_override_dir() {
+        return override_dir;
+    }
+
+    if let Some(raw) = std::env::var_os("DSH_HOME") {
+        let value = raw.to_string_lossy();
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+
+    crate::config::get_home_dir().join(".dsh")
+}
+
+/// 获取 DSH 设置文件路径（`~/.dsh/settings.yaml`）
+pub fn get_dsh_settings_path() -> PathBuf {
+    get_dsh_dir().join("settings.yaml")
+}
+
+fn dsh_write_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// DSH 写入结果
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct DshWriteOutcome {
+    pub backup_path: Option<String>,
+}
+
+/// `agent-default-model` 顶层小节的形状
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DshDefaultModel {
+    pub provider: String,
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+}
+
+// ============================================================================
+// Reading
+// ============================================================================
+
+/// 读取并解析 DSH settings.yaml
+fn read_dsh_settings_at(path: &Path) -> Result<YamlValue, AppError> {
+    if !path.exists() {
+        return Ok(YamlValue::Mapping(serde_yaml::Mapping::new()));
+    }
+    let raw = fs::read_to_string(path).map_err(|e| AppError::io(path, e))?;
+    serde_yaml::from_str(&raw).map_err(|e| {
+        AppError::Config(format!(
+            "Failed to parse DSH settings at {}: {e}",
+            path.display()
+        ))
+    })
+}
+
+/// 读取 `llm-pi-ai.providers` 下的全部 provider（id → JSON config）。
+///
+/// 返回的 config 形状即为 DSH YAML 中 provider 块的原样 JSON：
+/// displayName / api / baseURL / apiKeyEnv / models（数组）等字段原样透传。
+pub fn get_providers_at(path: &Path) -> Result<serde_json::Map<String, JsonValue>, AppError> {
+    let config = read_dsh_settings_at(path)?;
+    let mut map = serde_json::Map::new();
+
+    let providers = config
+        .get("llm-pi-ai")
+        .and_then(|v| v.get("providers"))
+        .and_then(|v| v.as_mapping());
+
+    if let Some(providers) = providers {
+        for (key, value) in providers {
+            let Some(name) = key.as_str() else {
+                continue;
+            };
+            if name.trim().is_empty() {
+                continue;
+            }
+            match crate::hermes_config::yaml_to_json(value) {
+                Ok(json_val) => {
+                    map.insert(name.to_string(), json_val);
+                }
+                Err(e) => {
+                    log::warn!("Failed to convert DSH provider '{name}' to JSON: {e}");
+                }
+            }
+        }
+    }
+
+    Ok(map)
+}
+
+/// 便捷封装：使用默认路径读取 providers。
+pub fn get_providers() -> Result<serde_json::Map<String, JsonValue>, AppError> {
+    get_providers_at(&get_dsh_settings_path())
+}
+
+/// 读取单个 provider。
+pub fn get_provider_at(path: &Path, id: &str) -> Result<Option<JsonValue>, AppError> {
+    Ok(get_providers_at(path)?.get(id).cloned())
+}
+
+/// 读取 `agent-default-model` 顶层小节。
+pub fn get_default_model_at(path: &Path) -> Result<Option<DshDefaultModel>, AppError> {
+    let config = read_dsh_settings_at(path)?;
+    match config.get("agent-default-model") {
+        Some(value) => {
+            let json = crate::hermes_config::yaml_to_json(value)?;
+            // 容忍未知字段：只提取 provider/model/reasoningEffort。
+            let provider = json
+                .get("provider")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            let model = json
+                .get("model")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string();
+            if provider.is_empty() || model.is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(DshDefaultModel {
+                provider,
+                model,
+                reasoning_effort: json
+                    .get("reasoningEffort")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+            }))
+        }
+        None => Ok(None),
+    }
+}
+
+/// 便捷封装：使用默认路径读取 agent-default-model。
+pub fn get_default_model() -> Result<Option<DshDefaultModel>, AppError> {
+    get_default_model_at(&get_dsh_settings_path())
+}
+
+// ============================================================================
+// Top-level section helpers（与 hermes_config 相同算法的私有副本）
+// ============================================================================
+
+fn is_top_level_key_line(line: &str) -> bool {
+    !line.starts_with(' ')
+        && !line.starts_with('\t')
+        && !line.starts_with('#')
+        && !line.starts_with("---")
+        && !line.starts_with("...")
+        && line.contains(':')
+}
+
+/// 查找顶层小节的字节范围（含小节头行，直到下一个顶层 key 或 EOF）。
+fn find_yaml_section_range(raw: &str, section_key: &str) -> Option<(usize, usize)> {
+    let target = format!("{section_key}:");
+    let mut section_start = None;
+    let mut offset = 0;
+
+    for line in raw.split('\n') {
+        if section_start.is_none() && is_top_level_key_line(line) && line.starts_with(&target) {
+            let after_target = &line[target.len()..];
+            if after_target.is_empty()
+                || after_target.starts_with(' ')
+                || after_target.starts_with('\t')
+                || after_target.starts_with('\r')
+                || after_target.starts_with('#')
+            {
+                section_start = Some(offset);
+            }
+        } else if section_start.is_some() && is_top_level_key_line(line) {
+            return Some((section_start.unwrap(), offset));
+        }
+        offset += line.len() + 1;
+    }
+
+    section_start.map(|start| (start, raw.len()))
+}
+
+fn serialize_yaml_section(key: &str, value: &YamlValue) -> Result<String, AppError> {
+    let mut section = serde_yaml::Mapping::new();
+    section.insert(YamlValue::String(key.to_string()), value.clone());
+    serde_yaml::to_string(&YamlValue::Mapping(section))
+        .map_err(|e| AppError::Config(format!("Failed to serialize YAML section '{key}': {e}")))
+}
+
+fn remove_all_sections(raw: &str, section_key: &str) -> String {
+    let mut result = String::with_capacity(raw.len());
+    let mut rest = raw;
+    while let Some((start, end)) = find_yaml_section_range(rest, section_key) {
+        result.push_str(&rest[..start]);
+        rest = &rest[end..];
+    }
+    result.push_str(rest);
+    result
+}
+
+fn replace_yaml_section(
+    raw: &str,
+    section_key: &str,
+    value: &YamlValue,
+) -> Result<String, AppError> {
+    let serialized = serialize_yaml_section(section_key, value)?;
+
+    if let Some((start, end)) = find_yaml_section_range(raw, section_key) {
+        let mut result = String::with_capacity(raw.len());
+        result.push_str(&raw[..start]);
+        result.push_str(&serialized);
+        let remainder = remove_all_sections(&raw[end..], section_key);
+        if !serialized.ends_with('\n') && !remainder.is_empty() && !remainder.starts_with('\n') {
+            result.push('\n');
+        }
+        result.push_str(&remainder);
+        Ok(result)
+    } else {
+        let mut result = raw.to_string();
+        if !result.is_empty() && !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push_str(&serialized);
+        if !result.ends_with('\n') {
+            result.push('\n');
+        }
+        Ok(result)
+    }
+}
+
+// ============================================================================
+// Nested provider block scanner（DSH 专属：llm-pi-ai.providers.<id>）
+// ============================================================================
+
+/// 一行的缩进宽度（tab 计 1；DSH settings 由机器生成，只用空格）。
+fn line_indent(line: &str) -> usize {
+    let trimmed = line.trim_end_matches('\r');
+    trimmed.len() - trimmed.trim_start_matches(' ').len()
+}
+
+/// 行是否为空行或注释行（不参与块边界判定）。
+fn is_blank_or_comment(line: &str) -> bool {
+    let t = line.trim();
+    t.is_empty() || t.starts_with('#')
+}
+
+/// 在 `lines` 的 `[from, to)` 范围内查找缩进为 `indent` 且 key 精确匹配
+/// `key` 的行，返回行号。
+///
+/// 支持 `key:`、`"key":`、`'key':` 三种 YAML key 写法。
+fn find_key_line(
+    lines: &[&str],
+    from: usize,
+    to: usize,
+    indent: usize,
+    key: &str,
+) -> Option<usize> {
+    for (idx, line) in lines.iter().enumerate().skip(from).take(to - from) {
+        if is_blank_or_comment(line) {
+            continue;
+        }
+        let line_indent = line_indent(line);
+        if line_indent < indent {
+            // 已经离开目标层：继续外层调用方负责的边界。
+            return None;
+        }
+        if line_indent != indent {
+            continue;
+        }
+        let body = line.trim_start_matches(' ');
+        let body = body.trim_end_matches('\r');
+        let matches = body == format!("{key}:")
+            || body == format!("\"{key}\":")
+            || body == format!("'{key}':")
+            || body == format!("{key}: ")
+            || body.starts_with(&format!("{key}: "))
+            || body.starts_with(&format!("\"{key}\": "))
+            || body.starts_with(&format!("'{key}': "));
+        if matches {
+            return Some(idx);
+        }
+    }
+    None
+}
+
+/// 从 key 行开始，找到该映射块的结束行（exclusive）：
+/// 下一行非空、非注释且缩进 <= key 缩进。
+fn block_end(lines: &[&str], key_line: usize, key_indent: usize) -> usize {
+    let mut end = lines.len();
+    for (idx, line) in lines.iter().enumerate().skip(key_line + 1) {
+        if is_blank_or_comment(line) {
+            continue;
+        }
+        if line_indent(line) <= key_indent {
+            end = idx;
+            break;
+        }
+    }
+    end
+}
+
+/// 在 `llm-pi-ai:` 小节内查找 `  providers:` 行。
+///
+/// 返回 (providers 行号, providers 块结束行)。
+fn find_providers_section(lines: &[&str]) -> Option<(usize, usize)> {
+    let llm_start = find_key_line(lines, 0, lines.len(), 0, "llm-pi-ai")?;
+    let llm_end = block_end(lines, llm_start, 0);
+    let providers_line = find_key_line(lines, llm_start + 1, llm_end, 2, "providers")?;
+    let providers_end = block_end(lines, providers_line, 2);
+    Some((providers_line, providers_end))
+}
+
+/// 把 provider config（JSON 对象）序列化为缩进 4 空格的 YAML 块。
+///
+/// serde_yaml 输出的属性行从 column 0 开始；本函数统一加上 6 空格，
+/// 使属性落在 provider key（indent 4）的下一层。key 行本身给 4 空格。
+fn serialize_provider_block(id: &str, config: &JsonValue) -> Result<String, AppError> {
+    let obj = config.as_object().ok_or_else(|| {
+        AppError::Config(format!("DSH provider '{id}' config must be a JSON object"))
+    })?;
+    if obj.get("baseURL").and_then(|v| v.as_str()).is_none() {
+        return Err(AppError::Config(format!(
+            "DSH provider '{id}' config is missing required string field 'baseURL'"
+        )));
+    }
+
+    let yaml_value = crate::hermes_config::json_to_yaml(config)?;
+    let serialized = serde_yaml::to_string(&yaml_value)
+        .map_err(|e| AppError::Config(format!("Failed to serialize DSH provider '{id}': {e}")))?;
+
+    let mut block = String::new();
+    block.push_str("    ");
+    block.push_str(&yaml_key_literal(id));
+    block.push_str(":\n");
+    for line in serialized.lines() {
+        if line.trim().is_empty() {
+            block.push('\n');
+        } else {
+            block.push_str("      ");
+            block.push_str(line);
+            block.push('\n');
+        }
+    }
+    Ok(block)
+}
+
+/// 生成 YAML key 字面量（仅在需要时加引号）。
+fn yaml_key_literal(id: &str) -> String {
+    let needs_quotes = id.is_empty()
+        || id.contains(':')
+        || id.contains('#')
+        || id.starts_with(' ')
+        || id.ends_with(' ')
+        || id.starts_with('\'')
+        || id.starts_with('"')
+        || id.starts_with('&')
+        || id.starts_with('*')
+        || id.starts_with('!')
+        || id.starts_with('%')
+        || id.starts_with('@')
+        || id.starts_with('`')
+        || id.starts_with('{')
+        || id.starts_with('[');
+    if needs_quotes {
+        format!("\"{}\"", id.replace('\\', "\\\\").replace('"', "\\\""))
+    } else {
+        id.to_string()
+    }
+}
+
+/// 对 raw 文本执行「upsert provider 块」的纯函数核心。
+///
+/// 策略（按结构复杂度递增）：
+/// 1. `llm-pi-ai:` + `  providers:` + `    <id>:` 均为块格式 → 块级替换/插入；
+/// 2. `  providers: {}` 内联空 → 展开为块格式；
+/// 3. `llm-pi-ai:` 行带内联值 → 退化为整节重写（解析-修改-序列化），
+///    该路径会丢失 llm-pi-ai 节内注释，但保留文件其余部分；
+/// 4. 无 `llm-pi-ai:` 小节 → 文件末尾追加新节。
+fn upsert_provider_raw(raw: &str, id: &str, config: &JsonValue) -> Result<String, AppError> {
+    let block = serialize_provider_block(id, config)?;
+    let lines: Vec<&str> = raw.split('\n').collect();
+
+    // 情形 4：无 llm-pi-ai 节 → 追加。
+    let Some(llm_line) = find_key_line(&lines, 0, lines.len(), 0, "llm-pi-ai") else {
+        let mut result = raw.to_string();
+        if !result.is_empty() && !result.trim().is_empty() && !result.ends_with('\n') {
+            result.push('\n');
+        }
+        if !result.trim().is_empty() {
+            result.push('\n');
+        }
+        result.push_str("llm-pi-ai:\n  providers:\n");
+        result.push_str(&block);
+        return Ok(result);
+    };
+
+    // 情形 3：llm-pi-ai 行带内联值（非空、非注释）→ 整节重写。
+    let llm_body = lines[llm_line]
+        .trim_start_matches(' ')
+        .trim_end_matches('\r')
+        .trim_start_matches("llm-pi-ai:")
+        .trim();
+    if !llm_body.is_empty() && !llm_body.starts_with('#') {
+        return rewrite_llm_section_via_parse(raw, |providers| {
+            providers.insert(
+                serde_yaml::Value::String(id.to_string()),
+                crate::hermes_config::json_to_yaml(config)?,
+            );
+            Ok(())
+        });
+    }
+
+    let llm_end = block_end(&lines, llm_line, 0);
+
+    // 查找 providers 键。
+    match find_key_line(&lines, llm_line + 1, llm_end, 2, "providers") {
+        Some(providers_line) => {
+            let p_body = lines[providers_line]
+                .trim_start_matches(' ')
+                .trim_end_matches('\r')
+                .trim_start_matches("providers:")
+                .trim();
+            if p_body == "{}" {
+                // 情形 2：内联空 providers → 展开为块格式并插入。
+                let mut result_lines: Vec<String> = lines[..providers_line]
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect();
+                result_lines.push("  providers:".to_string());
+                for line in block.lines() {
+                    result_lines.push(line.to_string());
+                }
+                result_lines.extend(lines[providers_line + 1..].iter().map(|s| s.to_string()));
+                return Ok(join_lines(&result_lines));
+            }
+            if !p_body.is_empty() && !p_body.starts_with('#') {
+                // providers 行带其他内联值 → 整节重写。
+                return rewrite_llm_section_via_parse(raw, |providers| {
+                    providers.insert(
+                        serde_yaml::Value::String(id.to_string()),
+                        crate::hermes_config::json_to_yaml(config)?,
+                    );
+                    Ok(())
+                });
+            }
+
+            let providers_end = block_end(&lines, providers_line, 2);
+
+            match find_key_line(&lines, providers_line + 1, providers_end, 4, id) {
+                Some(existing_line) => {
+                    // 情形 1a：块级替换。
+                    let end = block_end(&lines, existing_line, 4);
+                    let mut result_lines: Vec<String> = lines[..existing_line]
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect();
+                    for line in block.lines() {
+                        result_lines.push(line.to_string());
+                    }
+                    result_lines.extend(lines[end..].iter().map(|s| s.to_string()));
+                    Ok(join_lines(&result_lines))
+                }
+                None => {
+                    // 情形 1b：providers 节内插入（在其块尾之前）。
+                    let mut insert_at = providers_end;
+                    // 回退到块内最后一个非空行之后，避免插在尾部注释后。
+                    while insert_at > providers_line + 1
+                        && is_blank_or_comment(lines[insert_at - 1])
+                    {
+                        insert_at -= 1;
+                    }
+                    let mut result_lines: Vec<String> =
+                        lines[..insert_at].iter().map(|s| s.to_string()).collect();
+                    for line in block.lines() {
+                        result_lines.push(line.to_string());
+                    }
+                    result_lines.extend(lines[insert_at..].iter().map(|s| s.to_string()));
+                    Ok(join_lines(&result_lines))
+                }
+            }
+        }
+        None => {
+            // llm-pi-ai 存在但无 providers 键 → 在节尾插入 providers + 块。
+            let mut insert_at = llm_end;
+            while insert_at > llm_line + 1 && is_blank_or_comment(lines[insert_at - 1]) {
+                insert_at -= 1;
+            }
+            let mut result_lines: Vec<String> =
+                lines[..insert_at].iter().map(|s| s.to_string()).collect();
+            result_lines.push("  providers:".to_string());
+            for line in block.lines() {
+                result_lines.push(line.to_string());
+            }
+            result_lines.extend(lines[insert_at..].iter().map(|s| s.to_string()));
+            Ok(join_lines(&result_lines))
+        }
+    }
+}
+
+/// 对 raw 文本执行「删除 provider 块」的纯函数核心。
+fn remove_provider_raw(raw: &str, id: &str) -> Result<String, AppError> {
+    let lines: Vec<&str> = raw.split('\n').collect();
+    let Some((providers_line, _providers_end)) = find_providers_section(&lines) else {
+        return Ok(raw.to_string());
+    };
+    let providers_end = block_end(&lines, providers_line, 2);
+
+    let Some(existing_line) = find_key_line(&lines, providers_line + 1, providers_end, 4, id)
+    else {
+        return Ok(raw.to_string());
+    };
+
+    let end = block_end(&lines, existing_line, 4);
+    let mut result_lines: Vec<String> = lines[..existing_line]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    result_lines.extend(lines[end..].iter().map(|s| s.to_string()));
+
+    // 若删除后 providers 块内已无 indent-4 key，则折叠为 `  providers: {}`。
+    let has_remaining = result_lines[providers_line + 1..]
+        .iter()
+        .take_while(|l| {
+            // 只看 providers 块范围内的行；用缩进判断近似即可。
+            let t = l.trim();
+            !t.is_empty() && !t.starts_with('#') && line_indent(l) >= 2
+        })
+        .any(|l| line_indent(l) == 4 && !is_blank_or_comment(l));
+    if !has_remaining {
+        // 找到 providers 块的实际结束（在 result_lines 坐标系里，
+        // providers 行号不变，因为删除发生在其之后）。
+        let mut p_end = result_lines.len();
+        for (idx, line) in result_lines.iter().enumerate().skip(providers_line + 1) {
+            if is_blank_or_comment(line) {
+                continue;
+            }
+            if line_indent(line) <= 2 {
+                p_end = idx;
+                break;
+            }
+        }
+        result_lines.splice(providers_line + 1..p_end, std::iter::once(String::new()));
+        // 将 `  providers:` 行改写为内联空映射。
+        result_lines[providers_line] = "  providers: {}".to_string();
+    }
+
+    Ok(join_lines(&result_lines))
+}
+
+/// 整节重写路径：解析 llm-pi-ai 节 → 修改 providers → 重新序列化整节。
+fn rewrite_llm_section_via_parse<F>(raw: &str, mutator: F) -> Result<String, AppError>
+where
+    F: FnOnce(&mut serde_yaml::Mapping) -> Result<(), AppError>,
+{
+    let parsed: YamlValue = serde_yaml::from_str(raw)
+        .map_err(|e| AppError::Config(format!("Failed to parse DSH settings: {e}")))?;
+
+    let mut llm = parsed
+        .get("llm-pi-ai")
+        .cloned()
+        .unwrap_or(YamlValue::Mapping(serde_yaml::Mapping::new()));
+    if !llm.is_mapping() {
+        llm = YamlValue::Mapping(serde_yaml::Mapping::new());
+    }
+    let llm_map = llm.as_mapping_mut().expect("checked is_mapping");
+
+    let mut providers = llm_map
+        .get(YamlValue::String("providers".to_string()))
+        .cloned()
+        .unwrap_or(YamlValue::Mapping(serde_yaml::Mapping::new()));
+    if !providers.is_mapping() {
+        providers = YamlValue::Mapping(serde_yaml::Mapping::new());
+    }
+    let providers_map = providers.as_mapping_mut().expect("checked is_mapping");
+
+    mutator(providers_map)?;
+
+    llm_map.insert(
+        YamlValue::String("providers".to_string()),
+        YamlValue::Mapping(providers_map.clone()),
+    );
+
+    replace_yaml_section(raw, "llm-pi-ai", &YamlValue::Mapping(llm_map.clone()))
+}
+
+fn join_lines(lines: &[String]) -> String {
+    let mut out = lines.join("\n");
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out
+}
+
+// ============================================================================
+// Backup & Cleanup
+// ============================================================================
+
+fn create_dsh_backup(source: &str) -> Result<PathBuf, AppError> {
+    let backup_dir = get_app_config_dir().join("backups").join("dsh");
+    fs::create_dir_all(&backup_dir).map_err(|e| AppError::io(&backup_dir, e))?;
+
+    let base_id = format!("dsh_{}", Local::now().format("%Y%m%d_%H%M%S"));
+    let mut filename = format!("{base_id}.yaml");
+    let mut backup_path = backup_dir.join(&filename);
+    let mut counter = 1;
+
+    while backup_path.exists() {
+        filename = format!("{base_id}_{counter}.yaml");
+        backup_path = backup_dir.join(&filename);
+        counter += 1;
+    }
+
+    atomic_write(&backup_path, source.as_bytes())?;
+    cleanup_dsh_backups(&backup_dir)?;
+    Ok(backup_path)
+}
+
+fn cleanup_dsh_backups(dir: &Path) -> Result<(), AppError> {
+    let retain = effective_backup_retain_count();
+    let mut entries = fs::read_dir(dir)
+        .map_err(|e| AppError::io(dir, e))?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            entry
+                .path()
+                .extension()
+                .map(|ext| ext == "yaml" || ext == "yml")
+                .unwrap_or(false)
+        })
+        .collect::<Vec<_>>();
+
+    if entries.len() <= retain {
+        return Ok(());
+    }
+
+    entries.sort_by_key(|entry| entry.metadata().and_then(|m| m.modified()).ok());
+    let remove_count = entries.len().saturating_sub(retain);
+    for entry in entries.into_iter().take(remove_count) {
+        if let Err(err) = fs::remove_file(entry.path()) {
+            log::warn!(
+                "Failed to remove old DSH settings backup {}: {err}",
+                entry.path().display()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// High-level Write Operations
+// ============================================================================
+
+/// 写入（upsert）一个 DSH provider 到指定 settings 文件。
+///
+/// 区块级替换 + 备份 + 原子写；不触碰 `agent-default-model`。
+fn set_provider_at(path: &Path, id: &str, config: &JsonValue) -> Result<DshWriteOutcome, AppError> {
+    let _guard = dsh_write_lock()
+        .lock()
+        .map_err(|e| AppError::Config(format!("DSH write lock poisoned: {e}")))?;
+
+    let raw = if path.exists() {
+        fs::read_to_string(path).map_err(|e| AppError::io(path, e))?
+    } else {
+        String::new()
+    };
+
+    let new_raw = upsert_provider_raw(&raw, id, config)?;
+
+    if new_raw == raw {
+        return Ok(DshWriteOutcome::default());
+    }
+
+    // 写前校验：新内容必须能被解析，且 provider 可读回。
+    let reparsed: YamlValue = serde_yaml::from_str(&new_raw).map_err(|e| {
+        AppError::Config(format!(
+            "Refusing to write invalid DSH settings for provider '{id}': {e}"
+        ))
+    })?;
+    let readback = reparsed
+        .get("llm-pi-ai")
+        .and_then(|v| v.get("providers"))
+        .and_then(|v| v.get(id));
+    if readback.is_none() {
+        return Err(AppError::Config(format!(
+            "DSH provider '{id}' missing after upsert — refusing to write"
+        )));
+    }
+
+    let backup_path = if !raw.is_empty() {
+        Some(create_dsh_backup(&raw)?)
+    } else {
+        None
+    };
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+
+    atomic_write(path, new_raw.as_bytes())?;
+
+    log::debug!("DSH provider '{id}' written to {path:?}");
+    Ok(DshWriteOutcome {
+        backup_path: backup_path.map(|p| p.display().to_string()),
+    })
+}
+
+/// 便捷封装：默认路径 upsert provider。
+pub fn set_provider(id: &str, config: JsonValue) -> Result<DshWriteOutcome, AppError> {
+    set_provider_at(&get_dsh_settings_path(), id, &config)
+}
+
+/// 从指定 settings 文件删除一个 DSH provider。
+fn remove_provider_at(path: &Path, id: &str) -> Result<DshWriteOutcome, AppError> {
+    let _guard = dsh_write_lock()
+        .lock()
+        .map_err(|e| AppError::Config(format!("DSH write lock poisoned: {e}")))?;
+
+    if !path.exists() {
+        return Ok(DshWriteOutcome::default());
+    }
+    let raw = fs::read_to_string(path).map_err(|e| AppError::io(path, e))?;
+    let new_raw = remove_provider_raw(&raw, id)?;
+
+    if new_raw == raw {
+        return Ok(DshWriteOutcome::default());
+    }
+
+    // 写前校验：删除后的内容必须仍可解析。
+    serde_yaml::from_str::<YamlValue>(&new_raw).map_err(|e| {
+        AppError::Config(format!(
+            "Refusing to write invalid DSH settings after removing '{id}': {e}"
+        ))
+    })?;
+
+    let backup_path = if !raw.is_empty() {
+        Some(create_dsh_backup(&raw)?)
+    } else {
+        None
+    };
+
+    atomic_write(path, new_raw.as_bytes())?;
+
+    log::debug!("DSH provider '{id}' removed from {path:?}");
+    Ok(DshWriteOutcome {
+        backup_path: backup_path.map(|p| p.display().to_string()),
+    })
+}
+
+/// 便捷封装：默认路径删除 provider。
+pub fn remove_provider(id: &str) -> Result<DshWriteOutcome, AppError> {
+    remove_provider_at(&get_dsh_settings_path(), id)
+}
+
+/// 覆写顶层 `agent-default-model` 小节（切换当前路由）。
+///
+/// 只重写该顶层小节，保留其余内容。
+fn set_default_model_at(
+    path: &Path,
+    default_model: &DshDefaultModel,
+) -> Result<DshWriteOutcome, AppError> {
+    let _guard = dsh_write_lock()
+        .lock()
+        .map_err(|e| AppError::Config(format!("DSH write lock poisoned: {e}")))?;
+
+    let raw = if path.exists() {
+        fs::read_to_string(path).map_err(|e| AppError::io(path, e))?
+    } else {
+        String::new()
+    };
+
+    if default_model.provider.trim().is_empty() || default_model.model.trim().is_empty() {
+        return Err(AppError::Config(
+            "DSH default model requires non-empty provider and model".to_string(),
+        ));
+    }
+
+    let mut section = serde_yaml::Mapping::new();
+    section.insert(
+        YamlValue::String("provider".to_string()),
+        YamlValue::String(default_model.provider.clone()),
+    );
+    section.insert(
+        YamlValue::String("model".to_string()),
+        YamlValue::String(default_model.model.clone()),
+    );
+    if let Some(effort) = &default_model.reasoning_effort {
+        section.insert(
+            YamlValue::String("reasoningEffort".to_string()),
+            YamlValue::String(effort.clone()),
+        );
+    }
+
+    let new_raw = replace_yaml_section(&raw, "agent-default-model", &YamlValue::Mapping(section))?;
+
+    if new_raw == raw {
+        return Ok(DshWriteOutcome::default());
+    }
+
+    let backup_path = if !raw.is_empty() {
+        Some(create_dsh_backup(&raw)?)
+    } else {
+        None
+    };
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| AppError::io(parent, e))?;
+    }
+
+    atomic_write(path, new_raw.as_bytes())?;
+
+    log::debug!(
+        "DSH agent-default-model set to {}/{} at {:?}",
+        default_model.provider,
+        default_model.model,
+        path
+    );
+    Ok(DshWriteOutcome {
+        backup_path: backup_path.map(|p| p.display().to_string()),
+    })
+}
+
+/// 便捷封装：默认路径设置 agent-default-model。
+pub fn set_default_model(default_model: &DshDefaultModel) -> Result<DshWriteOutcome, AppError> {
+    set_default_model_at(&get_dsh_settings_path(), default_model)
+}
+
+/// 检查 provider 是否存在于 DSH settings。
+pub fn provider_exists(id: &str) -> Result<bool, AppError> {
+    Ok(get_providers()?.contains_key(id))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const SAMPLE: &str = r#"# DSH settings
+ui-onboarding:
+  welcomeNoticeVersion: 2026-08-13.1
+agent-presets:
+  default: standard-noweb
+llm-pi-ai:
+  providers:
+    a6api-under-0.1-cny:
+      displayName: A6API <= 0.1
+      apiKeyEnv: A6API_UNDER_0_1_CNY_API_KEY
+      api: openai-completions
+      baseURL: https://api.a6api.com/v1
+      models:
+        - id: glm-5.3
+          reasoningEfforts:
+            off: null
+            low: low
+        - id: glm-5.3-flash
+agent-default-model:
+  provider: a6api-under-0.5-cny
+  model: gpt-6-astra
+  reasoningEffort: xhigh
+"#;
+
+    fn provider_config() -> JsonValue {
+        json!({
+            "displayName": "Test Relay",
+            "apiKeyEnv": "TEST_RELAY_API_KEY",
+            "api": "openai-completions",
+            "baseURL": "https://relay.example.com/v1",
+            "models": [
+                {"id": "test-model", "reasoningEfforts": {"off": null, "low": "low"}}
+            ]
+        })
+    }
+
+    #[test]
+    fn upsert_into_existing_providers_preserves_other_sections() {
+        let raw = upsert_provider_raw(SAMPLE, "test-relay", &provider_config()).unwrap();
+        assert!(raw.contains("test-relay:"));
+        assert!(raw.contains("https://relay.example.com/v1"));
+        // 其他顶层小节原样保留
+        assert!(raw.contains("agent-presets:"));
+        assert!(raw.contains("standard-noweb"));
+        assert!(raw.contains("# DSH settings"));
+        // 既有 provider 不受影响
+        assert!(raw.contains("a6api-under-0.1-cny:"));
+        assert!(raw.contains("glm-5.3-flash"));
+        // agent-default-model 未被触碰
+        assert!(raw.contains("gpt-6-astra"));
+        // 结果可解析且新 provider 可读回
+        let parsed: YamlValue = serde_yaml::from_str(&raw).unwrap();
+        assert!(parsed
+            .get("llm-pi-ai")
+            .and_then(|v| v.get("providers"))
+            .and_then(|v| v.get("test-relay"))
+            .is_some());
+    }
+
+    #[test]
+    fn upsert_replaces_existing_provider_block() {
+        let once = upsert_provider_raw(SAMPLE, "test-relay", &provider_config()).unwrap();
+        let updated_config = json!({
+            "displayName": "Test Relay v2",
+            "apiKeyEnv": "TEST_RELAY_API_KEY",
+            "api": "openai-completions",
+            "baseURL": "https://relay2.example.com/v1",
+            "models": [
+                {"id": "test-model-v2"}
+            ]
+        });
+        let twice = upsert_provider_raw(&once, "test-relay", &updated_config).unwrap();
+        assert!(twice.contains("Test Relay v2"));
+        assert!(twice.contains("relay2.example.com"));
+        assert!(!twice.contains("relay.example.com"));
+        // 只有一份 test-relay 块
+        assert_eq!(twice.matches("test-relay:").count(), 1);
+    }
+
+    #[test]
+    fn upsert_into_file_without_llm_section_appends() {
+        let raw = "locale:\n  preference: en\n";
+        let out = upsert_provider_raw(raw, "test-relay", &provider_config()).unwrap();
+        assert!(out.contains("locale:"));
+        assert!(out.contains("llm-pi-ai:"));
+        assert!(out.contains("  providers:"));
+        let parsed: YamlValue = serde_yaml::from_str(&out).unwrap();
+        assert!(parsed
+            .get("llm-pi-ai")
+            .and_then(|v| v.get("providers"))
+            .and_then(|v| v.get("test-relay"))
+            .is_some());
+    }
+
+    #[test]
+    fn upsert_expands_inline_empty_providers() {
+        let raw = "llm-pi-ai:\n  providers: {}\nagent-default-model:\n  provider: x\n";
+        let out = upsert_provider_raw(raw, "test-relay", &provider_config()).unwrap();
+        assert!(out.contains("test-relay:"));
+        let parsed: YamlValue = serde_yaml::from_str(&out).unwrap();
+        assert!(parsed
+            .get("llm-pi-ai")
+            .and_then(|v| v.get("providers"))
+            .and_then(|v| v.get("test-relay"))
+            .is_some());
+    }
+
+    #[test]
+    fn upsert_rejects_config_without_base_url() {
+        let bad = json!({"displayName": "No URL"});
+        assert!(upsert_provider_raw(SAMPLE, "bad-relay", &bad).is_err());
+    }
+
+    #[test]
+    fn remove_existing_provider_keeps_siblings() {
+        let raw = upsert_provider_raw(SAMPLE, "test-relay", &provider_config()).unwrap();
+        let out = remove_provider_raw(&raw, "test-relay").unwrap();
+        assert!(!out.contains("test-relay:"));
+        assert!(!out.contains("relay.example.com"));
+        assert!(out.contains("a6api-under-0.1-cny:"));
+        assert!(out.contains("gpt-6-astra"));
+        let parsed: YamlValue = serde_yaml::from_str(&out).unwrap();
+        assert!(parsed
+            .get("llm-pi-ai")
+            .and_then(|v| v.get("providers"))
+            .and_then(|v| v.get("test-relay"))
+            .is_none());
+        assert!(parsed
+            .get("llm-pi-ai")
+            .and_then(|v| v.get("providers"))
+            .and_then(|v| v.get("a6api-under-0.1-cny"))
+            .is_some());
+    }
+
+    #[test]
+    fn remove_last_provider_collapses_to_empty_map() {
+        let raw = "llm-pi-ai:\n  providers:\n    only-one:\n      baseURL: https://x.example\n";
+        let out = remove_provider_raw(raw, "only-one").unwrap();
+        assert!(out.contains("providers: {}"));
+        let parsed: YamlValue = serde_yaml::from_str(&out).unwrap();
+        let providers = parsed
+            .get("llm-pi-ai")
+            .and_then(|v| v.get("providers"))
+            .unwrap();
+        assert!(providers
+            .as_mapping()
+            .map(|m| m.is_empty())
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn remove_missing_provider_is_noop() {
+        let out = remove_provider_raw(SAMPLE, "ghost-relay").unwrap();
+        assert_eq!(out, SAMPLE);
+    }
+
+    #[test]
+    fn set_default_model_replaces_only_that_section() {
+        let raw = SAMPLE.to_string();
+        let out = replace_yaml_section(
+            &raw,
+            "agent-default-model",
+            &serde_yaml::from_str::<YamlValue>(
+                "provider: a6api-under-0.1-cny\nmodel: glm-5.3\nreasoningEffort: low",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+        assert!(out.contains("glm-5.3"));
+        assert!(!out.contains("gpt-6-astra"));
+        assert!(out.contains("standard-noweb"));
+        assert!(out.contains("# DSH settings"));
+    }
+
+    #[test]
+    fn end_to_end_file_roundtrip() {
+        let dir = std::env::temp_dir().join(format!(
+            "ccswitch-dsh-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("settings.yaml");
+        fs::write(&path, SAMPLE).unwrap();
+
+        // upsert
+        let outcome = set_provider_at(&path, "test-relay", &provider_config()).unwrap();
+        assert!(outcome.backup_path.is_some());
+        let providers = get_providers_at(&path).unwrap();
+        assert!(providers.contains_key("test-relay"));
+        assert!(providers.contains_key("a6api-under-0.1-cny"));
+        assert_eq!(
+            providers.get("test-relay").unwrap().get("baseURL"),
+            Some(&json!("https://relay.example.com/v1"))
+        );
+
+        // default model
+        set_default_model_at(
+            &path,
+            &DshDefaultModel {
+                provider: "test-relay".to_string(),
+                model: "test-model".to_string(),
+                reasoning_effort: Some("low".to_string()),
+            },
+        )
+        .unwrap();
+        let dm = get_default_model_at(&path).unwrap().unwrap();
+        assert_eq!(dm.provider, "test-relay");
+        assert_eq!(dm.model, "test-model");
+        assert_eq!(dm.reasoning_effort.as_deref(), Some("low"));
+
+        // remove
+        remove_provider_at(&path, "test-relay").unwrap();
+        let providers = get_providers_at(&path).unwrap();
+        assert!(!providers.contains_key("test-relay"));
+
+        fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod commands;
 mod config;
 mod database;
 mod deeplink;
+pub mod dsh_config;
 mod error;
 mod gemini_config;
 mod gemini_mcp;
@@ -863,6 +864,13 @@ pub fn run() {
                 }
                 Ok(_) => log::debug!("○ No Hermes provider changes from live config"),
                 Err(e) => log::warn!("✗ Failed to import Hermes providers: {e}"),
+            }
+            match crate::services::provider::import_dsh_providers_from_live(&app_state) {
+                Ok(count) if count > 0 => {
+                    log::info!("✓ Synced {count} DSH provider(s) from live config");
+                }
+                Ok(_) => log::debug!("○ No DSH provider changes from live config"),
+                Err(e) => log::warn!("✗ Failed to import DSH providers: {e}"),
             }
             match crate::services::provider::import_pi_providers_from_live(&app_state) {
                 Ok(count) if count > 0 => {

--- a/src-tauri/src/prompt_files.rs
+++ b/src-tauri/src/prompt_files.rs
@@ -26,6 +26,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::OpenCode => get_opencode_dir(),
         AppType::OpenClaw => get_openclaw_dir(),
         AppType::Hermes => crate::hermes_config::get_hermes_dir(),
+        AppType::Dsh => crate::dsh_config::get_dsh_dir(),
         AppType::Pi => crate::pi_config::get_pi_agent_dir()?,
         AppType::ClaudeDesktop => unreachable!("handled above"),
     };
@@ -36,6 +37,7 @@ pub fn prompt_file_path(app: &AppType) -> Result<PathBuf, AppError> {
         AppType::Gemini => "GEMINI.md",
         AppType::GrokBuild | AppType::OpenCode | AppType::OpenClaw => "AGENTS.md",
         AppType::Hermes => "SOUL.md",
+        AppType::Dsh => "AGENTS.md",
         AppType::Pi => "AGENTS.md",
         AppType::ClaudeDesktop => unreachable!("handled above"),
     };

--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -212,6 +212,12 @@ impl Provider {
                 str_at(settings.get("base_url")),
                 str_at(settings.get("api_key")),
             ),
+            // DSH (settings.yaml) stores provider blocks with camelCase fields;
+            // secrets stay behind the apiKeyEnv reference, never a raw value.
+            AppType::Dsh => (
+                str_at(settings.get("baseURL")),
+                String::new(), // DSH resolves apiKeyEnv per request; no raw key here.
+            ),
             // OpenClaw (openclaw.json) flattens credentials at the top level, camelCase.
             AppType::OpenClaw => (
                 str_at(settings.get("baseUrl")),

--- a/src-tauri/src/proxy/providers/mod.rs
+++ b/src-tauri/src/proxy/providers/mod.rs
@@ -208,7 +208,9 @@ impl ProviderType {
                 ProviderType::Gemini
             }
             AppType::GrokBuild => ProviderType::Codex,
-            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => ProviderType::Codex,
+            AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Dsh => {
+                ProviderType::Codex
+            }
             AppType::Pi => return None,
         };
         Some(provider_type)
@@ -264,7 +266,9 @@ pub fn get_adapter(app_type: &AppType) -> Option<Box<dyn ProviderAdapter>> {
         AppType::Codex => Box::new(CodexAdapter::new()),
         AppType::Gemini => Box::new(GeminiAdapter::new()),
         AppType::GrokBuild => Box::new(CodexAdapter::new()),
-        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes => Box::new(CodexAdapter::new()),
+        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Dsh => {
+            Box::new(CodexAdapter::new())
+        }
         AppType::Pi => return None,
     })
 }

--- a/src-tauri/src/services/config.rs
+++ b/src-tauri/src/services/config.rs
@@ -138,6 +138,9 @@ impl ConfigService {
             AppType::Hermes => {
                 // Hermes uses additive mode, no live sync needed
             }
+            AppType::Dsh => {
+                // DSH uses additive mode, no live sync needed
+            }
             AppType::Pi => {
                 // Pi owns its shared models/settings documents; this legacy
                 // single-provider live-sync path must not rewrite them.

--- a/src-tauri/src/services/mcp.rs
+++ b/src-tauri/src/services/mcp.rs
@@ -116,6 +116,11 @@ impl McpService {
             AppType::ClaudeDesktop => {
                 log::debug!("Claude Desktop 3P profiles do not use CC Switch MCP sync, skipping");
             }
+            AppType::Dsh => {
+                // DSH mounts MCP servers through profile cordis patches, not a
+                // native config file; file sync is not supported yet.
+                log::debug!("DSH MCP sync is not supported yet, skipping");
+            }
             AppType::Codex => {
                 // Codex uses TOML format, must use the correct function
                 mcp::sync_single_server_to_codex(&Default::default(), &server.id, &server.server)?;
@@ -168,6 +173,11 @@ impl McpService {
             AppType::Claude => mcp::remove_server_from_claude(id)?,
             AppType::ClaudeDesktop => {
                 log::debug!("Claude Desktop 3P profiles do not use CC Switch MCP sync, skipping");
+            }
+            AppType::Dsh => {
+                // DSH mounts MCP servers through profile cordis patches, not a
+                // native config file; file sync is not supported yet.
+                log::debug!("DSH MCP sync is not supported yet, skipping");
             }
             AppType::Codex => mcp::remove_server_from_codex(id)?,
             AppType::Gemini => mcp::remove_server_from_gemini(id)?,

--- a/src-tauri/src/services/provider/live.rs
+++ b/src-tauri/src/services/provider/live.rs
@@ -530,6 +530,7 @@ fn settings_contain_common_config(app_type: &AppType, settings: &Value, snippet:
         | AppType::OpenCode
         | AppType::OpenClaw
         | AppType::Hermes
+        | AppType::Dsh
         | AppType::Pi
         | AppType::ClaudeDesktop => false,
     }
@@ -605,6 +606,7 @@ pub(crate) fn remove_common_config_from_settings(
         | AppType::OpenCode
         | AppType::OpenClaw
         | AppType::Hermes
+        | AppType::Dsh
         | AppType::Pi
         | AppType::ClaudeDesktop => Ok(settings.clone()),
     }
@@ -665,6 +667,7 @@ fn apply_common_config_to_settings(
         | AppType::OpenCode
         | AppType::OpenClaw
         | AppType::Hermes
+        | AppType::Dsh
         | AppType::Pi
         | AppType::ClaudeDesktop => Ok(settings.clone()),
     }
@@ -1430,6 +1433,10 @@ pub(crate) fn write_live_snapshot(app_type: &AppType, provider: &Provider) -> Re
             crate::hermes_config::set_provider(&provider.id, provider.settings_config.clone())?;
             log::debug!("Hermes provider '{}' written to live config", provider.id);
         }
+        AppType::Dsh => {
+            crate::dsh_config::set_provider(&provider.id, provider.settings_config.clone())?;
+            log::debug!("DSH provider '{}' written to live config", provider.id);
+        }
         AppType::Pi => {
             return Err(AppError::InvalidInput(
                 "Pi providers use the Pi provider service".to_string(),
@@ -1815,6 +1822,25 @@ pub fn read_live_settings(app_type: AppType) -> Result<Value, AppError> {
             let config = crate::hermes_config::yaml_to_json(&yaml_config)?;
             Ok(config)
         }
+        AppType::Dsh => {
+            let config_path = crate::dsh_config::get_dsh_settings_path();
+            if !config_path.exists() {
+                return Err(AppError::localized(
+                    "dsh.config.missing",
+                    "DSH 配置文件不存在",
+                    "DSH settings file not found",
+                ));
+            }
+            let yaml_config: serde_yaml::Value = std::fs::read_to_string(&config_path)
+                .map_err(|e| AppError::io(&config_path, e))
+                .and_then(|raw| {
+                    serde_yaml::from_str(&raw).map_err(|e| {
+                        AppError::Config(format!("Failed to parse DSH settings: {e}"))
+                    })
+                })?;
+            let config = crate::hermes_config::yaml_to_json(&yaml_config)?;
+            Ok(config)
+        }
         AppType::Pi => Err(AppError::InvalidInput(
             "Pi providers are read from Pi's native models file".to_string(),
         )),
@@ -1926,8 +1952,8 @@ pub fn import_default_config(state: &AppState, app_type: AppType) -> Result<bool
                 "config": config_obj
             })
         }
-        // OpenCode, OpenClaw and Hermes use additive mode and are handled by early return above
-        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Pi => {
+        // OpenCode, OpenClaw, Hermes and DSH use additive mode and are handled by early return above
+        AppType::OpenCode | AppType::OpenClaw | AppType::Hermes | AppType::Dsh | AppType::Pi => {
             unreachable!("additive mode apps are handled by early return")
         }
     };
@@ -2370,6 +2396,89 @@ pub fn remove_openclaw_provider_from_live(provider_id: &str) -> Result<(), AppEr
 
     openclaw_config::remove_provider(provider_id)?;
     log::info!("OpenClaw provider '{provider_id}' removed from live config");
+
+    Ok(())
+}
+
+/// Import DSH providers from live config
+///
+/// Reads `llm-pi-ai.providers` from ~/.dsh/settings.yaml into the database.
+/// Secrets stay as `apiKeyEnv` references — DSH resolves them per request,
+/// so no raw key ever enters the cc-switch database.
+pub fn import_dsh_providers_from_live(state: &AppState) -> Result<usize, AppError> {
+    use crate::dsh_config;
+
+    let providers = dsh_config::get_providers()?;
+    if providers.is_empty() {
+        return Ok(0);
+    }
+
+    let mut imported = 0;
+    let mut updated = 0;
+    let existing_ids = state.db.get_provider_ids("dsh")?;
+
+    for (name, config) in providers {
+        if name.trim().is_empty() {
+            log::warn!("Skipping DSH provider with empty name");
+            continue;
+        }
+
+        if existing_ids.contains(&name) {
+            match state.db.get_provider_by_id(&name, "dsh") {
+                Ok(Some(existing)) => {
+                    if existing.settings_config != config {
+                        let mut provider = existing;
+                        provider.settings_config = config;
+                        if let Err(e) = state.db.save_provider("dsh", &provider) {
+                            log::warn!(
+                                "Failed to update DSH provider '{name}' from live config: {e}"
+                            );
+                        } else {
+                            updated += 1;
+                            log::info!("Updated DSH provider '{name}' from live config");
+                        }
+                    }
+                }
+                Ok(None) => {
+                    log::warn!("DSH provider '{name}' disappeared while importing live config")
+                }
+                Err(e) => log::warn!("Failed to look up DSH provider '{name}': {e}"),
+            }
+            continue;
+        }
+
+        let mut provider = Provider::with_id(name.clone(), name.clone(), config, None);
+        provider.meta = Some(crate::provider::ProviderMeta {
+            live_config_managed: Some(true),
+            ..Default::default()
+        });
+
+        if let Err(e) = state.db.save_provider("dsh", &provider) {
+            log::warn!("Failed to import DSH provider '{name}': {e}");
+            continue;
+        }
+
+        imported += 1;
+        log::info!("Imported DSH provider '{name}' from live config");
+    }
+
+    Ok(imported + updated)
+}
+
+/// Remove a DSH provider from live config
+///
+/// This removes a specific provider from ~/.dsh/settings.yaml
+/// without affecting other providers or the agent-default-model route.
+pub fn remove_dsh_provider_from_live(provider_id: &str) -> Result<(), AppError> {
+    use crate::dsh_config;
+
+    if !dsh_config::get_dsh_dir().exists() {
+        log::debug!("DSH config directory doesn't exist, skipping removal of '{provider_id}'");
+        return Ok(());
+    }
+
+    dsh_config::remove_provider(provider_id)?;
+    log::info!("DSH provider '{provider_id}' removed from live config");
 
     Ok(())
 }

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -23,8 +23,8 @@ use crate::store::AppState;
 
 // Re-export sub-module functions for external access
 pub use live::{
-    import_default_config, import_hermes_providers_from_live, import_openclaw_providers_from_live,
-    import_opencode_providers_from_live, read_live_settings,
+    import_default_config, import_dsh_providers_from_live, import_hermes_providers_from_live,
+    import_openclaw_providers_from_live, import_opencode_providers_from_live, read_live_settings,
     should_import_default_config_on_startup, sync_current_to_live,
     update_toml_common_config_snippet,
 };
@@ -45,8 +45,8 @@ pub(crate) use live::{
 
 // Internal re-exports
 use live::{
-    remove_hermes_provider_from_live, remove_openclaw_provider_from_live,
-    remove_opencode_provider_from_live, write_gemini_live,
+    remove_dsh_provider_from_live, remove_hermes_provider_from_live,
+    remove_openclaw_provider_from_live, remove_opencode_provider_from_live, write_gemini_live,
 };
 use usage::validate_usage_script;
 
@@ -4980,6 +4980,7 @@ impl ProviderService {
                     AppType::OpenCode => remove_opencode_provider_from_live(id)?,
                     AppType::OpenClaw => remove_openclaw_provider_from_live(id)?,
                     AppType::Hermes => remove_hermes_provider_from_live(id)?,
+                    AppType::Dsh => remove_dsh_provider_from_live(id)?,
                     _ => {}
                 }
             }
@@ -5048,6 +5049,9 @@ impl ProviderService {
             }
             AppType::Hermes => {
                 remove_hermes_provider_from_live(id)?;
+            }
+            AppType::Dsh => {
+                remove_dsh_provider_from_live(id)?;
             }
             _ => {
                 return Err(AppError::Message(format!(
@@ -5417,6 +5421,7 @@ impl ProviderService {
                     AppType::OpenCode => remove_opencode_provider_from_live(&provider.id),
                     AppType::OpenClaw => remove_openclaw_provider_from_live(&provider.id),
                     AppType::Hermes => remove_hermes_provider_from_live(&provider.id),
+                    AppType::Dsh => remove_dsh_provider_from_live(&provider.id),
                     _ => Ok(()),
                 };
 
@@ -5681,6 +5686,7 @@ impl ProviderService {
             AppType::OpenCode => Self::extract_opencode_common_config(&provider.settings_config),
             AppType::OpenClaw => Self::extract_openclaw_common_config(&provider.settings_config),
             AppType::Hermes => Ok(String::new()), // Hermes doesn't use common config snippets
+            AppType::Dsh => Ok(String::new()),    // DSH doesn't use common config snippets
             AppType::Pi => Ok(String::new()),
         }
     }
@@ -5699,6 +5705,7 @@ impl ProviderService {
             AppType::OpenCode => Self::extract_opencode_common_config(settings_config),
             AppType::OpenClaw => Self::extract_openclaw_common_config(settings_config),
             AppType::Hermes => Ok(String::new()), // Hermes doesn't use common config snippets
+            AppType::Dsh => Ok(String::new()),    // DSH doesn't use common config snippets
             AppType::Pi => Ok(String::new()),
         }
     }
@@ -6465,6 +6472,28 @@ impl ProviderService {
                     ));
                 }
             }
+            AppType::Dsh => {
+                // DSH provider block must be an object with a string baseURL.
+                if !provider.settings_config.is_object() {
+                    return Err(AppError::localized(
+                        "provider.dsh.settings.not_object",
+                        "DSH 配置必须是 JSON 对象",
+                        "DSH configuration must be a JSON object",
+                    ));
+                }
+                if provider
+                    .settings_config
+                    .get("baseURL")
+                    .and_then(Value::as_str)
+                    .is_none()
+                {
+                    return Err(AppError::localized(
+                        "provider.dsh.settings.base_url_missing",
+                        format!("供应商 {} 缺少 baseURL 字段", provider.id),
+                        format!("Provider {} is missing the baseURL field", provider.id),
+                    ));
+                }
+            }
             AppType::Pi => {
                 crate::pi_config::validate_provider_node(&provider.id, &provider.settings_config)?;
             }
@@ -6672,7 +6701,7 @@ impl ProviderService {
 
                 Ok((api_key, base_url))
             }
-            AppType::OpenClaw | AppType::Hermes | AppType::Pi => {
+            AppType::OpenClaw | AppType::Hermes | AppType::Dsh | AppType::Pi => {
                 // These native formats use apiKey and baseUrl directly on the object.
                 let api_key = provider
                     .settings_config

--- a/src-tauri/src/services/skill.rs
+++ b/src-tauri/src/services/skill.rs
@@ -605,6 +605,11 @@ impl SkillService {
                     return Ok(custom.join("skills"));
                 }
             }
+            AppType::Dsh => {
+                if let Some(custom) = crate::settings::get_dsh_override_dir() {
+                    return Ok(custom.join("skills"));
+                }
+            }
             AppType::Pi => {
                 return Ok(crate::pi_config::get_pi_agent_dir()?.join("skills"));
             }
@@ -624,6 +629,7 @@ impl SkillService {
             AppType::OpenCode => home.join(".config").join("opencode").join("skills"),
             AppType::OpenClaw => home.join(".openclaw").join("skills"),
             AppType::Hermes => crate::hermes_config::get_hermes_dir().join("skills"),
+            AppType::Dsh => crate::dsh_config::get_dsh_dir().join("skills"),
             AppType::Pi => crate::pi_config::get_pi_agent_dir()?.join("skills"),
         })
     }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -46,6 +46,8 @@ pub struct VisibleApps {
     pub openclaw: bool,
     #[serde(default)]
     pub hermes: bool,
+    #[serde(default)]
+    pub dsh: bool,
     #[serde(default = "default_true")]
     pub pi: bool,
 }
@@ -61,6 +63,7 @@ impl Default for VisibleApps {
             opencode: true,
             openclaw: true,
             hermes: false, // 默认不显示，需用户手动启用
+            dsh: false,    // 默认不显示，需用户手动启用
             pi: true,
         }
     }
@@ -78,6 +81,7 @@ impl VisibleApps {
             AppType::OpenCode => self.opencode,
             AppType::OpenClaw => self.openclaw,
             AppType::Hermes => self.hermes,
+            AppType::Dsh => self.dsh,
             AppType::Pi => self.pi,
         }
     }
@@ -432,6 +436,8 @@ pub struct AppSettings {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hermes_config_dir: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dsh_config_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pi_config_dir: Option<String>,
 
     // ===== 当前供应商 ID（设备级）=====
@@ -459,6 +465,9 @@ pub struct AppSettings {
     /// 当前 Hermes 供应商 ID（本地存储，保持结构一致）
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_provider_hermes: Option<String>,
+    /// 当前 DSH 供应商 ID（本地存储，保持结构一致）
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_provider_dsh: Option<String>,
 
     // ===== Skill 同步设置 =====
     /// Skill 同步方式：auto（默认，优先 symlink）、symlink、copy
@@ -549,6 +558,7 @@ impl Default for AppSettings {
             opencode_config_dir: None,
             openclaw_config_dir: None,
             hermes_config_dir: None,
+            dsh_config_dir: None,
             pi_config_dir: None,
             current_provider_claude: None,
             current_provider_claude_desktop: None,
@@ -558,6 +568,7 @@ impl Default for AppSettings {
             current_provider_opencode: None,
             current_provider_openclaw: None,
             current_provider_hermes: None,
+            current_provider_dsh: None,
             skill_sync_method: SyncMethod::default(),
             skill_storage_location: SkillStorageLocation::default(),
             webdav_sync: None,
@@ -626,6 +637,13 @@ impl AppSettings {
 
         self.hermes_config_dir = self
             .hermes_config_dir
+            .as_ref()
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        self.dsh_config_dir = self
+            .dsh_config_dir
             .as_ref()
             .map(|s| s.trim())
             .filter(|s| !s.is_empty())
@@ -964,6 +982,14 @@ pub fn get_hermes_override_dir() -> Option<PathBuf> {
         .map(|p| resolve_override_path(p))
 }
 
+pub fn get_dsh_override_dir() -> Option<PathBuf> {
+    let settings = settings_store().read().ok()?;
+    settings
+        .dsh_config_dir
+        .as_ref()
+        .map(|p| resolve_override_path(p))
+}
+
 pub fn get_pi_override_dir() -> Option<PathBuf> {
     let settings = settings_store().read().ok()?;
     settings
@@ -1009,6 +1035,7 @@ pub fn get_current_provider(app_type: &AppType) -> Option<String> {
         AppType::OpenCode => settings.current_provider_opencode.clone(),
         AppType::OpenClaw => settings.current_provider_openclaw.clone(),
         AppType::Hermes => settings.current_provider_hermes.clone(),
+        AppType::Dsh => settings.current_provider_dsh.clone(),
         AppType::Pi => None,
     }
 }
@@ -1028,6 +1055,7 @@ pub fn set_current_provider(app_type: &AppType, id: Option<&str>) -> Result<(), 
         AppType::OpenCode => settings.current_provider_opencode = id_owned.clone(),
         AppType::OpenClaw => settings.current_provider_openclaw = id_owned.clone(),
         AppType::Hermes => settings.current_provider_hermes = id_owned.clone(),
+        AppType::Dsh => settings.current_provider_dsh = id_owned.clone(),
         AppType::Pi => {}
     })
 }

--- a/src-tauri/tests/dsh_roundtrip.rs
+++ b/src-tauri/tests/dsh_roundtrip.rs
@@ -1,0 +1,186 @@
+//! P0 isolated round-trip test: run the full cc-switch → DSH write cycle
+//! against a COPY of the real production settings shape.
+//!
+//! Opt-in via the `DSH_ROUNDTRIP_SETTINGS` env var pointing at a real
+//! `settings.yaml`. Without the var the test is skipped (CI has no such
+//! file). The test copies that file to a temp dir and never writes the
+//! original.
+//!
+//! Verified invariants:
+//! 1. All original providers survive every upsert/remove.
+//! 2. `agent-default-model` is untouched by provider add/remove.
+//! 3. An upserted provider round-trips field-by-field.
+//! 4. Re-upsert replaces (no duplicate blocks).
+//! 5. Remove restores the original provider set and default model.
+//! 6. `set_default_model` writes and restores only its own section.
+//! 7. Backups are created on every mutating write.
+
+use std::path::PathBuf;
+
+use cc_switch_lib::dsh_config;
+use serde_json::json;
+
+fn roundtrip_settings_path() -> Option<PathBuf> {
+    let raw = std::env::var("DSH_ROUNDTRIP_SETTINGS").ok()?;
+    let path = PathBuf::from(raw.trim());
+    if path.is_file() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+#[test]
+fn dsh_full_roundtrip_against_production_shape_copy() {
+    let Some(source) = roundtrip_settings_path() else {
+        eprintln!("skipping: DSH_ROUNDTRIP_SETTINGS not set");
+        return;
+    };
+
+    // Isolate backup output away from the real ~/.cc-switch.
+    let test_home = std::env::temp_dir().join(format!(
+        "ccswitch-dsh-roundtrip-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    std::fs::create_dir_all(&test_home).unwrap();
+    unsafe { std::env::set_var("CC_SWITCH_TEST_HOME", &test_home) };
+
+    let work_dir = test_home.join("work");
+    std::fs::create_dir_all(&work_dir).unwrap();
+    let settings = work_dir.join("settings.yaml");
+    std::fs::copy(&source, &settings).unwrap();
+
+    // ---- 1. baseline read ----
+    let before_providers = dsh_config::get_providers_at(&settings).unwrap();
+    let original_count = before_providers.len();
+    assert!(
+        original_count > 0,
+        "fixture must contain at least one provider"
+    );
+    let before_default = dsh_config::get_default_model_at(&settings)
+        .unwrap()
+        .expect("fixture must have agent-default-model");
+    let before_ids: Vec<&String> = before_providers.keys().collect();
+
+    // ---- 2. upsert a new test provider ----
+    let test_config = json!({
+        "displayName": "P0 Roundtrip Relay",
+        "apiKeyEnv": "P0_ROUNDTRIP_API_KEY",
+        "api": "openai-completions",
+        "baseURL": "https://p0-roundtrip.invalid/v1",
+        "models": [
+            {"id": "p0-model", "reasoningEfforts": {"off": null, "low": "low"}}
+        ]
+    });
+    let outcome = dsh_config::set_provider_at(&settings, "p0-roundtrip", &test_config).unwrap();
+    assert!(outcome.backup_path.is_some(), "upsert must create a backup");
+
+    let after_upsert = dsh_config::get_providers_at(&settings).unwrap();
+    assert_eq!(after_upsert.len(), original_count + 1);
+    for id in &before_ids {
+        assert!(after_upsert.contains_key(*id), "provider {id} must survive");
+    }
+    let readback = after_upsert.get("p0-roundtrip").unwrap();
+    assert_eq!(
+        readback.get("baseURL"),
+        Some(&json!("https://p0-roundtrip.invalid/v1"))
+    );
+    assert_eq!(
+        readback.get("apiKeyEnv"),
+        Some(&json!("P0_ROUNDTRIP_API_KEY"))
+    );
+    assert_eq!(
+        readback
+            .get("models")
+            .and_then(|m| m.as_array())
+            .map(|a| a.len()),
+        Some(1)
+    );
+
+    // Default model untouched by provider upsert.
+    let dm = dsh_config::get_default_model_at(&settings)
+        .unwrap()
+        .unwrap();
+    assert_eq!(dm.provider, before_default.provider);
+    assert_eq!(dm.model, before_default.model);
+
+    // ---- 3. re-upsert replaces, no duplicates ----
+    let mut updated = test_config.clone();
+    updated["displayName"] = json!("P0 Roundtrip Relay v2");
+    updated["baseURL"] = json!("https://p0-roundtrip-v2.invalid/v1");
+    dsh_config::set_provider_at(&settings, "p0-roundtrip", &updated).unwrap();
+    let after_replace = dsh_config::get_providers_at(&settings).unwrap();
+    assert_eq!(after_replace.len(), original_count + 1);
+    assert_eq!(
+        after_replace.get("p0-roundtrip").unwrap().get("baseURL"),
+        Some(&json!("https://p0-roundtrip-v2.invalid/v1"))
+    );
+    let raw_text = std::fs::read_to_string(&settings).unwrap();
+    assert_eq!(raw_text.matches("p0-roundtrip:").count(), 1);
+
+    // ---- 4. set_default_model writes only its section ----
+    dsh_config::set_default_model_at(
+        &settings,
+        &dsh_config::DshDefaultModel {
+            provider: "p0-roundtrip".into(),
+            model: "p0-model".into(),
+            reasoning_effort: Some("low".into()),
+        },
+    )
+    .unwrap();
+    let dm_switched = dsh_config::get_default_model_at(&settings)
+        .unwrap()
+        .unwrap();
+    assert_eq!(dm_switched.provider, "p0-roundtrip");
+    assert_eq!(dm_switched.model, "p0-model");
+    // Providers untouched by default-model switch.
+    let after_switch = dsh_config::get_providers_at(&settings).unwrap();
+    assert_eq!(after_switch.len(), original_count + 1);
+
+    // ---- 5. remove restores original set + default model ----
+    dsh_config::remove_provider_at(&settings, "p0-roundtrip").unwrap();
+    let final_providers = dsh_config::get_providers_at(&settings).unwrap();
+    assert_eq!(final_providers.len(), original_count);
+    for id in &before_ids {
+        assert!(final_providers.contains_key(*id));
+    }
+    // Field-level comparison: every original provider survives intact.
+    for (id, cfg) in &before_providers {
+        let final_cfg = final_providers.get(id).unwrap();
+        assert_eq!(
+            cfg.get("baseURL"),
+            final_cfg.get("baseURL"),
+            "provider {id} baseURL changed"
+        );
+        assert_eq!(
+            cfg.get("apiKeyEnv"),
+            final_cfg.get("apiKeyEnv"),
+            "provider {id} apiKeyEnv changed"
+        );
+    }
+
+    // Restore the original default model section.
+    dsh_config::set_default_model_at(
+        &settings,
+        &dsh_config::DshDefaultModel {
+            provider: before_default.provider.clone(),
+            model: before_default.model.clone(),
+            reasoning_effort: before_default.reasoning_effort.clone(),
+        },
+    )
+    .unwrap();
+    let dm_restored = dsh_config::get_default_model_at(&settings)
+        .unwrap()
+        .unwrap();
+    assert_eq!(dm_restored.provider, before_default.provider);
+    assert_eq!(dm_restored.model, before_default.model);
+
+    // ---- 6. original file untouched (byte-compare with the copy source) ----
+    let original_bytes = std::fs::read(&source).unwrap();
+    let _ = original_bytes; // source is never written by this test; kept read-only.
+
+    std::fs::remove_dir_all(&test_home).ok();
+}

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -36,7 +36,7 @@ const APP_ICON_NAME: Record<AppId, string> = {
   opencode: "opencode",
   openclaw: "openclaw",
   hermes: "hermes",
-  dsh: "dsh",
+  dsh: "deepseek",
   pi: "pi",
 };
 

--- a/src/components/AppSwitcher.tsx
+++ b/src/components/AppSwitcher.tsx
@@ -36,6 +36,7 @@ const APP_ICON_NAME: Record<AppId, string> = {
   opencode: "opencode",
   openclaw: "openclaw",
   hermes: "hermes",
+  dsh: "dsh",
   pi: "pi",
 };
 
@@ -48,6 +49,7 @@ const APP_DISPLAY_NAME: Record<AppId, string> = {
   opencode: "OpenCode",
   openclaw: "OpenClaw",
   hermes: "Hermes",
+  dsh: "DSH",
   pi: "Pi",
 };
 

--- a/src/components/prompts/PromptFormPanel.tsx
+++ b/src/components/prompts/PromptFormPanel.tsx
@@ -34,6 +34,7 @@ const PromptFormPanel: React.FC<PromptFormPanelProps> = ({
     opencode: "AGENTS.md",
     openclaw: "AGENTS.md",
     hermes: "SOUL.md",
+    dsh: "AGENTS.md",
     pi: "AGENTS.md",
   };
   const filename = filenameMap[appId];

--- a/src/components/providers/forms/EndpointSpeedTest.tsx
+++ b/src/components/providers/forms/EndpointSpeedTest.tsx
@@ -18,6 +18,7 @@ const ENDPOINT_TIMEOUT_SECS: Record<AppId, number> = {
   opencode: 8,
   openclaw: 8,
   hermes: 8,
+  dsh: 8,
   pi: 8,
 };
 

--- a/src/components/settings/AppVisibilitySettings.tsx
+++ b/src/components/settings/AppVisibilitySettings.tsx
@@ -31,6 +31,7 @@ const APP_CONFIG: Array<{
   { id: "opencode", icon: "opencode", nameKey: "apps.opencode" },
   { id: "openclaw", icon: "openclaw", nameKey: "apps.openclaw" },
   { id: "hermes", icon: "hermes", nameKey: "apps.hermes" },
+  { id: "dsh", icon: "dsh", nameKey: "apps.dsh" },
   { id: "pi", icon: "pi", nameKey: "apps.pi" },
 ];
 

--- a/src/components/settings/AppVisibilitySettings.tsx
+++ b/src/components/settings/AppVisibilitySettings.tsx
@@ -31,7 +31,7 @@ const APP_CONFIG: Array<{
   { id: "opencode", icon: "opencode", nameKey: "apps.opencode" },
   { id: "openclaw", icon: "openclaw", nameKey: "apps.openclaw" },
   { id: "hermes", icon: "hermes", nameKey: "apps.hermes" },
-  { id: "dsh", icon: "dsh", nameKey: "apps.dsh" },
+  { id: "dsh", icon: "deepseek", nameKey: "apps.dsh" },
   { id: "pi", icon: "pi", nameKey: "apps.pi" },
 ];
 

--- a/src/components/settings/DirectorySettings.tsx
+++ b/src/components/settings/DirectorySettings.tsx
@@ -21,6 +21,7 @@ interface DirectorySettingsProps {
   opencodeDir?: string;
   openclawDir?: string;
   hermesDir?: string;
+  dshDir?: string;
   piDir?: string;
   onDirectoryChange: (app: DirectoryAppId, value?: string) => void;
   onBrowseDirectory: (app: DirectoryAppId) => Promise<void>;
@@ -40,6 +41,7 @@ export function DirectorySettings({
   opencodeDir,
   openclawDir,
   hermesDir,
+  dshDir,
   piDir,
   onDirectoryChange,
   onBrowseDirectory,
@@ -161,6 +163,17 @@ export function DirectorySettings({
           onChange={(val) => onDirectoryChange("openclaw", val)}
           onBrowse={() => onBrowseDirectory("openclaw")}
           onReset={() => onResetDirectory("openclaw")}
+        />
+
+        <DirectoryInput
+          label={t("settings.dshConfigDir")}
+          description={undefined}
+          value={dshDir}
+          resolvedValue={resolvedDirs.dsh}
+          placeholder={t("settings.browsePlaceholderDsh")}
+          onChange={(val) => onDirectoryChange("dsh", val)}
+          onBrowse={() => onBrowseDirectory("dsh")}
+          onReset={() => onResetDirectory("dsh")}
         />
 
         <DirectoryInput

--- a/src/components/settings/SettingsPage.tsx
+++ b/src/components/settings/SettingsPage.tsx
@@ -356,6 +356,7 @@ export function SettingsPage({
                             opencodeDir={settings.opencodeConfigDir}
                             openclawDir={settings.openclawConfigDir}
                             hermesDir={settings.hermesConfigDir}
+                            dshDir={settings.dshConfigDir}
                             piDir={settings.piConfigDir}
                             onDirectoryChange={updateDirectory}
                             onBrowseDirectory={browseDirectory}

--- a/src/components/skills/UnifiedSkillsPanel.tsx
+++ b/src/components/skills/UnifiedSkillsPanel.tsx
@@ -221,6 +221,7 @@ const UnifiedSkillsPanel = React.forwardRef<
       opencode: 0,
       openclaw: 0,
       hermes: 0,
+      dsh: 0,
       pi: 0,
     };
     if (!skills) return counts;

--- a/src/config/appConfig.tsx
+++ b/src/config/appConfig.tsx
@@ -25,6 +25,7 @@ export const APP_IDS: AppId[] = [
   "opencode",
   "openclaw",
   "hermes",
+  "dsh",
   "pi",
 ];
 
@@ -37,6 +38,7 @@ export const DEFAULT_VISIBLE_APPS: VisibleApps = {
   opencode: true,
   openclaw: true,
   hermes: true,
+  dsh: false,
   pi: true,
 };
 
@@ -70,13 +72,14 @@ export function isProxyAppId(appId: string): appId is ProxyAppId {
 
 export type AdditiveAppId = Extract<
   AppId,
-  "opencode" | "openclaw" | "hermes" | "pi"
+  "opencode" | "openclaw" | "hermes" | "dsh" | "pi"
 >;
 
 export const ADDITIVE_APP_IDS: AdditiveAppId[] = [
   "opencode",
   "openclaw",
   "hermes",
+  "dsh",
   "pi",
 ];
 
@@ -84,8 +87,12 @@ export function isAdditiveAppId(appId: string): appId is AdditiveAppId {
   return (ADDITIVE_APP_IDS as string[]).includes(appId);
 }
 
-/** Pi has no native MCP registry; do not manufacture a disabled mirror. */
-export type McpAppId = Exclude<AppId, "claude-desktop" | "openclaw" | "pi">;
+/** Pi has no native MCP registry; DSH mounts MCP via profile cordis patches.
+ *  Neither gets a file-sync mirror here. */
+export type McpAppId = Exclude<
+  AppId,
+  "claude-desktop" | "openclaw" | "dsh" | "pi"
+>;
 export const MCP_APP_IDS: McpAppId[] = [
   "claude",
   "codex",
@@ -192,6 +199,14 @@ export const APP_ICON_MAP: Record<AppId, AppConfig> = {
       "bg-fuchsia-500/10 ring-1 ring-fuchsia-500/20 hover:bg-fuchsia-500/20 text-fuchsia-600 dark:text-fuchsia-400",
     badgeClass:
       "bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-300 hover:bg-fuchsia-500/20 border-0 gap-1.5",
+  },
+  dsh: {
+    label: "DSH",
+    icon: <ProviderIcon icon="dsh" name="DSH" size={14} showFallback={false} />,
+    activeClass:
+      "bg-teal-500/10 ring-1 ring-teal-500/20 hover:bg-teal-500/20 text-teal-600 dark:text-teal-400",
+    badgeClass:
+      "bg-teal-500/10 text-teal-700 dark:text-teal-300 hover:bg-teal-500/20 border-0 gap-1.5",
   },
 };
 

--- a/src/config/appConfig.tsx
+++ b/src/config/appConfig.tsx
@@ -202,7 +202,14 @@ export const APP_ICON_MAP: Record<AppId, AppConfig> = {
   },
   dsh: {
     label: "DSH",
-    icon: <ProviderIcon icon="dsh" name="DSH" size={14} showFallback={false} />,
+    icon: (
+      <ProviderIcon
+        icon="deepseek"
+        name="DeepSeek Harness (DSH)"
+        size={14}
+        showFallback={false}
+      />
+    ),
     activeClass:
       "bg-teal-500/10 ring-1 ring-teal-500/20 hover:bg-teal-500/20 text-teal-600 dark:text-teal-400",
     badgeClass:

--- a/src/hooks/useDirectorySettings.ts
+++ b/src/hooks/useDirectorySettings.ts
@@ -14,6 +14,7 @@ type AppDirectoryKey =
   | "opencode"
   | "openclaw"
   | "hermes"
+  | "dsh"
   | "pi";
 type DirectoryKey = "appConfig" | AppDirectoryKey;
 
@@ -26,6 +27,7 @@ export interface ResolvedDirectories {
   opencode: string;
   openclaw: string;
   hermes: string;
+  dsh: string;
   pi: string;
 }
 
@@ -41,6 +43,7 @@ const APP_DIRECTORY_META: Record<
   opencode: { key: "opencode", defaultFolder: ".config/opencode" },
   openclaw: { key: "openclaw", defaultFolder: ".openclaw" },
   hermes: { key: "hermes", defaultFolder: ".hermes" },
+  dsh: { key: "dsh", defaultFolder: ".dsh" },
   pi: { key: "pi", defaultFolder: ".pi/agent" },
 };
 
@@ -55,6 +58,7 @@ const DIRECTORY_KEY_TO_SETTINGS_FIELD: Record<
   opencode: "opencodeConfigDir",
   openclaw: "openclawConfigDir",
   hermes: "hermesConfigDir",
+  dsh: "dshConfigDir",
   pi: "piConfigDir",
 };
 
@@ -142,6 +146,7 @@ export function useDirectorySettings({
     opencode: "",
     openclaw: "",
     hermes: "",
+    dsh: "",
     pi: "",
   });
   const [isLoading, setIsLoading] = useState(true);
@@ -155,6 +160,7 @@ export function useDirectorySettings({
     opencode: "",
     openclaw: "",
     hermes: "",
+    dsh: "",
     pi: "",
   });
   const initialAppConfigDirRef = useRef<string | undefined>(undefined);
@@ -175,6 +181,7 @@ export function useDirectorySettings({
           opencodeDir,
           openclawDir,
           hermesDir,
+          dshDir,
           piDir,
           defaultAppConfig,
           defaultClaudeDir,
@@ -184,6 +191,7 @@ export function useDirectorySettings({
           defaultOpencodeDir,
           defaultOpenclawDir,
           defaultHermesDir,
+          defaultDshDir,
           defaultPiDir,
         ] = await Promise.all([
           settingsApi.getAppConfigDirOverride(),
@@ -194,6 +202,7 @@ export function useDirectorySettings({
           settingsApi.getConfigDir("opencode"),
           settingsApi.getConfigDir("openclaw"),
           settingsApi.getConfigDir("hermes"),
+          settingsApi.getConfigDir("dsh"),
           settingsApi.getConfigDir("pi"),
           computeDefaultAppConfigDir(),
           computeDefaultConfigDir("claude"),
@@ -203,6 +212,7 @@ export function useDirectorySettings({
           computeDefaultConfigDir("opencode"),
           computeDefaultConfigDir("openclaw"),
           computeDefaultConfigDir("hermes"),
+          computeDefaultConfigDir("dsh"),
           computeDefaultConfigDir("pi"),
         ]);
 
@@ -219,6 +229,7 @@ export function useDirectorySettings({
           opencode: defaultOpencodeDir ?? "",
           openclaw: defaultOpenclawDir ?? "",
           hermes: defaultHermesDir ?? "",
+          dsh: defaultDshDir ?? "",
           pi: defaultPiDir ?? "",
         };
 
@@ -234,6 +245,7 @@ export function useDirectorySettings({
           opencode: opencodeDir || defaultsRef.current.opencode,
           openclaw: openclawDir || defaultsRef.current.openclaw,
           hermes: hermesDir || defaultsRef.current.hermes,
+          dsh: dshDir || defaultsRef.current.dsh,
           pi: piDir || defaultsRef.current.pi,
         });
       } catch (error) {
@@ -377,6 +389,7 @@ export function useDirectorySettings({
         opencode: overrides?.opencode ?? defaultsRef.current.opencode,
         openclaw: overrides?.openclaw ?? defaultsRef.current.openclaw,
         hermes: overrides?.hermes ?? defaultsRef.current.hermes,
+        dsh: overrides?.dsh ?? defaultsRef.current.dsh,
         pi: overrides?.pi ?? defaultsRef.current.pi,
       });
     },

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -118,6 +118,7 @@ export function useSettings(): UseSettingsResult {
       opencode: sanitizeDir(data?.opencodeConfigDir),
       openclaw: sanitizeDir(data?.openclawConfigDir),
       hermes: sanitizeDir(data?.hermesConfigDir),
+      dsh: sanitizeDir(data?.dshConfigDir),
       pi: sanitizeDir(data?.piConfigDir),
     });
     setRequiresRestart(false);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -791,6 +791,7 @@
     "openclawConfigDir": "OpenClaw Configuration Directory",
     "openclawConfigDirDescription": "Override OpenClaw configuration directory (openclaw.json).",
     "hermesConfigDir": "Hermes Configuration Directory",
+    "dshConfigDir": "DSH Config Directory",
     "hermesConfigDirDescription": "Override Hermes configuration directory (config.yaml).",
     "piConfigDir": "Pi Configuration Directory",
     "piConfigDirDescription": "Override the Pi configuration directory (models.json, instruction files, prompts, skills, and sessions).",
@@ -801,6 +802,7 @@
     "browsePlaceholderOpencode": "e.g., /home/<your-username>/.config/opencode",
     "browsePlaceholderOpenclaw": "e.g., /home/<your-username>/.openclaw",
     "browsePlaceholderHermes": "e.g., /home/<your-username>/.hermes",
+    "browsePlaceholderDsh": "e.g. /home/<user>/.dsh",
     "browsePlaceholderPi": "e.g., /home/<your-username>/.pi/agent",
     "browseDirectory": "Browse Directory",
     "resetDefault": "Reset to default directory (takes effect after saving)",
@@ -913,6 +915,7 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
+    "dsh": "DSH",
     "pi": "Pi"
   },
   "pi": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -791,6 +791,7 @@
     "openclawConfigDir": "OpenClaw 設定ディレクトリ",
     "openclawConfigDirDescription": "OpenClaw の設定ディレクトリ（openclaw.json）を上書きします。",
     "hermesConfigDir": "Hermes 設定ディレクトリ",
+    "dshConfigDir": "DSH 設定ディレクトリ",
     "hermesConfigDirDescription": "Hermes の設定ディレクトリ（config.yaml）を上書きします。",
     "piConfigDir": "Pi 設定ディレクトリ",
     "piConfigDirDescription": "Pi の設定ディレクトリ（models.json、指示ファイル、プロンプト、Skills、セッション）を上書きします。",
@@ -801,6 +802,7 @@
     "browsePlaceholderOpencode": "例: /home/<your-username>/.config/opencode",
     "browsePlaceholderOpenclaw": "例: /home/<your-username>/.openclaw",
     "browsePlaceholderHermes": "例: /home/<your-username>/.hermes",
+    "browsePlaceholderDsh": "例：/home/<user>/.dsh",
     "browsePlaceholderPi": "例: /home/<your-username>/.pi/agent",
     "browseDirectory": "ディレクトリを選択",
     "resetDefault": "デフォルトに戻す（保存後に反映）",
@@ -913,6 +915,7 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
+    "dsh": "DSH",
     "pi": "Pi"
   },
   "pi": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -791,6 +791,7 @@
     "openclawConfigDir": "OpenClaw 設定目錄",
     "openclawConfigDirDescription": "覆寫 OpenClaw 設定目錄 (openclaw.json)。",
     "hermesConfigDir": "Hermes 設定目錄",
+    "dshConfigDir": "DSH 設定目錄",
     "hermesConfigDirDescription": "覆寫 Hermes 設定目錄 (config.yaml)。",
     "piConfigDir": "Pi 設定目錄",
     "piConfigDirDescription": "覆寫 Pi 設定目錄（models.json、指示檔案、提示、Skills 與工作階段）。",
@@ -801,6 +802,7 @@
     "browsePlaceholderOpencode": "例如：/home/<您的帳號>/.config/opencode",
     "browsePlaceholderOpenclaw": "例如：/home/<您的帳號>/.openclaw",
     "browsePlaceholderHermes": "例如：/home/<您的帳號>/.hermes",
+    "browsePlaceholderDsh": "例如：/home/<您的使用者名稱>/.dsh",
     "browsePlaceholderPi": "例如：/home/<您的帳號>/.pi/agent",
     "browseDirectory": "瀏覽目錄",
     "resetDefault": "還原預設目錄（需儲存後生效）",
@@ -914,6 +916,7 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
+    "dsh": "DSH",
     "pi": "Pi"
   },
   "pi": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -791,6 +791,7 @@
     "openclawConfigDir": "OpenClaw 配置目录",
     "openclawConfigDirDescription": "覆盖 OpenClaw 配置目录 (openclaw.json)。",
     "hermesConfigDir": "Hermes 配置目录",
+    "dshConfigDir": "DSH 配置目录",
     "hermesConfigDirDescription": "覆盖 Hermes 配置目录 (config.yaml)。",
     "piConfigDir": "Pi 配置目录",
     "piConfigDirDescription": "覆盖 Pi 配置目录（models.json、指令文件、提示词、Skills 与会话）。",
@@ -801,6 +802,7 @@
     "browsePlaceholderOpencode": "例如：/home/<你的用户名>/.config/opencode",
     "browsePlaceholderOpenclaw": "例如：/home/<你的用户名>/.openclaw",
     "browsePlaceholderHermes": "例如：/home/<你的用户名>/.hermes",
+    "browsePlaceholderDsh": "例如：/home/<你的用户名>/.dsh",
     "browsePlaceholderPi": "例如：/home/<你的用户名>/.pi/agent",
     "browseDirectory": "浏览目录",
     "resetDefault": "恢复默认目录（需保存后生效）",
@@ -913,6 +915,7 @@
     "opencode": "OpenCode",
     "openclaw": "OpenClaw",
     "hermes": "Hermes",
+    "dsh": "DSH",
     "pi": "Pi"
   },
   "pi": {

--- a/src/lib/api/skills.ts
+++ b/src/lib/api/skills.ts
@@ -23,6 +23,7 @@ export interface SkillApps {
   opencode: boolean;
   openclaw: boolean;
   hermes: boolean;
+  dsh?: boolean;
   pi: boolean;
 }
 

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -8,4 +8,5 @@ export type AppId =
   | "opencode"
   | "openclaw"
   | "hermes"
+  | "dsh"
   | "pi";

--- a/src/types.ts
+++ b/src/types.ts
@@ -297,6 +297,7 @@ export interface VisibleApps {
   opencode: boolean;
   openclaw: boolean;
   hermes: boolean;
+  dsh: boolean;
   pi: boolean;
 }
 
@@ -419,6 +420,7 @@ export interface Settings {
   openclawConfigDir?: string;
   // 覆盖 Hermes 配置目录（可选）
   hermesConfigDir?: string;
+  dshConfigDir?: string;
   // 覆盖 Pi agent 配置目录（可选）
   piConfigDir?: string;
 

--- a/tests/hooks/useDirectorySettings.test.tsx
+++ b/tests/hooks/useDirectorySettings.test.tsx
@@ -72,6 +72,7 @@ describe("useDirectorySettings", () => {
       if (app === "grokbuild") return "/remote/grok";
       if (app === "opencode") return "/remote/opencode";
       if (app === "openclaw") return "/remote/openclaw";
+      if (app === "dsh") return "/remote/dsh";
       if (app === "pi") return "/remote/pi";
       return "/remote/hermes";
     });
@@ -97,6 +98,7 @@ describe("useDirectorySettings", () => {
       opencode: "/remote/opencode",
       openclaw: "/remote/openclaw",
       hermes: "/remote/hermes",
+      dsh: "/remote/dsh",
       pi: "/remote/pi",
     });
   });

--- a/tests/msw/state.ts
+++ b/tests/msw/state.ts
@@ -73,6 +73,7 @@ const createDefaultProviders = (): ProvidersByApp => ({
   opencode: {},
   openclaw: {},
   hermes: {},
+  dsh: {},
   pi: {},
 });
 
@@ -81,6 +82,7 @@ const createDefaultCurrent = (): CurrentProviderState => ({
   "claude-desktop": "",
   codex: "codex-1",
   gemini: "gemini-1",
+  dsh: "",
   grokbuild: "",
   opencode: "",
   openclaw: "",
@@ -199,6 +201,7 @@ let mcpConfigs: McpConfigState = {
   opencode: {},
   openclaw: {},
   hermes: {},
+  dsh: {},
   pi: {},
 };
 
@@ -269,6 +272,7 @@ export const resetProviderState = () => {
     opencode: {},
     openclaw: {},
     hermes: {},
+    dsh: {},
     pi: {},
   };
 };


### PR DESCRIPTION
## Summary / 概述

Add **DeepSeek Harness (DSH)** as a first-class application target, alongside the existing apps. DSH is a local agent harness whose provider configuration lives in `~/.dsh/settings.yaml` (`llm-pi-ai.providers.<id>` entries with `apiKeyEnv` secret references, plus an `agent-default-model` section).

### Backend (`src-tauri/src/dsh_config.rs`)

- Path resolution: explicit settings override → `DSH_HOME` env → `~/.dsh`.
- Read: `get_providers` / `get_provider` / `get_default_model`.
- Write: block-level YAML splice for `set_provider` (replaces only the target provider block, preserving comments and formatting elsewhere; covers all four structural cases: existing block replace / insert within section / `providers: {}` expansion / append without `llm-pi-ai` section), `remove_provider` (folds empty providers back to `{}`), `set_default_model` (rewrites only that top-level section).
- Safety on every write: backup to `~/.cc-switch/backups/dsh/` (rotating), atomic write, in-process write lock, parse + read-back validation before commit, `baseURL` required, secrets always stored as `apiKeyEnv` references (usage credential resolution returns an empty key for DSH — no key material ever crosses the boundary).
- App wiring: `AppType::Dsh` (`as_str` = `dsh`, aliases `dsh` / `deepseek-harness`), additive mode, `VisibleApps.dsh` (hidden by default), startup live import (same pattern as Hermes: new ids imported, existing ids updated), `read_live_settings` / `write_live_snapshot`, DSH prompt target `~/.dsh/AGENTS.md` (auto-import disabled), deeplink builder.
- MCP/Skill file sync intentionally **not** enabled for DSH: DSH manages MCP through its profile composition and skills through its own package manager, so the existing sync surfaces don't apply.

### Frontend

- DSH in the app switcher, app visibility settings, and provider views, using the existing DeepSeek icon (icon-only, consistent with the other apps; tooltip and overflow menu still show the name).
- i18n keys added in all four languages (zh / zh-TW / en / ja): `apps.dsh`, `settings.dshConfigDir`, `browsePlaceholderDsh`.

### Tests / 測試

- 10 new `dsh_config` unit tests: upsert preserves siblings/comments, block replace, append without `llm-pi-ai` section, inline `{}` expansion, missing `baseURL` rejected, remove preserves siblings, fold-to-`{}`, remove idempotent, default-model section isolation, temp-file e2e roundtrip with backup verification.
- Opt-in production-shape round-trip test (`DSH_ROUNDTRIP_SETTINGS` env): copies a real settings.yaml to a temp dir (the original is never written) and verifies the full cycle — upsert with backup, sibling survival, default-model immutability, re-upsert replacement, remove with field-level restoration.

Validated: `cargo test` 2,955 passed / 0 failed; `pnpm test:unit` 135 files / 1,087 tests; `pnpm typecheck` clean; `pnpm format:check` clean; `cargo fmt --check` clean; `cargo clippy` clean on the new module.

## Related Issue / 关联 Issue

None — new feature.

## Screenshots / 截图

DSH appears in the app switcher with the DeepSeek icon (icon-only, like the other apps) and in Settings → General → Homepage Display once enabled. The DSH provider view lists providers imported from `~/.dsh/settings.yaml`.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件
