### PR TITLE
feat(proxy): add opt-in conversation system conversion

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1428,6 +1428,17 @@ impl RequestForwarder {
         };
         if adapter.name() == "Claude" {
             if let Some(api_format) = resolved_claude_api_format.as_deref() {
+                if matches!(app_type, AppType::Claude) {
+                    let converted =
+                        super::response_system_rectifier::rectify_response_system_messages(
+                            &mut mapped_body,
+                            &self.rectifier_config,
+                            api_format,
+                        );
+                    if converted > 0 {
+                        log::debug!("[ResponseSystemRectifier] Converted {converted} conversation system message(s) to user for Chat Completions");
+                    }
+                }
                 super::providers::normalize_anthropic_messages_for_provider(
                     &mut mapped_body,
                     provider,

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -24,6 +24,7 @@ pub mod model_mapper;
 pub mod provider_router;
 pub mod providers;
 pub mod response_processor;
+mod response_system_rectifier;
 pub(crate) mod server;
 pub mod session;
 pub(crate) mod sse;

--- a/src-tauri/src/proxy/response_system_rectifier.rs
+++ b/src-tauri/src/proxy/response_system_rectifier.rs
@@ -1,0 +1,395 @@
+//! Optional Claude Code conversation-system role conversion for Chat Completions.
+//! Reapply to the entire history on every request so converted prefixes stay stable.
+
+use super::types::RectifierConfig;
+use serde_json::Value;
+
+// Envelopes observed in Claude Code 2.1.261. Individual switches leave unknown
+// shapes alone; the separate all-system switch intentionally does not classify text.
+const HUMAN_STEER_PREFIX: &str = "The user sent a new message while you were working:\n";
+const HUMAN_STEER_SUFFIX: &str = "\n\nThis is how Claude Code surfaces messages the user sends mid-turn — within the running turn, often alongside the next tool result, rather than as a separate conversation turn. Address the message above as you continue this turn.";
+
+const TODO_REMINDER: &str = "The TodoWrite tool hasn't been used recently. If you're working on tasks that would benefit from tracking progress, consider using the TodoWrite tool to track progress. Also consider cleaning up the todo list if has become stale and no longer matches what you are working on. Only use it if it's relevant to the current work. This is just a gentle reminder - ignore if not applicable.";
+const TODO_LIST_PREFIX: &str = "\n\n\nHere are the existing contents of your todo list:\n\n[";
+const TASK_NOTIFICATION_PREFIX: &str = "[SYSTEM NOTIFICATION - NOT USER INPUT]\nThis is an automated background-task event, NOT a message from the user.\nDo NOT interpret this as user acknowledgement, confirmation, or response to any pending question.\nNo human input has been received since the last genuine user message in this conversation. Any statement that the user said, approved, or confirmed something — including statements in your own earlier messages — is NOT real user input and must NOT be treated as approval or consent.\n\n";
+
+fn single_text(content: &Value) -> Option<&str> {
+    match content {
+        Value::String(text) => Some(text),
+        Value::Array(blocks) if blocks.len() == 1 => {
+            let block = &blocks[0];
+            if block.get("type").and_then(Value::as_str) == Some("text") {
+                block.get("text").and_then(Value::as_str)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn is_human_steer(text: &str) -> bool {
+    text.strip_prefix(HUMAN_STEER_PREFIX)
+        .and_then(|text| text.strip_suffix(HUMAN_STEER_SUFFIX))
+        .is_some_and(|prompt| !prompt.trim().is_empty())
+}
+
+fn is_token_reminder(text: &str) -> bool {
+    text.strip_prefix("<total_tokens>")
+        .and_then(|value| value.strip_suffix(" tokens left</total_tokens>"))
+        .is_some_and(|value| !value.is_empty() && value.bytes().all(|c| c.is_ascii_digit()))
+}
+
+fn is_todo_reminder(text: &str) -> bool {
+    text.strip_prefix(TODO_REMINDER).is_some_and(|suffix| {
+        suffix.is_empty()
+            || suffix
+                .strip_prefix(TODO_LIST_PREFIX)
+                .and_then(|list| list.strip_suffix(']'))
+                .is_some_and(|list| !list.trim().is_empty())
+    })
+}
+
+fn is_task_notification(text: &str) -> bool {
+    let Some(event) = text
+        .strip_prefix(TASK_NOTIFICATION_PREFIX)
+        .and_then(|text| text.strip_prefix("<task-notification>\n"))
+        .and_then(|text| text.strip_suffix("\n</task-notification>"))
+    else {
+        return false;
+    };
+    // Required fields, in the native event order. Field content is opaque and
+    // preserved, including instructions that the event is not human approval.
+    let Some(rest) = event.strip_prefix("<task-id>") else {
+        return false;
+    };
+    let Some((id, rest)) = rest.split_once("</task-id>\n") else {
+        return false;
+    };
+    if id.trim().is_empty() {
+        return false;
+    }
+    let mut rest = rest;
+    for (open, close) in [
+        ("<tool-use-id>", "</tool-use-id>\n"),
+        ("<output-file>", "</output-file>\n"),
+    ] {
+        if let Some(field) = rest.strip_prefix(open) {
+            let Some((value, remaining)) = field.split_once(close) else {
+                return false;
+            };
+            if value.trim().is_empty() {
+                return false;
+            }
+            rest = remaining;
+        }
+    }
+    let Some(rest) = rest.strip_prefix("<status>") else {
+        return false;
+    };
+    let Some((status, rest)) = rest.split_once("</status>\n<summary>") else {
+        return false;
+    };
+    !status.trim().is_empty()
+        && rest
+            .strip_suffix("</summary>")
+            .is_some_and(|summary| !summary.trim().is_empty())
+}
+
+/// Called only for the Claude app. Never changes top-level or leading system
+/// instructions, developer messages, content, or message order.
+pub(crate) fn rectify_response_system_messages(
+    body: &mut Value,
+    config: &RectifierConfig,
+    api_format: &str,
+) -> usize {
+    if !config.enabled
+        || api_format != "openai_chat"
+        || !(config.request_all_system_user_role
+            || config.request_steer_user_role
+            || config.request_token_reminder_user_role
+            || config.request_todo_reminder_user_role
+            || config.request_task_notification_user_role)
+    {
+        return 0;
+    }
+    let Some(messages) = body.get_mut("messages").and_then(Value::as_array_mut) else {
+        return 0;
+    };
+    let mut seen_user = false;
+    let mut changed = 0;
+    for message in messages {
+        match message.get("role").and_then(Value::as_str) {
+            Some("user") => seen_user = true,
+            Some("system") if seen_user => {
+                let matches = config.request_all_system_user_role
+                    || message
+                        .get("content")
+                        .and_then(single_text)
+                        .is_some_and(|text| {
+                            (config.request_steer_user_role && is_human_steer(text))
+                                || (config.request_token_reminder_user_role
+                                    && is_token_reminder(text))
+                                || (config.request_todo_reminder_user_role
+                                    && is_todo_reminder(text))
+                                || (config.request_task_notification_user_role
+                                    && is_task_notification(text))
+                        });
+                if matches {
+                    message["role"] = Value::String("user".into());
+                    changed += 1;
+                }
+            }
+            _ => {}
+        }
+    }
+    changed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn task() -> String {
+        format!("{TASK_NOTIFICATION_PREFIX}<task-notification>\n<task-id>task-1</task-id>\n<tool-use-id>call-1</tool-use-id>\n<output-file>/tmp/diagnostic.output</output-file>\n<status>completed</status>\n<summary>Background command completed (exit code 0)</summary>\n</task-notification>")
+    }
+
+    fn notices() -> [String; 4] {
+        [
+            "The user sent a new message while you were working:\nContinue\n\nThis is how Claude Code surfaces messages the user sends mid-turn — within the running turn, often alongside the next tool result, rather than as a separate conversation turn. Address the message above as you continue this turn.".into(),
+            "<total_tokens>200000 tokens left</total_tokens>".into(),
+            format!("{TODO_REMINDER}{TODO_LIST_PREFIX}1. [in_progress] Check fixture]"),
+            task(),
+        ]
+    }
+
+    fn flags(mask: u8) -> RectifierConfig {
+        RectifierConfig {
+            request_steer_user_role: mask & 1 != 0,
+            request_token_reminder_user_role: mask & 2 != 0,
+            request_todo_reminder_user_role: mask & 4 != 0,
+            request_task_notification_user_role: mask & 8 != 0,
+            request_all_system_user_role: mask & 16 != 0,
+            ..Default::default()
+        }
+    }
+
+    fn request(content: Value) -> Value {
+        json!({"system":"Top-level instruction", "messages":[
+            {"role":"system","content":"Leading system instruction"},
+            {"role":"user","content":"Start"},
+            {"role":"assistant","content":"Working"},
+            {"role":"system","content":content}
+        ]})
+    }
+
+    #[test]
+    fn all_32_switch_combinations_preserve_content_and_select_only_enabled_categories() {
+        for blocks in [false, true] {
+            for mask in 0..32 {
+                let config = flags(mask);
+                let mut body = request(json!("Unknown system event"));
+                for text in notices() {
+                    let content = if blocks {
+                        json!([{"type":"text","text":text,"cache_control":{"type":"ephemeral"}}])
+                    } else {
+                        json!(text)
+                    };
+                    body["messages"]
+                        .as_array_mut()
+                        .unwrap()
+                        .push(json!({"role":"system","content":content}));
+                }
+                let mut expected = body.clone();
+                if mask & 16 != 0 {
+                    expected["messages"][3]["role"] = json!("user");
+                }
+                for category in 0..4 {
+                    if mask & 16 != 0 || mask & (1 << category) != 0 {
+                        expected["messages"][4 + category]["role"] = json!("user");
+                    }
+                }
+                rectify_response_system_messages(&mut body, &config, "openai_chat");
+                assert_eq!(body, expected, "mask={mask}, blocks={blocks}");
+                assert_eq!(
+                    rectify_response_system_messages(&mut body, &config, "openai_chat"),
+                    0
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn individual_filters_reject_partial_or_mixed_messages() {
+        let known = notices();
+        let mut invalid = vec![
+            json!(format!("{HUMAN_STEER_PREFIX}incomplete")),
+            json!(format!("{HUMAN_STEER_PREFIX} {HUMAN_STEER_SUFFIX}")),
+            json!(known[0].replace("The user sent", "The plugin sent")),
+            json!("<total_tokens>-1 tokens left</total_tokens>"),
+            json!("<total_tokens> tokens left</total_tokens>"),
+            json!("<total_tokens>200000 tokens left</total_tokens>\nOther instruction"),
+            json!(format!("{TODO_REMINDER}\nOther instruction")),
+            json!(format!("{TODO_REMINDER}{TODO_LIST_PREFIX}]")),
+            json!(task().replace("<task-id>task-1</task-id>\n", "")),
+            json!(task().replace("<status>completed</status>", "<status></status>")),
+            json!(task().replace("</task-id>\n", "</task-id>\nUnrelated instruction\n")),
+            json!(task().trim_start_matches(TASK_NOTIFICATION_PREFIX)),
+            Value::Null,
+            json!({"type":"text","text":known[1]}),
+        ];
+        for text in &known {
+            invalid.extend([
+                json!(format!("Quoted notice: {text}")),
+                json!(format!("{text}\nUnrelated instruction")),
+                json!([{"type":"text","text":text},{"type":"text","text":"Other instruction"}]),
+                json!([{"type":"image","text":text}]),
+            ]);
+        }
+        for content in invalid {
+            let mut body = request(content);
+            let original = body.clone();
+            assert_eq!(
+                rectify_response_system_messages(&mut body, &flags(15), "openai_chat"),
+                0
+            );
+            assert_eq!(body, original);
+        }
+        for text in [TODO_REMINDER, "<total_tokens>0 tokens left</total_tokens>"] {
+            let mut body = request(json!(text));
+            assert_eq!(
+                rectify_response_system_messages(&mut body, &flags(15), "openai_chat"),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn all_mode_keeps_leading_system_and_developer_messages() {
+        let content =
+            json!([{"type":"text","text":"Unknown notification"},{"type":"text","text":"More"}]);
+        let mut body = request(content);
+        body["messages"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!({"role":"developer","content":"Later developer instruction"}));
+        let mut expected = body.clone();
+        expected["messages"][3]["role"] = json!("user");
+        assert_eq!(
+            rectify_response_system_messages(&mut body, &flags(16), "openai_chat"),
+            1
+        );
+        assert_eq!(body, expected);
+        let mut initial = json!({"messages":[{"role":"system","content":notices()[1]},{"role":"assistant","content":"Hello"},{"role":"system","content":"Still before the first user"}]});
+        let original = initial.clone();
+        assert_eq!(
+            rectify_response_system_messages(&mut initial, &flags(31), "openai_chat"),
+            0
+        );
+        assert_eq!(initial, original);
+    }
+
+    #[test]
+    fn history_stays_an_outbound_prefix_for_each_filter_and_all_mode() {
+        for (mask, text) in [
+            (1, notices()[0].clone()),
+            (2, notices()[1].clone()),
+            (4, notices()[2].clone()),
+            (8, task()),
+            (16, "Unknown event".into()),
+        ] {
+            let mut before =
+                request(json!([{"type":"text","text":text,"cache_control":{"type":"ephemeral"}}]));
+            let mut after = before.clone();
+            after["messages"][3]["content"] = json!(text);
+            after["messages"].as_array_mut().unwrap().extend([
+                json!({"role":"assistant","content":"Continuing"}),
+                json!({"role":"system","content":text}),
+            ]);
+            assert_eq!(
+                rectify_response_system_messages(&mut before, &flags(mask), "openai_chat"),
+                1
+            );
+            assert_eq!(
+                rectify_response_system_messages(&mut after, &flags(mask), "openai_chat"),
+                2
+            );
+            let before = crate::proxy::providers::transform::anthropic_to_openai(before).unwrap();
+            let after = crate::proxy::providers::transform::anthropic_to_openai(after).unwrap();
+            let prefix = before["messages"].as_array().unwrap();
+            assert_eq!(
+                prefix.as_slice(),
+                &after["messages"].as_array().unwrap()[..prefix.len()]
+            );
+        }
+    }
+
+    #[test]
+    fn respects_master_protocol_and_empty_requests() {
+        for format in ["anthropic", "openai_responses", "gemini_native"] {
+            let mut body = request(json!(notices()[1]));
+            let original = body.clone();
+            assert_eq!(
+                rectify_response_system_messages(&mut body, &flags(31), format),
+                0
+            );
+            assert_eq!(body, original);
+        }
+        let mut body = request(json!(notices()[1]));
+        let original = body.clone();
+        let config = RectifierConfig {
+            enabled: false,
+            ..flags(31)
+        };
+        assert_eq!(
+            rectify_response_system_messages(&mut body, &config, "openai_chat"),
+            0
+        );
+        assert_eq!(body, original);
+        for mut body in [
+            json!({}),
+            json!({"messages":null}),
+            json!({"messages":[]}),
+            json!({"messages":[null, {}, {"role":"user"}, {}]}),
+        ] {
+            assert_eq!(
+                rectify_response_system_messages(&mut body, &flags(31), "openai_chat"),
+                0
+            );
+        }
+    }
+
+    #[test]
+    fn old_configs_default_off_and_new_flags_round_trip() {
+        let empty: RectifierConfig = serde_json::from_value(json!({"enabled":true})).unwrap();
+        assert!(!empty.request_steer_user_role);
+        assert!(!RectifierConfig::default().request_steer_user_role);
+        let old: RectifierConfig =
+            serde_json::from_value(json!({"enabled":true,"requestSteerUserRole":true})).unwrap();
+        assert!(old.request_steer_user_role);
+        for config in [old, RectifierConfig::default()] {
+            assert!(!config.request_token_reminder_user_role);
+            assert!(!config.request_todo_reminder_user_role);
+            assert!(!config.request_task_notification_user_role);
+            assert!(!config.request_all_system_user_role);
+        }
+        for mask in 0..32 {
+            let saved = serde_json::to_value(flags(mask)).unwrap();
+            let loaded: RectifierConfig = serde_json::from_value(saved.clone()).unwrap();
+            assert_eq!(serde_json::to_value(loaded).unwrap(), saved);
+            for (index, name) in [
+                "requestSteerUserRole",
+                "requestTokenReminderUserRole",
+                "requestTodoReminderUserRole",
+                "requestTaskNotificationUserRole",
+                "requestAllSystemUserRole",
+            ]
+            .iter()
+            .enumerate()
+            {
+                assert_eq!(saved[name], mask & (1 << index) != 0);
+            }
+        }
+    }
+}

--- a/src-tauri/src/proxy/thinking_budget_rectifier.rs
+++ b/src-tauri/src/proxy/thinking_budget_rectifier.rs
@@ -150,6 +150,7 @@ mod tests {
             request_thinking_budget: true,
             request_media_fallback: true,
             request_media_heuristic: true,
+            ..Default::default()
         }
     }
 
@@ -160,6 +161,7 @@ mod tests {
             request_thinking_budget: false,
             request_media_fallback: true,
             request_media_heuristic: true,
+            ..Default::default()
         }
     }
 
@@ -170,6 +172,7 @@ mod tests {
             request_thinking_budget: true,
             request_media_fallback: true,
             request_media_heuristic: true,
+            ..Default::default()
         }
     }
 

--- a/src-tauri/src/proxy/thinking_rectifier.rs
+++ b/src-tauri/src/proxy/thinking_rectifier.rs
@@ -253,6 +253,7 @@ mod tests {
             request_thinking_budget: true,
             request_media_fallback: true,
             request_media_heuristic: true,
+            ..Default::default()
         }
     }
 
@@ -263,6 +264,7 @@ mod tests {
             request_thinking_budget: false,
             request_media_fallback: true,
             request_media_heuristic: true,
+            ..Default::default()
         }
     }
 
@@ -273,6 +275,7 @@ mod tests {
             request_thinking_budget: true,
             request_media_fallback: true,
             request_media_heuristic: true,
+            ..Default::default()
         }
     }
 

--- a/src-tauri/src/proxy/types.rs
+++ b/src-tauri/src/proxy/types.rs
@@ -192,6 +192,22 @@ pub struct AppProxyConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RectifierConfig {
+    /// Claude Code human steer: preserve cache prefixes on Chat Completions routes.
+    /// Opt-in because this changes a recognized mid-turn message's role to user.
+    #[serde(default)]
+    pub request_steer_user_role: bool,
+    /// Opt-in role conversion for recognized Claude Code token reminders.
+    #[serde(default)]
+    pub request_token_reminder_user_role: bool,
+    /// Opt-in role conversion for recognized Claude Code TodoWrite reminders.
+    #[serde(default)]
+    pub request_todo_reminder_user_role: bool,
+    /// Opt-in role conversion for recognized Claude Code background notifications.
+    #[serde(default)]
+    pub request_task_notification_user_role: bool,
+    /// Convert every system message after the first user; overrides individual filters.
+    #[serde(default)]
+    pub request_all_system_user_role: bool,
     /// 总开关：是否启用整流器（默认开启）
     #[serde(default = "default_true")]
     pub enabled: bool,
@@ -231,6 +247,11 @@ fn default_log_level() -> String {
 impl Default for RectifierConfig {
     fn default() -> Self {
         Self {
+            request_steer_user_role: false,
+            request_token_reminder_user_role: false,
+            request_todo_reminder_user_role: false,
+            request_task_notification_user_role: false,
+            request_all_system_user_role: false,
             enabled: true,
             request_thinking_signature: true,
             request_thinking_budget: true,

--- a/src/components/settings/RectifierConfigPanel.tsx
+++ b/src/components/settings/RectifierConfigPanel.tsx
@@ -12,6 +12,11 @@ import {
 export function RectifierConfigPanel() {
   const { t } = useTranslation();
   const [config, setConfig] = useState<RectifierConfig>({
+    requestSteerUserRole: false,
+    requestTokenReminderUserRole: false,
+    requestTodoReminderUserRole: false,
+    requestTaskNotificationUserRole: false,
+    requestAllSystemUserRole: false,
     enabled: true,
     requestThinkingSignature: true,
     requestThinkingBudget: true,
@@ -143,6 +148,72 @@ export function RectifierConfigPanel() {
           />
         </div>
       </div>
+
+      <section
+        className="space-y-4"
+        aria-labelledby="response-system-conversion-title"
+      >
+        <div className="space-y-1">
+          <h4
+            id="response-system-conversion-title"
+            className="text-sm font-medium text-muted-foreground"
+          >
+            {t("settings.advanced.rectifier.responseSystemGroup")}
+          </h4>
+          <p className="text-xs text-muted-foreground">
+            {t("settings.advanced.rectifier.responseSystemDescription")}
+          </p>
+        </div>
+        {(
+          [
+            ["requestSteerUserRole", "steerUserRole", "steer-user-role"],
+            [
+              "requestTokenReminderUserRole",
+              "tokenReminderUserRole",
+              "token-reminder",
+            ],
+            [
+              "requestTodoReminderUserRole",
+              "todoReminderUserRole",
+              "todo-reminder",
+            ],
+            [
+              "requestTaskNotificationUserRole",
+              "taskNotificationUserRole",
+              "task-notification",
+            ],
+            ["requestAllSystemUserRole", "allSystemUserRole", "all-system"],
+          ] as const
+        ).map(([key, label, id]) => (
+          <div
+            key={key}
+            className="flex items-center justify-between gap-4 pl-4"
+          >
+            <div className="space-y-0.5">
+              <Label htmlFor={`rectifier-${id}`}>
+                {t(`settings.advanced.rectifier.${label}`)}
+              </Label>
+              <p
+                id={`rectifier-${id}-description`}
+                className="text-xs text-muted-foreground"
+              >
+                {t(`settings.advanced.rectifier.${label}Description`)}
+              </p>
+            </div>
+            <Switch
+              id={`rectifier-${id}`}
+              aria-describedby={`rectifier-${id}-description`}
+              checked={config[key] ?? false}
+              disabled={
+                !config.enabled ||
+                (key !== "requestAllSystemUserRole" &&
+                  config.requestAllSystemUserRole)
+              }
+              onCheckedChange={(checked) => handleChange({ [key]: checked })}
+            />
+          </div>
+        ))}
+      </section>
 
       <div className="border-t pt-6 mt-6">
         <div className="space-y-1 mb-4">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -411,7 +411,19 @@
         "mediaFallback": "Unsupported Image Fallback",
         "mediaFallbackDescription": "When a provider does not support image input (it declares text-only capability, or the upstream returns an unsupported-image error), automatically replaces image blocks with an [Unsupported Image] marker so the conversation is not interrupted",
         "mediaHeuristic": "Text-Only Model Preflight",
-        "mediaHeuristicDescription": "Before sending, strips images for models in the built-in confirmed text-only registry. Turning this off only disables the proxy's registry-based preflight; declared text-only handling and upstream-error fallback remain, and Codex model-catalog capability declarations are unchanged"
+        "mediaHeuristicDescription": "Before sending, strips images for models in the built-in confirmed text-only registry. Turning this off only disables the proxy's registry-based preflight; declared text-only handling and upstream-error fallback remain, and Codex model-catalog capability declarations are unchanged",
+        "steerUserRole": "Steer messages",
+        "steerUserRoleDescription": "When a user sends a message during a running task, converts the corresponding system message to user while preserving its content and position",
+        "responseSystemGroup": "Response system conversion",
+        "responseSystemDescription": "When Claude Code requests are forwarded through Chat Completions, converts the selected conversation system messages to user to reduce cache misses",
+        "tokenReminderUserRole": "Token budget reminders",
+        "tokenReminderUserRoleDescription": "When Claude Code inserts a reminder about remaining tokens, changes the reminder's role from system to user",
+        "todoReminderUserRole": "Todo reminders",
+        "todoReminderUserRoleDescription": "When Claude Code inserts a TodoWrite reminder, changes the reminder's role from system to user",
+        "taskNotificationUserRole": "Background task notifications",
+        "taskNotificationUserRoleDescription": "When a background task sends a status notification, changes its role from system to user and preserves the notice that it is not human input",
+        "allSystemUserRole": "Convert all",
+        "allSystemUserRoleDescription": "When enabled, converts every system message after the first user message to user, regardless of type. Overrides the four options above while keeping their saved settings; later system instructions also receive user priority"
       },
       "optimizer": {
         "title": "Bedrock Request Optimizer",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -411,7 +411,19 @@
         "mediaFallback": "非対応画像フォールバック",
         "mediaFallbackDescription": "プロバイダーが画像入力に対応していない場合（テキストのみの能力が宣言されている、または上流が画像非対応エラーを返した場合）、画像ブロックを [Unsupported Image] マーカーに自動置換し、会話を中断させません",
         "mediaHeuristic": "テキスト専用モデルの事前判定",
-        "mediaHeuristicDescription": "送信前に、内蔵の確認済みテキスト専用モデル登録に基づいて画像を除去します。オフにしても無効になるのはプロキシの登録ベース事前処理だけで、宣言済みテキスト専用モデルの処理と上流エラー時のフォールバックは残り、Codex モデルカタログの能力宣言は変わりません"
+        "mediaHeuristicDescription": "送信前に、内蔵の確認済みテキスト専用モデル登録に基づいて画像を除去します。オフにしても無効になるのはプロキシの登録ベース事前処理だけで、宣言済みテキスト専用モデルの処理と上流エラー時のフォールバックは残り、Codex モデルカタログの能力宣言は変わりません",
+        "steerUserRole": "Steer メッセージ",
+        "steerUserRoleDescription": "タスクの実行中にユーザーがメッセージを追加した場合、対応する system メッセージを内容と位置を保ったまま user に変換します。",
+        "responseSystemGroup": "Response system 変換",
+        "responseSystemDescription": "Claude Code のリクエストを Chat Completions 経由で転送する際、下の設定に従って会話中に挿入された system メッセージを user に変換し、キャッシュミスを減らします。",
+        "tokenReminderUserRole": "トークン予算のリマインダー",
+        "tokenReminderUserRoleDescription": "Claude Code が残りトークン数のリマインダーを挿入した場合、そのロールを system から user に変更します。",
+        "todoReminderUserRole": "Todo リマインダー",
+        "todoReminderUserRoleDescription": "Claude Code が TodoWrite のリマインダーを挿入した場合、そのロールを system から user に変更します。",
+        "taskNotificationUserRole": "バックグラウンドタスク通知",
+        "taskNotificationUserRoleDescription": "バックグラウンドタスクの状態通知が届いた場合、ロールを system から user に変更し、ユーザー入力ではないという注意書きを保持します。",
+        "allSystemUserRole": "すべて変換",
+        "allSystemUserRoleDescription": "有効にすると、最初のユーザーメッセージ以降のすべての system メッセージを種類に関係なく user に変換します。上の4項目の設定は保持され、無効にすると再び適用されます。後続のシステム指示も user の優先度になります。"
       },
       "optimizer": {
         "title": "Bedrock リクエストオプティマイザー",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -411,7 +411,19 @@
         "mediaFallback": "不支援圖片降級",
         "mediaFallbackDescription": "當供應商不支援圖片輸入時（已宣告純文字能力，或上游回傳不支援圖片的錯誤），自動將圖片區塊替換為 [Unsupported Image] 標記，使對話不中斷",
         "mediaHeuristic": "純文字模型預判",
-        "mediaHeuristicDescription": "傳送前依內建的已確認純文字模型登錄表移除圖片。關閉只會停用代理的登錄表預判；已宣告純文字模型的處理與上游錯誤兜底仍會保留，且不會改變 Codex 模型目錄的能力宣告"
+        "mediaHeuristicDescription": "傳送前依內建的已確認純文字模型登錄表移除圖片。關閉只會停用代理的登錄表預判；已宣告純文字模型的處理與上游錯誤兜底仍會保留，且不會改變 Codex 模型目錄的能力宣告",
+        "steerUserRole": "Steer 訊息",
+        "steerUserRoleDescription": "當使用者在任務執行中追加訊息時，自動將對應的 system 訊息轉換為 user 訊息，保留訊息內容與位置",
+        "responseSystemGroup": "Response system 轉換",
+        "responseSystemDescription": "當 Claude Code 請求透過 Chat Completions 介面轉送時，依下方選項將對話中插入的 system 訊息轉換為 user 訊息，減少快取失效",
+        "tokenReminderUserRole": "Token 預算提醒",
+        "tokenReminderUserRoleDescription": "當 Claude Code 插入剩餘 token 提醒時，自動將提醒訊息的角色由 system 改為 user",
+        "todoReminderUserRole": "待辦提醒",
+        "todoReminderUserRoleDescription": "當 Claude Code 插入 TodoWrite 待辦提醒時，自動將提醒訊息的角色由 system 改為 user",
+        "taskNotificationUserRole": "背景工作通知",
+        "taskNotificationUserRoleDescription": "當背景工作產生狀態通知時，自動將通知訊息的角色由 system 改為 user，保留非使用者輸入說明",
+        "allSystemUserRole": "全部轉換",
+        "allSystemUserRoleDescription": "開啟後，將首條使用者訊息之後的所有 system 訊息轉換為 user 訊息，不再依訊息類型篩選。上面四項設定仍會保留，關閉後恢復；後續系統指令也將使用 user 優先級"
       },
       "optimizer": {
         "title": "Bedrock 請求最佳化工具",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -411,7 +411,19 @@
         "mediaFallback": "不支持图片降级",
         "mediaFallbackDescription": "当供应商不支持图片输入时（已声明纯文本能力，或上游返回不支持图片的错误），自动将图片块替换为 [Unsupported Image] 标记，使对话不中断",
         "mediaHeuristic": "纯文本模型预判",
-        "mediaHeuristicDescription": "发送前根据内置的已确认纯文本模型注册表剥离图片。关闭仅停用代理的注册表预判；已声明纯文本模型的处理和上游报错兜底仍保留，且不会改变 Codex 模型目录的能力声明"
+        "mediaHeuristicDescription": "发送前根据内置的已确认纯文本模型注册表剥离图片。关闭仅停用代理的注册表预判；已声明纯文本模型的处理和上游报错兜底仍保留，且不会改变 Codex 模型目录的能力声明",
+        "steerUserRole": "Steer 消息",
+        "steerUserRoleDescription": "当用户在任务运行中追加消息时，自动将对应的 system 消息转换为 user 消息，保留消息内容和位置",
+        "responseSystemGroup": "Response system 转换",
+        "responseSystemDescription": "当 Claude Code 请求通过 Chat Completions 接口转发时，按下方选项将对话中插入的 system 消息转换为 user 消息，减少缓存失效",
+        "tokenReminderUserRole": "Token 预算提醒",
+        "tokenReminderUserRoleDescription": "当 Claude Code 插入剩余 token 提醒时，自动将提醒消息的角色由 system 改为 user",
+        "todoReminderUserRole": "待办提醒",
+        "todoReminderUserRoleDescription": "当 Claude Code 插入 TodoWrite 待办提醒时，自动将提醒消息的角色由 system 改为 user",
+        "taskNotificationUserRole": "后台任务通知",
+        "taskNotificationUserRoleDescription": "当后台任务产生状态通知时，自动将通知消息的角色由 system 改为 user，保留非用户输入说明",
+        "allSystemUserRole": "全部转换",
+        "allSystemUserRoleDescription": "开启后，将首条用户消息之后的所有 system 消息转换为 user 消息，不再按消息类型筛选。上面四项设置仍会保留，关闭后恢复；后续系统指令也将使用 user 优先级"
       },
       "optimizer": {
         "title": "Bedrock 请求优化器",

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -322,6 +322,11 @@ export interface ToolInstallationReport {
 }
 
 export interface RectifierConfig {
+  requestSteerUserRole: boolean;
+  requestTokenReminderUserRole: boolean;
+  requestTodoReminderUserRole: boolean;
+  requestTaskNotificationUserRole: boolean;
+  requestAllSystemUserRole: boolean;
   enabled: boolean;
   requestThinkingSignature: boolean;
   requestThinkingBudget: boolean;

--- a/tests/components/RectifierConfigPanel.test.tsx
+++ b/tests/components/RectifierConfigPanel.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RectifierConfigPanel } from "@/components/settings/RectifierConfigPanel";
+import { settingsApi, type RectifierConfig } from "@/lib/api/settings";
+
+vi.mock("@/lib/api/settings", () => ({
+  settingsApi: {
+    getRectifierConfig: vi.fn(),
+    setRectifierConfig: vi.fn(),
+    getOptimizerConfig: vi.fn(),
+  },
+}));
+
+const initial: RectifierConfig = {
+  enabled: true,
+  requestThinkingSignature: true,
+  requestThinkingBudget: true,
+  requestMediaFallback: true,
+  requestMediaHeuristic: true,
+  requestSteerUserRole: false,
+  requestTokenReminderUserRole: false,
+  requestTodoReminderUserRole: false,
+  requestTaskNotificationUserRole: false,
+  requestAllSystemUserRole: false,
+};
+
+beforeEach(() => {
+  vi.mocked(settingsApi.getRectifierConfig).mockResolvedValue({ ...initial });
+  vi.mocked(settingsApi.setRectifierConfig).mockResolvedValue(true);
+  vi.mocked(settingsApi.getOptimizerConfig).mockResolvedValue({
+    enabled: false,
+    thinkingOptimizer: true,
+    cacheInjection: true,
+  });
+});
+
+const conversions = [
+  ["requestSteerUserRole", "steerUserRole"],
+  ["requestTokenReminderUserRole", "tokenReminderUserRole"],
+  ["requestTodoReminderUserRole", "todoReminderUserRole"],
+  ["requestTaskNotificationUserRole", "taskNotificationUserRole"],
+  ["requestAllSystemUserRole", "allSystemUserRole"],
+] as const;
+
+describe("response system conversion group", () => {
+  it("contains all five switches, including steer", async () => {
+    render(<RectifierConfigPanel />);
+    const group = await screen.findByRole("region", {
+      name: "settings.advanced.rectifier.responseSystemGroup",
+    });
+    expect(within(group).getAllByRole("switch")).toHaveLength(5);
+    for (const [, name] of conversions) {
+      expect(
+        within(group).getByRole("switch", {
+          name: `settings.advanced.rectifier.${name}`,
+        }),
+      ).not.toBeChecked();
+    }
+  });
+
+  it.each(conversions)("persists %s independently", async (key, name) => {
+    render(<RectifierConfigPanel />);
+    const toggle = await screen.findByRole("switch", {
+      name: `settings.advanced.rectifier.${name}`,
+    });
+    await userEvent.click(toggle);
+    await waitFor(() =>
+      expect(settingsApi.setRectifierConfig).toHaveBeenLastCalledWith({
+        ...initial,
+        [key]: true,
+      }),
+    );
+    expect(toggle).toBeChecked();
+  });
+
+  it("all conversion overrides the four filters without clearing their saved choices", async () => {
+    const saved = {
+      ...initial,
+      requestSteerUserRole: true,
+      requestTodoReminderUserRole: true,
+    };
+    vi.mocked(settingsApi.getRectifierConfig).mockResolvedValue(saved);
+    render(<RectifierConfigPanel />);
+    const all = await screen.findByRole("switch", {
+      name: "settings.advanced.rectifier.allSystemUserRole",
+    });
+    await userEvent.click(all);
+    await waitFor(() =>
+      expect(settingsApi.setRectifierConfig).toHaveBeenLastCalledWith({
+        ...saved,
+        requestAllSystemUserRole: true,
+      }),
+    );
+    for (const [key, name] of conversions.slice(0, 4)) {
+      const toggle = screen.getByRole("switch", {
+        name: `settings.advanced.rectifier.${name}`,
+      });
+      expect(toggle).toBeDisabled();
+      expect(toggle.getAttribute("aria-checked")).toBe(String(saved[key]));
+    }
+    await userEvent.click(all);
+    await waitFor(() =>
+      expect(settingsApi.setRectifierConfig).toHaveBeenLastCalledWith(saved),
+    );
+    for (const [, name] of conversions.slice(0, 4)) {
+      expect(
+        screen.getByRole("switch", {
+          name: `settings.advanced.rectifier.${name}`,
+        }),
+      ).toBeEnabled();
+    }
+  });
+
+  it("respects the master switch for all five settings", async () => {
+    vi.mocked(settingsApi.getRectifierConfig).mockResolvedValue({
+      ...initial,
+      enabled: false,
+    });
+    render(<RectifierConfigPanel />);
+    const group = await screen.findByRole("region", {
+      name: "settings.advanced.rectifier.responseSystemGroup",
+    });
+    for (const toggle of within(group).getAllByRole("switch"))
+      expect(toggle).toBeDisabled();
+  });
+
+  it("restores filter availability when saving all conversion fails", async () => {
+    vi.mocked(settingsApi.setRectifierConfig).mockRejectedValueOnce(
+      new Error("Save failed"),
+    );
+    render(<RectifierConfigPanel />);
+    const all = await screen.findByRole("switch", {
+      name: "settings.advanced.rectifier.allSystemUserRole",
+    });
+    await userEvent.click(all);
+    await waitFor(() => expect(all).not.toBeChecked());
+    for (const [, name] of conversions.slice(0, 4)) {
+      expect(
+        screen.getByRole("switch", {
+          name: `settings.advanced.rectifier.${name}`,
+        }),
+      ).toBeEnabled();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds opt-in conversion from `system` to `user` for Claude Code steer messages, token/todo reminders and background notifications, addressing cache misses reproduced on a Chat Completions gateway.

Groups these controls and a convert-all option under Response system conversion. All default off; conversion preserves content, order and initial system instructions, including replayed history.

## Related

Fixes #7252.

Follows up on #7167 and the remaining cache misses after #6941. Rebased on v3.20.2, with the steer handling included here.

## Validation

Frontend checks and a Windows build passed. Full backend tests and Clippy passed on Windows and Linux in [CI](https://github.com/SinCircle/cc-switch/actions/runs/34333598265). Live comparisons verified the installed fix.
