### PR TITLE
fix(macOS): add WebKit sandbox entitlements for Tahoe

### DIFF
--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Allow WKWebView WebContent process to spawn and render on macOS 12+ -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <!-- Network access for local proxy and API requests -->
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,8 @@
       }
     },
     "macOS": {
-      "minimumSystemVersion": "12.0"
+      "minimumSystemVersion": "12.0",
+      "entitlements": "entitlements.plist"
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary / 概述

Fixes the invisible/blank CC Switch window on macOS 26 Tahoe by adding the entitlements required for the WKWebView WebContent process to initialize under the tightened sandbox restrictions.

- Adds `src-tauri/entitlements.plist` with WebKit executable-memory and library-validation entitlements.
- Enables client/server network access for CC Switch's local proxy and API requests.
- References the plist through `bundle.macOS.entitlements` so Tauri applies it during the existing signing and notarization flow.

Without these entitlements, Tahoe reports WebContent XPC error 159 (`Sandbox restriction`) and the app creates no visible window. With them, WebKit successfully creates its sandbox extension and renders the webview.

## Related Issue / 关联 Issue

Fixes #7301

Related upstream report: https://github.com/tauri-apps/tauri/issues/15517

## Verification / 验证

Reported macOS verification: CC Switch v3.20.2 (Tauri 2.8.2) on macOS 26.4, build 25E246.

| Before / 修改前 | After / 修改后 |
| --- | --- |
| WebContent XPC error 159 | Sandbox extensions created successfully |
| Window count: 0 | Window count: 1 |
| No WebContent process spawned | WebContent process running |
| WebView blank/not visible | WebView renders correctly |

Local validation performed on Windows:

- `pnpm tauri info` passes and loads the updated configuration.
- `pnpm typecheck` passes.
- `pnpm format:check` passes.
- `pnpm test:unit` passes: 135 files, 1090 tests.
- `tauri.conf.json` parses as JSON and `entitlements.plist` parses as XML.

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes (if Rust code changed) / 通过 Clippy 检查（未修改 Rust 代码）
- [x] Updated i18n files if user-facing text changed / 无用户可见文本变更