### PR TITLE
fix(proxy): fall back to concatenation when full URL stops at /v1

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1481,6 +1481,14 @@ impl RequestForwarder {
         let codex_anthropic_base_is_full_endpoint =
             codex_responses_to_anthropic && base_url_is_full_endpoint(&base_url, "/v1/messages");
 
+        // Mirror image of the guards above: a "full URL" that stops at the version prefix
+        // (`.../v1`) is never a complete endpoint — every wire API appends a further segment
+        // (`/v1/responses`, `/v1/chat/completions`, `/v1/messages`), so full-URL mode would
+        // drop the endpoint path entirely and POST to `.../v1` verbatim (an opaque upstream
+        // 404; e.g. a Codex provider configured from a versioned token-plan base). Fall back
+        // to base-URL concatenation, which already treats `/v1`-suffixed bases as versioned.
+        let full_url_is_version_prefix_only = base_url_is_full_endpoint(&base_url, "/v1");
+
         let codex_standalone_endpoint = matches!(app_type, AppType::Codex)
             .then(|| CodexStandaloneEndpoint::from_effective_endpoint(&effective_endpoint))
             .flatten();
@@ -1491,7 +1499,7 @@ impl RequestForwarder {
                 &effective_endpoint,
                 is_full_url,
             )
-        } else if is_full_url {
+        } else if is_full_url && !full_url_is_version_prefix_only {
             if let Some(endpoint) = codex_standalone_endpoint {
                 rewrite_codex_standalone_full_url(
                     &base_url,
@@ -4474,6 +4482,58 @@ mod tests {
             "https://host.example/v1/chat/completions?api-version=2024",
             "/chat/completions"
         ));
+    }
+
+    #[test]
+    fn full_url_version_prefix_falls_back_to_concatenation() {
+        // With the "full URL" switch on, a URL that stops at the version prefix is not a
+        // complete endpoint for any wire API — full-URL mode must not POST to `.../v1`
+        // verbatim (an opaque upstream 404). The guard routes such URLs through base-URL
+        // concatenation instead.
+        for base in [
+            "https://token-plan.example.com/v1",
+            "https://token-plan.example.com/v1/",
+            "https://host.example/api/v1", // prefixed gateway version prefix
+            "https://host.example/v1?x=1", // query must not hide the prefix
+            "  https://host.example/v1  ",
+        ] {
+            assert!(
+                base_url_is_full_endpoint(base, "/v1"),
+                "expected version-prefix match: {base:?}"
+            );
+        }
+
+        // Real full endpoints (and gemini-style `/v1beta` versions) must keep full-URL
+        // semantics — no fallback.
+        for base in [
+            "https://host.example/v1/responses",
+            "https://host.example/v1/chat/completions",
+            "https://host.example/v1/messages",
+            "https://host.example/v1beta",
+        ] {
+            assert!(
+                !base_url_is_full_endpoint(base, "/v1"),
+                "did not expect version-prefix match: {base:?}"
+            );
+        }
+
+        // After the fallback, concatenation lands on the real endpoint: both adapters
+        // already treat `/v1`-suffixed bases as versioned (direct append + `/v1/v1` dedup).
+        use super::super::providers::ProviderAdapter;
+        let codex = super::super::providers::CodexAdapter::new();
+        assert_eq!(
+            codex.build_url("https://token-plan.example.com/v1", "/responses"),
+            "https://token-plan.example.com/v1/responses"
+        );
+        assert_eq!(
+            codex.build_url("https://token-plan.example.com/v1", "/v1/responses"),
+            "https://token-plan.example.com/v1/responses"
+        );
+        let claude = super::super::providers::ClaudeAdapter;
+        assert_eq!(
+            claude.build_url("https://host.example/v1", "/v1/messages"),
+            "https://host.example/v1/messages"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

Hi! Another one from the pile behind #6482, this time for #7242.

**Problem.** Full-URL mode forwards the configured URL verbatim and never appends the wire-API endpoint path. That is correct for real full endpoints (`.../v1/responses`, `.../chat/completions`, `.../v1/messages`), but a URL that stops at the version prefix (`.../v1`) is never a complete endpoint — every supported wire API adds one more segment. With the switch on, requests POST to `.../v1` itself and the upstream answers with an opaque 404 (#7242: a Codex provider configured from a versioned token-plan base with `wire_api = "responses"`; the reporter's curl confirms `/v1/responses` itself is reachable, so only the missing suffix was at fault).

The Chat and Anthropic conversion paths already guard the mirror-image mistake (pasting a full endpoint while the switch is off → `codex_chat_base_is_full_endpoint` / `codex_anthropic_base_is_full_endpoint`); the native-Responses direction had no equivalent guard.

**Fix.** Reuse `base_url_is_full_endpoint(&base_url, "/v1")` to detect the version-prefix-only shape (query / fragment / trailing slash / case tolerated) and fall back to base-URL concatenation. Both `CodexAdapter::build_url` and `ClaudeAdapter::build_url` already treat `/v1`-suffixed bases as versioned (direct append + `/v1/v1` dedup), so the fallback lands on the real endpoint. Real full endpoints keep full-URL semantics, and the gemini-native branch keeps its own normalization.

One note on the issue's framing: I couldn't find any code path that auto-infers `isFullUrl` — the only writer is the form toggle, and the flag can also arrive via imported configs — so this hardens the proxy-side contract regardless of how the flag got enabled.

## Related Issue / 关联 Issue

Fixes #7242

## Screenshots / 截图

Not applicable — proxy URL building, no UI change.

## Test Plan / 测试

- New `full_url_version_prefix_falls_back_to_concatenation` in `forwarder.rs`: version-prefix shapes match (`/v1`, `/v1/`, `/api/v1` prefixed gateway, `/v1?x=1`), real full endpoints and `/v1beta` do not, and both adapters concatenate to the expected URL.
- Full `cargo test`: 2818 passed, 0 failed.
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check`, `pnpm typecheck`, `pnpm format:check` all pass.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（如修改了 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 如修改了用户可见文本，已更新国际化文件

(Last item N/A — no user-facing text changed.)

Happy to adjust — e.g. if you'd rather handle this in the provider form (warn/refuse when saving a version-prefix URL with the switch on) instead of the forwarder.
