### PR TITLE
feat(proxy): strip Claude Code fingerprint headers on non-Anthropic transform paths

### DIFF
--- a/src-tauri/src/provider.rs
+++ b/src-tauri/src/provider.rs
@@ -544,6 +544,14 @@ pub struct ProviderMeta {
     /// Custom User-Agent for local proxy routing.
     #[serde(rename = "customUserAgent", skip_serializing_if = "Option::is_none")]
     pub custom_user_agent: Option<String>,
+    /// Claude→非 Anthropic 转换路径是否剥离 Claude Code 客户端指纹头
+    /// （x-app / x-stainless-* / x-claude-code-*）。缺省（None）不剥离；
+    /// 显式 true 开启——用于向指纹敏感的网关隐藏 Claude Code 客户端特征。
+    #[serde(
+        rename = "stripClaudeCodeFingerprint",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub strip_claude_code_fingerprint: Option<bool>,
     /// Local proxy request overrides applied to the transformed upstream request.
     #[serde(
         rename = "localProxyRequestOverrides",
@@ -598,6 +606,11 @@ impl ProviderMeta {
     /// 经校验的 Provider 级自定义 User-Agent。见 [`parse_custom_user_agent`]。
     pub fn custom_user_agent_header(&self) -> Result<Option<HeaderValue>, InvalidHeaderValue> {
         parse_custom_user_agent(self.custom_user_agent.as_deref())
+    }
+
+    /// 转换路径是否剥离 Claude Code 指纹头。缺省关闭；显式 true 开启。
+    pub fn strip_claude_code_fingerprint_enabled(&self) -> bool {
+        self.strip_claude_code_fingerprint == Some(true)
     }
 
     /// 解析指定托管认证供应商绑定的账号 ID。
@@ -1121,6 +1134,23 @@ mod tests {
         let overrides = decoded.local_proxy_request_overrides.unwrap();
         assert_eq!(overrides.headers.get("X-Test"), Some(&"yes".to_string()));
         assert_eq!(overrides.body.unwrap()["temperature"], 0.2);
+    }
+
+    #[test]
+    fn strip_claude_code_fingerprint_defaults_to_disabled() {
+        let meta: ProviderMeta = serde_json::from_str("{}").unwrap();
+        assert!(!meta.strip_claude_code_fingerprint_enabled());
+
+        let meta: ProviderMeta =
+            serde_json::from_str(r#"{"stripClaudeCodeFingerprint": true}"#).unwrap();
+        assert!(meta.strip_claude_code_fingerprint_enabled());
+
+        let meta = ProviderMeta {
+            strip_claude_code_fingerprint: Some(true),
+            ..ProviderMeta::default()
+        };
+        let value = serde_json::to_value(&meta).unwrap();
+        assert_eq!(value["stripClaudeCodeFingerprint"], true);
     }
 
     #[test]

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -2137,9 +2137,7 @@ impl RequestForwarder {
             // --- Claude Code 指纹头 — 不泄露给非 Anthropic 上游 ---
             // 与上一条互为镜像：转换路径上的上游说另一种协议，客户端指纹头
             // 纯属身份泄露。名单集中在 is_claude_code_fingerprint_header。
-            if strip_claude_code_fingerprint_headers
-                && is_claude_code_fingerprint_header(key_str)
-            {
+            if strip_claude_code_fingerprint_headers && is_claude_code_fingerprint_header(key_str) {
                 continue;
             }
 

--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -2021,6 +2021,21 @@ impl RequestForwarder {
             None
         };
 
+        // Claude→非 Anthropic 转换路径（openai_chat / openai_responses / gemini）：
+        // 转换后的请求在协议层已经不是 Claude Code 的形态，CLI 的客户端指纹头
+        // （x-app / x-stainless-* / x-claude-code-*）只会向 OpenAI 兼容网关暴露
+        // 使用者身份，对上游没有任何功能价值 → 剥离。Anthropic 原生透传保留
+        //（严格网关会做 Claude Code 指纹校验）；Copilot 的指纹头单独管理。
+        // 供应商 meta 需显式开启（stripClaudeCodeFingerprint=true），缺省不剥离。
+        let strip_claude_code_fingerprint_headers = adapter.name() == "Claude"
+            && needs_transform
+            && !is_copilot
+            && provider
+                .meta
+                .as_ref()
+                .map(|meta| meta.strip_claude_code_fingerprint_enabled())
+                .unwrap_or(false);
+
         // ============================================================
         // 构建有序 HeaderMap — 内联替换，保持客户端原始顺序
         // ============================================================
@@ -2116,6 +2131,15 @@ impl RequestForwarder {
             // The full set lives in `is_codex_client_fingerprint_header` so it stays in one
             // place. (HeaderName is lowercased by the http crate, so a direct match is safe.)
             if codex_responses_to_anthropic && is_codex_client_fingerprint_header(key_str) {
+                continue;
+            }
+
+            // --- Claude Code 指纹头 — 不泄露给非 Anthropic 上游 ---
+            // 与上一条互为镜像：转换路径上的上游说另一种协议，客户端指纹头
+            // 纯属身份泄露。名单集中在 is_claude_code_fingerprint_header。
+            if strip_claude_code_fingerprint_headers
+                && is_claude_code_fingerprint_header(key_str)
+            {
                 continue;
             }
 
@@ -3058,6 +3082,18 @@ fn is_codex_client_fingerprint_header(key_str: &str) -> bool {
             | "openai-project"
     ) || key_str.starts_with("x-stainless-")
         || key_str.starts_with("x-codex-")
+}
+
+/// Claude Code CLI 发出的、能标识"来自 Claude Code"的头：应用标记（x-app）、
+/// Stainless SDK 遥测（x-stainless-*）、会话标识（x-claude-code-*）。
+/// 在 Claude→非 Anthropic 转换路径上剥离，避免转换后的请求向 OpenAI 兼容
+/// 网关泄露 CLI 指纹。与 Codex→Anthropic 路径的 `is_codex_client_fingerprint_header`
+/// 互为镜像。`key_str` 由 http crate 保证已小写。
+fn is_claude_code_fingerprint_header(key_str: &str) -> bool {
+    key_str == "x-app"
+        || key_str == "claude-code-session-id"
+        || key_str.starts_with("x-stainless-")
+        || key_str.starts_with("x-claude-code-")
 }
 
 fn codex_anthropic_error_envelope_message(body: &[u8]) -> Option<String> {
@@ -4533,6 +4569,41 @@ mod tests {
             assert!(
                 !is_codex_client_fingerprint_header(header),
                 "{header} must be preserved while impersonating Claude Code"
+            );
+        }
+    }
+
+    #[test]
+    fn claude_code_fingerprint_headers_are_dropped_for_non_anthropic_upstreams() {
+        // Claude Code 自身的指纹头 → 转换路径上必须剥离。
+        for header in [
+            "x-app",
+            "claude-code-session-id",
+            "x-claude-code-session-id",
+            "x-claude-code-client",
+            "x-stainless-lang",
+            "x-stainless-runtime",
+            "x-stainless-retry-count",
+        ] {
+            assert!(
+                is_claude_code_fingerprint_header(header),
+                "expected {header} to be dropped on non-Anthropic transform paths"
+            );
+        }
+
+        // 协议必需 / 中立头不能被误伤。
+        for header in [
+            "user-agent",
+            "authorization",
+            "anthropic-version",
+            "anthropic-beta",
+            "accept",
+            "content-type",
+            "x-session-id",
+        ] {
+            assert!(
+                !is_claude_code_fingerprint_header(header),
+                "{header} must not be caught by the Claude Code fingerprint denylist"
             );
         }
     }

--- a/src/components/providers/forms/ClaudeFormFields.tsx
+++ b/src/components/providers/forms/ClaudeFormFields.tsx
@@ -9,6 +9,7 @@ import {
 import { toast } from "sonner";
 import { Checkbox } from "@/components/ui/checkbox";
 import { FormLabel } from "@/components/ui/form";
+import { Switch } from "@/components/ui/switch";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -155,6 +156,9 @@ interface ClaudeFormFieldsProps {
   // Local proxy User-Agent override
   customUserAgent: string;
   onCustomUserAgentChange: (value: string) => void;
+  // Strip Claude Code fingerprint headers on transform paths (default false)
+  stripClaudeCodeFingerprint: boolean;
+  onStripClaudeCodeFingerprintChange: (value: boolean) => void;
   localProxyHeadersOverride: string;
   onLocalProxyHeadersOverrideChange: (value: string) => void;
   localProxyBodyOverride: string;
@@ -221,6 +225,8 @@ export function ClaudeFormFields({
   onFullUrlChange,
   customUserAgent,
   onCustomUserAgentChange,
+  stripClaudeCodeFingerprint,
+  onStripClaudeCodeFingerprintChange,
   localProxyHeadersOverride,
   onLocalProxyHeadersOverrideChange,
   localProxyBodyOverride,
@@ -240,6 +246,7 @@ export function ClaudeFormFields({
     (!isXaiOauthPreset && apiFormat !== "anthropic") ||
     apiKeyField !== "ANTHROPIC_AUTH_TOKEN" ||
     customUserAgent ||
+    stripClaudeCodeFingerprint ||
     hasRequestOverrides
   );
   const [advancedExpanded, setAdvancedExpanded] = useState(
@@ -1092,6 +1099,29 @@ export function ClaudeFormFields({
                     "用于未明确落到 Sonnet、Opus、Fable、Haiku 角色的请求。使用第三方/中转端点时建议填写：否则这些请求（含 Haiku 后台子任务）会以原始 Claude 模型名透传给上游，可能因上游无此模型而报错。官方端点可留空。",
                 })}
               </p>
+            </div>
+
+            <div className="flex items-center justify-between gap-4 border-t border-border-default pt-3">
+              <div className="space-y-1">
+                <FormLabel>
+                  {t("providerForm.stripClaudeCodeFingerprint", {
+                    defaultValue: "剥离 Claude Code 指纹头",
+                  })}
+                </FormLabel>
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  {t("providerForm.stripClaudeCodeFingerprintHint", {
+                    defaultValue:
+                      "默认关闭。开启后仅在 API 格式转换路径（OpenAI Chat / Responses / Gemini）生效：转发前移除 x-app、x-stainless-*、x-claude-code-* 等客户端指纹头。原生 Anthropic 透传不受影响。",
+                  })}
+                </p>
+              </div>
+              <Switch
+                checked={stripClaudeCodeFingerprint}
+                onCheckedChange={onStripClaudeCodeFingerprintChange}
+                aria-label={t("providerForm.stripClaudeCodeFingerprint", {
+                  defaultValue: "剥离 Claude Code 指纹头",
+                })}
+              />
             </div>
 
             <CustomUserAgentField

--- a/src/components/providers/forms/ProviderForm.tsx
+++ b/src/components/providers/forms/ProviderForm.tsx
@@ -422,6 +422,9 @@ function ProviderFormFull({
     setCodexChatReasoning(initialData?.meta?.codexChatReasoning ?? {});
     setPromptCacheRouting(initialData?.meta?.promptCacheRouting ?? "auto");
     setCustomUserAgent(initialData?.meta?.customUserAgent ?? "");
+    setStripClaudeCodeFingerprint(
+      initialData?.meta?.stripClaudeCodeFingerprint ?? false,
+    );
     setLocalProxyHeadersOverride(
       formatRequestOverrideObject(
         initialData?.meta?.localProxyRequestOverrides?.headers,
@@ -621,6 +624,10 @@ function ProviderFormFull({
   const [customUserAgent, setCustomUserAgent] = useState<string>(
     () => initialData?.meta?.customUserAgent ?? "",
   );
+  const [stripClaudeCodeFingerprint, setStripClaudeCodeFingerprint] =
+    useState<boolean>(
+      () => initialData?.meta?.stripClaudeCodeFingerprint ?? false,
+    );
   const [localProxyHeadersOverride, setLocalProxyHeadersOverride] =
     useState<string>(() =>
       formatRequestOverrideObject(
@@ -1773,6 +1780,13 @@ function ProviderFormFull({
         (appId === "claude" || appId === "codex") && category !== "official"
           ? customUserAgent.trim() || undefined
           : undefined,
+      // 仅在显式开启时持久化 true；缺省（undefined）视为关闭，与后端语义一致。
+      stripClaudeCodeFingerprint:
+        appId === "claude" &&
+        category !== "official" &&
+        stripClaudeCodeFingerprint
+          ? true
+          : undefined,
       localProxyRequestOverrides: shouldApplyLocalProxyRequestOverrides
         ? overridesResult.overrides
         : undefined,
@@ -2430,6 +2444,8 @@ function ProviderFormFull({
               onFullUrlChange={setLocalIsFullUrl}
               customUserAgent={customUserAgent}
               onCustomUserAgentChange={setCustomUserAgent}
+              stripClaudeCodeFingerprint={stripClaudeCodeFingerprint}
+              onStripClaudeCodeFingerprintChange={setStripClaudeCodeFingerprint}
               localProxyHeadersOverride={localProxyHeadersOverride}
               onLocalProxyHeadersOverrideChange={setLocalProxyHeadersOverride}
               localProxyBodyOverride={localProxyBodyOverride}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1283,6 +1283,8 @@
     "customUserAgentHint": "Only takes effect when local routing/proxy takeover is enabled; replaces the User-Agent in requests forwarded to the provider API.",
     "customUserAgentInvalid": "User-Agent must not contain control characters (e.g. line breaks); otherwise it will be ignored.",
     "customUserAgentPresets": "Presets",
+    "stripClaudeCodeFingerprint": "Strip Claude Code fingerprint headers",
+    "stripClaudeCodeFingerprintHint": "Disabled by default. When enabled, applies only on format-transform paths (OpenAI Chat / Responses / Gemini): removes client fingerprint headers (x-app, x-stainless-*, x-claude-code-*) before forwarding. Native Anthropic passthrough is unaffected.",
     "localProxyRequestOverrides": "Local proxy request overrides",
     "localProxyRequestOverridesHint": "Only takes effect after local routing/proxy takeover; applied to the transformed upstream request.",
     "localProxyRequestOverridesInvalid": "Local proxy request overrides format error: {{error}}",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1283,6 +1283,8 @@
     "customUserAgentHint": "ローカルルーティング/プロキシ引き継ぎが有効な場合にのみ適用され、プロバイダー API へ転送するリクエストの User-Agent を置き換えます。",
     "customUserAgentInvalid": "User-Agent に制御文字（改行など）を含めることはできません。含まれている場合は無視されます。",
     "customUserAgentPresets": "プリセット",
+    "stripClaudeCodeFingerprint": "Claude Code フィンガープリントヘッダーの除去",
+    "stripClaudeCodeFingerprintHint": "デフォルトは無効。有効にした場合、API フォーマット変換パス（OpenAI Chat / Responses / Gemini）でのみ動作し、転送前に x-app、x-stainless-*、x-claude-code-* などのクライアントフィンガープリントヘッダーを除去します。ネイティブ Anthropic パススルーには影響しません。",
     "localProxyRequestOverrides": "ローカルプロキシのリクエスト上書き",
     "localProxyRequestOverridesHint": "ローカルルーティング/プロキシ引き継ぎ後にのみ有効で、変換後の上流リクエストへ適用されます。",
     "localProxyRequestOverridesInvalid": "ローカルプロキシのリクエスト上書き形式エラー: {{error}}",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1284,6 +1284,8 @@
     "customUserAgentHint": "僅在開啟本地路由/代理接管後生效，會取代轉發至供應商 API 請求中的 User-Agent。",
     "customUserAgentInvalid": "User-Agent 不能包含控制字元（如換行字元），否則將被忽略。",
     "customUserAgentPresets": "預設",
+    "stripClaudeCodeFingerprint": "剝離 Claude Code 指紋頭",
+    "stripClaudeCodeFingerprintHint": "預設關閉。開啟後僅在 API 格式轉換路徑（OpenAI Chat / Responses / Gemini）生效：轉發前移除 x-app、x-stainless-*、x-claude-code-* 等客戶端指紋頭。原生 Anthropic 透傳不受影響。",
     "localProxyRequestOverrides": "本地代理請求覆蓋",
     "localProxyRequestOverridesHint": "僅在本地路由/代理接管後生效，套用於協定轉換後的上游請求。",
     "localProxyRequestOverridesInvalid": "本地代理請求覆蓋格式錯誤：{{error}}",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1283,6 +1283,8 @@
     "customUserAgentHint": "仅在开启本地路由/代理接管后生效，会替换转发到供应商 API 请求中的 User-Agent。",
     "customUserAgentInvalid": "User-Agent 不能包含控制字符（如换行符），否则将被忽略。",
     "customUserAgentPresets": "预设",
+    "stripClaudeCodeFingerprint": "剥离 Claude Code 指纹头",
+    "stripClaudeCodeFingerprintHint": "默认关闭。开启后仅在 API 格式转换路径（OpenAI Chat / Responses / Gemini）生效：转发前移除 x-app、x-stainless-*、x-claude-code-* 等客户端指纹头。原生 Anthropic 透传不受影响。",
     "localProxyRequestOverrides": "本地代理请求覆盖",
     "localProxyRequestOverridesHint": "仅在本地路由/代理接管后生效，应用于协议转换后的上游请求。",
     "localProxyRequestOverridesInvalid": "本地代理请求覆盖格式错误：{{error}}",

--- a/src/types.ts
+++ b/src/types.ts
@@ -228,6 +228,10 @@ export interface ProviderMeta {
   maxOutputTokens?: number;
   // Custom User-Agent for local proxy routing. Only applied by the local proxy.
   customUserAgent?: string;
+  // Strip Claude Code fingerprint headers (x-app / x-stainless-* / x-claude-code-*)
+  // on format-transform paths (openai_chat / openai_responses / gemini_native).
+  // Absent = disabled (default); only an explicit true enables the stripping.
+  stripClaudeCodeFingerprint?: boolean;
   // Local proxy request overrides. Only applied by the local proxy after route transforms.
   localProxyRequestOverrides?: LocalProxyRequestOverrides;
   // Whether this provider is currently projected into an additive app's live config.

--- a/tests/components/ClaudeFormFields.test.tsx
+++ b/tests/components/ClaudeFormFields.test.tsx
@@ -96,6 +96,8 @@ const renderCopilotForm = (overrides: Partial<ClaudeFormFieldsProps> = {}) => {
     onFullUrlChange: vi.fn(),
     customUserAgent: "",
     onCustomUserAgentChange: vi.fn(),
+    stripClaudeCodeFingerprint: false,
+    onStripClaudeCodeFingerprintChange: vi.fn(),
     localProxyHeadersOverride: "",
     onLocalProxyHeadersOverrideChange: vi.fn(),
     localProxyBodyOverride: "",


### PR DESCRIPTION
## Motivation and use case

When CC Switch's local proxy converts Claude Code requests to OpenAI Chat, OpenAI Responses, or Gemini format, the forwarded requests can still carry Claude Code and Stainless SDK identification headers. Although the request format has changed, an upstream gateway can still use these headers to identify the client.

This PR adds a per-provider, opt-in setting to remove `x-app`, `claude-code-session-id`, `x-stainless-*`, and `x-claude-code-*` on these conversion paths. This reduces the client and session identification metadata forwarded upstream and provides a compatibility option for gateways that treat these headers specially.

For example, when using Claude Code with an OpenAI-compatible gateway that applies special handling to Claude Code-specific headers, users can enable this setting for that provider so converted requests no longer carry those headers.

To use it, enable **Strip Claude Code fingerprint headers** in the Claude provider's advanced settings and route requests through the local proxy using one of the supported API format conversions. The setting is disabled by default. Anthropic passthrough, Codex-to-Anthropic impersonation, and Copilot retain their existing behavior.

This option only removes the specified headers. `User-Agent` remains controlled by the existing custom User-Agent setting, so this does not fully conceal client identity or guarantee that a gateway will accept a request.

## Summary
- add an opt-in Claude provider setting to strip Claude Code client-fingerprint headers
- remove x-app, x-stainless-*, and x-claude-code-* headers on Claude-to-OpenAI/Gemini transform paths
- preserve headers for Anthropic passthrough, Codex-to-Anthropic impersonation, and Copilot
- add localized UI copy and regression tests

## Tests
- pnpm exec vitest run tests/components/ClaudeFormFields.test.tsx
- pnpm typecheck
- cargo test --manifest-path src-tauri/Cargo.toml --lib strip_claude_code_fingerprint_defaults_to_disabled
- cargo test --manifest-path src-tauri/Cargo.toml --lib claude_code_fingerprint_headers_are_dropped_for_non_anthropic_upstreams
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml` — passed locally with Rust 1.95
