### PR TITLE
fix(proxy): bypass inherited proxy for loopback upstream targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Run tests
         run: cargo test --manifest-path src-tauri/Cargo.toml
 
+      - name: Run test-hooks integration tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml --features test-hooks loopback_upstream -- --test-threads=1
+
   backend-windows-wsl2:
     name: Backend Checks (Windows + WSL2 home)
     runs-on: windows-2025

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -2351,47 +2351,92 @@ impl RequestForwarder {
                 "[Forwarder] Using pooled reqwest client (preserve_exact_header_case={preserve_exact_header_case}, socks_proxy={is_socks_proxy})"
             );
             // loopback upstream 必须直连：无显式代理时不得继承系统代理。
-            let client = if super::http_client::should_direct_connect_to(
-                &url,
-                upstream_proxy_url.as_deref(),
-            ) {
-                log::debug!(
-                    "[Forwarder] Loopback upstream detected; using direct client (inherited proxy bypassed)"
-                );
-                super::http_client::get_direct()
-            } else {
-                super::http_client::get()
-            };
-            let mut request = client.request(method.clone(), &url);
-            if request_is_streaming {
-                // reqwest 的 timeout 是整请求超时；流式请求交给 response_processor
-                // 的首包/静默期超时控制，避免长流被总时长误杀。
-                request = request.timeout(std::time::Duration::from_secs(24 * 60 * 60));
-            } else if !self.non_streaming_timeout.is_zero() {
-                request = request.timeout(self.non_streaming_timeout);
-            }
-            for (key, value) in &ordered_headers {
-                request = request.header(key, value);
-            }
-            let send = request.body(body_bytes).send();
-            let send_result = if request_is_streaming {
-                let header_timeout = if self.streaming_first_byte_timeout.is_zero() {
-                    timeout
+            // 每个 redirect hop 依新目标重新选择 transport：reqwest 的 redirect
+            // policy 只在同类别 hop 内跟随，跨类别 hop（loopback <-> 外部）停止并
+            // 返回 30x，由本循环重选 transport 后重发；method/body/敏感头语义镜像
+            // reqwest/tower-http 的 redirect 处理（review finding P2-A）。
+            let mut redirect_url = url.clone();
+            let mut redirect_method = method.clone();
+            let mut redirect_headers = ordered_headers.clone();
+            let mut redirect_body: Option<Vec<u8>> = Some(body_bytes);
+            let mut manual_redirect_hops = 0usize;
+
+            let reqwest_resp = loop {
+                let client = super::http_client::select_client_for_url(redirect_url.as_str());
+                let mut request = client.request(redirect_method.clone(), &redirect_url);
+                if request_is_streaming {
+                    // reqwest 的 timeout 是整请求超时；流式请求交给 response_processor
+                    // 的首包/静默期超时控制，避免长流被总时长误杀。
+                    request = request.timeout(std::time::Duration::from_secs(24 * 60 * 60));
+                } else if !self.non_streaming_timeout.is_zero() {
+                    request = request.timeout(self.non_streaming_timeout);
+                }
+                for (key, value) in &redirect_headers {
+                    request = request.header(key, value);
+                }
+                if let Some(body) = redirect_body.as_ref() {
+                    request = request.body(body.clone());
+                }
+                let send = request.send();
+                let send_result = if request_is_streaming {
+                    let header_timeout = if self.streaming_first_byte_timeout.is_zero() {
+                        timeout
+                    } else {
+                        self.streaming_first_byte_timeout
+                    };
+                    tokio::time::timeout(header_timeout, send)
+                        .await
+                        .map_err(|_| {
+                            ProxyError::Timeout(format!(
+                                "流式响应首包超时: {}s（上游未返回响应头）",
+                                header_timeout.as_secs()
+                            ))
+                        })?
                 } else {
-                    self.streaming_first_byte_timeout
+                    send.await
                 };
-                tokio::time::timeout(header_timeout, send)
-                    .await
-                    .map_err(|_| {
-                        ProxyError::Timeout(format!(
-                            "流式响应首包超时: {}s（上游未返回响应头）",
-                            header_timeout.as_secs()
-                        ))
-                    })?
-            } else {
-                send.await
+                let resp = send_result.map_err(map_reqwest_send_error)?;
+
+                // 跨类别 redirect：policy 已 stop（返回 30x），这里依新目标重选
+                // transport 重发；method/body/敏感头语义镜像 reqwest/tower-http。
+                if manual_redirect_hops < MAX_MANUAL_REDIRECT_HOPS {
+                    if let Some(next_url) =
+                        next_redirect_target(&redirect_url, resp.status(), resp.headers())
+                    {
+                        let (new_method, drop_body, drop_payload_headers) =
+                            redirect_method_transform(&redirect_method, resp.status());
+                        if drop_body {
+                            redirect_body = None;
+                        }
+                        if drop_payload_headers {
+                            for header in [
+                                http::header::CONTENT_TYPE,
+                                http::header::CONTENT_LENGTH,
+                                http::header::CONTENT_ENCODING,
+                                http::header::TRANSFER_ENCODING,
+                            ] {
+                                redirect_headers.remove(header);
+                            }
+                        }
+                        if redirect_cross_host(&redirect_url, &next_url) {
+                            for header in [
+                                http::header::AUTHORIZATION,
+                                http::header::COOKIE,
+                                http::header::PROXY_AUTHORIZATION,
+                                http::header::WWW_AUTHENTICATE,
+                            ] {
+                                redirect_headers.remove(header);
+                            }
+                            redirect_headers.remove("cookie2");
+                        }
+                        redirect_url = next_url.to_string();
+                        redirect_method = new_method;
+                        manual_redirect_hops += 1;
+                        continue;
+                    }
+                }
+                break resp;
             };
-            let reqwest_resp = send_result.map_err(map_reqwest_send_error)?;
             ProxyResponse::Reqwest(reqwest_resp)
         } else {
             // HTTP 代理或直连：走 hyper raw write（保持 header 大小写）
@@ -3572,6 +3617,63 @@ fn should_force_identity_encoding(
     headers: &axum::http::HeaderMap,
 ) -> bool {
     is_streaming_request(endpoint, body, headers)
+}
+
+/// 手工跨类别 redirect 的单链预算（与 reqwest 默认单链上限一致）。
+const MAX_MANUAL_REDIRECT_HOPS: usize = 10;
+
+/// 解析 30x 响应的下一跳目标（仅在跨类别 hop 需要重选 transport 时调用）。
+fn next_redirect_target(
+    current: &str,
+    status: reqwest::StatusCode,
+    headers: &http::HeaderMap,
+) -> Option<reqwest::Url> {
+    if !matches!(status.as_u16(), 301 | 302 | 303 | 307 | 308) {
+        return None;
+    }
+    let location = headers.get(http::header::LOCATION)?.to_str().ok()?;
+    let base = reqwest::Url::parse(current).ok()?;
+    base.join(location).ok()
+}
+
+/// 镜像 reqwest/tower-http 的 redirect method/body 变换。
+///
+/// 返回 (新 method, 是否丢弃 body, 是否移除 payload headers)：
+/// - 301/302：POST -> GET（丢 body 与 payload headers），其余方法保持不变；
+/// - 303：非 HEAD -> GET，恒丢 body 与 payload headers；
+/// - 307/308：method/body 不变。
+fn redirect_method_transform(
+    method: &http::Method,
+    status: reqwest::StatusCode,
+) -> (http::Method, bool, bool) {
+    match status.as_u16() {
+        301 | 302 => {
+            if *method == http::Method::POST {
+                (http::Method::GET, true, true)
+            } else {
+                (method.clone(), false, false)
+            }
+        }
+        303 => {
+            let new_method = if *method == http::Method::HEAD {
+                method.clone()
+            } else {
+                http::Method::GET
+            };
+            (new_method, true, true)
+        }
+        307 | 308 => (method.clone(), false, false),
+        _ => (method.clone(), false, false),
+    }
+}
+
+/// 跨 host/port 判断（镜像 reqwest 的 remove_sensitive_headers 条件）。
+fn redirect_cross_host(previous: &str, next: &reqwest::Url) -> bool {
+    let Ok(previous) = reqwest::Url::parse(previous) else {
+        return true;
+    };
+    next.host_str() != previous.host_str()
+        || next.port_or_known_default() != previous.port_or_known_default()
 }
 
 fn map_reqwest_send_error(error: reqwest::Error) -> ProxyError {

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -2350,7 +2350,18 @@ impl RequestForwarder {
             log::debug!(
                 "[Forwarder] Using pooled reqwest client (preserve_exact_header_case={preserve_exact_header_case}, socks_proxy={is_socks_proxy})"
             );
-            let client = super::http_client::get();
+            // loopback upstream 必须直连：无显式代理时不得继承系统代理。
+            let client = if super::http_client::should_direct_connect_to(
+                &url,
+                upstream_proxy_url.as_deref(),
+            ) {
+                log::debug!(
+                    "[Forwarder] Loopback upstream detected; using direct client (inherited proxy bypassed)"
+                );
+                super::http_client::get_direct()
+            } else {
+                super::http_client::get()
+            };
             let mut request = client.request(method.clone(), &url);
             if request_is_streaming {
                 // reqwest 的 timeout 是整请求超时；流式请求交给 response_processor

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -2320,21 +2320,12 @@ impl RequestForwarder {
             short_value_hash(Some(&filtered_body))
         );
 
-        // 确定超时
+        // 确定超时（logical-request 级别；redirect 链共享同一预算）
         let timeout = if self.non_streaming_timeout.is_zero() {
             std::time::Duration::from_secs(600) // 默认 600 秒
         } else {
             self.non_streaming_timeout
         };
-
-        // 获取全局代理 URL
-        let upstream_proxy_url: Option<String> = super::http_client::get_current_proxy_url();
-
-        // SOCKS5 代理不支持 CONNECT 隧道，需要用 reqwest
-        let is_socks_proxy = upstream_proxy_url
-            .as_deref()
-            .map(|u| u.starts_with("socks5"))
-            .unwrap_or(false);
 
         let preserve_exact_header_case = should_preserve_exact_header_case(
             adapter.name(),
@@ -2343,6 +2334,13 @@ impl RequestForwarder {
             is_copilot,
         );
 
+        // 首个 hop 的原子路由决策：reqwest/hyper 分支判断、SOCKS/HTTP/direct
+        // 判断、explicit proxy 元数据与实际 Client 全部来自同一次快照
+        // （review finding MAJOR-2：禁止先读 metadata、再独立选 client）。
+        // 分支在请求启动时确定；链内每个 hop 重新解析（见下方循环）。
+        let initial_route = super::http_client::resolve_route_for_url(&url);
+        let is_socks_proxy = initial_route.proxy_kind == super::http_client::RouteProxyKind::Socks5;
+
         // 发送请求
         let response = if is_socks_proxy || !preserve_exact_header_case {
             // OpenAI / Copilot / Codex 类后端不依赖原始 header 大小写；走 reqwest
@@ -2350,28 +2348,61 @@ impl RequestForwarder {
             log::debug!(
                 "[Forwarder] Using pooled reqwest client (preserve_exact_header_case={preserve_exact_header_case}, socks_proxy={is_socks_proxy})"
             );
-            // loopback upstream 必须直连：无显式代理时不得继承系统代理。
-            // 每个 redirect hop 依新目标重新选择 transport：reqwest 的 redirect
-            // policy 只在同类别 hop 内跟随，跨类别 hop（loopback <-> 外部）停止并
-            // 返回 30x，由本循环重选 transport 后重发；method/body/敏感头语义镜像
-            // reqwest/tower-http 的 redirect 处理（review finding P2-A）。
+            // loopback upstream 必须直连：无显式代理时不得继承系统代理；
+            // redirect 由统一显式状态机处理（客户端禁用自动 redirect）：
+            // 同一 logical budget（初始请求不计，≤10 次 follow，第 11 次拒绝）
+            // + 单一 request-level deadline；method/body/敏感头/Referer 语义镜像
+            // reqwest 0.12 / tower-http 0.6（review findings P2-A/MAJOR-1/MINOR-2）。
             let mut redirect_url = url.clone();
             let mut redirect_method = method.clone();
             let mut redirect_headers = ordered_headers.clone();
             let mut redirect_body: Option<Vec<u8>> = Some(body_bytes);
-            let mut manual_redirect_hops = 0usize;
+            let mut redirects_followed = 0usize;
+            let mut route = initial_route.clone();
+            let mut hop_referer: Option<http::header::HeaderValue> = None;
+            // 非流式：整条 redirect 链共享一个绝对的 deadline。
+            let non_streaming_deadline = std::time::Instant::now() + timeout;
+            // 流式：首包等待窗口同样是整条链共享的绝对窗口；拿到真正的
+            // streaming response 后交回 response_processor 的生命周期控制。
+            let header_budget = if self.streaming_first_byte_timeout.is_zero() {
+                timeout
+            } else {
+                self.streaming_first_byte_timeout
+            };
+            let header_deadline = std::time::Instant::now() + header_budget;
 
             let reqwest_resp = loop {
-                let client = super::http_client::select_client_for_url(redirect_url.as_str());
-                let mut request = client.request(redirect_method.clone(), &redirect_url);
+                // 诊断：每个 hop 的路由决策（同一次快照派生；见 resolve_route_for_url）。
+                log::debug!(
+                    "[GlobalProxy] route hop={} gen={} loopback_direct={} proxy_kind={:?}",
+                    redirects_followed,
+                    route.generation,
+                    route.loopback_direct,
+                    route.proxy_kind
+                );
+                let mut request = route.client.request(redirect_method.clone(), &redirect_url);
                 if request_is_streaming {
                     // reqwest 的 timeout 是整请求超时；流式请求交给 response_processor
                     // 的首包/静默期超时控制，避免长流被总时长误杀。
                     request = request.timeout(std::time::Duration::from_secs(24 * 60 * 60));
-                } else if !self.non_streaming_timeout.is_zero() {
-                    request = request.timeout(self.non_streaming_timeout);
+                } else {
+                    let remaining =
+                        non_streaming_deadline.saturating_duration_since(std::time::Instant::now());
+                    if remaining.is_zero() {
+                        return Err(ProxyError::Timeout(format!(
+                            "上游请求超时: {}s 内 redirect 链未完成",
+                            timeout.as_secs()
+                        )));
+                    }
+                    request = request.timeout(remaining);
                 }
-                for (key, value) in &redirect_headers {
+                // 本跳请求头 = 链头 map + 本跳 Referer（历史 hop 的 Referer
+                // 绝不进入链头 map；与 tower-http 的 headers/on_request 分离一致）。
+                let mut headers_for_hop = redirect_headers.clone();
+                if let Some(referer) = hop_referer.as_ref() {
+                    headers_for_hop.insert(http::header::REFERER, referer.clone());
+                }
+                for (key, value) in &headers_for_hop {
                     request = request.header(key, value);
                 }
                 if let Some(body) = redirect_body.as_ref() {
@@ -2379,82 +2410,181 @@ impl RequestForwarder {
                 }
                 let send = request.send();
                 let send_result = if request_is_streaming {
-                    let header_timeout = if self.streaming_first_byte_timeout.is_zero() {
-                        timeout
-                    } else {
-                        self.streaming_first_byte_timeout
-                    };
-                    tokio::time::timeout(header_timeout, send)
-                        .await
-                        .map_err(|_| {
-                            ProxyError::Timeout(format!(
-                                "流式响应首包超时: {}s（上游未返回响应头）",
-                                header_timeout.as_secs()
-                            ))
-                        })?
+                    let remaining =
+                        header_deadline.saturating_duration_since(std::time::Instant::now());
+                    if remaining.is_zero() {
+                        return Err(ProxyError::Timeout(format!(
+                            "流式响应首包超时: {}s（上游未返回响应头）",
+                            header_budget.as_secs()
+                        )));
+                    }
+                    tokio::time::timeout(remaining, send).await.map_err(|_| {
+                        ProxyError::Timeout(format!(
+                            "流式响应首包超时: {}s（上游未返回响应头）",
+                            header_budget.as_secs()
+                        ))
+                    })?
                 } else {
                     send.await
                 };
                 let resp = send_result.map_err(map_reqwest_send_error)?;
 
-                // 跨类别 redirect：policy 已 stop（返回 30x），这里依新目标重选
-                // transport 重发；method/body/敏感头语义镜像 reqwest/tower-http。
-                if manual_redirect_hops < MAX_MANUAL_REDIRECT_HOPS {
-                    if let Some(next_url) =
-                        next_redirect_target(&redirect_url, resp.status(), resp.headers())
-                    {
-                        let (new_method, drop_body, drop_payload_headers) =
-                            redirect_method_transform(&redirect_method, resp.status());
-                        if drop_body {
-                            redirect_body = None;
-                        }
-                        if drop_payload_headers {
-                            for header in [
-                                http::header::CONTENT_TYPE,
-                                http::header::CONTENT_LENGTH,
-                                http::header::CONTENT_ENCODING,
-                                http::header::TRANSFER_ENCODING,
-                            ] {
-                                redirect_headers.remove(header);
-                            }
-                        }
-                        if redirect_cross_host(&redirect_url, &next_url) {
-                            for header in [
-                                http::header::AUTHORIZATION,
-                                http::header::COOKIE,
-                                http::header::PROXY_AUTHORIZATION,
-                                http::header::WWW_AUTHENTICATE,
-                            ] {
-                                redirect_headers.remove(header);
-                            }
-                            redirect_headers.remove("cookie2");
-                        }
-                        redirect_url = next_url.to_string();
-                        redirect_method = new_method;
-                        manual_redirect_hops += 1;
+                // 统一 redirect 记账（与 raw hyper 分支共用同一实现）：任何类别
+                // 组合都消费同一个 logical budget；第 11 次 follow 被拒绝。
+                match apply_redirect_bookkeeping(
+                    &redirect_url,
+                    resp.status(),
+                    resp.headers(),
+                    &mut redirect_method,
+                    &mut redirect_headers,
+                    &mut redirect_body,
+                    redirects_followed,
+                )? {
+                    Some((next_url, referer)) => {
+                        hop_referer = referer;
+                        redirect_url = next_url;
+                        redirects_followed += 1;
+                        // 下一跳：新的原子路由决策（ONE HOP = ONE SNAPSHOT）。
+                        route = super::http_client::resolve_route_for_url(&redirect_url);
                         continue;
                     }
+                    None => break resp,
                 }
-                break resp;
             };
             ProxyResponse::Reqwest(reqwest_resp)
         } else {
-            // HTTP 代理或直连：走 hyper raw write（保持 header 大小写）
-            // 如果有 HTTP 代理，hyper_client 会用 CONNECT 隧道穿过代理
-            let uri: http::Uri = url.parse().map_err(|e| {
-                ProxyError::ForwardFailed(format!("Invalid upstream URL ({target_for_log}): {e}"))
-            })?;
-            super::hyper_client::send_request(
-                uri,
-                &target_for_log,
-                method.clone(),
-                ordered_headers,
-                extensions.clone(),
-                body_bytes,
-                timeout,
-                upstream_proxy_url.as_deref(),
-            )
-            .await?
+            // HTTP 代理或直连：走 hyper raw write（保持 header 大小写）；
+            // redirect 由与 reqwest 分支相同的统一状态机处理：单一 logical
+            // budget、单一 request-level deadline、同一 method/body/敏感头/
+            // Referer 语义，且每跳重新解析一个原子 RouteDecision（review
+            // finding MAJOR-3：两侧 transport 必须共享同一链语义）。
+            let mut redirect_url = url.clone();
+            let mut redirect_method = method.clone();
+            let mut redirect_headers = ordered_headers.clone();
+            let mut redirect_body: Option<Vec<u8>> = Some(body_bytes);
+            let mut redirects_followed = 0usize;
+            let mut route = initial_route.clone();
+            let mut hop_referer: Option<http::header::HeaderValue> = None;
+            let non_streaming_deadline = std::time::Instant::now() + timeout;
+            let header_budget = if self.streaming_first_byte_timeout.is_zero() {
+                timeout
+            } else {
+                self.streaming_first_byte_timeout
+            };
+            let header_deadline = std::time::Instant::now() + header_budget;
+            loop {
+                let uri: http::Uri = redirect_url.parse().map_err(|e| {
+                    ProxyError::ForwardFailed(format!(
+                        "Invalid upstream URL ({target_for_log}): {e}"
+                    ))
+                })?;
+                let hop_timeout = if request_is_streaming {
+                    // 流式：交由 response_processor 控制生命周期，仅用绝对首包
+                    // 窗口约束 header 获取阶段。
+                    std::time::Duration::from_secs(24 * 60 * 60)
+                } else {
+                    let remaining =
+                        non_streaming_deadline.saturating_duration_since(std::time::Instant::now());
+                    if remaining.is_zero() {
+                        return Err(ProxyError::Timeout(format!(
+                            "上游请求超时: {}s 内 redirect 链未完成",
+                            timeout.as_secs()
+                        )));
+                    }
+                    remaining
+                };
+                // 本跳请求头 = 链头 map + 本跳 Referer（历史 hop 的 Referer 绝不
+                // 进入链头 map；与 tower-http 的 headers/on_request 分离一致）。
+                let mut headers_for_hop = redirect_headers.clone();
+                if let Some(referer) = hop_referer.as_ref() {
+                    headers_for_hop.insert(http::header::REFERER, referer.clone());
+                }
+                // 本跳 transport 由同一 RouteDecision 决定：SOCKS5 代理无法用
+                // hyper 的 HTTP-CONNECT 表达，切换为该决策自带的 reqwest 客户端
+                // （review finding：链内 transport 重选必须与决策同源）。
+                let hop_resp = if route.proxy_kind == super::http_client::RouteProxyKind::Socks5 {
+                    let mut request = route.client.request(redirect_method.clone(), &redirect_url);
+                    request = if request_is_streaming {
+                        request.timeout(std::time::Duration::from_secs(24 * 60 * 60))
+                    } else {
+                        request.timeout(hop_timeout)
+                    };
+                    for (key, value) in &headers_for_hop {
+                        request = request.header(key, value);
+                    }
+                    if let Some(body) = redirect_body.as_ref() {
+                        request = request.body(body.clone());
+                    }
+                    let send = request.send();
+                    let send_result = if request_is_streaming {
+                        let remaining =
+                            header_deadline.saturating_duration_since(std::time::Instant::now());
+                        if remaining.is_zero() {
+                            return Err(ProxyError::Timeout(format!(
+                                "流式响应首包超时: {}s（上游未返回响应头）",
+                                header_budget.as_secs()
+                            )));
+                        }
+                        tokio::time::timeout(remaining, send).await.map_err(|_| {
+                            ProxyError::Timeout(format!(
+                                "流式响应首包超时: {}s（上游未返回响应头）",
+                                header_budget.as_secs()
+                            ))
+                        })?
+                    } else {
+                        send.await
+                    };
+                    ProxyResponse::Reqwest(send_result.map_err(map_reqwest_send_error)?)
+                } else {
+                    let send = super::hyper_client::send_request(
+                        uri,
+                        &target_for_log,
+                        redirect_method.clone(),
+                        headers_for_hop,
+                        extensions.clone(),
+                        redirect_body.clone().unwrap_or_default(),
+                        hop_timeout,
+                        route.explicit_proxy_url.as_deref(),
+                    );
+                    if request_is_streaming {
+                        let remaining =
+                            header_deadline.saturating_duration_since(std::time::Instant::now());
+                        if remaining.is_zero() {
+                            return Err(ProxyError::Timeout(format!(
+                                "流式响应首包超时: {}s（上游未返回响应头）",
+                                header_budget.as_secs()
+                            )));
+                        }
+                        tokio::time::timeout(remaining, send).await.map_err(|_| {
+                            ProxyError::Timeout(format!(
+                                "流式响应首包超时: {}s（上游未返回响应头）",
+                                header_budget.as_secs()
+                            ))
+                        })??
+                    } else {
+                        send.await?
+                    }
+                };
+                match apply_redirect_bookkeeping(
+                    &redirect_url,
+                    hop_resp.status(),
+                    hop_resp.headers(),
+                    &mut redirect_method,
+                    &mut redirect_headers,
+                    &mut redirect_body,
+                    redirects_followed,
+                )? {
+                    Some((next_url, referer)) => {
+                        hop_referer = referer;
+                        redirect_url = next_url;
+                        redirects_followed += 1;
+                        // 下一跳：新的原子路由决策（ONE HOP = ONE SNAPSHOT）。
+                        route = super::http_client::resolve_route_for_url(&redirect_url);
+                        continue;
+                    }
+                    None => break hop_resp,
+                }
+            }
         };
 
         // 检查响应状态
@@ -3619,8 +3749,85 @@ fn should_force_identity_encoding(
     is_streaming_request(endpoint, body, headers)
 }
 
-/// 手工跨类别 redirect 的单链预算（与 reqwest 默认单链上限一致）。
-const MAX_MANUAL_REDIRECT_HOPS: usize = 10;
+/// logical-request 级别的 redirect 预算：跨所有 hop（同类别/跨类别/混合链）
+/// 共享；初始 HTTP 请求不计，允许 10 次 follow，第 11 次拒绝——与 reqwest
+/// 默认 10-hop 单链语义一致（review finding MAJOR-1）。
+const MAX_LOGICAL_REDIRECTS: usize = 10;
+
+/// 统一 redirect 记账（reqwest 与 raw hyper 两条 transport 路径共用）：
+/// 预算门（第 11 次 follow 拒绝）+ method/body/payload-header/敏感头语义
+/// （镜像 reqwest 0.12 / tower-http 0.6）。返回 `Some((next_url, referer))`
+/// = 继续下一跳（referer = 本跳应携带的 Referer，None = 不发送——HTTPS→HTTP
+/// 降级；历史 hop 的 Referer 绝不写入链头 header map，与 tower-http 的
+/// `this.headers` / `on_request` 分离语义一致）；`None` = 当前响应不是
+/// redirect（调用方直接使用该响应）。
+#[allow(clippy::too_many_arguments)]
+fn apply_redirect_bookkeeping(
+    from_url: &str,
+    status: reqwest::StatusCode,
+    resp_headers: &http::HeaderMap,
+    redirect_method: &mut http::Method,
+    redirect_headers: &mut http::HeaderMap,
+    redirect_body: &mut Option<Vec<u8>>,
+    redirects_followed: usize,
+) -> Result<Option<(String, Option<http::HeaderValue>)>, ProxyError> {
+    let Some(next_url) = next_redirect_target(from_url, status, resp_headers) else {
+        return Ok(None);
+    };
+    if redirects_followed >= MAX_LOGICAL_REDIRECTS {
+        return Err(ProxyError::ForwardFailed(format!(
+            "上游重定向次数超过上限（{MAX_LOGICAL_REDIRECTS} 次重定向）"
+        )));
+    }
+    let (new_method, drop_body, drop_payload_headers) =
+        redirect_method_transform(redirect_method, status);
+    if drop_body {
+        *redirect_body = None;
+    }
+    if drop_payload_headers {
+        for header in [
+            http::header::CONTENT_TYPE,
+            http::header::CONTENT_LENGTH,
+            http::header::CONTENT_ENCODING,
+            http::header::TRANSFER_ENCODING,
+        ] {
+            redirect_headers.remove(header);
+        }
+    }
+    if redirect_cross_host(from_url, &next_url) {
+        for header in [
+            http::header::AUTHORIZATION,
+            http::header::COOKIE,
+            http::header::PROXY_AUTHORIZATION,
+            http::header::WWW_AUTHENTICATE,
+        ] {
+            redirect_headers.remove(header);
+        }
+        redirect_headers.remove("cookie2");
+    }
+    // Referer 语义镜像 reqwest（make_referer + tower-http 的链头/hop 分离）：
+    // 下一跳携带 Referer = 上一跳 URL；HTTPS→HTTP 降级时不发送。返回值由调用方
+    // 在发送前并入该跳的请求头，绝不写回 redirect_headers。
+    let referer = redirect_referer(from_url, &next_url);
+    *redirect_method = new_method;
+    Ok(Some((next_url.to_string(), referer)))
+}
+
+/// 生成下一跳的 Referer（镜像 reqwest `make_referer`，reqwest-0.12.28
+/// `src/redirect.rs:293`）：Referer = 上一跳 URL，剥离 user/password/fragment；
+/// HTTPS→HTTP 降级时不发送（返回 None）。review finding MINOR-2。
+pub(crate) fn redirect_referer(previous: &str, next: &reqwest::Url) -> Option<http::HeaderValue> {
+    let Ok(mut referer) = reqwest::Url::parse(previous) else {
+        return None;
+    };
+    if next.scheme() == "http" && referer.scheme() == "https" {
+        return None;
+    }
+    let _ = referer.set_username("");
+    let _ = referer.set_password(None);
+    referer.set_fragment(None);
+    referer.as_str().parse().ok()
+}
 
 /// 解析 30x 响应的下一跳目标（仅在跨类别 hop 需要重选 transport 时调用）。
 fn next_redirect_target(

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -19,6 +19,10 @@ static CURRENT_PROXY_URL: OnceCell<RwLock<Option<String>>> = OnceCell::new();
 /// CC Switch 代理服务器当前监听的端口
 static CC_SWITCH_PROXY_PORT: OnceCell<RwLock<u16>> = OnceCell::new();
 
+/// 全局直连 HTTP 客户端（永不使用任何代理，包括系统代理）。
+/// 用于 loopback upstream 目标：本地目标必须直连，否则会被系统代理截获。
+static DIRECT_CLIENT: OnceCell<Client> = OnceCell::new();
+
 /// 设置 CC Switch 代理服务器的监听端口
 ///
 /// 应在代理服务器启动时调用，以便系统代理检测能正确识别自己的端口
@@ -196,6 +200,51 @@ pub fn get() -> Client {
         })
 }
 
+/// 获取全局直连 HTTP 客户端（永不使用任何代理，包括系统代理/环境变量代理）。
+///
+/// 用于 loopback upstream 目标：本地环回地址必须直连，
+/// 避免被系统代理（如 ClashX / v2rayN）截获导致请求无法到达本地服务。
+pub fn get_direct() -> Client {
+    DIRECT_CLIENT
+        .get_or_init(|| {
+            build_client_with(None, true).unwrap_or_else(|e| {
+                log::warn!(
+                    "[GlobalProxy] [GP-009] Direct client build failed, using fallback: {e}"
+                );
+                Client::builder().no_proxy().build().unwrap_or_default()
+            })
+        })
+        .clone()
+}
+
+/// 判断最终 upstream URL 的 host 是否为 loopback 目标。
+///
+/// 使用标准 URL/IP 解析（url crate + IpAddr::is_loopback），不做字符串前缀粗判：
+/// - localhost（大小写不敏感）
+/// - IPv4 loopback（127.0.0.0/8，例如 127.0.0.1）
+/// - IPv6 loopback（::1）
+pub fn is_loopback_upstream_url(url: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(url.trim()) else {
+        return false;
+    };
+    match parsed.host() {
+        Some(url::Host::Domain(host)) => host.eq_ignore_ascii_case("localhost"),
+        Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+        None => false,
+    }
+}
+
+/// 判断给定 upstream 目标是否必须使用「直连客户端」。
+///
+/// 仅当未配置用户显式 upstream 代理（explicit_proxy_url == None）且目标为 loopback
+/// 时返回 true：
+/// - loopback 目标不得继承系统代理（系统代理会截获回环请求）；
+/// - 用户显式配置的代理语义保持不变（存在显式代理时始终返回 false）。
+pub fn should_direct_connect_to(url: &str, explicit_proxy_url: Option<&str>) -> bool {
+    explicit_proxy_url.is_none() && is_loopback_upstream_url(url)
+}
+
 /// 获取当前代理 URL
 ///
 /// 返回当前配置的代理 URL，None 表示直连。
@@ -214,6 +263,14 @@ pub fn is_proxy_enabled() -> bool {
 
 /// 构建 HTTP 客户端
 fn build_client(proxy_url: Option<&str>) -> Result<Client, String> {
+    build_client_with(proxy_url, false)
+}
+
+/// 构建 HTTP 客户端（force_direct = true 时禁用一切代理）。
+///
+/// force_direct 为 true 时客户端永不使用任何代理（包括系统代理/环境变量代理），
+/// 用于 loopback upstream：本地目标必须直连，避免被系统代理截获。
+fn build_client_with(proxy_url: Option<&str>, force_direct: bool) -> Result<Client, String> {
     let mut builder = Client::builder()
         .timeout(Duration::from_secs(600))
         .connect_timeout(Duration::from_secs(30))
@@ -225,6 +282,15 @@ fn build_client(proxy_url: Option<&str>) -> Result<Client, String> {
         .no_brotli()
         .no_deflate()
         .no_zstd();
+
+    if force_direct {
+        // 直连语义：显式禁用一切代理，不进入下方的代理选择逻辑。
+        builder = builder.no_proxy();
+        log::debug!("[GlobalProxy] Direct client built (all proxies disabled)");
+        return builder
+            .build()
+            .map_err(|e| format!("Failed to build direct HTTP client: {e}"));
+    }
 
     // 有代理地址则使用代理，否则跟随系统代理
     if let Some(url) = proxy_url {
@@ -342,7 +408,7 @@ pub fn mask_url(url: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::{Arc, Mutex, OnceLock};
 
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -461,5 +527,219 @@ mod tests {
         for key in &keys {
             std::env::remove_var(key);
         }
+    }
+
+    const OPENAI_CHAT_BODY: &str = r#"{"id":"chatcmpl-test","object":"chat.completion","created":0,"model":"test-model","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#;
+
+    /// 启动一个记录请求的 mock 服务器（可充当 mock 上游或 mock 代理），固定返回 200 + OPENAI_CHAT_BODY。
+    async fn spawn_recording_server(
+        record: Arc<Mutex<Vec<String>>>,
+        body: &'static str,
+    ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+        let app = axum::Router::new().fallback(move |req: axum::extract::Request| {
+            let record = record.clone();
+            async move {
+                record
+                    .lock()
+                    .unwrap()
+                    .push(format!("{} {}", req.method(), req.uri()));
+                (
+                    axum::http::StatusCode::OK,
+                    [(axum::http::header::CONTENT_TYPE, "application/json")],
+                    body,
+                )
+            }
+        });
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock server");
+        let addr = listener.local_addr().expect("mock server addr");
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (addr, handle)
+    }
+
+    #[test]
+    fn test_is_loopback_upstream_url_classification() {
+        // 1) localhost（大小写不敏感）
+        assert!(is_loopback_upstream_url(
+            "http://localhost:8080/v1/chat/completions"
+        ));
+        assert!(is_loopback_upstream_url("http://LOCALHOST/v1"));
+        assert!(is_loopback_upstream_url("http://LocalHost/v1"));
+        // 2) 127.0.0.1
+        assert!(is_loopback_upstream_url("http://127.0.0.1:8080/v1"));
+        // 3) 任意 127/8 地址
+        assert!(is_loopback_upstream_url("http://127.8.8.8:9/v1"));
+        assert!(is_loopback_upstream_url("http://127.255.255.254/v1"));
+        // 4) IPv6 ::1
+        assert!(is_loopback_upstream_url("http://[::1]:8080/v1"));
+        // 5) 公网/私网 IPv4 不是 loopback
+        assert!(!is_loopback_upstream_url("https://8.8.8.8/v1"));
+        assert!(!is_loopback_upstream_url("https://192.168.1.10:7890/v1"));
+        assert!(!is_loopback_upstream_url("https://10.0.0.2/v1"));
+        // 6) 普通主机名不是 loopback
+        assert!(!is_loopback_upstream_url("https://api.openai.com/v1"));
+        assert!(!is_loopback_upstream_url("https://localhost.evil.com/v1"));
+        // 非法输入保守返回 false
+        assert!(!is_loopback_upstream_url("not a url"));
+    }
+
+    #[test]
+    fn test_should_direct_connect_to_policy() {
+        // 8) loopback + 无显式代理 → 直连（不继承系统代理）
+        assert!(should_direct_connect_to("http://127.0.0.1:8080/v1", None));
+        assert!(should_direct_connect_to("http://localhost:8080/v1", None));
+        assert!(should_direct_connect_to("http://[::1]:8080/v1", None));
+        // 9) 外部目标 + 无显式代理 → 保持既有语义（跟随系统/继承代理）
+        assert!(!should_direct_connect_to("https://api.openai.com/v1", None));
+        assert!(!should_direct_connect_to("http://192.0.2.1/v1", None));
+        // 10) loopback + 显式代理 → 保持显式代理语义
+        assert!(!should_direct_connect_to(
+            "http://127.0.0.1:8080/v1",
+            Some("http://127.0.0.1:7890")
+        ));
+        // 11) 外部 + 显式代理 → 保持显式代理语义
+        assert!(!should_direct_connect_to(
+            "https://api.openai.com/v1",
+            Some("socks5://127.0.0.1:1080")
+        ));
+    }
+
+    /// 12) loopback 目标不得被「继承代理」（环境变量/系统代理）截获：
+    /// 直连客户端在继承代理存在时仍必须直连到本地服务器。
+    #[tokio::test]
+    async fn test_direct_client_ignores_inherited_env_proxy_for_loopback_target() {
+        let _guard = env_lock().lock().unwrap();
+        let prev_http = env::var("HTTP_PROXY").ok();
+        let prev_http_lower = env::var("http_proxy").ok();
+
+        let upstream_rec: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let (upstream_addr, upstream_handle) =
+            spawn_recording_server(upstream_rec.clone(), OPENAI_CHAT_BODY).await;
+        let proxy_rec: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let (proxy_addr, proxy_handle) =
+            spawn_recording_server(proxy_rec.clone(), OPENAI_CHAT_BODY).await;
+
+        env::set_var(
+            "HTTP_PROXY",
+            format!("http://127.0.0.1:{}", proxy_addr.port()),
+        );
+        env::set_var(
+            "http_proxy",
+            format!("http://127.0.0.1:{}", proxy_addr.port()),
+        );
+
+        let direct = get_direct();
+        let result = direct
+            .get(format!("http://127.0.0.1:{}/", upstream_addr.port()))
+            .send()
+            .await;
+
+        match prev_http {
+            Some(v) => env::set_var("HTTP_PROXY", v),
+            None => env::remove_var("HTTP_PROXY"),
+        }
+        match prev_http_lower {
+            Some(v) => env::set_var("http_proxy", v),
+            None => env::remove_var("http_proxy"),
+        }
+
+        let resp = result.expect("direct client must bypass inherited proxy");
+        assert_eq!(resp.status(), 200);
+        assert_eq!(
+            upstream_rec.lock().unwrap().len(),
+            1,
+            "loopback target must be reached directly"
+        );
+        assert_eq!(
+            proxy_rec.lock().unwrap().len(),
+            0,
+            "inherited proxy must not be used for a loopback target"
+        );
+        upstream_handle.abort();
+        proxy_handle.abort();
+    }
+
+    /// 13) 未配置显式代理时，外部目标仍遵循继承代理（既有语义不变）。
+    #[tokio::test]
+    async fn test_following_client_still_uses_inherited_env_proxy_for_external_target() {
+        let _guard = env_lock().lock().unwrap();
+        let prev_http = env::var("HTTP_PROXY").ok();
+        let prev_http_lower = env::var("http_proxy").ok();
+
+        let proxy_rec: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let (proxy_addr, proxy_handle) =
+            spawn_recording_server(proxy_rec.clone(), OPENAI_CHAT_BODY).await;
+
+        env::set_var(
+            "HTTP_PROXY",
+            format!("http://127.0.0.1:{}", proxy_addr.port()),
+        );
+        env::set_var(
+            "http_proxy",
+            format!("http://127.0.0.1:{}", proxy_addr.port()),
+        );
+
+        let following = build_client(None).expect("build following client");
+        // 非 loopback 目标（TEST-NET-1 不可路由；由 mock 代理直接应答，无需真实网络）
+        let result = following.get("http://192.0.2.1/v1").send().await;
+
+        match prev_http {
+            Some(v) => env::set_var("HTTP_PROXY", v),
+            None => env::remove_var("HTTP_PROXY"),
+        }
+        match prev_http_lower {
+            Some(v) => env::set_var("http_proxy", v),
+            None => env::remove_var("http_proxy"),
+        }
+
+        let resp = result.expect("external request should go through the inherited proxy");
+        assert_eq!(resp.status(), 200);
+        let rec = proxy_rec.lock().unwrap().clone();
+        assert_eq!(
+            rec.len(),
+            1,
+            "external target must keep following the inherited proxy"
+        );
+        assert!(rec[0].contains("192.0.2.1"), "{}", rec[0]);
+        proxy_handle.abort();
+    }
+
+    /// 10/11) 显式代理语义保持：loopback 与外部目标都经显式代理，不被本 patch 静默覆盖。
+    #[tokio::test]
+    async fn test_explicit_proxy_is_used_for_loopback_and_external_targets() {
+        let proxy_rec: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let (proxy_addr, proxy_handle) =
+            spawn_recording_server(proxy_rec.clone(), OPENAI_CHAT_BODY).await;
+
+        let proxy_url = format!("http://127.0.0.1:{}", proxy_addr.port());
+        let client = build_client(Some(proxy_url.as_str())).expect("build explicit-proxy client");
+
+        // loopback 目标：不得被静默改为直连（目标端口无需真实监听——由显式代理应答）
+        let resp = client
+            .get("http://127.0.0.1:9/loopback/check")
+            .send()
+            .await
+            .expect("request via explicit proxy");
+        assert_eq!(resp.status(), 200);
+        // 外部目标：同样遵循显式代理
+        let resp2 = client
+            .get("http://192.0.2.1/external/check")
+            .send()
+            .await
+            .expect("external request via explicit proxy");
+        assert_eq!(resp2.status(), 200);
+
+        let rec = proxy_rec.lock().unwrap().clone();
+        assert_eq!(
+            rec.len(),
+            2,
+            "both requests must go through the explicit proxy"
+        );
+        assert!(rec[0].contains("127.0.0.1:9/loopback/check"), "{}", rec[0]);
+        assert!(rec[1].contains("192.0.2.1/external/check"), "{}", rec[1]);
+        proxy_handle.abort();
     }
 }

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -7,14 +7,28 @@ use once_cell::sync::OnceCell;
 use reqwest::Client;
 use std::env;
 use std::net::IpAddr;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-/// 全局 HTTP 客户端实例
-static GLOBAL_CLIENT: OnceCell<RwLock<Client>> = OnceCell::new();
+/// 路由状态快照：把「用于选择 transport 的 explicit proxy 元数据」与
+/// 「对应的 following/pooled Client」放进同一个不可分割的快照。
+///
+/// 所有写者（init/apply_proxy/update_proxy）构建完整的新快照后整体替换 Arc，
+/// 读者一次读取即拿到自洽的 (metadata, client) 组合——热更新期间不存在
+/// 「旧元数据 + 新 client」或反向的撕裂配对（review finding P2-B）。
+pub struct RouteState {
+    /// 单调递增的发布序号（诊断与测试证据用）。
+    generation: u64,
+    /// 当前 proxy 配置对应的 following/pooled 客户端。
+    client: Client,
+    /// 当前配置的 explicit proxy URL；None = 直连/跟随系统代理。
+    explicit_proxy_url: Option<String>,
+}
 
-/// 当前代理 URL（用于日志和状态查询）
-static CURRENT_PROXY_URL: OnceCell<RwLock<Option<String>>> = OnceCell::new();
+static ROUTE_STATE: OnceCell<RwLock<Arc<RouteState>>> = OnceCell::new();
+
+/// 路由状态发布序号计数器。
+static ROUTE_GENERATION: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// CC Switch 代理服务器当前监听的端口
 static CC_SWITCH_PROXY_PORT: OnceCell<RwLock<u16>> = OnceCell::new();
@@ -47,6 +61,34 @@ fn get_proxy_port() -> u16 {
         .unwrap_or(15721) // 默认端口作为回退
 }
 
+/// 构建新一代路由状态快照（尚未发布）。
+fn build_route_state(client: Client, explicit_proxy_url: Option<String>) -> Arc<RouteState> {
+    Arc::new(RouteState {
+        generation: ROUTE_GENERATION.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1,
+        client,
+        explicit_proxy_url,
+    })
+}
+
+/// 读取当前路由状态快照。一次读取即原子自洽：元数据与 client 来自同一代。
+pub fn route_snapshot() -> Arc<RouteState> {
+    let snapshot = ROUTE_STATE
+        .get()
+        .and_then(|lock| lock.read().ok())
+        .map(|guard| guard.clone());
+    match snapshot {
+        Some(state) => state,
+        None => {
+            log::warn!("[GlobalProxy] [GP-004] Route state not initialized, using fallback");
+            Arc::new(RouteState {
+                generation: 0,
+                client: build_client(None).unwrap_or_default(),
+                explicit_proxy_url: None,
+            })
+        }
+    }
+}
+
 /// 初始化全局 HTTP 客户端
 ///
 /// 应在应用启动时调用一次。
@@ -57,9 +99,12 @@ fn get_proxy_port() -> u16 {
 pub fn init(proxy_url: Option<&str>) -> Result<(), String> {
     let effective_url = proxy_url.filter(|s| !s.trim().is_empty());
     let client = build_client(effective_url)?;
+    let state = build_route_state(client, effective_url.map(|s| s.to_string()));
 
-    // 尝试初始化全局客户端，如果已存在则记录警告并使用 apply_proxy 更新
-    if GLOBAL_CLIENT.set(RwLock::new(client.clone())).is_err() {
+    // 尝试初始化路由状态，如果已存在则记录警告并使用 apply_proxy 更新
+    #[cfg(feature = "test-hooks")]
+    crate::proxy::test_hooks::record_publish(state.generation, state.explicit_proxy_url.as_deref());
+    if ROUTE_STATE.set(RwLock::new(state)).is_err() {
         log::warn!(
             "[GlobalProxy] [GP-003] Already initialized, updating instead: {}",
             effective_url
@@ -69,9 +114,6 @@ pub fn init(proxy_url: Option<&str>) -> Result<(), String> {
         // 已初始化，改用 apply_proxy 更新
         return apply_proxy(proxy_url);
     }
-
-    // 初始化代理 URL 记录
-    let _ = CURRENT_PROXY_URL.set(RwLock::new(effective_url.map(|s| s.to_string())));
 
     log::info!(
         "[GlobalProxy] Initialized: {}",
@@ -110,30 +152,28 @@ pub fn validate_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 pub fn apply_proxy(proxy_url: Option<&str>) -> Result<(), String> {
     let effective_url = proxy_url.filter(|s| !s.trim().is_empty());
     let new_client = build_client(effective_url)?;
+    let new_state = build_route_state(new_client, effective_url.map(|s| s.to_string()));
 
-    // 更新客户端
-    if let Some(lock) = GLOBAL_CLIENT.get() {
-        let mut client = lock.write().map_err(|e| {
+    // 发布：在写锁临界区内整体替换快照；读者要么看到旧快照要么看到新快照。
+    let generation = new_state.generation;
+    if let Some(lock) = ROUTE_STATE.get() {
+        let mut guard = lock.write().map_err(|e| {
             log::error!("[GlobalProxy] [GP-001] Failed to acquire write lock: {e}");
             "Failed to update proxy: lock poisoned".to_string()
         })?;
-        *client = new_client;
+        #[cfg(feature = "test-hooks")]
+        crate::proxy::test_hooks::record_publish(
+            new_state.generation,
+            new_state.explicit_proxy_url.as_deref(),
+        );
+        *guard = new_state;
     } else {
         // 如果还没初始化，则初始化
         return init(proxy_url);
     }
 
-    // 更新代理 URL 记录
-    if let Some(lock) = CURRENT_PROXY_URL.get() {
-        let mut url = lock.write().map_err(|e| {
-            log::error!("[GlobalProxy] [GP-002] Failed to acquire URL write lock: {e}");
-            "Failed to update proxy URL record: lock poisoned".to_string()
-        })?;
-        *url = effective_url.map(|s| s.to_string());
-    }
-
     log::info!(
-        "[GlobalProxy] Applied: {}",
+        "[GlobalProxy] Applied (gen {generation}): {}",
         effective_url
             .map(mask_url)
             .unwrap_or_else(|| "direct connection".to_string())
@@ -154,26 +194,23 @@ pub fn apply_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 pub fn update_proxy(proxy_url: Option<&str>) -> Result<(), String> {
     let effective_url = proxy_url.filter(|s| !s.trim().is_empty());
     let new_client = build_client(effective_url)?;
+    let new_state = build_route_state(new_client, effective_url.map(|s| s.to_string()));
 
-    // 更新客户端
-    if let Some(lock) = GLOBAL_CLIENT.get() {
-        let mut client = lock.write().map_err(|e| {
+    // 发布：与 apply_proxy 相同——单锁临界区内整体替换快照。
+    if let Some(lock) = ROUTE_STATE.get() {
+        let mut guard = lock.write().map_err(|e| {
             log::error!("[GlobalProxy] [GP-001] Failed to acquire write lock: {e}");
             "Failed to update proxy: lock poisoned".to_string()
         })?;
-        *client = new_client;
+        #[cfg(feature = "test-hooks")]
+        crate::proxy::test_hooks::record_publish(
+            new_state.generation,
+            new_state.explicit_proxy_url.as_deref(),
+        );
+        *guard = new_state;
     } else {
         // 如果还没初始化，则初始化
         return init(proxy_url);
-    }
-
-    // 更新代理 URL 记录
-    if let Some(lock) = CURRENT_PROXY_URL.get() {
-        let mut url = lock.write().map_err(|e| {
-            log::error!("[GlobalProxy] [GP-002] Failed to acquire URL write lock: {e}");
-            "Failed to update proxy URL record: lock poisoned".to_string()
-        })?;
-        *url = effective_url.map(|s| s.to_string());
     }
 
     log::info!(
@@ -190,14 +227,7 @@ pub fn update_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 ///
 /// 返回配置了代理的客户端（如果已配置代理），否则返回跟随系统代理的客户端。
 pub fn get() -> Client {
-    GLOBAL_CLIENT
-        .get()
-        .and_then(|lock| lock.read().ok())
-        .map(|c| c.clone())
-        .unwrap_or_else(|| {
-            log::warn!("[GlobalProxy] [GP-004] Client not initialized, using fallback");
-            build_client(None).unwrap_or_default()
-        })
+    route_snapshot().client.clone()
 }
 
 /// 获取全局直连 HTTP 客户端（永不使用任何代理，包括系统代理/环境变量代理）。
@@ -245,14 +275,42 @@ pub fn should_direct_connect_to(url: &str, explicit_proxy_url: Option<&str>) -> 
     explicit_proxy_url.is_none() && is_loopback_upstream_url(url)
 }
 
+/// 选择该 upstream 目标应使用的 Client（唯一原子快照）。
+///
+/// 元数据（explicit proxy）与对应 Client 来自同一次 `route_snapshot()` 读取，
+/// 热更新期间不存在撕裂配对（review finding P2-B）。
+pub fn select_client_for_url(url: &str) -> Client {
+    let snapshot = route_snapshot();
+    #[cfg(feature = "test-hooks")]
+    crate::proxy::test_hooks::pause_point();
+    if should_direct_connect_to(url, snapshot.explicit_proxy_url.as_deref()) {
+        log::debug!(
+            "[GlobalProxy] Loopback upstream detected; using direct client (inherited proxy bypassed)"
+        );
+        get_direct()
+    } else {
+        snapshot.client.clone()
+    }
+}
+
+/// 测试证据入口（test-hooks）：返回 (是否选择直连, 所用快照的发布序号)。
+///
+/// 与 `select_client_for_url` 使用同一次快照读取，供并发/原子性测试验证
+/// 「决策必须与其快照世代的发布内容一致」。
+#[cfg(feature = "test-hooks")]
+#[allow(dead_code)]
+pub fn select_for_test(url: &str) -> (bool, u64) {
+    let snapshot = route_snapshot();
+    crate::proxy::test_hooks::pause_point();
+    let direct = should_direct_connect_to(url, snapshot.explicit_proxy_url.as_deref());
+    (direct, snapshot.generation)
+}
+
 /// 获取当前代理 URL
 ///
 /// 返回当前配置的代理 URL，None 表示直连。
 pub fn get_current_proxy_url() -> Option<String> {
-    CURRENT_PROXY_URL
-        .get()
-        .and_then(|lock| lock.read().ok())
-        .and_then(|url| url.clone())
+    route_snapshot().explicit_proxy_url.clone()
 }
 
 /// 检查是否正在使用代理
@@ -266,6 +324,30 @@ fn build_client(proxy_url: Option<&str>) -> Result<Client, String> {
     build_client_with(proxy_url, false)
 }
 
+/// redirect 目标类别与当前 client 的一致性策略（review finding P2-A）：
+/// - direct client（force_direct）只跟随 loopback 目标；
+/// - following client 只跟随非 loopback 目标。
+///
+/// 跨类别 hop 在此停止并返回 30x，由 forwarder 依新目标重选 transport 重发，
+/// 保证「只有 loopback hop 被强制直连」而外部 hop 保持继承/显式代理语义。
+/// 跳数上限与 reqwest 默认单链上限一致。
+fn redirect_policy_for(follow_loopback_targets: bool) -> reqwest::redirect::Policy {
+    reqwest::redirect::Policy::custom(move |attempt: reqwest::redirect::Attempt| {
+        if attempt.previous().len() >= MAX_REDIRECT_HOPS {
+            return attempt.error("too many redirects");
+        }
+        let next_is_loopback = is_loopback_upstream_url(attempt.url().as_str());
+        if next_is_loopback == follow_loopback_targets {
+            attempt.follow()
+        } else {
+            attempt.stop()
+        }
+    })
+}
+
+/// 与 reqwest 默认策略一致的单链上限。
+const MAX_REDIRECT_HOPS: usize = 10;
+
 /// 构建 HTTP 客户端（force_direct = true 时禁用一切代理）。
 ///
 /// force_direct 为 true 时客户端永不使用任何代理（包括系统代理/环境变量代理），
@@ -276,6 +358,9 @@ fn build_client_with(proxy_url: Option<&str>, force_direct: bool) -> Result<Clie
         .connect_timeout(Duration::from_secs(30))
         .pool_max_idle_per_host(10)
         .tcp_keepalive(Duration::from_secs(60))
+        // 跨类别 redirect hop 由 forwarder 手工重选 transport 后重发；
+        // 同类别 hop 仍由 reqwest 内部跟随（默认上限 10）。
+        .redirect(redirect_policy_for(force_direct))
         // 禁用 reqwest 自动解压：防止 reqwest 覆盖客户端原始 accept-encoding header。
         // 响应解压由 response_processor 根据 content-encoding 手动处理。
         .no_gzip()

--- a/src-tauri/src/proxy/http_client.rs
+++ b/src-tauri/src/proxy/http_client.rs
@@ -19,8 +19,12 @@ use std::time::Duration;
 pub struct RouteState {
     /// 单调递增的发布序号（诊断与测试证据用）。
     generation: u64,
-    /// 当前 proxy 配置对应的 following/pooled 客户端。
+    /// 当前 proxy 配置对应的 following/pooled 客户端
+    /// （非 forwarder 消费者使用；保留 reqwest 默认 redirect 行为）。
     client: Client,
+    /// forwarder 专用客户端（禁用 reqwest 自动 redirect；redirect 由
+    /// forwarder 统一显式状态机处理，跨越所有 hop 共享单一预算与 deadline）。
+    route_client: Client,
     /// 当前配置的 explicit proxy URL；None = 直连/跟随系统代理。
     explicit_proxy_url: Option<String>,
 }
@@ -35,6 +39,7 @@ static CC_SWITCH_PROXY_PORT: OnceCell<RwLock<u16>> = OnceCell::new();
 
 /// 全局直连 HTTP 客户端（永不使用任何代理，包括系统代理）。
 /// 用于 loopback upstream 目标：本地目标必须直连，否则会被系统代理截获。
+#[cfg(feature = "test-hooks")]
 static DIRECT_CLIENT: OnceCell<Client> = OnceCell::new();
 
 /// 设置 CC Switch 代理服务器的监听端口
@@ -62,12 +67,13 @@ fn get_proxy_port() -> u16 {
 }
 
 /// 构建新一代路由状态快照（尚未发布）。
-fn build_route_state(client: Client, explicit_proxy_url: Option<String>) -> Arc<RouteState> {
-    Arc::new(RouteState {
+fn build_route_state(proxy_url: Option<&str>) -> Result<Arc<RouteState>, String> {
+    Ok(Arc::new(RouteState {
         generation: ROUTE_GENERATION.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1,
-        client,
-        explicit_proxy_url,
-    })
+        client: build_client(proxy_url)?,
+        route_client: build_route_client(proxy_url)?,
+        explicit_proxy_url: proxy_url.map(|s| s.to_string()),
+    }))
 }
 
 /// 读取当前路由状态快照。一次读取即原子自洽：元数据与 client 来自同一代。
@@ -83,6 +89,7 @@ pub fn route_snapshot() -> Arc<RouteState> {
             Arc::new(RouteState {
                 generation: 0,
                 client: build_client(None).unwrap_or_default(),
+                route_client: build_client_with(None, false, false).unwrap_or_default(),
                 explicit_proxy_url: None,
             })
         }
@@ -98,8 +105,7 @@ pub fn route_snapshot() -> Arc<RouteState> {
 ///   传入 None 或空字符串表示直连
 pub fn init(proxy_url: Option<&str>) -> Result<(), String> {
     let effective_url = proxy_url.filter(|s| !s.trim().is_empty());
-    let client = build_client(effective_url)?;
-    let state = build_route_state(client, effective_url.map(|s| s.to_string()));
+    let state = build_route_state(effective_url)?;
 
     // 尝试初始化路由状态，如果已存在则记录警告并使用 apply_proxy 更新
     #[cfg(feature = "test-hooks")]
@@ -151,8 +157,7 @@ pub fn validate_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 /// * `proxy_url` - 代理 URL，None 或空字符串表示直连
 pub fn apply_proxy(proxy_url: Option<&str>) -> Result<(), String> {
     let effective_url = proxy_url.filter(|s| !s.trim().is_empty());
-    let new_client = build_client(effective_url)?;
-    let new_state = build_route_state(new_client, effective_url.map(|s| s.to_string()));
+    let new_state = build_route_state(effective_url)?;
 
     // 发布：在写锁临界区内整体替换快照；读者要么看到旧快照要么看到新快照。
     let generation = new_state.generation;
@@ -193,8 +198,7 @@ pub fn apply_proxy(proxy_url: Option<&str>) -> Result<(), String> {
 #[allow(dead_code)]
 pub fn update_proxy(proxy_url: Option<&str>) -> Result<(), String> {
     let effective_url = proxy_url.filter(|s| !s.trim().is_empty());
-    let new_client = build_client(effective_url)?;
-    let new_state = build_route_state(new_client, effective_url.map(|s| s.to_string()));
+    let new_state = build_route_state(effective_url)?;
 
     // 发布：与 apply_proxy 相同——单锁临界区内整体替换快照。
     if let Some(lock) = ROUTE_STATE.get() {
@@ -234,14 +238,36 @@ pub fn get() -> Client {
 ///
 /// 用于 loopback upstream 目标：本地环回地址必须直连，
 /// 避免被系统代理（如 ClashX / v2rayN）截获导致请求无法到达本地服务。
+#[cfg(feature = "test-hooks")]
 pub fn get_direct() -> Client {
     DIRECT_CLIENT
         .get_or_init(|| {
-            build_client_with(None, true).unwrap_or_else(|e| {
+            build_client_with(None, true, true).unwrap_or_else(|e| {
                 log::warn!(
                     "[GlobalProxy] [GP-009] Direct client build failed, using fallback: {e}"
                 );
                 Client::builder().no_proxy().build().unwrap_or_default()
+            })
+        })
+        .clone()
+}
+
+/// forwarder 直连路由客户端：无代理 + 禁用自动 redirect（redirect 由
+/// forwarder 显式状态机处理；见 `resolve_route_for_url`）。
+static DIRECT_ROUTE_CLIENT: OnceCell<Client> = OnceCell::new();
+
+fn get_direct_route_client() -> Client {
+    DIRECT_ROUTE_CLIENT
+        .get_or_init(|| {
+            build_client_with(None, true, false).unwrap_or_else(|e| {
+                log::warn!(
+                    "[GlobalProxy] [GP-010] Direct route client build failed, using fallback: {e}"
+                );
+                Client::builder()
+                    .no_proxy()
+                    .redirect(reqwest::redirect::Policy::none())
+                    .build()
+                    .unwrap_or_default()
             })
         })
         .clone()
@@ -275,27 +301,89 @@ pub fn should_direct_connect_to(url: &str, explicit_proxy_url: Option<&str>) -> 
     explicit_proxy_url.is_none() && is_loopback_upstream_url(url)
 }
 
-/// 选择该 upstream 目标应使用的 Client（唯一原子快照）。
+/// 单个 hop 的显式代理形态（由同一快照的 explicit proxy URL 派生）。
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RouteProxyKind {
+    /// 无 explicit proxy：直连 / 跟随系统代理。
+    None,
+    /// explicit HTTP(S) 代理。
+    Http,
+    /// explicit SOCKS5 代理。
+    Socks5,
+}
+
+/// 单个 hop 的路由决策：所有字段来自**同一次**原子快照读取。
 ///
-/// 元数据（explicit proxy）与对应 Client 来自同一次 `route_snapshot()` 读取，
-/// 热更新期间不存在撕裂配对（review finding P2-B）。
-pub fn select_client_for_url(url: &str) -> Client {
+/// 同一个 hop 内 reqwest/hyper 分支判断、SOCKS/HTTP/direct 判断、
+/// explicit proxy 元数据、实际使用的 Client 与 loopback-direct 决策不得来自
+/// 不同世代（review finding MAJOR-2：禁止「先读 metadata、再独立选 client」）。
+/// redirect 到下一 hop 时允许重新解析一个新的原子决策（proxy 配置可能在两个
+/// hop 之间改变）。ONE HOP = ONE COHERENT ROUTE SNAPSHOT。
+#[derive(Clone)]
+pub struct RouteDecision {
+    /// 本次决策所用快照的发布序号。
+    pub generation: u64,
+    /// 与 client 同源的 explicit proxy URL（None = 无 explicit proxy）。
+    pub explicit_proxy_url: Option<String>,
+    /// explicit proxy 形态（与 explicit_proxy_url 同源派生）。
+    pub proxy_kind: RouteProxyKind,
+    /// 本目标在此快照下是否应直连（loopback 且无 explicit proxy）。
+    pub loopback_direct: bool,
+    /// 本 hop 应使用的 forwarder 客户端（无自动 redirect）。
+    pub client: Client,
+}
+
+/// 代理形态分类：必须与 `build_client_with` 接受 URL 的方式一致（解析后的
+/// scheme，大小写不敏感；SOCKS 族含 socks4/4a/5/5h——hyper 的 HTTP-CONNECT
+/// 无法表达任何一种 SOCKS URL，必须统一走 reqwest 客户端）。
+fn route_proxy_kind(explicit_proxy_url: Option<&str>) -> RouteProxyKind {
+    match explicit_proxy_url {
+        None => RouteProxyKind::None,
+        Some(url) => match reqwest::Url::parse(url) {
+            Ok(parsed) if parsed.scheme().to_ascii_lowercase().starts_with("socks") => {
+                RouteProxyKind::Socks5
+            }
+            _ => RouteProxyKind::Http,
+        },
+    }
+}
+
+/// 解析该 upstream 目标的一个原子路由决策（ONE HOP = ONE SNAPSHOT）。
+///
+/// 元数据（explicit proxy / proxy kind / loopback-direct）与对应 Client 来自
+/// 同一次 `route_snapshot()` 读取，热更新期间不存在撕裂配对。
+pub fn resolve_route_for_url(url: &str) -> RouteDecision {
     let snapshot = route_snapshot();
     #[cfg(feature = "test-hooks")]
     crate::proxy::test_hooks::pause_point();
-    if should_direct_connect_to(url, snapshot.explicit_proxy_url.as_deref()) {
+    let loopback_direct = should_direct_connect_to(url, snapshot.explicit_proxy_url.as_deref());
+    let proxy_kind = route_proxy_kind(snapshot.explicit_proxy_url.as_deref());
+    #[cfg(feature = "test-hooks")]
+    crate::proxy::test_hooks::record_resolution(
+        snapshot.generation,
+        loopback_direct,
+        is_loopback_upstream_url(url),
+    );
+    let client = if loopback_direct {
         log::debug!(
             "[GlobalProxy] Loopback upstream detected; using direct client (inherited proxy bypassed)"
         );
-        get_direct()
+        get_direct_route_client()
     } else {
-        snapshot.client.clone()
+        snapshot.route_client.clone()
+    };
+    RouteDecision {
+        generation: snapshot.generation,
+        explicit_proxy_url: snapshot.explicit_proxy_url.clone(),
+        proxy_kind,
+        loopback_direct,
+        client,
     }
 }
 
 /// 测试证据入口（test-hooks）：返回 (是否选择直连, 所用快照的发布序号)。
 ///
-/// 与 `select_client_for_url` 使用同一次快照读取，供并发/原子性测试验证
+/// 与 `resolve_route_for_url` 使用同一次快照读取，供并发/原子性测试验证
 /// 「决策必须与其快照世代的发布内容一致」。
 #[cfg(feature = "test-hooks")]
 #[allow(dead_code)]
@@ -319,54 +407,45 @@ pub fn is_proxy_enabled() -> bool {
     get_current_proxy_url().is_some()
 }
 
-/// 构建 HTTP 客户端
+/// 构建 HTTP 客户端（非 forwarder 消费者；保留 reqwest 默认 redirect 行为）。
 fn build_client(proxy_url: Option<&str>) -> Result<Client, String> {
-    build_client_with(proxy_url, false)
+    build_client_with(proxy_url, false, true)
 }
 
-/// redirect 目标类别与当前 client 的一致性策略（review finding P2-A）：
-/// - direct client（force_direct）只跟随 loopback 目标；
-/// - following client 只跟随非 loopback 目标。
+/// 构建 forwarder 路由客户端：禁用 reqwest 自动 redirect。
 ///
-/// 跨类别 hop 在此停止并返回 30x，由 forwarder 依新目标重选 transport 重发，
-/// 保证「只有 loopback hop 被强制直连」而外部 hop 保持继承/显式代理语义。
-/// 跳数上限与 reqwest 默认单链上限一致。
-fn redirect_policy_for(follow_loopback_targets: bool) -> reqwest::redirect::Policy {
-    reqwest::redirect::Policy::custom(move |attempt: reqwest::redirect::Attempt| {
-        if attempt.previous().len() >= MAX_REDIRECT_HOPS {
-            return attempt.error("too many redirects");
-        }
-        let next_is_loopback = is_loopback_upstream_url(attempt.url().as_str());
-        if next_is_loopback == follow_loopback_targets {
-            attempt.follow()
-        } else {
-            attempt.stop()
-        }
-    })
+/// forwarder 的 redirect 由统一显式状态机处理（跨越 automatic/manual 边界
+/// 共享同一 logical budget 与 request-level deadline），客户端本身绝不自动
+/// 跟随 redirect（review finding MAJOR-1 的单一预算语义）。
+fn build_route_client(proxy_url: Option<&str>) -> Result<Client, String> {
+    build_client_with(proxy_url, false, false)
 }
-
-/// 与 reqwest 默认策略一致的单链上限。
-const MAX_REDIRECT_HOPS: usize = 10;
 
 /// 构建 HTTP 客户端（force_direct = true 时禁用一切代理）。
 ///
 /// force_direct 为 true 时客户端永不使用任何代理（包括系统代理/环境变量代理），
 /// 用于 loopback upstream：本地目标必须直连，避免被系统代理截获。
-fn build_client_with(proxy_url: Option<&str>, force_direct: bool) -> Result<Client, String> {
+fn build_client_with(
+    proxy_url: Option<&str>,
+    force_direct: bool,
+    follow_redirects: bool,
+) -> Result<Client, String> {
     let mut builder = Client::builder()
         .timeout(Duration::from_secs(600))
         .connect_timeout(Duration::from_secs(30))
         .pool_max_idle_per_host(10)
         .tcp_keepalive(Duration::from_secs(60))
-        // 跨类别 redirect hop 由 forwarder 手工重选 transport 后重发；
-        // 同类别 hop 仍由 reqwest 内部跟随（默认上限 10）。
-        .redirect(redirect_policy_for(force_direct))
         // 禁用 reqwest 自动解压：防止 reqwest 覆盖客户端原始 accept-encoding header。
         // 响应解压由 response_processor 根据 content-encoding 手动处理。
         .no_gzip()
         .no_brotli()
         .no_deflate()
         .no_zstd();
+    if !follow_redirects {
+        // forwarder 路径：redirect 由统一显式状态机处理（单一 logical budget /
+        // request-level deadline），客户端绝不自动跟随。
+        builder = builder.redirect(reqwest::redirect::Policy::none());
+    }
 
     if force_direct {
         // 直连语义：显式禁用一切代理，不进入下方的代理选择逻辑。

--- a/src-tauri/src/proxy/loopback_upstream_tests.rs
+++ b/src-tauri/src/proxy/loopback_upstream_tests.rs
@@ -6,40 +6,120 @@
 //! - loopback target + no explicit proxy -> direct transport (mock upstream sees it)
 //! - loopback target + explicit proxy    -> explicit proxy transport
 //! - external target + explicit proxy    -> explicit proxy transport
+//! - cross-class redirect chains (loopback <-> external) re-select transport per
+//!   hop: only loopback hops are forced direct, and method/body/sensitive-header
+//!   semantics mirror reqwest/tower-http redirect handling
+//! - route-state publication is a single atomic snapshot: the explicit-proxy
+//!   metadata and its client are always read as one unit, even while
+//!   `apply_proxy` hot-updates configuration concurrently
 //!
 //! They mutate process-global HTTP client state, so they are gated behind the
 //! existing `test-hooks` feature (excluded from default `cargo test`/CI) and
-//! kept in a single sequential test function. Run them with:
+//! kept sequential. Run them with:
 //!
 //! `cargo test --features test-hooks loopback_upstream -- --test-threads=1`
 
 use super::{http_client, server::ProxyServer, ProxyConfig};
 use crate::database::Database;
 use crate::provider::{Provider, ProviderMeta};
+use axum::response::IntoResponse;
 use serde_json::json;
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 const OPENAI_CHAT_BODY: &str = r#"{"id":"chatcmpl-test","object":"chat.completion","created":0,"model":"test-model","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#;
 const PLACEHOLDER_TOKEN: &str = "test-placeholder-token";
 
-/// Mock server that records every request it receives and always answers
-/// `200` + `OPENAI_CHAT_BODY`. Used both as a mock upstream and as a mock
-/// explicit proxy.
-async fn spawn_recording_server(
-    record: Arc<Mutex<Vec<String>>>,
+/// A request observed by a mock server (used both as a mock upstream and as a
+/// mock proxy).
+#[derive(Clone, Debug)]
+struct RecReq {
+    method: String,
+    uri: String,
+    authorization: Option<String>,
+    x_api_key: Option<String>,
+    body: Vec<u8>,
+}
+
+impl RecReq {
+    fn body_text(&self) -> String {
+        String::from_utf8_lossy(&self.body).to_string()
+    }
+
+    fn has_credential(&self) -> bool {
+        self.authorization.is_some() || self.x_api_key.is_some()
+    }
+}
+
+#[derive(Clone)]
+enum MockReply {
+    /// 200 + OPENAI_CHAT_BODY (final upstream response).
+    Json200,
+    /// Fixed status with optional Location header (redirect hop).
+    Status(u16, Option<String>),
+}
+
+async fn record_request(req: axum::extract::Request, record: Arc<Mutex<Vec<RecReq>>>) {
+    let (parts, body) = req.into_parts();
+    let method = parts.method.to_string();
+    let uri = parts.uri.to_string();
+    let get = |name: &axum::http::HeaderName| {
+        parts
+            .headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+    };
+    let authorization = get(&axum::http::header::AUTHORIZATION);
+    let x_api_key = get(&axum::http::HeaderName::from_static("x-api-key"));
+    let body = axum::body::to_bytes(body, 10 * 1024 * 1024)
+        .await
+        .map(|b| b.to_vec())
+        .unwrap_or_default();
+    record.lock().unwrap().push(RecReq {
+        method,
+        uri,
+        authorization,
+        x_api_key,
+        body,
+    });
+}
+
+fn build_reply(reply: &MockReply) -> axum::response::Response {
+    match reply {
+        MockReply::Json200 => (
+            axum::http::StatusCode::OK,
+            [(axum::http::header::CONTENT_TYPE, "application/json")],
+            OPENAI_CHAT_BODY,
+        )
+            .into_response(),
+        MockReply::Status(code, location) => {
+            let mut resp = axum::http::StatusCode::from_u16(*code)
+                .expect("valid mock status")
+                .into_response();
+            if let Some(loc) = location {
+                resp.headers_mut().insert(
+                    axum::http::header::LOCATION,
+                    axum::http::HeaderValue::from_str(loc).expect("valid location"),
+                );
+            }
+            resp
+        }
+    }
+}
+
+/// Mock server with a fixed reply; records every request it receives.
+async fn spawn_mock(
+    record: Arc<Mutex<Vec<RecReq>>>,
+    reply: MockReply,
 ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
     let app = axum::Router::new().fallback(move |req: axum::extract::Request| {
         let record = record.clone();
+        let reply = reply.clone();
         async move {
-            record
-                .lock()
-                .unwrap()
-                .push(format!("{} {}", req.method(), req.uri()));
-            (
-                axum::http::StatusCode::OK,
-                [(axum::http::header::CONTENT_TYPE, "application/json")],
-                OPENAI_CHAT_BODY,
-            )
+            record_request(req, record).await;
+            build_reply(&reply)
         }
     });
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -50,6 +130,71 @@ async fn spawn_recording_server(
         let _ = axum::serve(listener, app).await;
     });
     (addr, handle)
+}
+
+/// Mock server that pops its reply from a queue per request; records every
+/// request. An empty queue answers `500`.
+async fn spawn_mock_queue(
+    record: Arc<Mutex<Vec<RecReq>>>,
+    queue: Arc<Mutex<VecDeque<MockReply>>>,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let app = axum::Router::new().fallback(move |req: axum::extract::Request| {
+        let record = record.clone();
+        let queue = queue.clone();
+        async move {
+            record_request(req, record).await;
+            match queue.lock().unwrap().pop_front() {
+                Some(reply) => build_reply(&reply),
+                None => (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "mock queue exhausted",
+                )
+                    .into_response(),
+            }
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock queue server");
+    let addr = listener.local_addr().expect("mock queue server addr");
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (addr, handle)
+}
+
+/// Sets HTTP_PROXY/http_proxy for the duration of a test and restores the
+/// previous values on drop. The following/inherited client picks these up at
+/// `build_client` time (i.e. at `apply_proxy`/`init`).
+struct EnvProxyGuard {
+    prev_http: Option<String>,
+    prev_lower: Option<String>,
+}
+
+impl EnvProxyGuard {
+    fn set(url: &str) -> Self {
+        let prev_http = std::env::var("HTTP_PROXY").ok();
+        let prev_lower = std::env::var("http_proxy").ok();
+        std::env::set_var("HTTP_PROXY", url);
+        std::env::set_var("http_proxy", url);
+        Self {
+            prev_http,
+            prev_lower,
+        }
+    }
+}
+
+impl Drop for EnvProxyGuard {
+    fn drop(&mut self) {
+        match &self.prev_http {
+            Some(v) => std::env::set_var("HTTP_PROXY", v),
+            None => std::env::remove_var("HTTP_PROXY"),
+        }
+        match &self.prev_lower {
+            Some(v) => std::env::set_var("http_proxy", v),
+            None => std::env::remove_var("http_proxy"),
+        }
+    }
 }
 
 fn seed_provider(db: &Database, base_url: String) {
@@ -74,6 +219,20 @@ fn seed_provider(db: &Database, base_url: String) {
         .expect("select test provider");
 }
 
+fn fast_config() -> ProxyConfig {
+    ProxyConfig {
+        listen_port: 0,
+        enable_logging: false,
+        // Single attempt (no provider failover retries) so failure-path tests are
+        // deterministic and bounded.
+        max_retries: 0,
+        // Bound redirect/failure paths quickly so transport mistakes surface as
+        // fast errors instead of multi-minute hangs.
+        non_streaming_timeout: 5,
+        ..ProxyConfig::default()
+    }
+}
+
 async fn send_messages(port: u16) -> reqwest::Response {
     // Test-side client must itself bypass any host-level system proxy so the
     // assertions observe the proxy server's behavior, not the test runner's.
@@ -91,34 +250,32 @@ async fn send_messages(port: u16) -> reqwest::Response {
         .expect("send /v1/messages request")
 }
 
+async fn start_server(db: Arc<Database>) -> (super::ProxyServerInfo, ProxyServer) {
+    let server = ProxyServer::new(fast_config(), db, None);
+    let info = server.start().await.expect("start proxy server");
+    (info, server)
+}
+
 #[tokio::test]
 async fn loopback_upstream_direct_connect_contract_end_to_end() {
     let home = tempfile::tempdir().expect("temp home");
     std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
 
     let db = Arc::new(Database::init().expect("init isolated database"));
-    let upstream_rec: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-    let (upstream_addr, upstream_handle) = spawn_recording_server(upstream_rec.clone()).await;
-    let proxy_rec: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let upstream_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (upstream_addr, upstream_handle) =
+        spawn_mock(upstream_rec.clone(), MockReply::Json200).await;
+    let proxy_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
     let (explicit_proxy_addr, explicit_proxy_handle) =
-        spawn_recording_server(proxy_rec.clone()).await;
+        spawn_mock(proxy_rec.clone(), MockReply::Json200).await;
 
-    seed_provider(&db, format!("http://127.0.0.1:{}", upstream_addr.port()));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", upstream_addr.port()));
 
     let _ = http_client::init(None);
 
     // Scenario 1: no explicit proxy -> loopback target must go direct.
     http_client::apply_proxy(None).expect("reset to no explicit proxy");
-    let server = ProxyServer::new(
-        ProxyConfig {
-            listen_port: 0,
-            enable_logging: false,
-            ..ProxyConfig::default()
-        },
-        db.clone(),
-        None,
-    );
-    let info = server.start().await.expect("start proxy server");
+    let (info, server) = start_server(db.clone()).await;
     let resp = send_messages(info.port).await;
     assert_eq!(resp.status(), 200, "direct loopback request must succeed");
     assert_eq!(
@@ -137,19 +294,7 @@ async fn loopback_upstream_direct_connect_contract_end_to_end() {
     // (explicit proxy semantics are preserved, not silently overridden).
     let explicit_proxy_url = format!("http://127.0.0.1:{}", explicit_proxy_addr.port());
     http_client::apply_proxy(Some(explicit_proxy_url.as_str())).expect("apply explicit proxy");
-    let server = ProxyServer::new(
-        ProxyConfig {
-            listen_port: 0,
-            enable_logging: false,
-            ..ProxyConfig::default()
-        },
-        db.clone(),
-        None,
-    );
-    let info = server
-        .start()
-        .await
-        .expect("start proxy server (explicit proxy)");
+    let (info, server) = start_server(db.clone()).await;
     let resp = send_messages(info.port).await;
     assert_eq!(resp.status(), 200, "explicit-proxied request must succeed");
     assert_eq!(
@@ -165,10 +310,6 @@ async fn loopback_upstream_direct_connect_contract_end_to_end() {
     server.stop().await.expect("stop proxy server");
 
     // Scenario 3: explicit proxy + external target must also use the proxy.
-    db.set_current_provider("claude", "loopback-e2e-provider")
-        .expect("re-select provider");
-    // External (TEST-NET-1, non-routable) target: the mock proxy answers, so no
-    // real network traffic is required.
     {
         let mut external = Provider::with_id(
             "external-e2e-provider".to_string(),
@@ -190,16 +331,7 @@ async fn loopback_upstream_direct_connect_contract_end_to_end() {
         db.set_current_provider("claude", "external-e2e-provider")
             .expect("select external provider");
     }
-    let server = ProxyServer::new(
-        ProxyConfig {
-            listen_port: 0,
-            enable_logging: false,
-            ..ProxyConfig::default()
-        },
-        db.clone(),
-        None,
-    );
-    let info = server.start().await.expect("start proxy server (external)");
+    let (info, server) = start_server(db.clone()).await;
     let resp = send_messages(info.port).await;
     assert_eq!(
         resp.status(),
@@ -213,9 +345,9 @@ async fn loopback_upstream_direct_connect_contract_end_to_end() {
         "external request must go through the explicit proxy"
     );
     assert!(
-        rec.last().unwrap().contains("192.0.2.1"),
+        rec.last().unwrap().uri.contains("192.0.2.1"),
         "{}",
-        rec.last().unwrap()
+        rec.last().unwrap().uri
     );
     server.stop().await.expect("stop proxy server");
 
@@ -223,4 +355,498 @@ async fn loopback_upstream_direct_connect_contract_end_to_end() {
     let _ = http_client::apply_proxy(None);
     upstream_handle.abort();
     explicit_proxy_handle.abort();
+}
+
+/// Redirect contract 1: loopback -> loopback (same origin) stays direct, keeps
+/// method/body (307) and does not touch the inherited proxy.
+#[tokio::test]
+async fn loopback_upstream_redirect_loopback_to_loopback_stays_direct() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+    let proxy_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (proxy_addr, proxy_handle) = spawn_mock(proxy_rec.clone(), MockReply::Json200).await;
+    let _env = EnvProxyGuard::set(&format!("http://127.0.0.1:{}", proxy_addr.port()));
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let a_queue = Arc::new(Mutex::new(VecDeque::new()));
+    let (a_addr, a_handle) = spawn_mock_queue(a_rec.clone(), a_queue.clone()).await;
+    // Location is filled in below once we know our own port.
+    a_queue.lock().unwrap().push_back(MockReply::Status(
+        307,
+        Some(format!("http://127.0.0.1:{}/step2", a_addr.port())),
+    ));
+    a_queue.lock().unwrap().push_back(MockReply::Json200);
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+    let resp = send_messages(info.port).await;
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "loopback->loopback redirect must succeed"
+    );
+    let a = a_rec.lock().unwrap().clone();
+    assert_eq!(
+        a.len(),
+        2,
+        "both hops must reach the loopback mock directly"
+    );
+    assert_eq!(a[0].method, "POST");
+    assert!(
+        a[0].has_credential(),
+        "loopback hop must carry upstream auth"
+    );
+    assert!(a[0].body_text().contains("ping"));
+    assert!(a[1].uri.contains("/step2"), "{}", a[1].uri);
+    // 307 keeps method and body.
+    assert_eq!(a[1].method, "POST", "307 must keep the method");
+    assert!(a[1].body_text().contains("ping"), "307 must keep the body");
+    // Same origin (host+port): credentials must NOT be stripped.
+    assert!(
+        a[1].has_credential(),
+        "same-origin redirect must keep credentials"
+    );
+    assert_eq!(
+        proxy_rec.lock().unwrap().len(),
+        0,
+        "no hop may touch the inherited proxy for loopback targets"
+    );
+
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+    proxy_handle.abort();
+}
+
+/// Redirect contract 2: loopback -> external re-selects transport for the
+/// external hop (inherited proxy must be used, not the no-proxy client).
+#[tokio::test]
+async fn loopback_upstream_redirect_loopback_to_external_reselects_transport() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+    let proxy_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (proxy_addr, proxy_handle) = spawn_mock(proxy_rec.clone(), MockReply::Json200).await;
+    let _env = EnvProxyGuard::set(&format!("http://127.0.0.1:{}", proxy_addr.port()));
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (a_addr, a_handle) = spawn_mock(
+        a_rec.clone(),
+        MockReply::Status(307, Some("http://192.0.2.1/step2".to_string())),
+    )
+    .await;
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+    let resp = send_messages(info.port).await;
+
+    assert_eq!(resp.status(), 200, "redirected external hop must succeed");
+    assert_eq!(a_rec.lock().unwrap().len(), 1, "first hop stays direct");
+    let p = proxy_rec.lock().unwrap().clone();
+    assert_eq!(
+        p.len(),
+        1,
+        "external redirect hop must go through the inherited proxy"
+    );
+    assert!(p[0].uri.contains("192.0.2.1/step2"), "{}", p[0].uri);
+    assert_eq!(p[0].method, "POST", "307 must keep the method");
+    assert!(p[0].body_text().contains("ping"), "307 must keep the body");
+    assert!(
+        p[0].authorization.is_none(),
+        "cross-host redirect must strip the Authorization header"
+    );
+
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+    proxy_handle.abort();
+}
+
+/// Redirect contract 3: external -> loopback re-selects transport for the
+/// loopback hop (direct), with 302 POST->GET method/body semantics.
+#[tokio::test]
+async fn loopback_upstream_redirect_external_to_loopback_reselects_transport() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let b_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (b_addr, b_handle) = spawn_mock(b_rec.clone(), MockReply::Json200).await;
+
+    let proxy_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let proxy_queue = Arc::new(Mutex::new(VecDeque::new()));
+    proxy_queue.lock().unwrap().push_back(MockReply::Status(
+        302,
+        Some(format!("http://127.0.0.1:{}/final", b_addr.port())),
+    ));
+    let (proxy_addr, proxy_handle) = spawn_mock_queue(proxy_rec.clone(), proxy_queue.clone()).await;
+    let _env = EnvProxyGuard::set(&format!("http://127.0.0.1:{}", proxy_addr.port()));
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, "http://192.0.2.1/start".to_string());
+
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+    let resp = send_messages(info.port).await;
+
+    assert_eq!(resp.status(), 200, "redirected loopback hop must succeed");
+    let p = proxy_rec.lock().unwrap().clone();
+    assert_eq!(
+        p.len(),
+        1,
+        "only the external first hop may go through the proxy"
+    );
+    assert!(p[0].uri.contains("192.0.2.1/start"), "{}", p[0].uri);
+    let b = b_rec.lock().unwrap().clone();
+    assert_eq!(
+        b.len(),
+        1,
+        "loopback redirect hop must be reached directly, not via the proxy"
+    );
+    assert!(b[0].uri.contains("/final"), "{}", b[0].uri);
+    // 302 with POST: method becomes GET and the body is dropped.
+    assert_eq!(b[0].method, "GET", "302 must switch POST to GET");
+    assert!(b[0].body.is_empty(), "302 must drop the request body");
+
+    server.stop().await.expect("stop proxy server");
+    b_handle.abort();
+    proxy_handle.abort();
+}
+
+/// Redirect contract 4: with an explicit proxy configured, every hop keeps
+/// using it (explicit precedence is not overridden by the loopback rule).
+#[tokio::test]
+async fn loopback_upstream_redirect_explicit_proxy_precedence_preserved() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let env_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (env_addr, env_handle) = spawn_mock(env_rec.clone(), MockReply::Json200).await;
+    let _env = EnvProxyGuard::set(&format!("http://127.0.0.1:{}", env_addr.port()));
+
+    let explicit_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let explicit_queue = Arc::new(Mutex::new(VecDeque::new()));
+    explicit_queue.lock().unwrap().push_back(MockReply::Status(
+        302,
+        Some("http://192.0.2.1/after".to_string()),
+    ));
+    explicit_queue.lock().unwrap().push_back(MockReply::Json200);
+    let (explicit_addr, explicit_handle) =
+        spawn_mock_queue(explicit_rec.clone(), explicit_queue.clone()).await;
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (a_addr, a_handle) = spawn_mock(a_rec.clone(), MockReply::Json200).await;
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+
+    let _ = http_client::init(None);
+    let explicit_url = format!("http://127.0.0.1:{}", explicit_addr.port());
+    http_client::apply_proxy(Some(explicit_url.as_str())).expect("apply explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+    let resp = send_messages(info.port).await;
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "explicit-proxied redirect chain must succeed"
+    );
+    let e = explicit_rec.lock().unwrap().clone();
+    assert_eq!(e.len(), 2, "both hops must go through the explicit proxy");
+    assert!(
+        e[0].uri.contains("127.0.0.1") && e[0].uri.contains("/chat/completions"),
+        "first hop (loopback) must go through the explicit proxy: {}",
+        e[0].uri
+    );
+    assert!(e[1].uri.contains("192.0.2.1/after"), "{}", e[1].uri);
+    assert_eq!(
+        a_rec.lock().unwrap().len(),
+        0,
+        "loopback upstream must not be reached directly while an explicit proxy is set"
+    );
+    assert_eq!(
+        env_rec.lock().unwrap().len(),
+        0,
+        "explicit proxy must take precedence over the inherited/env proxy"
+    );
+
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+    explicit_handle.abort();
+    env_handle.abort();
+}
+
+/// Redirect contract 5: 301/302/303 vs 307/308 method/body semantics and
+/// cross-host sensitive-header stripping for redirected hops.
+#[tokio::test]
+async fn loopback_upstream_redirect_method_and_body_semantics() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+    let proxy_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (proxy_addr, proxy_handle) = spawn_mock(proxy_rec.clone(), MockReply::Json200).await;
+    let _env = EnvProxyGuard::set(&format!("http://127.0.0.1:{}", proxy_addr.port()));
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let a_queue = Arc::new(Mutex::new(VecDeque::new()));
+    let (a_addr, a_handle) = spawn_mock_queue(a_rec.clone(), a_queue.clone()).await;
+    for (status, path) in [
+        (307u16, "r307"),
+        (308, "r308"),
+        (303, "r303"),
+        (301, "r301"),
+        (302, "r302"),
+    ] {
+        a_queue.lock().unwrap().push_back(MockReply::Status(
+            status,
+            Some(format!("http://192.0.2.1/{path}")),
+        ));
+    }
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+
+    for _ in 0..5 {
+        let resp = send_messages(info.port).await;
+        assert_eq!(resp.status(), 200, "redirect case must succeed");
+    }
+
+    let a = a_rec.lock().unwrap().clone();
+    assert_eq!(a.len(), 5);
+    for req in &a {
+        assert!(req.has_credential(), "loopback hop must carry credentials");
+    }
+    let p = proxy_rec.lock().unwrap().clone();
+    assert_eq!(
+        p.len(),
+        5,
+        "every cross-host hop must use the inherited proxy"
+    );
+    // 307 / 308 keep method + body.
+    for (idx, path) in [(0usize, "r307"), (1, "r308")] {
+        assert!(p[idx].uri.contains(path), "{}", p[idx].uri);
+        assert_eq!(p[idx].method, "POST", "307/308 must keep the method");
+        assert!(
+            p[idx].body_text().contains("ping"),
+            "307/308 must keep the body"
+        );
+    }
+    // 303 / 301 / 302 switch POST -> GET and drop the body.
+    for (idx, path) in [(2usize, "r303"), (3, "r301"), (4, "r302")] {
+        assert!(p[idx].uri.contains(path), "{}", p[idx].uri);
+        assert_eq!(p[idx].method, "GET", "{path} must switch POST to GET");
+        assert!(p[idx].body.is_empty(), "{path} must drop the request body");
+    }
+    // Cross-host hops must not carry the Authorization header.
+    for req in &p {
+        assert!(
+            req.authorization.is_none(),
+            "cross-host redirect must strip Authorization"
+        );
+    }
+
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+    proxy_handle.abort();
+}
+
+/// Redirect contract 6 (safety net): a redirect loop across transports stays
+/// bounded and never hangs.
+#[tokio::test]
+async fn loopback_upstream_redirect_chain_is_bounded() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+    let proxy_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let proxy_queue = Arc::new(Mutex::new(VecDeque::new()));
+    for i in 0..12 {
+        proxy_queue.lock().unwrap().push_back(MockReply::Status(
+            307,
+            Some(format!("http://192.0.2.1/loop{i}")),
+        ));
+    }
+    let (proxy_addr, proxy_handle) = spawn_mock_queue(proxy_rec.clone(), proxy_queue.clone()).await;
+    let _env = EnvProxyGuard::set(&format!("http://127.0.0.1:{}", proxy_addr.port()));
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (a_addr, a_handle) = spawn_mock(
+        a_rec.clone(),
+        MockReply::Status(307, Some("http://192.0.2.1/orig".to_string())),
+    )
+    .await;
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+
+    let started = std::time::Instant::now();
+    let resp = send_messages(info.port).await;
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "redirect chain must terminate quickly, took {elapsed:?}"
+    );
+    assert_ne!(
+        resp.status(),
+        200,
+        "a redirect loop must not report success"
+    );
+    assert_eq!(a_rec.lock().unwrap().len(), 1, "first hop once");
+    assert!(
+        proxy_rec.lock().unwrap().len() <= 12,
+        "redirect hops must stay bounded"
+    );
+
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+    proxy_handle.abort();
+}
+
+/// Atomicity contract 1 (deterministic): a selection paused between the proxy
+/// metadata read and the transport decision must not pair a stale metadata
+/// snapshot with a client from a newer configuration. The decision must be
+/// consistent with the *published snapshot* it used (loopback direct iff that
+/// snapshot had no explicit proxy).
+#[tokio::test]
+async fn loopback_upstream_atomic_snapshot_deterministic_pause() {
+    use crate::proxy::test_hooks;
+
+    let _ = http_client::init(None);
+    test_hooks::clear_publish_log();
+    test_hooks::set_gate(None);
+
+    // Direction 1: None -> explicit during the paused selection.
+    http_client::apply_proxy(None).expect("baseline None");
+    let gate = test_hooks::new_gate();
+    gate.arm();
+    test_hooks::set_gate(Some(gate.clone()));
+    let handle =
+        tokio::task::spawn_blocking(|| http_client::select_for_test("http://127.0.0.1:8080/v1"));
+    assert!(
+        gate.wait_entered(Duration::from_secs(10)),
+        "selection must reach the pause point"
+    );
+    http_client::apply_proxy(Some("http://127.0.0.1:59888")).expect("apply explicit proxy");
+    gate.release();
+    test_hooks::set_gate(None);
+    let (direct, generation) = handle.await.expect("selection task");
+    let published = test_hooks::published_explicit_proxy(generation)
+        .expect("generation must be a published route-state snapshot");
+    assert_eq!(
+        direct,
+        published.is_none(),
+        "None->explicit: selection must be consistent with its snapshot generation \
+         (loopback direct iff that snapshot had no explicit proxy)"
+    );
+
+    // Direction 2: explicit -> None during the paused selection.
+    http_client::apply_proxy(Some("http://127.0.0.1:59888")).expect("baseline explicit");
+    let gate = test_hooks::new_gate();
+    gate.arm();
+    test_hooks::set_gate(Some(gate.clone()));
+    let handle =
+        tokio::task::spawn_blocking(|| http_client::select_for_test("http://127.0.0.1:8080/v1"));
+    assert!(
+        gate.wait_entered(Duration::from_secs(10)),
+        "selection must reach the pause point"
+    );
+    http_client::apply_proxy(None).expect("switch back to None");
+    gate.release();
+    test_hooks::set_gate(None);
+    let (direct, generation) = handle.await.expect("selection task");
+    let published = test_hooks::published_explicit_proxy(generation)
+        .expect("generation must be a published route-state snapshot");
+    assert_eq!(
+        direct,
+        published.is_none(),
+        "explicit->None: selection must be consistent with its snapshot generation"
+    );
+
+    let _ = http_client::apply_proxy(None);
+}
+
+/// Atomicity contract 2 (stress): concurrent `apply_proxy` writers and
+/// selection readers never produce a decision inconsistent with the published
+/// snapshot generation (no torn metadata/client pair; a loopback request never
+/// silently bypasses an already-effective explicit proxy).
+#[tokio::test]
+async fn loopback_upstream_atomic_snapshot_concurrent_stress() {
+    use crate::proxy::test_hooks;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let _ = http_client::init(None);
+    test_hooks::clear_publish_log();
+    // Re-publish once after clearing so the currently-live generation is present
+    // in the log; otherwise readers racing before the first writer publish would
+    // look up a generation whose record was just cleared (test-side artifact).
+    http_client::apply_proxy(None).expect("re-publish current route state");
+    test_hooks::set_gate(None); // no pauses in the stress test
+
+    let violations = Arc::new(AtomicUsize::new(0));
+    let details = Arc::new(Mutex::new(Vec::<String>::new()));
+    let mut handles = Vec::new();
+
+    for w in 0..3 {
+        handles.push(std::thread::spawn(move || {
+            for i in 0..30 {
+                let url = if (w + i) % 2 == 0 {
+                    Some("http://127.0.0.1:59888")
+                } else {
+                    None
+                };
+                let _ = http_client::apply_proxy(url);
+            }
+        }));
+    }
+
+    for _ in 0..4 {
+        let violations = violations.clone();
+        let details = details.clone();
+        handles.push(std::thread::spawn(move || {
+            for _ in 0..400 {
+                let (direct, generation) = http_client::select_for_test("http://127.0.0.1:8080/v1");
+                let published = test_hooks::published_explicit_proxy(generation);
+                let consistent = match &published {
+                    Some(published) => direct == published.is_none(),
+                    None => false,
+                };
+                if !consistent {
+                    let n = violations.fetch_add(1, Ordering::SeqCst);
+                    if let Ok(mut d) = details.lock() {
+                        if d.len() < 8 {
+                            d.push(format!(
+                                "gen={generation} direct={direct} published={published:?}"
+                            ));
+                        }
+                    }
+                    let _ = n;
+                }
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.join().expect("worker thread");
+    }
+    let violation_count = violations.load(Ordering::SeqCst);
+    assert_eq!(
+        violation_count,
+        0,
+        "no reader may observe a (decision, generation) pair inconsistent with the published snapshot; details: {:?}",
+        details.lock().map(|d| d.clone()).unwrap_or_default()
+    );
+
+    let _ = http_client::apply_proxy(None);
 }

--- a/src-tauri/src/proxy/loopback_upstream_tests.rs
+++ b/src-tauri/src/proxy/loopback_upstream_tests.rs
@@ -1,0 +1,226 @@
+//! Loopback upstream direct-connect contract tests (forwarder level, end-to-end).
+//!
+//! These tests drive the real `ProxyServer` forwarding path against mock
+//! endpoints so the loopback transport decision is verified end to end:
+//!
+//! - loopback target + no explicit proxy -> direct transport (mock upstream sees it)
+//! - loopback target + explicit proxy    -> explicit proxy transport
+//! - external target + explicit proxy    -> explicit proxy transport
+//!
+//! They mutate process-global HTTP client state, so they are gated behind the
+//! existing `test-hooks` feature (excluded from default `cargo test`/CI) and
+//! kept in a single sequential test function. Run them with:
+//!
+//! `cargo test --features test-hooks loopback_upstream -- --test-threads=1`
+
+use super::{http_client, server::ProxyServer, ProxyConfig};
+use crate::database::Database;
+use crate::provider::{Provider, ProviderMeta};
+use serde_json::json;
+use std::sync::{Arc, Mutex};
+
+const OPENAI_CHAT_BODY: &str = r#"{"id":"chatcmpl-test","object":"chat.completion","created":0,"model":"test-model","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#;
+const PLACEHOLDER_TOKEN: &str = "test-placeholder-token";
+
+/// Mock server that records every request it receives and always answers
+/// `200` + `OPENAI_CHAT_BODY`. Used both as a mock upstream and as a mock
+/// explicit proxy.
+async fn spawn_recording_server(
+    record: Arc<Mutex<Vec<String>>>,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let app = axum::Router::new().fallback(move |req: axum::extract::Request| {
+        let record = record.clone();
+        async move {
+            record
+                .lock()
+                .unwrap()
+                .push(format!("{} {}", req.method(), req.uri()));
+            (
+                axum::http::StatusCode::OK,
+                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                OPENAI_CHAT_BODY,
+            )
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock server");
+    let addr = listener.local_addr().expect("mock server addr");
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (addr, handle)
+}
+
+fn seed_provider(db: &Database, base_url: String) {
+    let mut provider = Provider::with_id(
+        "loopback-e2e-provider".to_string(),
+        "Loopback E2E".to_string(),
+        json!({
+            "env": {
+                "ANTHROPIC_BASE_URL": base_url,
+                "ANTHROPIC_AUTH_TOKEN": PLACEHOLDER_TOKEN
+            }
+        }),
+        None,
+    );
+    provider.meta = Some(
+        serde_json::from_value::<ProviderMeta>(json!({ "apiFormat": "openai_chat" }))
+            .expect("provider meta"),
+    );
+    db.save_provider("claude", &provider)
+        .expect("save test provider");
+    db.set_current_provider("claude", &provider.id)
+        .expect("select test provider");
+}
+
+async fn send_messages(port: u16) -> reqwest::Response {
+    // Test-side client must itself bypass any host-level system proxy so the
+    // assertions observe the proxy server's behavior, not the test runner's.
+    http_client::get_direct()
+        .post(format!("http://127.0.0.1:{port}/v1/messages"))
+        .header("x-api-key", PLACEHOLDER_TOKEN)
+        .header("anthropic-version", "2023-06-01")
+        .json(&json!({
+            "model": "test-model",
+            "max_tokens": 16,
+            "messages": [{"role": "user", "content": "ping"}]
+        }))
+        .send()
+        .await
+        .expect("send /v1/messages request")
+}
+
+#[tokio::test]
+async fn loopback_upstream_direct_connect_contract_end_to_end() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    let upstream_rec: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let (upstream_addr, upstream_handle) = spawn_recording_server(upstream_rec.clone()).await;
+    let proxy_rec: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let (explicit_proxy_addr, explicit_proxy_handle) =
+        spawn_recording_server(proxy_rec.clone()).await;
+
+    seed_provider(&db, format!("http://127.0.0.1:{}", upstream_addr.port()));
+
+    let _ = http_client::init(None);
+
+    // Scenario 1: no explicit proxy -> loopback target must go direct.
+    http_client::apply_proxy(None).expect("reset to no explicit proxy");
+    let server = ProxyServer::new(
+        ProxyConfig {
+            listen_port: 0,
+            enable_logging: false,
+            ..ProxyConfig::default()
+        },
+        db.clone(),
+        None,
+    );
+    let info = server.start().await.expect("start proxy server");
+    let resp = send_messages(info.port).await;
+    assert_eq!(resp.status(), 200, "direct loopback request must succeed");
+    assert_eq!(
+        upstream_rec.lock().unwrap().len(),
+        1,
+        "loopback provider must be reached directly (no explicit proxy)"
+    );
+    assert_eq!(
+        proxy_rec.lock().unwrap().len(),
+        0,
+        "no proxy must be involved without an explicit proxy"
+    );
+    server.stop().await.expect("stop proxy server");
+
+    // Scenario 2: explicit proxy configured -> loopback request must use it
+    // (explicit proxy semantics are preserved, not silently overridden).
+    let explicit_proxy_url = format!("http://127.0.0.1:{}", explicit_proxy_addr.port());
+    http_client::apply_proxy(Some(explicit_proxy_url.as_str())).expect("apply explicit proxy");
+    let server = ProxyServer::new(
+        ProxyConfig {
+            listen_port: 0,
+            enable_logging: false,
+            ..ProxyConfig::default()
+        },
+        db.clone(),
+        None,
+    );
+    let info = server
+        .start()
+        .await
+        .expect("start proxy server (explicit proxy)");
+    let resp = send_messages(info.port).await;
+    assert_eq!(resp.status(), 200, "explicit-proxied request must succeed");
+    assert_eq!(
+        proxy_rec.lock().unwrap().len(),
+        1,
+        "loopback request must go through the explicit proxy"
+    );
+    assert_eq!(
+        upstream_rec.lock().unwrap().len(),
+        1,
+        "loopback provider must not be reached directly while an explicit proxy is set"
+    );
+    server.stop().await.expect("stop proxy server");
+
+    // Scenario 3: explicit proxy + external target must also use the proxy.
+    db.set_current_provider("claude", "loopback-e2e-provider")
+        .expect("re-select provider");
+    // External (TEST-NET-1, non-routable) target: the mock proxy answers, so no
+    // real network traffic is required.
+    {
+        let mut external = Provider::with_id(
+            "external-e2e-provider".to_string(),
+            "External E2E".to_string(),
+            json!({
+                "env": {
+                    "ANTHROPIC_BASE_URL": "http://192.0.2.1",
+                    "ANTHROPIC_AUTH_TOKEN": PLACEHOLDER_TOKEN
+                }
+            }),
+            None,
+        );
+        external.meta = Some(
+            serde_json::from_value::<ProviderMeta>(json!({ "apiFormat": "openai_chat" }))
+                .expect("provider meta"),
+        );
+        db.save_provider("claude", &external)
+            .expect("save external provider");
+        db.set_current_provider("claude", "external-e2e-provider")
+            .expect("select external provider");
+    }
+    let server = ProxyServer::new(
+        ProxyConfig {
+            listen_port: 0,
+            enable_logging: false,
+            ..ProxyConfig::default()
+        },
+        db.clone(),
+        None,
+    );
+    let info = server.start().await.expect("start proxy server (external)");
+    let resp = send_messages(info.port).await;
+    assert_eq!(
+        resp.status(),
+        200,
+        "external request via explicit proxy must succeed"
+    );
+    let rec = proxy_rec.lock().unwrap().clone();
+    assert_eq!(
+        rec.len(),
+        2,
+        "external request must go through the explicit proxy"
+    );
+    assert!(
+        rec.last().unwrap().contains("192.0.2.1"),
+        "{}",
+        rec.last().unwrap()
+    );
+    server.stop().await.expect("stop proxy server");
+
+    // Restore global state for any follow-up tests in the same binary.
+    let _ = http_client::apply_proxy(None);
+    upstream_handle.abort();
+    explicit_proxy_handle.abort();
+}

--- a/src-tauri/src/proxy/loopback_upstream_tests.rs
+++ b/src-tauri/src/proxy/loopback_upstream_tests.rs
@@ -38,6 +38,7 @@ struct RecReq {
     method: String,
     uri: String,
     authorization: Option<String>,
+    referer: Option<String>,
     x_api_key: Option<String>,
     body: Vec<u8>,
 }
@@ -72,6 +73,7 @@ async fn record_request(req: axum::extract::Request, record: Arc<Mutex<Vec<RecRe
             .map(|s| s.to_string())
     };
     let authorization = get(&axum::http::header::AUTHORIZATION);
+    let referer = get(&axum::http::header::REFERER);
     let x_api_key = get(&axum::http::HeaderName::from_static("x-api-key"));
     let body = axum::body::to_bytes(body, 10 * 1024 * 1024)
         .await
@@ -81,6 +83,7 @@ async fn record_request(req: axum::extract::Request, record: Arc<Mutex<Vec<RecRe
         method,
         uri,
         authorization,
+        referer,
         x_api_key,
         body,
     });
@@ -163,6 +166,41 @@ async fn spawn_mock_queue(
     (addr, handle)
 }
 
+/// Mock server that pops its reply from a queue per request, with a fixed delay
+/// applied before each reply (used to probe request-level timeout deadlines).
+async fn spawn_mock_queue_delayed(
+    record: Arc<Mutex<Vec<RecReq>>>,
+    queue: Arc<Mutex<VecDeque<MockReply>>>,
+    delay: Duration,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let app = axum::Router::new().fallback(move |req: axum::extract::Request| {
+        let record = record.clone();
+        let queue = queue.clone();
+        async move {
+            record_request(req, record).await;
+            tokio::time::sleep(delay).await;
+            match queue.lock().unwrap().pop_front() {
+                Some(reply) => build_reply(&reply),
+                None => (
+                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                    "mock queue exhausted",
+                )
+                    .into_response(),
+            }
+        }
+    });
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind delayed mock queue server");
+    let addr = listener
+        .local_addr()
+        .expect("delayed mock queue server addr");
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (addr, handle)
+}
+
 /// Sets HTTP_PROXY/http_proxy for the duration of a test and restores the
 /// previous values on drop. The following/inherited client picks these up at
 /// `build_client` time (i.e. at `apply_proxy`/`init`).
@@ -198,6 +236,10 @@ impl Drop for EnvProxyGuard {
 }
 
 fn seed_provider(db: &Database, base_url: String) {
+    seed_provider_with_format(db, base_url, "openai_chat");
+}
+
+fn seed_provider_with_format(db: &Database, base_url: String, api_format: &str) {
     let mut provider = Provider::with_id(
         "loopback-e2e-provider".to_string(),
         "Loopback E2E".to_string(),
@@ -210,7 +252,7 @@ fn seed_provider(db: &Database, base_url: String) {
         None,
     );
     provider.meta = Some(
-        serde_json::from_value::<ProviderMeta>(json!({ "apiFormat": "openai_chat" }))
+        serde_json::from_value::<ProviderMeta>(json!({ "apiFormat": api_format }))
             .expect("provider meta"),
     );
     db.save_provider("claude", &provider)
@@ -849,4 +891,762 @@ async fn loopback_upstream_atomic_snapshot_concurrent_stress() {
     );
 
     let _ = http_client::apply_proxy(None);
+}
+
+// ===========================================================================
+// R2: one logical redirect budget / request-level deadline / Referer contract
+// ===========================================================================
+
+/// R2 budget contract 1: exactly 10 redirects are followed (11 HTTP requests in
+/// total: 1 initial + 10 followed), then the final 200 is returned.
+#[tokio::test]
+async fn r2_redirect_budget_allows_exactly_ten_follows() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let a_queue = Arc::new(Mutex::new(VecDeque::new()));
+    let (a_addr, a_handle) = spawn_mock_queue(a_rec.clone(), a_queue.clone()).await;
+    for i in 0..10 {
+        a_queue.lock().unwrap().push_back(MockReply::Status(
+            307,
+            Some(format!("http://127.0.0.1:{}/r{i}", a_addr.port())),
+        ));
+    }
+    a_queue.lock().unwrap().push_back(MockReply::Json200);
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+    let resp = send_messages(info.port).await;
+
+    assert_eq!(resp.status(), 200, "a 10-redirect chain must succeed");
+    assert_eq!(
+        a_rec.lock().unwrap().len(),
+        11,
+        "exactly 10 redirects followed => 11 HTTP requests total"
+    );
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+}
+
+/// R2 budget contract 2: the 11th redirect is rejected; the chain stops after
+/// exactly 11 HTTP requests and never sends a 12th.
+#[tokio::test]
+async fn r2_redirect_budget_rejects_eleventh() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let a_queue = Arc::new(Mutex::new(VecDeque::new()));
+    let (a_addr, a_handle) = spawn_mock_queue(a_rec.clone(), a_queue.clone()).await;
+    for i in 0..12 {
+        a_queue.lock().unwrap().push_back(MockReply::Status(
+            307,
+            Some(format!("http://127.0.0.1:{}/r{i}", a_addr.port())),
+        ));
+    }
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+    let resp = send_messages(info.port).await;
+
+    let status = resp.status();
+    assert!(
+        !status.is_success() && !status.is_redirection(),
+        "11th redirect must be rejected with a proxy error, got {status}"
+    );
+    assert_eq!(
+        a_rec.lock().unwrap().len(),
+        11,
+        "the logical budget must stop after 1 initial + 10 followed requests"
+    );
+    let body = resp.text().await.unwrap_or_default();
+    assert!(
+        body.contains("重定向") || body.to_lowercase().contains("redirect"),
+        "rejection must be reported as a redirect-limit error: {body}"
+    );
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+}
+
+/// R2 budget contract 3: the budget is shared across transport classes —
+/// alternating loopback <-> external hops must NOT get a fresh budget per hop.
+/// 12 alternating redirects stop at 1 initial + 10 followed requests
+/// (loopback mock A = 6, env-proxy mock P = 5).
+#[tokio::test]
+async fn r2_redirect_budget_shared_across_classes() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let a_queue = Arc::new(Mutex::new(VecDeque::new()));
+    let (a_addr, a_handle) = spawn_mock_queue(a_rec.clone(), a_queue.clone()).await;
+
+    let proxy_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let proxy_queue = Arc::new(Mutex::new(VecDeque::new()));
+    let (proxy_addr, proxy_handle) = spawn_mock_queue(proxy_rec.clone(), proxy_queue.clone()).await;
+    let _env = EnvProxyGuard::set(&format!("http://127.0.0.1:{}", proxy_addr.port()));
+
+    // Alternating chain: A -> external (via env proxy) -> A -> external -> ...
+    for _ in 0..6 {
+        a_queue.lock().unwrap().push_back(MockReply::Status(
+            307,
+            Some("http://192.0.2.1/ext".to_string()),
+        ));
+    }
+    for _ in 0..5 {
+        proxy_queue.lock().unwrap().push_back(MockReply::Status(
+            307,
+            Some(format!("http://127.0.0.1:{}/back", a_addr.port())),
+        ));
+    }
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+    let resp = send_messages(info.port).await;
+
+    let status = resp.status();
+    assert!(
+        !status.is_success() && !status.is_redirection(),
+        "the shared budget must reject the 11th redirect, got {status}"
+    );
+    let a = a_rec.lock().unwrap().len();
+    let p = proxy_rec.lock().unwrap().len();
+    assert_eq!(
+        (a, p),
+        (6, 5),
+        "loopback/external hops must share ONE budget: expected A=6, P=5 (11 total)"
+    );
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+    proxy_handle.abort();
+}
+
+/// R2 timeout contract: the redirect chain shares ONE request-level deadline.
+/// A 3s non-streaming timeout against a mock that delays every reply by 1.5s
+/// must stop near the deadline (<= 3 requests), not walk the whole chain.
+#[tokio::test]
+async fn r2_redirect_timeout_is_request_level_deadline() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let a_queue = Arc::new(Mutex::new(VecDeque::new()));
+    let (a_addr, a_handle) =
+        spawn_mock_queue_delayed(a_rec.clone(), a_queue.clone(), Duration::from_millis(1500)).await;
+    for i in 0..15 {
+        a_queue.lock().unwrap().push_back(MockReply::Status(
+            307,
+            Some(format!("http://127.0.0.1:{}/slow{i}", a_addr.port())),
+        ));
+    }
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+    // Timeouts are loaded from the per-app DB row and are bypassed while
+    // auto-failover is disabled: enable the 3s non-streaming budget in the row.
+    let row = db
+        .get_proxy_config_for_app("claude")
+        .await
+        .expect("read proxy config row");
+    let row = crate::proxy::types::AppProxyConfig {
+        auto_failover_enabled: true,
+        non_streaming_timeout: 3,
+        ..row
+    };
+    db.update_proxy_config_for_app(row)
+        .await
+        .expect("update proxy config row");
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let config = ProxyConfig {
+        non_streaming_timeout: 3,
+        ..fast_config()
+    };
+    let server = ProxyServer::new(config, db.clone(), None);
+    let info = server.start().await.expect("start proxy server");
+
+    let started = std::time::Instant::now();
+    let resp = send_messages(info.port).await;
+    let elapsed = started.elapsed();
+
+    assert!(!resp.status().is_success(), "the slow chain must time out");
+    assert!(
+        elapsed < Duration::from_secs(9),
+        "one logical deadline must cap total wall time (no per-hop reset), took {elapsed:?}"
+    );
+    let n = a_rec.lock().unwrap().len();
+    assert!(
+        n <= 3,
+        "the deadline must stop the chain near 3s (<= 3 delayed requests), made {n}"
+    );
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+}
+
+/// R2 Referer contract (cross-class hop): the manually resumed hop must carry
+/// `Referer` = the previous hop's URL, mirroring reqwest's automatic behavior.
+#[tokio::test]
+async fn r2_referer_contract_cross_class_hop() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (a_addr, a_handle) = spawn_mock(
+        a_rec.clone(),
+        MockReply::Status(307, Some("http://192.0.2.1/next".to_string())),
+    )
+    .await;
+
+    let proxy_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (proxy_addr, proxy_handle) = spawn_mock(proxy_rec.clone(), MockReply::Json200).await;
+    let _env = EnvProxyGuard::set(&format!("http://127.0.0.1:{}", proxy_addr.port()));
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+    let resp = send_messages(info.port).await;
+
+    assert_eq!(resp.status(), 200, "cross-class redirect must succeed");
+    let p = proxy_rec.lock().unwrap().clone();
+    assert_eq!(p.len(), 1, "second hop must go through the inherited proxy");
+    assert_eq!(
+        p[0].referer.as_deref(),
+        Some(format!("http://127.0.0.1:{}/v1/chat/completions", a_addr.port()).as_str()),
+        "manually resumed hop must carry Referer = previous hop URL (reqwest parity)"
+    );
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+    proxy_handle.abort();
+}
+
+/// R2 Referer contract (same-class hop): reqwest-parity behavior already
+/// applies within one send and must be preserved.
+#[tokio::test]
+async fn r2_referer_contract_same_class_hop() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let a_queue = Arc::new(Mutex::new(VecDeque::new()));
+    let (a_addr, a_handle) = spawn_mock_queue(a_rec.clone(), a_queue.clone()).await;
+    a_queue.lock().unwrap().push_back(MockReply::Status(
+        307,
+        Some(format!("http://127.0.0.1:{}/step2", a_addr.port())),
+    ));
+    a_queue.lock().unwrap().push_back(MockReply::Json200);
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+    let resp = send_messages(info.port).await;
+
+    assert_eq!(resp.status(), 200, "same-class redirect must succeed");
+    let a = a_rec.lock().unwrap().clone();
+    assert_eq!(a.len(), 2);
+    assert_eq!(
+        a[1].referer.as_deref(),
+        Some(format!("http://127.0.0.1:{}/v1/chat/completions", a_addr.port()).as_str()),
+        "same-class hop must carry Referer = previous hop URL"
+    );
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+}
+
+// ===========================================================================
+// R2: forwarder-level route-decision atomicity (ONE HOP = ONE SNAPSHOT)
+// ===========================================================================
+
+/// F-1 (deterministic barrier, None -> explicit HTTP): a hop paused between
+/// route resolution and send must consume the DECISION it resolved — a hot
+/// `apply_proxy` during the pause must not retroactively re-route that hop.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn r2_route_decision_none_to_http_deterministic() {
+    use crate::proxy::test_hooks;
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let env_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (env_addr, env_handle) = spawn_mock(env_rec.clone(), MockReply::Json200).await;
+    let _env = EnvProxyGuard::set(&format!("http://127.0.0.1:{}", env_addr.port()));
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (a_addr, a_handle) = spawn_mock(a_rec.clone(), MockReply::Json200).await;
+
+    let q_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (q_addr, q_handle) = spawn_mock(q_rec.clone(), MockReply::Json200).await;
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+
+    let gate = test_hooks::new_gate();
+    gate.arm();
+    test_hooks::set_gate(Some(gate.clone()));
+    let handle = tokio::spawn(async move { send_messages(info.port).await });
+    assert!(
+        gate.wait_entered(Duration::from_secs(10)),
+        "forwarder must reach the route-resolution pause point"
+    );
+    http_client::apply_proxy(Some(&format!("http://127.0.0.1:{}", q_addr.port())))
+        .expect("apply explicit proxy mid-hop");
+    gate.release();
+    test_hooks::set_gate(None);
+    let resp = handle.await.expect("request task");
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "paused hop must complete via its own decision"
+    );
+    assert_eq!(
+        a_rec.lock().unwrap().len(),
+        1,
+        "hop must use the pre-switch decision (loopback direct), not a re-read"
+    );
+    assert_eq!(
+        q_rec.lock().unwrap().len(),
+        0,
+        "mid-hop explicit proxy must not serve this hop (no second read)"
+    );
+    assert_eq!(
+        env_rec.lock().unwrap().len(),
+        0,
+        "inherited proxy not involved"
+    );
+
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+    q_handle.abort();
+    env_handle.abort();
+    let _ = http_client::apply_proxy(None);
+}
+
+/// F-2 (deterministic barrier, explicit -> None): with an explicit proxy
+/// configured, a hop paused at route resolution must still use that explicit
+/// proxy even if `apply_proxy(None)` lands during the pause (an explicit-proxy
+/// snapshot effective for the hop is never bypassed).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn r2_route_decision_explicit_to_none_deterministic() {
+    use crate::proxy::test_hooks;
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (a_addr, a_handle) = spawn_mock(a_rec.clone(), MockReply::Json200).await;
+
+    let q_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (q_addr, q_handle) = spawn_mock(q_rec.clone(), MockReply::Json200).await;
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+    let _ = http_client::init(None);
+    http_client::apply_proxy(Some(&format!("http://127.0.0.1:{}", q_addr.port())))
+        .expect("explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+
+    let gate = test_hooks::new_gate();
+    gate.arm();
+    test_hooks::set_gate(Some(gate.clone()));
+    let handle = tokio::spawn(async move { send_messages(info.port).await });
+    assert!(
+        gate.wait_entered(Duration::from_secs(10)),
+        "forwarder must reach the route-resolution pause point"
+    );
+    http_client::apply_proxy(None).expect("remove explicit proxy mid-hop");
+    gate.release();
+    test_hooks::set_gate(None);
+    let resp = handle.await.expect("request task");
+
+    assert_eq!(
+        resp.status(),
+        200,
+        "paused hop must complete via its own decision"
+    );
+    assert_eq!(
+        q_rec.lock().unwrap().len(),
+        1,
+        "the hop must honor the explicit-proxy snapshot effective at its resolution"
+    );
+    assert_eq!(
+        a_rec.lock().unwrap().len(),
+        0,
+        "no re-read => loopback must not be forced direct after the switch"
+    );
+
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+    q_handle.abort();
+    let _ = http_client::apply_proxy(None);
+}
+
+/// F-3 (deterministic barrier, SOCKS5): a hop resolved while an explicit SOCKS5
+/// proxy is configured must consume the SOCKS5 decision (and fail against the
+/// dead port) instead of silently falling back to the direct path after a
+/// concurrent `apply_proxy(None)`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn r2_route_decision_socks5_never_falls_back_deterministic() {
+    use crate::proxy::test_hooks;
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let (a_addr, a_handle) = spawn_mock(a_rec.clone(), MockReply::Json200).await;
+
+    // Reserve a loopback port, then drop the listener: guaranteed-refused port.
+    let dead_port = {
+        let l = std::net::TcpListener::bind("127.0.0.1:0").expect("bind temp port");
+        l.local_addr().expect("addr").port()
+    };
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+    let _ = http_client::init(None);
+    http_client::apply_proxy(Some(&format!("socks5://127.0.0.1:{dead_port}")))
+        .expect("socks5 explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+
+    let gate = test_hooks::new_gate();
+    gate.arm();
+    test_hooks::set_gate(Some(gate.clone()));
+    let handle = tokio::spawn(async move { send_messages(info.port).await });
+    assert!(
+        gate.wait_entered(Duration::from_secs(10)),
+        "forwarder must reach the route-resolution pause point"
+    );
+    http_client::apply_proxy(None).expect("remove explicit proxy mid-hop");
+    gate.release();
+    test_hooks::set_gate(None);
+    let resp = handle.await.expect("request task");
+
+    assert!(
+        !resp.status().is_success(),
+        "socks5-resolved hop must not silently succeed by falling back to direct"
+    );
+    assert_eq!(
+        a_rec.lock().unwrap().len(),
+        0,
+        "the loopback mock must NOT be reached (no re-read to a direct decision)"
+    );
+
+    server.stop().await.expect("stop proxy server");
+    a_handle.abort();
+    let _ = http_client::apply_proxy(None);
+}
+
+/// F-4 (stress, supplementary): deliberate `apply_proxy` churn across
+/// None / HTTP / SOCKS5 while readers resolve both loopback and external URLs.
+/// Every recorded resolution must be consistent with the *published snapshot
+/// generation* it consumed: `direct == (url_is_loopback && explicit.is_none())`.
+#[tokio::test]
+async fn r2_route_decision_stress_no_mixed_generations() {
+    use crate::proxy::test_hooks;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let _ = http_client::init(None);
+    test_hooks::clear_publish_log();
+    test_hooks::clear_resolution_log();
+    http_client::apply_proxy(None).expect("re-publish baseline snapshot");
+    test_hooks::set_gate(None);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let mut handles = Vec::new();
+    for w in 0..3usize {
+        let stop = stop.clone();
+        handles.push(std::thread::spawn(move || {
+            let mut i = 0usize;
+            while !stop.load(Ordering::SeqCst) {
+                let url = match (w + i) % 3 {
+                    0 => Some("http://127.0.0.1:59888".to_string()),
+                    1 => Some("socks5://127.0.0.1:59889".to_string()),
+                    _ => None,
+                };
+                let _ = http_client::apply_proxy(url.as_deref());
+                i += 1;
+            }
+        }));
+    }
+    for r in 0..4usize {
+        let stop = stop.clone();
+        handles.push(std::thread::spawn(move || {
+            while !stop.load(Ordering::SeqCst) {
+                let url = if r % 2 == 0 {
+                    "http://127.0.0.1:8080/v1"
+                } else {
+                    "http://192.0.2.1/v1"
+                };
+                let _ = http_client::resolve_route_for_url(url);
+            }
+        }));
+    }
+    std::thread::sleep(Duration::from_millis(500));
+    stop.store(true, Ordering::SeqCst);
+    for handle in handles {
+        handle.join().expect("stress worker");
+    }
+
+    let resolutions = test_hooks::resolutions();
+    assert!(
+        resolutions.len() > 100,
+        "stress must record resolutions, got {}",
+        resolutions.len()
+    );
+    let mut violations = Vec::new();
+    for (generation, direct, url_is_loopback) in &resolutions {
+        if let Some(published) = test_hooks::published_explicit_proxy(*generation) {
+            let expected = *url_is_loopback && published.is_none();
+            if *direct != expected {
+                violations.push(format!(
+                    "gen={generation} direct={direct} url_loopback={url_is_loopback} published={published:?}"
+                ));
+            }
+        }
+        // generation 0 = fallback snapshot (not published); ignore.
+    }
+    assert!(
+        violations.is_empty(),
+        "route decisions must never mix generations under churn: {violations:?}"
+    );
+    let _ = http_client::apply_proxy(None);
+}
+
+// ===========================================================================
+// R2: differential contract — forwarder redirect handling vs plain reqwest
+// ===========================================================================
+
+/// Drives identical redirect scenarios through (a) the forwarder path and
+/// (b) a plain reqwest client using the *default* (upstream) redirect policy,
+/// then compares per-hop method / body presence / authorization / referer
+/// presence. This is the differential proof that the unified explicit state
+/// machine matches reqwest's own redirect semantics (review finding MINOR-2
+/// plus the method/body/header contract).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn r2_differential_forwarder_matches_plain_reqwest() {
+    #[derive(Debug, PartialEq)]
+    struct Hop {
+        method: String,
+        has_body: bool,
+        has_auth: bool,
+        has_referer: bool,
+    }
+    fn hops(rec: &Arc<Mutex<Vec<RecReq>>>) -> Vec<Hop> {
+        rec.lock()
+            .unwrap()
+            .iter()
+            .map(|r| Hop {
+                method: r.method.clone(),
+                has_body: !r.body.is_empty(),
+                has_auth: r.authorization.is_some(),
+                has_referer: r.referer.is_some(),
+            })
+            .collect()
+    }
+
+    for status in [302u16, 303, 307] {
+        // ---- (a) plain reqwest baseline (default redirect policy) ----
+        let plain_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+        let plain_q = Arc::new(Mutex::new(VecDeque::new()));
+        let (plain_addr, plain_handle) = spawn_mock_queue(plain_rec.clone(), plain_q.clone()).await;
+        plain_q.lock().unwrap().push_back(MockReply::Status(
+            status,
+            Some(format!("http://127.0.0.1:{}/hop2", plain_addr.port())),
+        ));
+        plain_q.lock().unwrap().push_back(MockReply::Json200);
+        let plain_client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("plain client");
+        let resp = plain_client
+            .request(
+                reqwest::Method::POST,
+                format!("http://127.0.0.1:{}/hop1", plain_addr.port()),
+            )
+            .header("authorization", "Bearer differential")
+            .header("content-type", "application/json")
+            .body("hello-body")
+            .send()
+            .await
+            .expect("plain send");
+        assert_eq!(resp.status(), 200);
+        let plain_hops = hops(&plain_rec);
+        plain_handle.abort();
+
+        // ---- (b) forwarder path (isolated proxy) ----
+        let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+        let a_q = Arc::new(Mutex::new(VecDeque::new()));
+        let (a_addr, a_handle) = spawn_mock_queue(a_rec.clone(), a_q.clone()).await;
+        a_q.lock().unwrap().push_back(MockReply::Status(
+            status,
+            Some(format!("http://127.0.0.1:{}/hop2", a_addr.port())),
+        ));
+        a_q.lock().unwrap().push_back(MockReply::Json200);
+        let home = tempfile::tempdir().expect("temp home");
+        std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+        let db = Arc::new(Database::init().expect("init isolated database"));
+        seed_provider(&db, format!("http://127.0.0.1:{}/v1", a_addr.port()));
+        let _ = http_client::init(None);
+        http_client::apply_proxy(None).expect("no explicit proxy");
+        let (info, server) = start_server(db.clone()).await;
+        let resp = send_messages(info.port).await;
+        assert_eq!(
+            resp.status(),
+            200,
+            "status {status}: forwarder must succeed"
+        );
+        let fwd_hops = hops(&a_rec);
+        server.stop().await.expect("stop");
+        a_handle.abort();
+        let _ = http_client::apply_proxy(None);
+
+        // ---- compare ----
+        assert_eq!(
+            fwd_hops.len(),
+            plain_hops.len(),
+            "status {status}: hop count must match plain reqwest"
+        );
+        for (i, (f, p)) in fwd_hops.iter().zip(plain_hops.iter()).enumerate() {
+            assert_eq!(f.method, p.method, "status {status} hop{i}: method");
+            assert_eq!(
+                f.has_body, p.has_body,
+                "status {status} hop{i}: body presence"
+            );
+            assert_eq!(
+                f.has_auth, p.has_auth,
+                "status {status} hop{i}: authorization"
+            );
+            assert_eq!(
+                f.has_referer, p.has_referer,
+                "status {status} hop{i}: referer presence"
+            );
+        }
+    }
+}
+
+/// R2: the raw hyper path (exact header-case preservation, native anthropic
+/// format) must drive redirects through the SAME logical budget / deadline /
+/// semantics state machine as the reqwest path. 12 self-redirects stop after
+/// 1 initial + 10 followed requests and the 11th redirect is rejected.
+#[tokio::test]
+async fn r2_redirect_budget_raw_hyper_path() {
+    let home = tempfile::tempdir().expect("temp home");
+    std::env::set_var("CC_SWITCH_TEST_HOME", home.path());
+
+    let a_rec: Arc<Mutex<Vec<RecReq>>> = Arc::new(Mutex::new(Vec::new()));
+    let a_queue = Arc::new(Mutex::new(VecDeque::new()));
+    let (a_addr, a_handle) = spawn_mock_queue(a_rec.clone(), a_queue.clone()).await;
+    for _ in 0..12 {
+        a_queue.lock().unwrap().push_back(MockReply::Status(
+            307,
+            Some(format!("http://127.0.0.1:{}/next", a_addr.port())),
+        ));
+    }
+    a_queue.lock().unwrap().push_back(MockReply::Json200);
+
+    let db = Arc::new(Database::init().expect("init isolated database"));
+    // Native anthropic format (no OAuth adapter) selects the raw write path
+    // with exact header-case preservation.
+    seed_provider_with_format(
+        &db,
+        format!("http://127.0.0.1:{}/v1", a_addr.port()),
+        "anthropic",
+    );
+    let _ = http_client::init(None);
+    http_client::apply_proxy(None).expect("no explicit proxy");
+    let (info, server) = start_server(db.clone()).await;
+    let resp = send_messages(info.port).await;
+
+    let status = resp.status();
+    assert!(
+        !status.is_success() && !status.is_redirection(),
+        "raw hyper path must reject the 11th redirect, got {status}"
+    );
+    let recs = a_rec.lock().unwrap();
+    assert_eq!(
+        recs.len(),
+        11,
+        "raw hyper path must share the same 10-follow budget (1 initial + 10)"
+    );
+    let hop1_uri = recs[0].uri.clone();
+    let expected_referer = if hop1_uri.starts_with("http") {
+        hop1_uri
+    } else {
+        format!("http://127.0.0.1:{}{}", a_addr.port(), hop1_uri)
+    };
+    assert_eq!(
+        recs[1].referer.as_deref(),
+        Some(expected_referer.as_str()),
+        "followed hops on the raw path must carry Referer = previous hop URL"
+    );
+    drop(recs);
+    server.stop().await.expect("stop");
+    a_handle.abort();
+}
+
+/// R2: proxy-kind classification must match the client builder's URL-scheme
+/// acceptance (case-insensitive, SOCKS family incl. uppercase `SOCKS5://`).
+/// A mis-classification would hand a SOCKS URL to hyper's HTTP-CONNECT.
+#[test]
+fn r2_proxy_kind_matches_builder_scheme_acceptance() {
+    let _ = http_client::init(None);
+    let _ = http_client::apply_proxy(None);
+    assert_eq!(
+        http_client::resolve_route_for_url("http://127.0.0.1:1").proxy_kind,
+        http_client::RouteProxyKind::None,
+        "no explicit proxy => None kind"
+    );
+    let _ = http_client::apply_proxy(Some("SOCKS5://127.0.0.1:1"));
+    let decision = http_client::resolve_route_for_url("http://192.0.2.1/");
+    assert_eq!(
+        decision.proxy_kind,
+        http_client::RouteProxyKind::Socks5,
+        "uppercase SOCKS scheme must classify as SOCKS (builder accepts it)"
+    );
+    assert!(
+        !decision.loopback_direct,
+        "explicit proxy must win even for loopback targets"
+    );
+    let _ = http_client::apply_proxy(None);
+}
+
+// ===========================================================================
+// R2: Referer helper edges (mirrors reqwest make_referer exactly)
+// ===========================================================================
+
+#[test]
+fn r2_referer_helper_matches_reqwest_edges() {
+    let next_http = reqwest::Url::parse("http://b.example/z").expect("url");
+    let next_https = reqwest::Url::parse("https://b.example/z").expect("url");
+
+    // http -> http: Referer = previous URL, fragment stripped.
+    let r = super::forwarder::redirect_referer("http://a.example/x?y=1#frag", &next_http);
+    assert_eq!(
+        r.as_ref().and_then(|v| v.to_str().ok()),
+        Some("http://a.example/x?y=1")
+    );
+
+    // https -> https: Referer = previous URL; credentials stripped.
+    let r = super::forwarder::redirect_referer("https://u:p@a.example/x", &next_https);
+    assert_eq!(
+        r.as_ref().and_then(|v| v.to_str().ok()),
+        Some("https://a.example/x")
+    );
+
+    // https -> http (security downgrade): NOT sent (reqwest parity).
+    let r = super::forwarder::redirect_referer("https://a.example/x", &next_http);
+    assert!(r.is_none(), "https->http must not send Referer");
 }

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -30,6 +30,9 @@ pub(crate) mod server;
 pub mod session;
 pub(crate) mod sse;
 pub(crate) mod switch_lock;
+#[cfg(feature = "test-hooks")]
+#[allow(dead_code)]
+pub(crate) mod test_hooks;
 pub mod thinking_budget_rectifier;
 pub mod thinking_optimizer;
 pub mod thinking_rectifier;

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -19,6 +19,8 @@ pub mod http_client;
 pub mod hyper_client;
 pub(crate) mod json_canonical;
 pub mod log_codes;
+#[cfg(all(test, feature = "test-hooks"))]
+mod loopback_upstream_tests;
 pub mod media_sanitizer;
 pub mod model_mapper;
 pub mod provider_router;

--- a/src-tauri/src/proxy/test_hooks.rs
+++ b/src-tauri/src/proxy/test_hooks.rs
@@ -1,0 +1,121 @@
+//! Test-only hooks (behind the `test-hooks` feature; zero cost in production builds).
+//!
+//! Two capabilities:
+//! 1. **Programmable pause point** — lets a deterministic test interleave two
+//!    threads at a chosen semantic point (instead of sleep/retry timing games),
+//!    so the proxy-state atomicity contract can be exercised exactly at the
+//!    reader/writer boundary.
+//! 2. **Publish log** — records every published route-state generation together
+//!    with the explicit-proxy value it was published with. Tests can verify that
+//!    a reader's decision and generation correspond to one *real* published
+//!    snapshot (never a torn combination of metadata + client).
+
+use std::collections::HashMap;
+use std::sync::{Condvar, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+#[derive(Default)]
+struct GateInner {
+    armed: bool,
+    entered: u64,
+}
+
+pub struct PauseGate {
+    state: Mutex<GateInner>,
+    cv: Condvar,
+}
+
+impl PauseGate {
+    /// Arm the gate and reset the "entered" counter.
+    pub fn arm(&self) {
+        *self.state.lock().unwrap() = GateInner {
+            armed: true,
+            entered: 0,
+        };
+    }
+
+    /// Release all threads currently blocked in `pause_point`.
+    pub fn release(&self) {
+        let mut s = self.state.lock().unwrap();
+        s.armed = false;
+        self.cv.notify_all();
+    }
+
+    /// Block until at least one thread has entered `pause_point`.
+    pub fn wait_entered(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let mut s = self.state.lock().unwrap();
+        while s.entered == 0 {
+            let now = Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            let (guard, _) = self
+                .cv
+                .wait_timeout(s, deadline - now)
+                .expect("condvar wait");
+            s = guard;
+        }
+        true
+    }
+}
+
+static PAUSE: OnceLock<Mutex<Option<std::sync::Arc<PauseGate>>>> = OnceLock::new();
+static PUBLISH_LOG: OnceLock<Mutex<HashMap<u64, Option<String>>>> = OnceLock::new();
+
+fn pause_cell() -> &'static Mutex<Option<std::sync::Arc<PauseGate>>> {
+    PAUSE.get_or_init(|| Mutex::new(None))
+}
+
+fn log_cell() -> &'static Mutex<HashMap<u64, Option<String>>> {
+    PUBLISH_LOG.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Install / remove the active pause gate. `None` disables the pause point.
+pub fn set_gate(gate: Option<std::sync::Arc<PauseGate>>) {
+    *pause_cell().lock().unwrap() = gate;
+}
+
+pub fn new_gate() -> std::sync::Arc<PauseGate> {
+    std::sync::Arc::new(PauseGate {
+        state: Mutex::new(GateInner {
+            armed: false,
+            entered: 0,
+        }),
+        cv: Condvar::new(),
+    })
+}
+
+/// The pause point itself. When a gate is installed and armed, this blocks
+/// until the gate is released (or removed), after signalling `wait_entered`.
+pub fn pause_point() {
+    let gate = pause_cell().lock().unwrap().clone();
+    if let Some(gate) = gate {
+        let mut s = gate.state.lock().unwrap();
+        s.entered += 1;
+        gate.cv.notify_all();
+        while s.armed {
+            s = gate.cv.wait(s).expect("condvar wait");
+        }
+    }
+}
+
+/// Record a route-state publication (called by the writer inside its
+/// critical section). `generation` must be unique per publication.
+pub fn record_publish(generation: u64, explicit_proxy_url: Option<&str>) {
+    log_cell()
+        .lock()
+        .unwrap()
+        .insert(generation, explicit_proxy_url.map(|s| s.to_string()));
+}
+
+/// Look up what explicit-proxy value generation `generation` was published
+/// with. `None` (the outer Option) means that generation was never published.
+pub fn published_explicit_proxy(generation: u64) -> Option<Option<String>> {
+    log_cell().lock().unwrap().get(&generation).cloned()
+}
+
+/// Clear the publish log between tests.
+pub fn clear_publish_log() {
+    log_cell().lock().unwrap().clear();
+}

--- a/src-tauri/src/proxy/test_hooks.rs
+++ b/src-tauri/src/proxy/test_hooks.rs
@@ -119,3 +119,31 @@ pub fn published_explicit_proxy(generation: u64) -> Option<Option<String>> {
 pub fn clear_publish_log() {
     log_cell().lock().unwrap().clear();
 }
+
+/// Records every route resolution performed by `resolve_route_for_url`:
+/// `(generation, loopback_direct, url_is_loopback)`. Used by the concurrency
+/// regression tests to prove that every decision is consistent with the snapshot
+/// generation it actually consumed (never a torn metadata/client pairing).
+static RESOLUTION_LOG: OnceLock<Mutex<Vec<(u64, bool, bool)>>> = OnceLock::new();
+
+fn resolution_cell() -> &'static Mutex<Vec<(u64, bool, bool)>> {
+    RESOLUTION_LOG.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+/// Record a route resolution (called by `resolve_route_for_url`).
+pub fn record_resolution(generation: u64, loopback_direct: bool, url_is_loopback: bool) {
+    resolution_cell()
+        .lock()
+        .unwrap()
+        .push((generation, loopback_direct, url_is_loopback));
+}
+
+/// Snapshot of all recorded resolutions.
+pub fn resolutions() -> Vec<(u64, bool, bool)> {
+    resolution_cell().lock().unwrap().clone()
+}
+
+/// Clear the resolution log between tests.
+pub fn clear_resolution_log() {
+    resolution_cell().lock().unwrap().clear();
+}


### PR DESCRIPTION
### Problem

Local provider endpoints on loopback — for example a local OpenAI-compatible server such as `http://127.0.0.1:<port>` — never receive requests when the machine has a system proxy enabled (ClashX / Clash Verge / v2rayN, etc.):

- With no explicit proxy configured, CC Switch's upstream HTTP client intentionally follows the system proxy (`build_client(None)` → "Following system proxy").
- For a loopback upstream target the request is therefore sent *to the proxy* instead of the local server. Most proxies reject or misroute loopback targets and answer with an empty-body `502` (or the connection fails), so the local provider is never reached.
- The macOS/Windows proxy bypass lists do not help here: they are honored by browsers/curl, but CC Switch's own outbound client does not consult them for these requests.

### Fix

**1. Target-scoped transport** (minimal; no global behavior change):

- Classify the **final upstream URL host** with standard parsing — `url::Url` + `url::Host`, and `IpAddr::is_loopback()` for addresses (not string prefixes): `localhost` (case-insensitive), IPv4 `127.0.0.0/8`, IPv6 `::1`.
- If the target is loopback **and** no explicit user-configured upstream proxy exists, forward that request with a dedicated no-proxy client so it goes **direct** to the local endpoint.
- **Explicit upstream proxy precedence is unchanged**: when a proxy is explicitly configured it is always honored, loopback or not. External upstreams keep following the inherited/system proxy.

**2. Unified explicit redirect handling (both forwarder transport paths):**

- The forwarder owns **one logical redirect budget**: the initial request does not count, every truly followed 3xx `Location` counts, 10 follows are allowed in total and the 11th is rejected — *across every hop*, regardless of the class mix (loopback→loopback, loopback→external, external→loopback, alternating chains). There is no second budget and no per-hop reset: the forwarder path uses dedicated clients with automatic redirects disabled, so reqwest's internal policy no longer runs a parallel budget.
- **Both transports run the same state machine.** The pooled reqwest-client path and the exact-header-case raw write path share one redirect bookkeeping implementation (budget gate, method/body/payload-header/sensitive-header transforms, Referer), so the guarantees below hold for every hop regardless of which transport the hop uses.
- The non-streaming path runs on a **single request-level timeout deadline**: the first hop establishes `deadline = now + non_streaming_timeout`, every later hop may only consume the remaining budget, and a chain can therefore never cost `N × timeout`. Streaming keeps its dedicated semantics: the header/first-byte wait for the whole chain shares one absolute window, and once a real streaming response arrives the existing `response_processor` silence/stream lifecycle takes over. Requests without redirects keep exactly the previous semantics.
- Redirect **method/body/header semantics mirror reqwest 0.12 / tower-http 0.6**: 301/302 turn POST into GET and drop the body plus payload headers, 303 converts non-HEAD to GET, 307/308 preserve method and body; cross-origin hops strip `Authorization` / `Cookie` / `cookie2` / `Proxy-Authorization` / `WWW-Authenticate` (host + effective port comparison).
- **Referer** is reproduced from reqwest's own `make_referer`: each followed hop carries `Referer = previous URL` with credentials and fragment stripped, and no Referer is sent on an HTTPS→HTTP downgrade.
- The shared client used by every other consumer keeps reqwest's **default** redirect policy untouched; only the forwarder path opts out of automatic redirects.

**3. One atomic route snapshot per hop:**

- The proxy configuration is published as a single `RouteState { generation, client, route_client, explicit_proxy_url }` inside one lock; readers take exactly one `Arc` snapshot, so a client can never be paired with proxy metadata from a different generation (no torn read under a hot `apply_proxy`).
- Every hop resolves through a single call, `resolve_route_for_url(url) -> RouteDecision { generation, explicit_proxy_url, proxy_kind, loopback_direct, client }`: the reqwest/hyper branch decision, the SOCKS/HTTP/direct classification, the explicit proxy metadata and the actual client all come from the **same generation**. A redirect hop re-resolves a fresh decision for the new URL (the configuration may legitimately change between two hops) — but within one hop nothing is re-read after the decision.
- The forwarder consumes the decision for both the branch choice and the send, so the former "read metadata, then independently select a client" double read is gone.

### Relationship to open PRs

- **#5043** proposes `build_client(None) -> .no_proxy()` **globally**, which its own description calls a breaking change for users who rely on the inherited system proxy to reach *external* AI providers. This PR fixes the same class of loopback failures with a **target-scoped** rule: direct only for loopback targets; zero behavior change for external traffic. If maintainers prefer the global approach, this patch becomes unnecessary for the no-explicit-proxy case — otherwise it delivers the loopback fix without the breaking aspect.
- **#6656** changes proxy *discovery* (registry/env + watcher + bypass list; `get_proxy_for_url`). This PR is a *target-level selection* rule applied after discovery — the two compose. When folding into #6656's architecture, keep the "explicit vs inherited" provenance in `get_proxy_for_url` and apply "loopback + non-explicit => direct" after it.
- **#7030** (refresh the client when the macOS system proxy changes) is the same discovery/refresh family; no semantic overlap.

### Tests

- Unit: loopback classification (localhost / 127.0.0.1 / arbitrary 127/8 / ::1 vs public IPv4, private IPv4, regular hostnames, malformed input), selection policy (loopback+no-proxy → direct; external+no-proxy → unchanged; loopback/external+explicit → explicit preserved), and the Referer helper edges (http→http, https→http suppression, credential/fragment stripping).
- Behavioral: the direct client ignores inherited env/system proxies for loopback targets; the default client still follows the inherited proxy for external targets; an explicit proxy is used for both loopback and external targets.
- Redirect budget matrix (end-to-end against mock chains): 0 redirects; exactly 10 redirects (11 HTTP requests); 11th redirect rejected; 10 same-class redirects; alternating loopback↔external chains that must share the one budget; bounded redirect loops; the same budget/rejection/Referer contract on the exact-header-case raw write path.
- Request-level deadline: a chain of delayed redirects must fail near the deadline instead of `N × timeout` wall time.
- Redirect semantics: method/body contract per status code; cross-class sensitive-header stripping; Referer on same-class and cross-class hops.
- Differential contract: the same scenarios (302/303/307) are driven through a plain `reqwest::Client` with the default policy and through the forwarder, and the per-hop method/body/authorization/referer observations must match.
- Concurrency: deterministic pause gates prove a hop consumes the decision it resolved (None→HTTP, HTTP→None, SOCKS→never-falls-back-to-direct), plus a stress invariant that every recorded resolution matches its published generation — no metadata/client mixing under a hot `apply_proxy`.
- End-to-end (forwarder level, behind the existing `test-hooks` feature; wired into CI as a serial step):
  `cargo test --manifest-path src-tauri/Cargo.toml --features test-hooks loopback_upstream -- --test-threads=1`

Local results (macOS): `cargo fmt --check` and `cargo clippy -- -D warnings` clean; the full `proxy::` suite reports 1496 passed / 5 failed, where the 5 failures are the same pre-existing environmental cases whose own test-side clients call `127.0.0.1` mocks and are intercepted on a host with a system proxy enabled (they fail **identically on unpatched main**; pass on CI).

### Security note

Not a generic SSRF or proxy bypass: the transport changes only for **targets the user themselves configured as loopback provider endpoints**, and only when no explicit proxy was requested. It does not expand provider allowlists, inbound bindings, remote access, or credential exposure. Explicitly configured proxies keep precedence.

### Compatibility / migration

None required. External provider behavior is unchanged; the only behavioral difference applies to loopback targets that previously could not work while an inherited proxy intercepted them. Redirect behavior for non-redirect requests is unchanged, and redirected chains keep reqwest's documented contract: at most 10 followed redirects per logical request.
