### PR TITLE
fix(codex): honor proxy URL when model_provider is omitted

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -4101,9 +4101,9 @@ pub fn restore_codex_settings_for_backfill(
 ///
 /// Supported fields:
 /// - `"base_url"`: writes to `[model_providers.<current>].base_url` if `model_provider` exists,
-///   otherwise falls back to top-level `base_url`.
+///   otherwise uses `openai_base_url` for Codex's default built-in provider.
 /// - `"wire_api"`: writes to `[model_providers.<current>].wire_api` if `model_provider` exists,
-///   otherwise falls back to top-level `wire_api`.
+///   otherwise leaves the built-in provider's Responses protocol unchanged.
 /// - `"model"` / `"model_catalog_json"`: writes to top-level field.
 ///
 /// Empty value removes the field.
@@ -4119,7 +4119,9 @@ pub fn update_codex_toml_field(toml_str: &str, field: &str, value: &str) -> Resu
             let model_provider = doc
                 .get("model_provider")
                 .and_then(|item| item.as_str())
-                .map(str::to_string);
+                .map(str::to_string)
+                // Codex defaults to openai when the selector is absent.
+                .or_else(|| (!doc.contains_key("model_provider")).then(|| "openai".to_string()));
 
             if let Some(provider_key) = model_provider {
                 // validate_reserved_model_provider_ids（0.148 起）对配置里出现
@@ -6471,7 +6473,7 @@ model = "gpt-4"
     }
 
     #[test]
-    fn base_url_falls_back_to_top_level_without_model_provider() {
+    fn base_url_uses_openai_override_without_model_provider() {
         let input = r#"model = "gpt-4"
 "#;
 
@@ -6479,10 +6481,18 @@ model = "gpt-4"
         let parsed: toml::Value = toml::from_str(&result).unwrap();
 
         let base_url = parsed
-            .get("base_url")
+            .get("openai_base_url")
             .and_then(|v| v.as_str())
-            .expect("should set top-level base_url");
+            .expect("should set the built-in provider's URL override");
         assert_eq!(base_url, "https://fallback.api/v1");
+        assert!(parsed.get("base_url").is_none());
+        let responses = update_codex_toml_field(&result, "wire_api", "responses").unwrap();
+        assert_eq!(responses, result);
+        let cleared = update_codex_toml_field(&result, "base_url", "").unwrap();
+        assert_eq!(
+            toml::from_str::<toml::Value>(&cleared).unwrap(),
+            toml::from_str::<toml::Value>(input).unwrap()
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/proxy.rs
+++ b/src-tauri/src/services/proxy.rs
@@ -7099,6 +7099,34 @@ requires_openai_auth = true
     }
 
     #[test]
+    fn codex_takeover_without_provider_selects_a_local_authenticated_route() {
+        for input in [
+            "",
+            "model = \"gpt-5\"\nbase_url = \"https://old.example/v1\"\n",
+            "model_providers = { cc-switch = { name = \"Existing\", base_url = \"https://keep.example/v1\" } }\n",
+        ] {
+            let url = "http://127.0.0.1:15721/v1";
+            let projected = ProxyService::apply_codex_proxy_toml_config_for_provider(input, url, None).unwrap();
+            let auth = json!({"OPENAI_API_KEY": PROXY_TOKEN_PLACEHOLDER});
+            let live = crate::codex_config::prepare_codex_provider_live_config(&auth, &projected).unwrap();
+            println!("takeover_fixture={}", serde_json::to_string(&live).unwrap());
+            let doc: toml::Value = toml::from_str(&live).unwrap();
+            let id = doc["model_provider"].as_str().expect("explicit provider");
+            assert_ne!(id, "openai");
+            let table = &doc["model_providers"][id];
+            assert_eq!(table["base_url"].as_str(), Some(url));
+            assert_eq!(table["wire_api"].as_str(), Some("responses"));
+            assert_eq!(table["experimental_bearer_token"].as_str(), Some(PROXY_TOKEN_PLACEHOLDER));
+            if input.contains("Existing") {
+                assert_eq!(doc["model_providers"]["cc-switch"]["base_url"].as_str(), Some("https://keep.example/v1"));
+            }
+            let repeated = ProxyService::apply_codex_proxy_toml_config_for_provider(&live, url, None).unwrap();
+            let repeated = crate::codex_config::prepare_codex_provider_live_config(&auth, &repeated).unwrap();
+            assert_eq!(toml::from_str::<toml::Value>(&repeated).unwrap(), doc);
+        }
+    }
+
+    #[test]
     fn apply_codex_proxy_toml_config_forces_local_responses_wire_api() {
         let input = r#"
 model_provider = "chat_only"
@@ -7311,22 +7339,22 @@ wire_api = "responses"
     }
 
     #[test]
-    fn update_toml_base_url_falls_back_to_top_level_base_url() {
+    fn update_toml_base_url_uses_implicit_openai_override() {
         let input = r#"
 model = "gpt-5.1-codex"
 "#;
 
         let new_url = "http://127.0.0.1:5000/v1";
         let output = crate::codex_config::update_codex_toml_field(input, "base_url", new_url)
-            .expect("update top-level base_url");
+            .expect("update implicit openai base_url");
 
         let parsed: toml::Value =
             toml::from_str(&output).expect("updated config should be valid TOML");
 
         let base_url = parsed
-            .get("base_url")
+            .get("openai_base_url")
             .and_then(|v| v.as_str())
-            .expect("base_url should exist");
+            .expect("openai_base_url should exist");
 
         assert_eq!(base_url, new_url);
     }


### PR DESCRIPTION
## Summary / 概述

未指定 `model_provider` 时，Codex 默认使用内置 `openai`，但 CC Switch 改写地址时写入了 Codex 不使用的顶层 `base_url`。代理配置看似包含本地地址，Responses 请求却仍可能发往官方。

将缺省供应商按内置 `openai` 处理，写入有效的 `openai_base_url`。第三方接管随后复用已有规范化流程，生成自定义供应商并注入 `PROXY_MANAGED`。已有供应商选择不变。

## Related Issue / 关联 Issue

Related to #7217：修复缺失供应商选择时的路由分支。不覆盖客户端显式以 `modelProvider=openai` 覆盖自定义供应商的情况；登录状态修复见 #7262。

## Verification / 验证

- 新回归测试修复前失败、修复后通过，覆盖空配置、遗留顶层地址、供应商名称冲突及重复接管。
- `codex_config::tests`：117 passed；排除依赖符号链接权限的既有测试 `resolve_catalog_rejects_symlink_escaping_config_dir`。
- `services::proxy::tests`：95 passed。
- 将测试生成的三组配置交给官方 Codex app-server v0.153.4：均选择自定义供应商，携带占位 bearer 请求本地 `/v1/responses`，未尝试连接 `api.openai.com`。模拟上游返回预设 400，仅验证路由和认证头，不验证模型生成。
- `cargo fmt --check`、`git diff --check`、`cargo clippy --lib -- -D warnings` 通过。

## Checklist / 检查清单

- [ ] `pnpm typecheck`（无前端改动，未运行）
- [ ] `pnpm format:check`（无前端改动，未运行）
- [x] `cargo clippy` passes
- [x] 无用户界面文案变更
