### PR TITLE
fix(proxy): clamp sub-floor max_tokens to the Responses API minimum

### DIFF
--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -24,6 +24,11 @@ use super::reasoning_bridge::{
 
 pub(crate) const TOOL_RESULT_ERROR_MARKER: &str = "[cc-switch:tool-result-error]";
 
+/// OpenAI Responses API 拒绝 `max_output_tokens` 小于 16。Anthropic 侧的合法
+/// 小预算探测请求（如 Claude Desktop 的模型可用性探测发 `max_tokens=1`）
+/// 会被严格网关整体拒绝，转换时把低于下限的预算抬到最小值而不是让请求失败。
+pub(crate) const RESPONSES_MIN_MAX_OUTPUT_TOKENS: u64 = 16;
+
 fn has_http_url_scheme(value: &str) -> bool {
     value
         .get(.."http://".len())
@@ -1805,9 +1810,20 @@ pub fn anthropic_to_responses(
         result["input"] = json!(input);
     }
 
-    // max_tokens → max_output_tokens (Responses API uses max_output_tokens for all models)
+    // max_tokens → max_output_tokens (Responses API uses max_output_tokens for
+    // all models). The Responses API rejects values below 16 ("The number must
+    // be `>= 16`"), while Anthropic clients legitimately send tiny probe
+    // budgets (Claude Desktop's model-availability probe uses max_tokens=1),
+    // so sub-floor budgets are clamped up to the minimum instead of failing
+    // the whole request. 0 and non-integer values keep their existing
+    // pass-through semantics.
     if let Some(v) = body.get("max_tokens") {
-        result["max_output_tokens"] = v.clone();
+        result["max_output_tokens"] = match v.as_u64() {
+            Some(n) if (1..RESPONSES_MIN_MAX_OUTPUT_TOKENS).contains(&n) => {
+                json!(RESPONSES_MIN_MAX_OUTPUT_TOKENS)
+            }
+            _ => v.clone(),
+        };
     }
 
     // 直接透传的参数
@@ -5014,6 +5030,44 @@ mod tests {
         let result = anthropic_to_responses(input, None, false, false).unwrap();
 
         assert_eq!(result["max_output_tokens"], json!(1024));
+    }
+
+    #[test]
+    fn test_anthropic_to_responses_clamps_sub_floor_max_tokens() {
+        // Responses API 拒绝 max_output_tokens < 16（"The number must be >= 16"）。
+        // Claude Desktop 的模型可用性探测发 max_tokens=1，原样转发会让整个
+        // 探测请求 400，客户端因此判定"配置的模型不可用"（#7103）。
+        for budget in [1u64, 8, 15] {
+            let input = json!({
+                "model": "claude-haiku-4-5",
+                "max_tokens": budget,
+                "messages": [{"role": "user", "content": "ping"}]
+            });
+            let result = anthropic_to_responses(input, None, false, false).unwrap();
+            assert_eq!(result["max_output_tokens"], json!(16));
+        }
+
+        // 下限本身与正常预算保持原样
+        for budget in [16u64, 1024] {
+            let input = json!({
+                "model": "claude-haiku-4-5",
+                "max_tokens": budget,
+                "messages": [{"role": "user", "content": "ping"}]
+            });
+            let result = anthropic_to_responses(input, None, false, false).unwrap();
+            assert_eq!(result["max_output_tokens"], json!(budget));
+        }
+
+        // 0 与非整数不抬升：保持既有透传语义，把非法值留给上游裁决
+        for raw in [json!(0), json!("16"), json!(12.5)] {
+            let input = json!({
+                "model": "claude-haiku-4-5",
+                "max_tokens": raw,
+                "messages": [{"role": "user", "content": "ping"}]
+            });
+            let result = anthropic_to_responses(input, None, false, false).unwrap();
+            assert_eq!(result["max_output_tokens"], raw);
+        }
     }
 
     // ==================== 第二轮：P0 + P1 字段对齐 ====================


### PR DESCRIPTION
## Summary / 概述

Responses API 拒绝 `max_output_tokens` 小于 16（"The number must be `>= 16`"）。Claude Desktop 的模型可用性探测发 `max_tokens=1`，而 Anthropic→Responses 转换此前原样拷贝该值，严格上游（如 OpenCode Zen Go）直接 400，Claude Desktop 便判定「配置的模型不可用」，本地路由下映射的模型无法选用。

转换时把 1..=15 的预算抬到 16；16 及以上、0、非整数保持原有透传语义。正常会话请求（Claude Code CLI 的输出上限远大于 16）转换字节不变，不影响 prompt cache；Codex OAuth 路径随后照旧删除 `max_output_tokens`，不受影响。

## Related Issue / 关联 Issue

Fixes #7103

## Verification / 验证

- 新增回归测试 `test_anthropic_to_responses_clamps_sub_floor_max_tokens`：1/8/15 → 16；16/1024 原样；0/字符串/浮点原样透传。修复前失败、修复后通过。
- `cargo test --lib`：2824 passed / 0 failed。
- `cargo fmt --check`、`cargo clippy --lib --all-targets`（0 warning）、`git diff --check` 通过。

## Checklist / 检查清单

- [ ] `pnpm typecheck`（无前端改动，未运行）
- [ ] `pnpm format:check`（无前端改动，未运行）
- [x] `cargo clippy` passes
- [x] 无用户界面文案变更