### PR TITLE
fix(proxy): split upstream-inlined <think> blocks on the Claude path (#7271)

### DIFF
--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -35,6 +35,9 @@ pub(crate) mod tool_media;
 pub(crate) mod types;
 pub mod usage;
 
+#[cfg(test)]
+mod tests_issue_7271;
+
 // 公开导出给外部使用（commands, services等模块需要）
 #[allow(unused_imports)]
 pub use circuit_breaker::{

--- a/src-tauri/src/proxy/providers/codex_chat_common.rs
+++ b/src-tauri/src/proxy/providers/codex_chat_common.rs
@@ -237,3 +237,135 @@ pub(crate) fn strip_leading_think_open_tag(text: &str) -> Option<String> {
 fn strip_think_answer_separator(text: &str) -> &str {
     text.trim_start_matches(['\r', '\n', '\t', ' '])
 }
+
+/// 内联思考前缀（`<think>`）的判定结果
+pub(crate) enum ThinkPrefixDecision {
+    /// 前缀尚未确定（可能正处在 `<think>` 的前几个字符上），继续缓冲
+    NeedMore,
+    /// 确认是内联思考
+    Reasoning,
+    /// 不是内联思考，按正文处理
+    Text,
+}
+
+pub(crate) fn leading_think_prefix_decision(buffer: &str) -> ThinkPrefixDecision {
+    let trimmed = buffer.trim_start();
+    if trimmed.is_empty() {
+        return ThinkPrefixDecision::NeedMore;
+    }
+
+    if trimmed.starts_with(THINK_OPEN_TAG) {
+        return ThinkPrefixDecision::Reasoning;
+    }
+
+    if THINK_OPEN_TAG.starts_with(trimmed) {
+        return ThinkPrefixDecision::NeedMore;
+    }
+
+    ThinkPrefixDecision::Text
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum InlineThinkMode {
+    #[default]
+    Detecting,
+    Reasoning,
+    Text,
+}
+
+/// 拆分出的片段：`true` = 思考内容，`false` = 正文
+pub(crate) type InlineThinkPart = (bool, String);
+
+/// 把内联了思考（`<think>…</think>`）的正文流拆成「思考 / 正文」片段序列。
+///
+/// 部分 OpenAI Chat 兼容上游（MiniMax M3、OpenCode Go 等）不用
+/// `reasoning_content` 字段回传思考，而是把它内联在 `delta.content` /
+/// `message.content` 文本前部。下游的 Responses / Anthropic 协议都要求思考
+/// 是独立内容块，直接透传会让思考当正文明文显示（issue #7271），因此两条
+/// 转换路径共用本拆分器。
+///
+/// 开标签可能被切分到多个 chunk，`Detecting` 阶段先缓冲最短前缀，判定不了
+/// 就等下一段；`Reasoning` 期间持续缓冲，直到出现完整 `</think>`。
+#[derive(Debug, Default)]
+pub(crate) struct InlineThinkSplitter {
+    mode: InlineThinkMode,
+    buffer: String,
+}
+
+impl InlineThinkSplitter {
+    /// 送入一段正文，返回按序可直接下发的片段（可能为空）。
+    pub(crate) fn push(&mut self, delta: &str) -> Vec<InlineThinkPart> {
+        match self.mode {
+            InlineThinkMode::Text => inline_think_part(false, delta),
+            InlineThinkMode::Detecting => {
+                self.buffer.push_str(delta);
+                match leading_think_prefix_decision(&self.buffer) {
+                    ThinkPrefixDecision::NeedMore => Vec::new(),
+                    ThinkPrefixDecision::Reasoning => {
+                        self.mode = InlineThinkMode::Reasoning;
+                        self.drain_complete_block()
+                    }
+                    ThinkPrefixDecision::Text => {
+                        self.mode = InlineThinkMode::Text;
+                        inline_think_part(false, &std::mem::take(&mut self.buffer))
+                    }
+                }
+            }
+            InlineThinkMode::Reasoning => {
+                self.buffer.push_str(delta);
+                self.drain_complete_block()
+            }
+        }
+    }
+
+    /// 缓冲里是否还有未判定的内容（`Detecting` 期间的前缀或未闭合的思考）
+    pub(crate) fn has_buffered(&self) -> bool {
+        !self.buffer.trim().is_empty()
+    }
+
+    /// 边界（工具调用 / 流结束）时冲出缓冲：未闭合的 `<think>` 按当前模式解读
+    pub(crate) fn flush(&mut self) -> Vec<InlineThinkPart> {
+        match self.mode {
+            InlineThinkMode::Text => Vec::new(),
+            InlineThinkMode::Detecting => {
+                self.mode = InlineThinkMode::Text;
+                inline_think_part(false, &std::mem::take(&mut self.buffer))
+            }
+            InlineThinkMode::Reasoning => {
+                let buffered = std::mem::take(&mut self.buffer);
+                self.mode = InlineThinkMode::Text;
+                if let Some((reasoning, answer)) = split_leading_think_block(&buffered) {
+                    let mut parts = inline_think_part(true, &reasoning);
+                    parts.extend(inline_think_part(false, &answer));
+                    return parts;
+                }
+
+                let reasoning = strip_leading_think_open_tag(&buffered).unwrap_or(buffered);
+                inline_think_part(true, &reasoning)
+            }
+        }
+    }
+
+    /// 缓冲区出现完整 `</think>` 时拆出思考与正文，否则继续等待
+    fn drain_complete_block(&mut self) -> Vec<InlineThinkPart> {
+        let Some((reasoning, answer)) = split_leading_think_block(&self.buffer) else {
+            return Vec::new();
+        };
+
+        self.mode = InlineThinkMode::Text;
+        self.buffer.clear();
+
+        let mut parts = inline_think_part(true, &reasoning);
+        parts.extend(inline_think_part(false, &answer));
+        parts
+    }
+}
+
+/// 空片段不下发
+fn inline_think_part(is_thinking: bool, text: &str) -> Vec<InlineThinkPart> {
+    if text.is_empty() {
+        Vec::new()
+    } else {
+        vec![(is_thinking, text.to_string())]
+    }
+}

--- a/src-tauri/src/proxy/providers/streaming.rs
+++ b/src-tauri/src/proxy/providers/streaming.rs
@@ -2,6 +2,7 @@
 //!
 //! 实现 OpenAI SSE → Anthropic SSE 格式转换
 
+use super::codex_chat_common::{InlineThinkPart, InlineThinkSplitter};
 use crate::proxy::sse::{strip_sse_field, take_sse_block};
 use bytes::Bytes;
 use futures::stream::{Stream, StreamExt};
@@ -145,6 +146,104 @@ fn build_message_delta_event(stop_reason: Option<String>, usage_json: Option<Val
     })
 }
 
+/// 非工具内容块（thinking / text）的开启状态
+#[derive(Default)]
+struct NonToolBlockState {
+    kind: Option<&'static str>,
+    index: Option<u32>,
+}
+
+impl NonToolBlockState {
+    /// 关闭当前打开的非工具块（若有）
+    fn close(&mut self) -> Vec<Bytes> {
+        self.kind = None;
+        self.index
+            .take()
+            .map(|index| {
+                vec![sse_event(
+                    &json!({"type": "content_block_stop", "index": index}),
+                )]
+            })
+            .unwrap_or_default()
+    }
+}
+
+/// 序列化一个 Anthropic SSE 帧（事件名取 JSON 的 type 字段）
+fn sse_event(event: &Value) -> Bytes {
+    let event_type = event
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("message");
+    let data = serde_json::to_string(event).unwrap_or_default();
+    Bytes::from(format!("event: {event_type}\ndata: {data}\n\n"))
+}
+
+/// 把一段思考或正文写进 Anthropic SSE 事件流：与当前打开的块类型不同时先停旧块
+/// 再开新块，然后发对应的 content_block_delta。空文本不产出事件。
+fn emit_non_tool_delta(
+    state: &mut NonToolBlockState,
+    next_content_index: &mut u32,
+    is_thinking: bool,
+    text: &str,
+) -> Vec<Bytes> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+
+    let kind: &'static str = if is_thinking { "thinking" } else { "text" };
+    let mut events = Vec::new();
+    if state.kind != Some(kind) {
+        events.extend(state.close());
+        let index = *next_content_index;
+        *next_content_index += 1;
+        let content_block = if is_thinking {
+            json!({"type": "thinking", "thinking": ""})
+        } else {
+            json!({"type": "text", "text": ""})
+        };
+        events.push(sse_event(&json!({
+            "type": "content_block_start",
+            "index": index,
+            "content_block": content_block
+        })));
+        state.kind = Some(kind);
+        state.index = Some(index);
+    }
+
+    if let Some(index) = state.index {
+        let delta = if is_thinking {
+            json!({"type": "thinking_delta", "thinking": text})
+        } else {
+            json!({"type": "text_delta", "text": text})
+        };
+        events.push(sse_event(&json!({
+            "type": "content_block_delta",
+            "index": index,
+            "delta": delta
+        })));
+    }
+
+    events
+}
+
+/// 按序下发一组「思考 / 正文」片段
+fn emit_inline_think_parts(
+    state: &mut NonToolBlockState,
+    next_content_index: &mut u32,
+    parts: Vec<InlineThinkPart>,
+) -> Vec<Bytes> {
+    let mut events = Vec::new();
+    for (is_thinking, text) in parts {
+        events.extend(emit_non_tool_delta(
+            state,
+            next_content_index,
+            is_thinking,
+            &text,
+        ));
+    }
+    events
+}
+
 /// 创建 Anthropic SSE 流
 pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
     stream: impl Stream<Item = Result<Bytes, E>> + Send + 'static,
@@ -166,8 +265,9 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
         let mut has_sent_message_stop = false;
         let mut stream_ended_with_error = false;
         let mut latest_usage: Option<Value> = None;
-        let mut current_non_tool_block_type: Option<&'static str> = None;
-        let mut current_non_tool_block_index: Option<u32> = None;
+        let mut non_tool_block = NonToolBlockState::default();
+        // 上游把思考内联在 content 里（`<think>…</think>`）时拆成 thinking 块
+        let mut inline_think = InlineThinkSplitter::default();
         let mut tool_blocks_by_index: HashMap<usize, ToolBlockState> = HashMap::new();
         let mut open_tool_block_indices: HashSet<u32> = HashSet::new();
 
@@ -187,6 +287,15 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                             if let Some(data) = strip_sse_field(l, "data") {
                                 if data.trim() == "[DONE]" {
                                     log::debug!("[Claude/OpenRouter] <<< OpenAI SSE: [DONE]");
+
+                                    // 冲出内联思考缓冲，避免把未下发的思考文本留在流外
+                                    for event in emit_inline_think_parts(
+                                        &mut non_tool_block,
+                                        &mut next_content_index,
+                                        inline_think.flush(),
+                                    ) {
+                                        yield Ok(event);
+                                    }
 
                                     // 流正常结束，发出缓存的 message_delta（含完整 usage）。
                                     if let Some((stop_reason, usage_json)) = pending_message_delta.take() {
@@ -268,91 +377,26 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
 
                                         // 处理 reasoning（thinking）
                                         if let Some(reasoning) = &choice.delta.reasoning {
-                                            if current_non_tool_block_type != Some("thinking") {
-                                                if let Some(index) = current_non_tool_block_index.take() {
-                                                    let event = json!({
-                                                        "type": "content_block_stop",
-                                                        "index": index
-                                                    });
-                                                    let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
-                                                        serde_json::to_string(&event).unwrap_or_default());
-                                                    yield Ok(Bytes::from(sse_data));
-                                                }
-                                                let index = next_content_index;
-                                                next_content_index += 1;
-                                                let event = json!({
-                                                    "type": "content_block_start",
-                                                    "index": index,
-                                                    "content_block": {
-                                                        "type": "thinking",
-                                                        "thinking": ""
-                                                    }
-                                                });
-                                                let sse_data = format!("event: content_block_start\ndata: {}\n\n",
-                                                    serde_json::to_string(&event).unwrap_or_default());
-                                                yield Ok(Bytes::from(sse_data));
-                                                current_non_tool_block_type = Some("thinking");
-                                                current_non_tool_block_index = Some(index);
-                                            }
-
-                                            if let Some(index) = current_non_tool_block_index {
-                                                let event = json!({
-                                                    "type": "content_block_delta",
-                                                    "index": index,
-                                                    "delta": {
-                                                        "type": "thinking_delta",
-                                                        "thinking": reasoning
-                                                    }
-                                                });
-                                                let sse_data = format!("event: content_block_delta\ndata: {}\n\n",
-                                                    serde_json::to_string(&event).unwrap_or_default());
-                                                yield Ok(Bytes::from(sse_data));
+                                            for event in emit_non_tool_delta(
+                                                &mut non_tool_block,
+                                                &mut next_content_index,
+                                                true,
+                                                reasoning,
+                                            ) {
+                                                yield Ok(event);
                                             }
                                         }
 
-                                        // 处理文本内容
+                                        // 处理文本内容（含上游内联的 <think> 块）
                                         if let Some(content) = &choice.delta.content {
                                             if !content.is_empty() {
-                                                if current_non_tool_block_type != Some("text") {
-                                                    if let Some(index) = current_non_tool_block_index.take() {
-                                                        let event = json!({
-                                                            "type": "content_block_stop",
-                                                            "index": index
-                                                        });
-                                                        let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
-                                                            serde_json::to_string(&event).unwrap_or_default());
-                                                        yield Ok(Bytes::from(sse_data));
-                                                    }
-
-                                                    let index = next_content_index;
-                                                    next_content_index += 1;
-                                                    let event = json!({
-                                                        "type": "content_block_start",
-                                                        "index": index,
-                                                        "content_block": {
-                                                            "type": "text",
-                                                            "text": ""
-                                                        }
-                                                    });
-                                                    let sse_data = format!("event: content_block_start\ndata: {}\n\n",
-                                                        serde_json::to_string(&event).unwrap_or_default());
-                                                    yield Ok(Bytes::from(sse_data));
-                                                    current_non_tool_block_type = Some("text");
-                                                    current_non_tool_block_index = Some(index);
-                                                }
-
-                                                if let Some(index) = current_non_tool_block_index {
-                                                    let event = json!({
-                                                        "type": "content_block_delta",
-                                                        "index": index,
-                                                        "delta": {
-                                                            "type": "text_delta",
-                                                            "text": content
-                                                        }
-                                                    });
-                                                    let sse_data = format!("event: content_block_delta\ndata: {}\n\n",
-                                                        serde_json::to_string(&event).unwrap_or_default());
-                                                    yield Ok(Bytes::from(sse_data));
+                                                let parts = inline_think.push(content);
+                                                for event in emit_inline_think_parts(
+                                                    &mut non_tool_block,
+                                                    &mut next_content_index,
+                                                    parts,
+                                                ) {
+                                                    yield Ok(event);
                                                 }
                                             }
                                         }
@@ -360,16 +404,19 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                         // 处理工具调用
                                         if let Some(tool_calls) = &choice.delta.tool_calls {
                                             if !tool_calls.is_empty() {
-                                                if let Some(index) = current_non_tool_block_index.take() {
-                                                    let event = json!({
-                                                        "type": "content_block_stop",
-                                                        "index": index
-                                                    });
-                                                    let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
-                                                        serde_json::to_string(&event).unwrap_or_default());
-                                                    yield Ok(Bytes::from(sse_data));
+                                                // 工具块开始前先把内联思考的缓冲冲出：
+                                                // 否则未闭合的思考会被后面的工具块吞掉
+                                                let parts = inline_think.flush();
+                                                for event in emit_inline_think_parts(
+                                                    &mut non_tool_block,
+                                                    &mut next_content_index,
+                                                    parts,
+                                                ) {
+                                                    yield Ok(event);
                                                 }
-                                                current_non_tool_block_type = None;
+                                                for event in non_tool_block.close() {
+                                                    yield Ok(event);
+                                                }
 
                                                 for tool_call in tool_calls {
                                                     let (
@@ -528,16 +575,18 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
                                             }
                                             has_emitted_message_delta = true;
 
-                                            if let Some(index) = current_non_tool_block_index.take() {
-                                                let event = json!({
-                                                    "type": "content_block_stop",
-                                                    "index": index
-                                                });
-                                                let sse_data = format!("event: content_block_stop\ndata: {}\n\n",
-                                                    serde_json::to_string(&event).unwrap_or_default());
-                                                yield Ok(Bytes::from(sse_data));
+                                            // 收尾前冲出内联思考缓冲（未闭合的思考按思考下发）
+                                            let parts = inline_think.flush();
+                                            for event in emit_inline_think_parts(
+                                                &mut non_tool_block,
+                                                &mut next_content_index,
+                                                parts,
+                                            ) {
+                                                yield Ok(event);
                                             }
-                                            current_non_tool_block_type = None;
+                                            for event in non_tool_block.close() {
+                                                yield Ok(event);
+                                            }
 
                                             // Late start for blocks that accumulated args before id/name arrived.
                                             let mut late_tool_starts: Vec<(u32, String, String, String)> =
@@ -647,6 +696,12 @@ pub fn create_anthropic_sse_stream<E: std::error::Error + Send + 'static>(
         // 流自然结束但未收到 [DONE] 时，确保发送缓存的 message_delta 和 message_stop。
         // 若上游已显式报错，则只保留 error 事件，避免把失败伪装成成功完成。
         if !stream_ended_with_error {
+            // 自然结束（未收到 [DONE]）也要冲出内联思考缓冲
+            let parts = inline_think.flush();
+            for event in emit_inline_think_parts(&mut non_tool_block, &mut next_content_index, parts) {
+                yield Ok(event);
+            }
+
             let emitted_pending_message_delta = if let Some((stop_reason, usage_json)) =
                 pending_message_delta.take()
             {
@@ -722,18 +777,21 @@ mod tests {
     use serde_json::Value;
     use std::collections::HashMap;
 
-    async fn collect_anthropic_events(input: &str) -> Vec<Value> {
+    async fn collect_anthropic_raw(input: &str) -> String {
         let upstream = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::from(
             input.as_bytes().to_vec(),
         ))]);
         let converted = create_anthropic_sse_stream(upstream);
         let chunks: Vec<_> = converted.collect().await;
-        let merged = chunks
+        chunks
             .into_iter()
             .map(|chunk| String::from_utf8_lossy(chunk.unwrap().as_ref()).to_string())
-            .collect::<String>();
+            .collect::<String>()
+    }
 
-        merged
+    async fn collect_anthropic_events(input: &str) -> Vec<Value> {
+        collect_anthropic_raw(input)
+            .await
             .split("\n\n")
             .filter_map(|block| {
                 let data = block
@@ -1244,5 +1302,143 @@ mod tests {
         assert!(!events
             .iter()
             .any(|e| e.get("type").and_then(|v| v.as_str()) == Some("message_stop")));
+    }
+
+    /// 拼接所有指定类型的 content_block_delta 文本
+    fn delta_text(events: &[Value], delta_type: &str) -> String {
+        let field = if delta_type == "thinking_delta" {
+            "thinking"
+        } else {
+            "text"
+        };
+        events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_delta"))
+            .filter(|event| {
+                event.pointer("/delta/type").and_then(|v| v.as_str()) == Some(delta_type)
+            })
+            .filter_map(|event| {
+                event
+                    .pointer(&format!("/delta/{field}"))
+                    .and_then(|v| v.as_str())
+            })
+            .collect()
+    }
+
+    /// 指定类型的 content_block_start 块索引
+    fn block_indices(events: &[Value], block_type: &str) -> Vec<u64> {
+        events
+            .iter()
+            .filter(|event| event_type(event) == Some("content_block_start"))
+            .filter(|event| {
+                event
+                    .pointer("/content_block/type")
+                    .and_then(|v| v.as_str())
+                    == Some(block_type)
+            })
+            .filter_map(|event| event.get("index").and_then(|v| v.as_u64()))
+            .collect()
+    }
+
+    /// #7271：上游把思考内联在 content 里（MiniMax M3 / OpenCode Go 走 OpenAI
+    /// Chat 协议）时必须拆成 thinking 块，且标签本身不能泄漏到下游，否则
+    /// Claude Code 会把整段思考当正文明文显示。
+    #[tokio::test]
+    async fn test_inline_think_content_becomes_thinking_block() {
+        let input = concat!(
+            // 开标签被切在两个 chunk 之间：Detecting 阶段必须缓冲等待
+            "data: {\"id\":\"chatcmpl_think\",\"model\":\"minimax-m3\",\"choices\":[{\"delta\":{\"content\":\"<thi\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_think\",\"model\":\"minimax-m3\",\"choices\":[{\"delta\":{\"content\":\"nk>Weighing costs</thi\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_think\",\"model\":\"minimax-m3\",\"choices\":[{\"delta\":{\"content\":\"nk>The bat costs $1.05.\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_think\",\"model\":\"minimax-m3\",\"choices\":[{\"delta\":{\"content\":\" The ball costs $0.05.\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_think\",\"model\":\"minimax-m3\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":30,\"completion_tokens\":20}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let raw = collect_anthropic_raw(input).await;
+        let events = collect_anthropic_events(input).await;
+
+        assert!(
+            !raw.contains("<think>"),
+            "inline think open tag leaked: {raw}"
+        );
+        assert!(
+            !raw.contains("</think>"),
+            "inline think close tag leaked: {raw}"
+        );
+
+        assert_eq!(block_indices(&events, "thinking"), vec![0]);
+        assert_eq!(block_indices(&events, "text"), vec![1]);
+        assert_eq!(delta_text(&events, "thinking_delta"), "Weighing costs");
+        assert_eq!(
+            delta_text(&events, "text_delta"),
+            "The bat costs $1.05. The ball costs $0.05."
+        );
+    }
+
+    /// 未闭合的 `<think>`（上游截断或直接进入工具调用）在工具块开始前冲出：
+    /// 思考内容仍以 thinking 块下发，既不能吞掉，也不能泄漏标签。
+    #[tokio::test]
+    async fn test_inline_think_flushed_before_tool_calls() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_tool\",\"model\":\"minimax-m3\",\"choices\":[{\"delta\":{\"content\":\"<think>Need to run pwd\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_tool\",\"model\":\"minimax-m3\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"Bash\",\"arguments\":\"{\\\"command\\\":\\\"pwd\\\"}\"}}]}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_tool\",\"model\":\"minimax-m3\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":8}}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let raw = collect_anthropic_raw(input).await;
+        let events = collect_anthropic_events(input).await;
+
+        assert!(
+            !raw.contains("<think>"),
+            "inline think open tag leaked: {raw}"
+        );
+        assert_eq!(block_indices(&events, "thinking"), vec![0]);
+        assert_eq!(delta_text(&events, "thinking_delta"), "Need to run pwd");
+        assert_eq!(block_indices(&events, "text").len(), 0);
+        assert!(events.iter().any(|event| {
+            event
+                .pointer("/content_block/name")
+                .and_then(|v| v.as_str())
+                == Some("Bash")
+        }));
+        assert!(events.iter().any(|event| {
+            event.pointer("/delta/stop_reason").and_then(|v| v.as_str()) == Some("tool_use")
+        }));
+    }
+
+    /// 没有内联思考的普通文本不受拆分器影响（含 `<` 开头的非 think 文本）。
+    #[tokio::test]
+    async fn test_plain_content_not_affected_by_inline_think_detection() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_plain\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"<\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_plain\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\"div>hello\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_plain\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{\"content\":\" world\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_plain\",\"model\":\"gpt-4o\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+
+        assert_eq!(block_indices(&events, "thinking").len(), 0);
+        assert_eq!(delta_text(&events, "text_delta"), "<div>hello world");
+    }
+
+    /// 只有思考没有正文时只下发 thinking 块，不产生空 text 块。
+    #[tokio::test]
+    async fn test_inline_think_without_answer_emits_no_text_block() {
+        let input = concat!(
+            "data: {\"id\":\"chatcmpl_think_only\",\"model\":\"minimax-m3\",\"choices\":[{\"delta\":{\"content\":\"<think>only reasoning</think>\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl_think_only\",\"model\":\"minimax-m3\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+
+        let events = collect_anthropic_events(input).await;
+
+        assert_eq!(block_indices(&events, "thinking"), vec![0]);
+        assert_eq!(delta_text(&events, "thinking_delta"), "only reasoning");
+        assert!(delta_text(&events, "text_delta").is_empty());
+        assert_eq!(block_indices(&events, "text").len(), 0);
     }
 }

--- a/src-tauri/src/proxy/providers/streaming_codex_chat.rs
+++ b/src-tauri/src/proxy/providers/streaming_codex_chat.rs
@@ -2,9 +2,7 @@
 
 use super::codex_responses_sse as sse;
 use super::{
-    codex_chat_common::{
-        extract_reasoning_field_text, split_leading_think_block, strip_leading_think_open_tag,
-    },
+    codex_chat_common::{extract_reasoning_field_text, InlineThinkPart, InlineThinkSplitter},
     transform_codex_chat::{
         chat_usage_to_responses_usage, custom_tool_input_from_chat_arguments,
         response_id_from_chat_id, response_status_from_finish_reason,
@@ -37,20 +35,6 @@ struct ReasoningItemState {
     done: bool,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-enum InlineThinkMode {
-    #[default]
-    Detecting,
-    Reasoning,
-    Text,
-}
-
-#[derive(Debug, Default)]
-struct InlineThinkState {
-    mode: InlineThinkMode,
-    buffer: String,
-}
-
 #[derive(Debug, Default)]
 struct ToolCallState {
     output_index: Option<u32>,
@@ -73,7 +57,7 @@ struct ChatToResponsesState {
     next_output_index: u32,
     text: TextItemState,
     reasoning: ReasoningItemState,
-    inline_think: InlineThinkState,
+    inline_think: InlineThinkSplitter,
     tools: BTreeMap<usize, ToolCallState>,
     next_tool_index_to_add: usize,
     output_items: Vec<(u32, Value)>,
@@ -95,7 +79,7 @@ impl Default for ChatToResponsesState {
             next_output_index: 0,
             text: TextItemState::default(),
             reasoning: ReasoningItemState::default(),
-            inline_think: InlineThinkState::default(),
+            inline_think: InlineThinkSplitter::default(),
             tools: BTreeMap::new(),
             next_tool_index_to_add: 0,
             output_items: Vec::new(),
@@ -176,95 +160,29 @@ impl ChatToResponsesState {
     }
 
     fn push_content_delta(&mut self, delta: &str) -> Vec<Bytes> {
-        match self.inline_think.mode {
-            InlineThinkMode::Text => {
-                let mut events = self.finalize_reasoning();
-                events.extend(self.push_text_delta(delta));
-                events
-            }
-            InlineThinkMode::Detecting => {
-                self.inline_think.buffer.push_str(delta);
-                match leading_think_prefix_decision(&self.inline_think.buffer) {
-                    ThinkPrefixDecision::NeedMore => Vec::new(),
-                    ThinkPrefixDecision::Reasoning => {
-                        self.inline_think.mode = InlineThinkMode::Reasoning;
-                        self.drain_complete_inline_think()
-                    }
-                    ThinkPrefixDecision::Text => {
-                        self.inline_think.mode = InlineThinkMode::Text;
-                        let text = std::mem::take(&mut self.inline_think.buffer);
-                        let mut events = self.finalize_reasoning();
-                        events.extend(self.push_text_delta(&text));
-                        events
-                    }
-                }
-            }
-            InlineThinkMode::Reasoning => {
-                self.inline_think.buffer.push_str(delta);
-                self.drain_complete_inline_think()
-            }
-        }
+        let parts = self.inline_think.push(delta);
+        self.emit_inline_think_parts(parts)
     }
 
-    fn drain_complete_inline_think(&mut self) -> Vec<Bytes> {
-        let Some((reasoning, answer)) = split_leading_think_block(&self.inline_think.buffer) else {
-            return Vec::new();
-        };
-
-        self.inline_think.mode = InlineThinkMode::Text;
-        self.inline_think.buffer.clear();
-
+    /// 把拆分出的「思考 / 正文」片段按序转成事件：思考进 reasoning item，
+    /// 正文进 text item；两者切换前先收尾 reasoning item。
+    fn emit_inline_think_parts(&mut self, parts: Vec<InlineThinkPart>) -> Vec<Bytes> {
         let mut events = Vec::new();
-        if !reasoning.is_empty() {
-            events.extend(self.push_reasoning_delta(&reasoning));
-            events.extend(self.finalize_reasoning());
+        for (is_thinking, text) in parts {
+            if is_thinking {
+                events.extend(self.push_reasoning_delta(&text));
+                events.extend(self.finalize_reasoning());
+            } else {
+                events.extend(self.finalize_reasoning());
+                events.extend(self.push_text_delta(&text));
+            }
         }
-        if !answer.is_empty() {
-            events.extend(self.push_text_delta(&answer));
-        }
-
         events
     }
 
     fn flush_inline_think_at_boundary(&mut self) -> Vec<Bytes> {
-        match self.inline_think.mode {
-            InlineThinkMode::Text => Vec::new(),
-            InlineThinkMode::Detecting => {
-                self.inline_think.mode = InlineThinkMode::Text;
-                let text = std::mem::take(&mut self.inline_think.buffer);
-                if text.is_empty() {
-                    Vec::new()
-                } else {
-                    let mut events = self.finalize_reasoning();
-                    events.extend(self.push_text_delta(&text));
-                    events
-                }
-            }
-            InlineThinkMode::Reasoning => {
-                let buffered = std::mem::take(&mut self.inline_think.buffer);
-                self.inline_think.mode = InlineThinkMode::Text;
-                if let Some((reasoning, answer)) = split_leading_think_block(&buffered) {
-                    let mut events = Vec::new();
-                    if !reasoning.is_empty() {
-                        events.extend(self.push_reasoning_delta(&reasoning));
-                        events.extend(self.finalize_reasoning());
-                    }
-                    if !answer.is_empty() {
-                        events.extend(self.push_text_delta(&answer));
-                    }
-                    return events;
-                }
-
-                let reasoning = strip_leading_think_open_tag(&buffered).unwrap_or(buffered);
-                if reasoning.is_empty() {
-                    Vec::new()
-                } else {
-                    let mut events = self.push_reasoning_delta(&reasoning);
-                    events.extend(self.finalize_reasoning());
-                    events
-                }
-            }
-        }
+        let parts = self.inline_think.flush();
+        self.emit_inline_think_parts(parts)
     }
 
     fn ensure_response_started(&mut self) -> Vec<Bytes> {
@@ -510,7 +428,7 @@ impl ChatToResponsesState {
     fn has_substantive_output(&self) -> bool {
         !self.text.text.trim().is_empty()
             || !self.reasoning.text.trim().is_empty()
-            || !self.inline_think.buffer.trim().is_empty()
+            || self.inline_think.has_buffered()
             || !self.output_items.is_empty()
             || self.tools.values().any(|state| {
                 state.added
@@ -773,29 +691,6 @@ impl ChatToResponsesState {
 
 fn chat_delta_reasoning_text(delta: &Value) -> Option<String> {
     extract_reasoning_field_text(delta)
-}
-
-enum ThinkPrefixDecision {
-    NeedMore,
-    Reasoning,
-    Text,
-}
-
-fn leading_think_prefix_decision(buffer: &str) -> ThinkPrefixDecision {
-    let trimmed = buffer.trim_start();
-    if trimmed.is_empty() {
-        return ThinkPrefixDecision::NeedMore;
-    }
-
-    if trimmed.starts_with("<think>") {
-        return ThinkPrefixDecision::Reasoning;
-    }
-
-    if "<think>".starts_with(trimmed) {
-        return ThinkPrefixDecision::NeedMore;
-    }
-
-    ThinkPrefixDecision::Text
 }
 
 /// Create a stream that converts Chat Completions SSE chunks into Responses SSE events.

--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -3,6 +3,7 @@
 //! 实现 Anthropic ↔ OpenAI 格式转换，用于 OpenRouter 支持
 //! 参考: anthropic-proxy-rs
 
+use super::codex_chat_common::split_leading_think_block;
 use crate::proxy::{
     error::ProxyError,
     json_canonical::canonical_json_string,
@@ -501,6 +502,30 @@ fn clean_schema_inner(mut schema: Value, is_root: bool) -> Value {
     schema
 }
 
+/// 把一段文本追加进 Anthropic content 数组。
+///
+/// 部分 OpenAI Chat 兼容上游（MiniMax M3、OpenCode Go 等）不用
+/// `reasoning_content` 回传思考，而是内联在文本前部（`<think>…</think>`）。
+/// 直接当正文透传会让思考明文显示（issue #7271），这里拆成 thinking + text
+/// 两个块，与流式路径行为一致。
+fn push_text_with_inline_think(content: &mut Vec<Value>, text: &str) {
+    if text.is_empty() {
+        return;
+    }
+
+    match split_leading_think_block(text) {
+        Some((thinking, answer)) => {
+            if !thinking.is_empty() {
+                content.push(json!({"type": "thinking", "thinking": thinking}));
+            }
+            if !answer.is_empty() {
+                content.push(json!({"type": "text", "text": answer}));
+            }
+        }
+        None => content.push(json!({"type": "text", "text": text})),
+    }
+}
+
 /// OpenAI 响应 → Anthropic 响应
 pub fn openai_to_anthropic(body: Value) -> Result<Value, ProxyError> {
     let choices = body
@@ -529,18 +554,14 @@ pub fn openai_to_anthropic(body: Value) -> Result<Value, ProxyError> {
     // 文本/拒绝内容
     if let Some(msg_content) = message.get("content") {
         if let Some(text) = msg_content.as_str() {
-            if !text.is_empty() {
-                content.push(json!({"type": "text", "text": text}));
-            }
+            push_text_with_inline_think(&mut content, text);
         } else if let Some(parts) = msg_content.as_array() {
             for part in parts {
                 let part_type = part.get("type").and_then(|t| t.as_str()).unwrap_or("");
                 match part_type {
                     "text" | "output_text" => {
                         if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                            if !text.is_empty() {
-                                content.push(json!({"type": "text", "text": text}));
-                            }
+                            push_text_with_inline_think(&mut content, text);
                         }
                     }
                     "refusal" => {
@@ -1320,6 +1341,100 @@ mod tests {
         assert_eq!(result["stop_reason"], "end_turn");
         assert_eq!(result["usage"]["input_tokens"], 10);
         assert_eq!(result["usage"]["output_tokens"], 5);
+    }
+
+    /// #7271：上游把思考内联在 content 里（MiniMax M3 / OpenCode Go）时，
+    /// 非流式响应也必须拆成 thinking + text 块，标签不能残留。
+    #[test]
+    fn test_openai_to_anthropic_splits_inline_think_content() {
+        let input = json!({
+            "id": "chatcmpl-inline-think",
+            "object": "chat.completion",
+            "model": "minimax-m3",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "<think>The bat costs $1.05 more.</think>\n\nThe ball costs $0.05."
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 20, "completion_tokens": 30, "total_tokens": 50}
+        });
+
+        let result = openai_to_anthropic(input).unwrap();
+
+        assert_eq!(result["content"][0]["type"], "thinking");
+        assert_eq!(
+            result["content"][0]["thinking"],
+            "The bat costs $1.05 more."
+        );
+        assert_eq!(result["content"][1]["type"], "text");
+        assert_eq!(result["content"][1]["text"], "The ball costs $0.05.");
+
+        let serialized = serde_json::to_string(&result).unwrap();
+        assert!(
+            !serialized.contains("<think>"),
+            "think tag leaked: {serialized}"
+        );
+    }
+
+    /// content 数组形式的文本同样拆分
+    #[test]
+    fn test_openai_to_anthropic_splits_inline_think_in_content_parts() {
+        let input = json!({
+            "id": "chatcmpl-parts-think",
+            "object": "chat.completion",
+            "model": "minimax-m3",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "<think>quick check</think>Answer: 42."}
+                    ]
+                },
+                "finish_reason": "stop"
+            }]
+        });
+
+        let result = openai_to_anthropic(input).unwrap();
+
+        assert_eq!(result["content"][0]["type"], "thinking");
+        assert_eq!(result["content"][0]["thinking"], "quick check");
+        assert_eq!(result["content"][1]["type"], "text");
+        assert_eq!(result["content"][1]["text"], "Answer: 42.");
+    }
+
+    /// 没有完整思考块的正文保持原样：非行首的 `<think>` 是普通文本，
+    /// 未闭合的 `<think>`（上游截断）与 codex 非流式路径一样按正文下发。
+    #[test]
+    fn test_openai_to_anthropic_keeps_content_without_complete_think_block() {
+        let inline = json!({
+            "id": "chatcmpl-inline-literal",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "Explain <think> literally."},
+                "finish_reason": "stop"
+            }]
+        });
+        let result = openai_to_anthropic(inline).unwrap();
+        assert_eq!(result["content"][0]["type"], "text");
+        assert_eq!(result["content"][0]["text"], "Explain <think> literally.");
+
+        let unterminated = json!({
+            "id": "chatcmpl-unterminated",
+            "object": "chat.completion",
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "<think>cut off"},
+                "finish_reason": "length"
+            }]
+        });
+        let result = openai_to_anthropic(unterminated).unwrap();
+        assert_eq!(result["content"][0]["type"], "text");
+        assert_eq!(result["content"][0]["text"], "<think>cut off");
     }
 
     #[test]

--- a/src-tauri/src/proxy/tests_issue_7271.rs
+++ b/src-tauri/src/proxy/tests_issue_7271.rs
@@ -1,0 +1,342 @@
+//! 复现测试：Issue #7271 - Claude(Anthropic) 路径未剥离 OpenAI Chat 上游内联的 `<think>` 块
+//!
+//! 复现 issue「方式 B」：Claude Code 的 provider 经 CC Switch 本地代理指向一个
+//! OpenAI Chat 兼容上游（MiniMax M3 / OpenCode Go 形态），上游不返回
+//! `reasoning_content` 字段，而是把思考内联在 `message.content` / `delta.content`
+//! 文本前部（`<think>…</think>`）。期望代理转成 Anthropic 的 thinking 块；修复前
+//! 整段思考被当作正文明文下发（含标签），Claude Code 里看不到折叠块。
+//!
+//! 测试用 axum 模拟这类上游，经真实 `ProxyServer` 发 HTTP 请求验证端到端行为。
+
+#[cfg(test)]
+mod tests {
+    use crate::database::Database;
+    use crate::provider::Provider;
+    use crate::proxy::server::ProxyServer;
+    use crate::proxy::types::ProxyConfig;
+    use axum::{
+        body::Body,
+        extract::State,
+        http::{header, StatusCode},
+        response::{IntoResponse, Response},
+        routing::post,
+        Json, Router,
+    };
+    use serde_json::{json, Value};
+    use serial_test::serial;
+    use std::env;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+    use tokio::net::TcpListener;
+
+    const REASONING: &str = "The bat costs $1.05 more than the ball.";
+    const ANSWER: &str = "The ball costs $0.05.";
+    /// 上游内联思考的原始文本（与变换后应当出现的两段对应）
+    const INLINE_THINK_CONTENT: &str =
+        "<think>The bat costs $1.05 more than the ball.</think>\n\nThe ball costs $0.05.";
+
+    #[derive(Clone, Debug)]
+    struct CapturedRequest {
+        path: String,
+        stream: bool,
+    }
+
+    /// 模拟 OpenAI Chat 上游：思考内联在 content 里。
+    /// 非流式返回整体 JSON，流式（`stream=true`）返回把 `<think>` 标签跨 chunk
+    /// 切分的 SSE——上游确实会这么切，转换必须能缓冲前缀。
+    async fn mock_inline_think_upstream(
+        State(captured): State<Arc<Mutex<Vec<CapturedRequest>>>>,
+        req: axum::extract::Request,
+    ) -> Response {
+        let path = req.uri().path().to_string();
+        let body_bytes = axum::body::to_bytes(req.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&body_bytes).unwrap_or(json!({}));
+        let stream = body
+            .get("stream")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        captured
+            .lock()
+            .unwrap()
+            .push(CapturedRequest { path, stream });
+
+        if !stream {
+            return Json(json!({
+                "id": "chatcmpl-inline-think",
+                "object": "chat.completion",
+                "model": "minimax-m3",
+                "choices": [{
+                    "index": 0,
+                    "message": {"role": "assistant", "content": INLINE_THINK_CONTENT},
+                    "finish_reason": "stop"
+                }],
+                "usage": {"prompt_tokens": 30, "completion_tokens": 25, "total_tokens": 55}
+            }))
+            .into_response();
+        }
+
+        let chunks = [
+            json!({"id":"chatcmpl-inline-think","model":"minimax-m3","choices":[{"delta":{"content":"<thi"}}]}),
+            json!({"id":"chatcmpl-inline-think","model":"minimax-m3","choices":[{"delta":{"content":"nk>The bat costs $1.05 more than the ball.</thi"}}]}),
+            json!({"id":"chatcmpl-inline-think","model":"minimax-m3","choices":[{"delta":{"content":"nk>The ball costs $0.05."}}]}),
+            json!({"id":"chatcmpl-inline-think","model":"minimax-m3","choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":30,"completion_tokens":25}}),
+        ];
+        let mut sse = String::new();
+        for chunk in chunks {
+            sse.push_str(&format!("data: {chunk}\n\n"));
+        }
+        sse.push_str("data: [DONE]\n\n");
+
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .body(Body::from(sse))
+            .unwrap()
+    }
+
+    /// 启动假上游，返回 (base_url, 收到的请求)
+    async fn start_inline_think_upstream() -> (String, Arc<Mutex<Vec<CapturedRequest>>>) {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/v1/chat/completions", post(mock_inline_think_upstream))
+            .route("/chat/completions", post(mock_inline_think_upstream))
+            .with_state(Arc::clone(&captured));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        (format!("http://{addr}"), captured)
+    }
+
+    /// 建库（provider 走 OpenAI Chat 协议）+ 启动 CC Switch 代理
+    ///
+    /// 返回值里必须带上 `ProxyServer` 本身：它持有 shutdown oneshot 的 sender，
+    /// 一旦被 drop，服务器 accept 循环会立刻退出（请求表现为连接被重置）。
+    async fn start_proxy_with_inline_think_provider(
+        mock_base_url: String,
+    ) -> (ProxyServer, String) {
+        let db = Arc::new(Database::memory().unwrap());
+        let provider = Provider::with_id(
+            "test-inline-think".to_string(),
+            "MiniMax M3 (OpenAI Chat upstream)".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": mock_base_url,
+                    "ANTHROPIC_AUTH_TOKEN": "test-inline-think-key"
+                },
+                "api_format": "openai_chat"
+            }),
+            None,
+        );
+        db.save_provider("claude", &provider).unwrap();
+        db.set_current_provider("claude", &provider.id).unwrap();
+
+        let proxy = ProxyServer::new(
+            ProxyConfig {
+                listen_port: 0,
+                enable_logging: false,
+                non_streaming_timeout: 10,
+                ..ProxyConfig::default()
+            },
+            db.clone(),
+            None,
+        );
+        let info = proxy.start().await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        (proxy, format!("http://127.0.0.1:{}", info.port))
+    }
+
+    fn anthropic_request_body(stream: bool) -> Value {
+        json!({
+            "model": "claude-sonnet-4-6",
+            "max_tokens": 200,
+            "stream": stream,
+            "messages": [{
+                "role": "user",
+                "content": "A bat and ball cost $1.10 total. The bat costs $1.00 more than the ball. How much does the ball cost?"
+            }]
+        })
+    }
+
+    struct TempHome {
+        #[allow(dead_code)]
+        dir: TempDir,
+        original_home: Option<String>,
+        original_userprofile: Option<String>,
+        original_test_home: Option<String>,
+    }
+
+    impl TempHome {
+        fn new() -> Self {
+            let dir = TempDir::new().expect("failed to create temp home");
+            let original_home = env::var("HOME").ok();
+            let original_userprofile = env::var("USERPROFILE").ok();
+            let original_test_home = env::var("CC_SWITCH_TEST_HOME").ok();
+
+            env::set_var("HOME", dir.path());
+            env::set_var("USERPROFILE", dir.path());
+            env::set_var("CC_SWITCH_TEST_HOME", dir.path());
+            crate::settings::reload_settings().expect("reload settings");
+
+            Self {
+                dir,
+                original_home,
+                original_userprofile,
+                original_test_home,
+            }
+        }
+    }
+
+    impl Drop for TempHome {
+        fn drop(&mut self) {
+            match &self.original_home {
+                Some(value) => env::set_var("HOME", value),
+                None => env::remove_var("HOME"),
+            }
+            match &self.original_userprofile {
+                Some(value) => env::set_var("USERPROFILE", value),
+                None => env::remove_var("USERPROFILE"),
+            }
+            match &self.original_test_home {
+                Some(value) => env::set_var("CC_SWITCH_TEST_HOME", value),
+                None => env::remove_var("CC_SWITCH_TEST_HOME"),
+            }
+        }
+    }
+
+    /// 非流式：`/v1/messages` 的响应里思考必须是独立 thinking 块，标签不能泄漏
+    #[tokio::test]
+    #[serial]
+    async fn proxy_converts_inline_think_to_thinking_block_non_streaming() {
+        let _home = TempHome::new();
+        let (mock_base_url, captured) = start_inline_think_upstream().await;
+        let (_proxy, proxy_url) = start_proxy_with_inline_think_provider(mock_base_url).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("{proxy_url}/v1/messages"))
+            .header("x-api-key", "test-inline-think-key")
+            .header("anthropic-version", "2023-06-01")
+            .json(&anthropic_request_body(false))
+            .send()
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let body_text = response.text().await.unwrap();
+        assert_eq!(
+            status,
+            reqwest::StatusCode::OK,
+            "代理应返回 200，实际 {status}: {body_text}"
+        );
+
+        let body: Value = serde_json::from_str(&body_text).unwrap();
+        assert_eq!(
+            body["content"][0]["type"], "thinking",
+            "全段思考都应成为独立 thinking 块（修复前是明文 text）: {body_text}"
+        );
+        assert_eq!(body["content"][0]["thinking"], REASONING);
+        assert_eq!(body["content"][1]["type"], "text");
+        assert_eq!(body["content"][1]["text"], ANSWER);
+        assert_eq!(body["stop_reason"], "end_turn");
+        assert!(
+            !body_text.contains("<think>") && !body_text.contains("</think>"),
+            "内联思考标签不应泄漏到 Anthropic 响应: {body_text}"
+        );
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 1, "上游应收到 1 个请求");
+        assert!(
+            captured[0].path.ends_with("/chat/completions"),
+            "provider 声明 openai_chat，上游应收到 Chat Completions 请求，实际 {}",
+            captured[0].path
+        );
+    }
+
+    /// 流式：`<think>` 标签跨 chunk 切分时仍要缓冲判定，输出 thinking_delta +
+    /// text_delta，标签同样不能泄漏
+    #[tokio::test]
+    #[serial]
+    async fn proxy_converts_inline_think_to_thinking_block_streaming() {
+        let _home = TempHome::new();
+        let (mock_base_url, captured) = start_inline_think_upstream().await;
+        let (_proxy, proxy_url) = start_proxy_with_inline_think_provider(mock_base_url).await;
+
+        let response = reqwest::Client::new()
+            .post(format!("{proxy_url}/v1/messages"))
+            .header("x-api-key", "test-inline-think-key")
+            .header("anthropic-version", "2023-06-01")
+            .json(&anthropic_request_body(true))
+            .send()
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let body_text = response.text().await.unwrap();
+        assert_eq!(
+            status,
+            reqwest::StatusCode::OK,
+            "代理应返回 200，实际 {status}: {body_text}"
+        );
+
+        let events: Vec<Value> = body_text
+            .split("\n\n")
+            .filter_map(|block| {
+                let data = block.lines().find_map(|line| line.strip_prefix("data: "))?;
+                serde_json::from_str(data).ok()
+            })
+            .collect();
+
+        let thinking_delta: String = events
+            .iter()
+            .filter(|event| event["type"] == "content_block_delta")
+            .filter(|event| {
+                event.pointer("/delta/type").and_then(|v| v.as_str()) == Some("thinking_delta")
+            })
+            .filter_map(|event| event.pointer("/delta/thinking").and_then(|v| v.as_str()))
+            .collect();
+        let text_delta: String = events
+            .iter()
+            .filter(|event| event["type"] == "content_block_delta")
+            .filter(|event| {
+                event.pointer("/delta/type").and_then(|v| v.as_str()) == Some("text_delta")
+            })
+            .filter_map(|event| event.pointer("/delta/text").and_then(|v| v.as_str()))
+            .collect();
+
+        assert_eq!(
+            thinking_delta, REASONING,
+            "思考应以 thinking_delta 下发（修复前整段混在 text_delta 里）: {body_text}"
+        );
+        assert_eq!(text_delta, ANSWER);
+        assert!(
+            !body_text.contains("<think>") && !body_text.contains("</think>"),
+            "内联思考标签不应泄漏到 SSE: {body_text}"
+        );
+        assert!(
+            events.iter().any(|event| {
+                event["type"] == "content_block_start"
+                    && event
+                        .pointer("/content_block/type")
+                        .and_then(|v| v.as_str())
+                        == Some("thinking")
+            }),
+            "应发出 thinking 内容块: {body_text}"
+        );
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        assert!(captured[0].stream, "客户端请求流式时上游也应是流式");
+        assert!(
+            captured[0].path.ends_with("/chat/completions"),
+            "provider 声明 openai_chat，上游应收到 Chat Completions 请求，实际 {}",
+            captured[0].path
+        );
+    }
+}


### PR DESCRIPTION
## Issue Description (Issue #7271)

When a Claude Code provider is mapped to an OpenAI Chat-compatible upstream that inlines its reasoning (MiniMax M3 / OpenCode Go), the answer comes back as one plain text block: the thinking is printed together with the answer and the `<think>` tags are visible.

Expected (Anthropic shape):

```json
{"content": [{"type": "thinking", "thinking": "..."}, {"type": "text", "text": "..."}]}
```

## Root Cause

Those upstreams return no `reasoning_content` field; they inline the reasoning in the message text as a leading `<think>…</think>` block. The Codex/Responses path already coped with that (the inline-think state machine in `streaming_codex_chat.rs`), but the Claude path — `streaming.rs::create_anthropic_sse_stream` for streaming and `transform.rs::openai_to_anthropic` for non-streaming — forwarded the text verbatim.

## Fix

1. `codex_chat_common.rs`: the inline-think state machine is now shared. `InlineThinkSplitter` (plus the `ThinkPrefixDecision` prefix check it is built on) returns `(is_thinking, text)` parts. The open tag can be split across chunks, so it buffers the shortest ambiguous prefix or an unterminated think body.
2. `streaming_codex_chat.rs`: maps those parts onto exactly the same reasoning/text items it emitted before — behaviour unchanged, its existing tests pass untouched.
3. `streaming.rs`: content deltas go through the splitter and thinking/text content blocks are emitted by one shared helper (which also replaces the two hand-rolled emit sites for the `reasoning`/`reasoning_content` field). The buffer is flushed at the tool-call and finish_reason boundaries and at stream end, so an unterminated `<think>` is still delivered as thinking rather than swallowed by the following tool block. Field reasoning and inline thinking share one block, so a provider that sends both does not produce duplicates.
4. `transform.rs`: non-streaming splits a leading think block out of both the string and the content-parts form, matching what `transform_codex_chat` already does. An unterminated `<think>` stays text there, as in the existing Codex non-streaming path.

## Tests

5 new tests: tag split across chunks → thinking block with no leaked tags, tool-call boundary flush, think-only content (no empty text block), plain-text passthrough (including `<`-prefixed non-think text), and the two non-streaming forms. Each fails when its mechanism is reverted; the 848 existing provider tests (including the Codex inline-think ones) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
