### PR TITLE
fix(codex): mirror vision-capable DeepSeek catalog and un-gate the legacy v4-flash alias

### DIFF
--- a/src-tauri/src/codex_config.rs
+++ b/src-tauri/src/codex_config.rs
@@ -7082,13 +7082,13 @@ base_url = "https://production.api/v1"
     #[test]
     fn vendor_catalog_matched_model_keeps_vendor_modalities() {
         // A model that IS in the official catalog must keep the vendor's
-        // declared modalities (deepseek-v4-flash is text-only).
+        // declared modalities verbatim (deepseek-v4-pro is text-only there).
         let settings = json!({
             "modelCatalog": {
                 "models": [
                     {
-                        "model": "deepseek-v4-flash",
-                        "displayName": "DeepSeek V4 Flash"
+                        "model": "deepseek-v4-pro",
+                        "displayName": "DeepSeek V4 Pro"
                     }
                 ]
             }
@@ -7319,7 +7319,7 @@ wire_api = "responses"
         let settings = json!({
             "modelCatalog": {
                 "models": [
-                    { "model": "deepseek-v4-flash", "displayName": "DeepSeek V4 Flash" },
+                    { "model": "deepseek-flash", "displayName": "DeepSeek Flash" },
                     { "model": "deepseek-v4-pro", "contextWindow": 500_000 }
                 ]
             }
@@ -7336,7 +7336,7 @@ wire_api = "responses"
         let flash = &catalog["models"][0];
         assert_eq!(
             flash.get("slug").and_then(|v| v.as_str()),
-            Some("deepseek-v4-flash")
+            Some("deepseek-flash")
         );
         assert_eq!(
             flash.get("apply_patch_tool_type").and_then(|v| v.as_str()),
@@ -7368,7 +7368,13 @@ wire_api = "responses"
             flash.get("supports_reasoning_summaries"),
             Some(&json!(true))
         );
-        assert_eq!(flash.get("input_modalities"), Some(&json!(["text"])));
+        // deepseek-flash accepts image input per the vendor's own catalog and
+        // vision guide (api-docs.deepseek.com/guides/vision); the legacy
+        // deepseek-v4-flash alias routes to it and must not be gated (#7283).
+        assert_eq!(
+            flash.get("input_modalities"),
+            Some(&json!(["text", "image"]))
+        );
         assert!(
             flash.get("model_messages").is_some(),
             "official entries are mirrored verbatim, incl. model_messages"
@@ -7382,7 +7388,7 @@ wire_api = "responses"
         // Explicit user display name still wins over the official one.
         assert_eq!(
             flash.get("display_name").and_then(|v| v.as_str()),
-            Some("DeepSeek V4 Flash")
+            Some("DeepSeek Flash")
         );
 
         let pro = &catalog["models"][1];
@@ -7453,6 +7459,37 @@ wire_api = "responses"
             .get("base_instructions")
             .and_then(|v| v.as_str())
             .is_some_and(|s| !s.trim().is_empty()));
+    }
+
+    #[test]
+    fn deepseek_official_catalog_legacy_flash_alias_stays_image_capable() {
+        // The vendor's catalog now ships `deepseek-flash` only; the legacy
+        // `deepseek-v4-flash` id the preset defaulted to is still accepted by
+        // the API and routes to the same vision-capable Flash model, so it must
+        // clone the flagship and resolve image-capable instead of being gated
+        // text-only (#7283).
+        let settings = json!({
+            "modelCatalog": { "models": [{ "model": "deepseek-v4-flash" }] }
+        });
+
+        let catalog = codex_model_catalog_from_settings(
+            &settings,
+            DEEPSEEK_NATIVE_CONFIG,
+            CodexCatalogToolProfile::NativeResponses,
+        )
+        .expect("vendor catalog generation should not error")
+        .expect("non-empty modelCatalog must yield a catalog");
+
+        let entry = &catalog["models"][0];
+        assert_eq!(
+            entry.get("slug").and_then(|v| v.as_str()),
+            Some("deepseek-v4-flash")
+        );
+        assert_eq!(
+            entry.get("input_modalities"),
+            Some(&json!(["text", "image"])),
+            "the legacy alias routes to the vision-capable Flash model and must fail open"
+        );
     }
 
     #[test]
@@ -7868,7 +7905,7 @@ web_search = "disabled"
                 { "slug": "gpt-5.4", "input_modalities": ["text", "image"] },
                 { "slug": "deepseek-v4-pro", "input_modalities": ["text"] },
                 { "slug": "gpt-text-override", "input_modalities": ["text"] },
-                { "slug": "deepseek-v4-flash", "input_modalities": ["text", "image"] }
+                { "slug": "glm-5.2", "input_modalities": ["text", "image"] }
             ]
         }"#;
 

--- a/src-tauri/src/model_capabilities.rs
+++ b/src-tauri/src/model_capabilities.rs
@@ -73,7 +73,10 @@ pub(crate) fn is_confirmed_text_only_model(model: &str) -> bool {
         "ark-code-latest",
         "deepseek-chat",
         "deepseek-reasoner",
-        "deepseek-v4-flash",
+        // `deepseek-v4-flash` is intentionally absent: it is a legacy alias the
+        // vendor still accepts and routes to the vision-capable `deepseek-flash`
+        // (api-docs.deepseek.com/guides/vision), so it must fail open. Pro stays
+        // confirmed text-only per the vendor's own catalog.
         "deepseek-v4-pro",
         "glm-5.1",
         // Exact rather than prefix matching: GLM visual models use a `v`
@@ -217,6 +220,7 @@ mod tests {
     #[test]
     fn confirmed_text_only_registry_normalizes_namespaces_and_context_markers() {
         assert!(is_confirmed_text_only_model("deepseek/deepseek-v4-pro"));
+        assert!(!is_confirmed_text_only_model("deepseek/deepseek-v4-flash"));
         assert!(is_confirmed_text_only_model("GLM-5.2[1M]"));
         assert!(is_confirmed_text_only_model("GLM-5.3[1M]"));
         assert!(is_confirmed_text_only_model("qwen/qwen3-coder-plus"));

--- a/src-tauri/src/proxy/media_sanitizer.rs
+++ b/src-tauri/src/proxy/media_sanitizer.rs
@@ -509,7 +509,7 @@ mod tests {
     fn confirmed_text_only_models_replace_chat_image_url_before_send() {
         let provider = provider(json!({}));
         let mut body = json!({
-            "model": "deepseek-v4-flash",
+            "model": "deepseek-v4-pro",
             "messages": [{
                 "role": "user",
                 "content": [
@@ -533,7 +533,7 @@ mod tests {
     fn confirmed_text_only_models_replace_codex_input_image_before_send() {
         let provider = provider(json!({}));
         let mut body = json!({
-            "model": "deepseek-v4-flash",
+            "model": "deepseek-v4-pro",
             "input": [{
                 "role": "user",
                 "content": [

--- a/src-tauri/src/resources/codex_deepseek_catalog_template.json
+++ b/src-tauri/src/resources/codex_deepseek_catalog_template.json
@@ -1,16 +1,17 @@
 {
   "models": [
     {
-      "slug": "deepseek-v4-flash",
+      "slug": "deepseek-flash",
       "prefer_websockets": false,
       "support_verbosity": true,
       "default_verbosity": "low",
       "apply_patch_tool_type": "freeform",
       "web_search_tool_type": "text",
       "input_modalities": [
-        "text"
+        "text",
+        "image"
       ],
-      "supports_image_detail_original": false,
+      "supports_image_detail_original": true,
       "truncation_policy": {
         "mode": "tokens",
         "limit": 10000
@@ -28,8 +29,8 @@
       "comp_hash": "3000",
       "reasoning_summary_format": "experimental",
       "default_reasoning_summary": "none",
-      "display_name": "DeepSeek-V4-Flash",
-      "description": "Latest frontier agentic coding model.",
+      "display_name": "DeepSeek-Flash",
+      "description": "Latest frontier agentic coding model with image input.",
       "default_reasoning_level": "high",
       "supported_reasoning_levels": [
         {


### PR DESCRIPTION
## Summary / 概述

DeepSeek 官方目录已更新：`deepseek-flash` 自带 `input_modalities: ["text", "image"]`，旧名 `deepseek-v4-flash` 仍是官方明示接受、并路由到该视觉模型的兼容别名（api-docs.deepseek.com/guides/vision，官方一键脚本的刷新逻辑也会移除旧的 `deepseek-v4-flash*` 条目）。CC Switch 内置的官方目录镜像停留在旧文件、`deepseek-v4-flash` 也还在确认纯文本名单里，两条路都把图片拦下：代理把图片块替换成 `[Unsupported Image]`（图片根本没有到达上游），生成的 Codex 目录也声明 text-only，客户端不允许附图。

- 按厂商当前 models.json 刷新内置镜像：slug `deepseek-flash`、图片模态、`supports_image_detail_original: true`。`supports_search_tool` 保持 false——这是 #6647/#6653 的有意偏离（true 会让 Codex 把 MCP 工具藏进 DeepSeek 供不了的 tool_search），本次不动。
- 从 `CONFIRMED_TAILS` 移除 `deepseek-v4-flash`：旧别名走 fail-open，媒体整流器放行图片、非厂商路径目录声明 image-capable；DeepSeek 官方 host 上未匹配的旧别名 id 沿用既有「克隆旗舰条目」机制并解析为 image-capable。`deepseek-v4-pro` 依厂商目录保持确认纯文本。

## Related Issue / 关联 Issue

Fixes #7283

## Verification / 验证

- 新增回归测试 `deepseek_official_catalog_legacy_flash_alias_stays_image_capable`：修复前失败（旧别名被判 text-only）、修复后通过。
- 既有断言随事实更新：镜像测试改喂 `deepseek-flash`（modalities `["text", "image"]`）；matched-modalities 测试改用 `deepseek-v4-pro` 保持「厂商声明透传」原意图；media_sanitizer 两个用例的纯文本正例换成 v4-pro；squash 测试的「显式图片覆盖」fixture 换成 `glm-5.2`（v4-flash 的覆盖值现在与推断值相同、会被挤压）。
- `cargo test --lib`：2824 passed / 0 failed。
- `cargo fmt --check`、`cargo clippy --lib --all-targets`（0 warning）、`git diff --check` 通过。
- 模板与厂商当前 models.json 逐字段比对：除有意保留的 `supports_search_tool: false` 外完全一致。

## Checklist / 检查清单

- [ ] `pnpm typecheck`（无前端改动，未运行）
- [ ] `pnpm format:check`（无前端改动，未运行）
- [x] `cargo clippy` passes
- [x] 无用户界面文案变更