### PR TITLE
feat(proxy): stamp x-opencode-session for OpenCode Go upstream

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1983,6 +1983,16 @@ impl RequestForwarder {
         let should_send_anthropic_headers = adapter.name() == "Claude"
             && matches!(resolved_claude_api_format.as_deref(), Some("anthropic"));
 
+        // 目标上游是否为 OpenCode Go 网关（opencode.ai）。Claude/Claude Desktop
+        // 的 /zen/go 端点 host 为 opencode.ai。按 host 而非 path 判定：这里是路由
+        // 注入，不能因同域其它路径的误判而给非 Go 网关附加会话头。
+        let is_opencode_go_upstream = url
+            .parse::<http::Uri>()
+            .ok()
+            .and_then(|u| u.host().map(str::to_owned))
+            .map(|h| h == "opencode.ai" || h.ends_with(".opencode.ai"))
+            .unwrap_or(false);
+
         // 预计算 anthropic-beta 值（仅 Claude）
         let anthropic_beta_value = if should_send_anthropic_headers {
             const CLAUDE_CODE_BETA: &str = "claude-code-20250219";
@@ -2251,6 +2261,21 @@ impl RequestForwarder {
         // 只发送客户端提供的 session_id；生成的 UUID 每次不同，反而会破坏前缀缓存。
         for (name, value) in codex_oauth_session_headers {
             ordered_headers.insert(name, value);
+        }
+
+        // OpenCode Go 网关（issue #7088）要求随对话携带稳定的 x-opencode-session
+        // 以便路由亲和与提示词缓存；Claude 客户端自己不发送该头，这里把代理已从
+        // 请求中提取的 Claude 会话 ID 原样映射过去。只映射客户端提供的 ID——
+        // 与 Codex OAuth 同理，自生成的 UUID 逐请求不同，反而不利于缓存——且
+        // 不覆盖客户端已显式携带的 x-opencode-session（如官方 opencode 客户端）。
+        if is_opencode_go_upstream && should_send_anthropic_headers {
+            if let Some(value) = maybe_opencode_session_header(
+                &self.session_id,
+                self.session_client_provided,
+                ordered_headers.contains_key("x-opencode-session"),
+            ) {
+                ordered_headers.append("x-opencode-session", value);
+            }
         }
 
         // 序列化请求体。GET/HEAD 是 idempotent/safe 方法，按 HTTP 语义不应携带 body；
@@ -3437,6 +3462,27 @@ fn rewrite_codex_standalone_full_url(
     }
 
     Ok(rewritten)
+}
+
+/// OpenCode Go 网关会话头的取值判定（issue #7088）。
+///
+/// opencode.ai/go 要求客户端随对话发送稳定的 `x-opencode-session`。Claude 客户端
+/// 自己不发送该头，本地代理把已从请求中提取的 Claude 会话 ID 原样映射过去。
+/// 仅当会话 ID 确由客户端提供时才返回：自生成的 UUID 逐请求变化，反而破坏网关的
+/// 前缀缓存（与 Codex OAuth 的考量一致）。已有客户端显式携带的头不覆盖。
+fn maybe_opencode_session_header(
+    session_id: &str,
+    client_provided: bool,
+    already_present: bool,
+) -> Option<http::HeaderValue> {
+    if !client_provided || already_present {
+        return None;
+    }
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return None;
+    }
+    http::HeaderValue::from_str(session_id).ok()
 }
 
 fn build_codex_oauth_session_headers(
@@ -5491,5 +5537,39 @@ mod tests {
         });
         let body = body_with_image("any-model");
         assert!(fwd.media_retry_should_trigger("Claude", false, &body, &image_unsupported_error()));
+    }
+
+    // ========== OpenCode Go 会话头（maybe_opencode_session_header）测试 ==========
+
+    #[test]
+    fn opencode_session_uses_client_provided_id() {
+        let value = maybe_opencode_session_header("conv-724f4275", true, false)
+            .expect("should inject when client provided the id");
+        assert_eq!(value.to_str().unwrap(), "conv-724f4275");
+    }
+
+    #[test]
+    fn opencode_session_skips_when_header_already_present() {
+        assert!(maybe_opencode_session_header("conv-724f4275", true, true).is_none());
+    }
+
+    #[test]
+    fn opencode_session_skips_generated_uuid() {
+        // 自生成的 UUID 逐请求不同，注入反而破坏网关前缀缓存 → 只在客户端
+        // 真正提供会话 ID 时才发。
+        assert!(maybe_opencode_session_header("5e1f9f88-9ad1-4e35-a5e0-b0f2c7aa9b31", false, false)
+            .is_none());
+    }
+
+    #[test]
+    fn opencode_session_skips_blank_id() {
+        assert!(maybe_opencode_session_header("", true, false).is_none());
+        assert!(maybe_opencode_session_header("   ", true, false).is_none());
+    }
+
+    #[test]
+    fn opencode_session_rejects_non_ascii_id() {
+        // 非法 header 值（如含换行）不能注入，返回 None 而不是 panic。
+        assert!(maybe_opencode_session_header("bad\nvalue", true, false).is_none());
     }
 }

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1983,16 +1983,6 @@ impl RequestForwarder {
         let should_send_anthropic_headers = adapter.name() == "Claude"
             && matches!(resolved_claude_api_format.as_deref(), Some("anthropic"));
 
-        // 目标上游是否为 OpenCode Go 网关（opencode.ai）。Claude/Claude Desktop
-        // 的 /zen/go 端点 host 为 opencode.ai。按 host 而非 path 判定：这里是路由
-        // 注入，不能因同域其它路径的误判而给非 Go 网关附加会话头。
-        let is_opencode_go_upstream = url
-            .parse::<http::Uri>()
-            .ok()
-            .and_then(|u| u.host().map(str::to_owned))
-            .map(|h| h == "opencode.ai" || h.ends_with(".opencode.ai"))
-            .unwrap_or(false);
-
         // 预计算 anthropic-beta 值（仅 Claude）
         let anthropic_beta_value = if should_send_anthropic_headers {
             const CLAUDE_CODE_BETA: &str = "claude-code-20250219";
@@ -2268,7 +2258,7 @@ impl RequestForwarder {
         // 请求中提取的 Claude 会话 ID 原样映射过去。只映射客户端提供的 ID——
         // 与 Codex OAuth 同理，自生成的 UUID 逐请求不同，反而不利于缓存——且
         // 不覆盖客户端已显式携带的 x-opencode-session（如官方 opencode 客户端）。
-        if is_opencode_go_upstream && should_send_anthropic_headers {
+        if is_opencode_go_upstream_url(&url) && should_send_anthropic_headers {
             if let Some(value) = maybe_opencode_session_header(
                 &self.session_id,
                 self.session_client_provided,
@@ -3534,6 +3524,23 @@ fn is_managed_account_upstream_url(url: &str) -> bool {
         || host.ends_with(".githubcopilot.com")
         || (host == "chatgpt.com" && uri.path().starts_with("/backend-api/codex"))
         || (host == "api.x.ai" && uri.path().starts_with("/v1/"))
+}
+
+/// 目标上游是否为 OpenCode Go 网关（opencode.ai）。
+///
+/// Claude / Claude Desktop 的 `/zen/go` 端点 host 为 opencode.ai。按 host 判定
+/// （而非 path），避免给同域其它路径误加会话头；host 大小写归一化，与
+/// `is_managed_account_upstream_url` 一致（DNS 主机名不区分大小写）。
+fn is_opencode_go_upstream_url(url: &str) -> bool {
+    let Ok(uri) = url.parse::<http::Uri>() else {
+        return false;
+    };
+
+    let Some(host) = uri.host().map(str::to_ascii_lowercase) else {
+        return false;
+    };
+
+    host == "opencode.ai" || host.ends_with(".opencode.ai")
 }
 
 fn headers_contain_proxy_placeholder(headers: &http::HeaderMap) -> bool {
@@ -5557,8 +5564,12 @@ mod tests {
     fn opencode_session_skips_generated_uuid() {
         // 自生成的 UUID 逐请求不同，注入反而破坏网关前缀缓存 → 只在客户端
         // 真正提供会话 ID 时才发。
-        assert!(maybe_opencode_session_header("5e1f9f88-9ad1-4e35-a5e0-b0f2c7aa9b31", false, false)
-            .is_none());
+        assert!(maybe_opencode_session_header(
+            "5e1f9f88-9ad1-4e35-a5e0-b0f2c7aa9b31",
+            false,
+            false
+        )
+        .is_none());
     }
 
     #[test]
@@ -5571,5 +5582,29 @@ mod tests {
     fn opencode_session_rejects_non_ascii_id() {
         // 非法 header 值（如含换行）不能注入，返回 None 而不是 panic。
         assert!(maybe_opencode_session_header("bad\nvalue", true, false).is_none());
+    }
+
+    // ========== OpenCode Go 上游判定（is_opencode_go_upstream_url）测试 ==========
+
+    #[test]
+    fn opencode_upstream_matches_host_case_insensitively() {
+        assert!(is_opencode_go_upstream_url(
+            "https://opencode.ai/zen/go/v1/messages"
+        ));
+        assert!(is_opencode_go_upstream_url(
+            "https://OpenCode.AI/zen/go/v1/messages"
+        ));
+        assert!(is_opencode_go_upstream_url("https://Go.Opencode.ai/zen/go"));
+    }
+
+    #[test]
+    fn opencode_upstream_rejects_other_hosts() {
+        assert!(!is_opencode_go_upstream_url(
+            "https://api.anthropic.com/v1/messages"
+        ));
+        assert!(!is_opencode_go_upstream_url(
+            "https://notopencode.ai/v1/messages"
+        ));
+        assert!(!is_opencode_go_upstream_url("not a url"));
     }
 }

--- a/src-tauri/src/proxy/session.rs
+++ b/src-tauri/src/proxy/session.rs
@@ -5,7 +5,8 @@
 //! ## Session ID 提取
 //!
 //! 支持从客户端请求中提取 Session ID，用于关联同一对话的多个请求：
-//! - Claude: 从 `metadata.user_id` (格式: `user_xxx_session_yyy`) 或 `metadata.session_id` 提取
+//! - Claude / Claude Desktop（`claude-desktop`）: 从 header `x-claude-code-session-id`
+//!   或 `metadata.user_id` (格式: `user_xxx_session_yyy`) / `metadata.session_id` 提取
 //! - Codex: 从 headers 中的 `session_id` / `x-session-id` 或 `metadata.session_id` 提取
 //! - Grok Build: 从 headers 中的 `x-grok-conv-id` / `x-grok-session-id` 提取
 //! - 其他: 生成新的 UUID
@@ -73,7 +74,7 @@ pub fn extract_session_id(
     body: &serde_json::Value,
     client_format: &str,
 ) -> SessionIdResult {
-    if client_format == "claude" {
+    if matches!(client_format, "claude" | "claude-desktop") {
         if let Some(result) = extract_claude_session(headers, body) {
             return result;
         }
@@ -455,5 +456,26 @@ mod tests {
         // 没有 "_session_" 分隔符的情况
         assert_eq!(parse_session_from_user_id("user_john_abc123"), None);
         assert_eq!(parse_session_from_user_id("_session_"), None);
+    }
+
+    #[test]
+    fn test_claude_desktop_uses_claude_session_header() {
+        // Claude Desktop 的 app_type_str 是 "claude-desktop"，必须和 "claude"
+        // 一样读 Claude 会话头，否则下游的 x-opencode-session 映射拿不到 ID。
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-claude-code-session-id",
+            "d937243f-2702-4f20-97b6-c9682235ab81".parse().unwrap(),
+        );
+        let body = json!({
+            "model": "claude-3-5-sonnet",
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = extract_session_id(&headers, &body, "claude-desktop");
+
+        assert_eq!(result.session_id, "d937243f-2702-4f20-97b6-c9682235ab81");
+        assert_eq!(result.source, SessionIdSource::Header);
+        assert!(result.client_provided);
     }
 }


### PR DESCRIPTION
## Summary

Closes #7088.

OpenCode Go (opencode.ai/go) asks clients to send a stable `x-opencode-session` header per conversation for routing affinity and prompt caching; from 2026-09-06 requests missing it may error. Claude Code / Claude Desktop never send it themselves, so when the cc-switch local proxy forwards an Anthropic request to an **opencode.ai** upstream it now maps the client-provided Claude session id onto the header.

Behavior:
- Injection happens in `RequestForwarder` header assembly, gated on the upstream host being `opencode.ai` (`.opencode.ai`) and the adapter being Claude (`should_send_anthropic_headers`), so only Claude-family traffic headed to OpenCode Go is affected.
- Value = the conversation session id already extracted from the request (`x-claude-code-session-id` header or body `metadata.user_id`/`session_id`), i.e. stable across the conversation.
- Only **client-provided** ids are stamped. A per-request generated UUID would defeat the gateway's prefix cache — same rationale already documented for the Codex OAuth path (forwarder.rs).
- A client-supplied `x-opencode-session` (e.g. official opencode clients) is left untouched.

## Test plan

- New unit tests for `maybe_opencode_session_header` (inject / skip when present / skip generated / skip blank / reject invalid value) all pass under the pinned 1.95 toolchain.
- Full `cc_switch_lib` test build passes; no regressions (2822 other tests unaffected).

Note: only takes effect when Claude / Claude Desktop traffic is routed through the cc-switch local proxy (not in direct base-URL mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)