### PR TITLE
fix(tools): add probe timeout to npm dist-tags fetch to prevent stuck version cards

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -951,7 +951,7 @@ async fn fetch_npm_dist_tags(
     package: &str,
 ) -> Option<serde_json::Map<String, serde_json::Value>> {
     let url = format!("https://registry.npmjs.org/{package}");
-    let resp = client.get(&url).send().await.ok()?;
+    let resp = client.get(&url).timeout(LATEST_PROBE_TIMEOUT).send().await.ok()?;
     let json = resp.json::<serde_json::Value>().await.ok()?;
     json.get("dist-tags")?.as_object().cloned()
 }


### PR DESCRIPTION
## 问题

「关于 → 本地环境检查」里，npm 系工具（claude / codex / gemini / grok / opencode / openclaw / pi）的卡片偶发「当前版本 / 最新版本」一直转圈（加载中）。由于前端是逐工具独立刷新，往往只有部分卡片受影响，看起来"时好时坏"。

## 根因

`get_single_tool_version_impl` 分两步：本地探测 + 远程最新版本查询。本地探测（`zsh -lic "{tool} --version"`）实测 ~0.6s 即返回，卡住的是后者 —— `fetch_npm_dist_tags`（`src-tauri/src/commands/misc.rs:949`）：

- 它复用全局 HTTP 客户端（`proxy/http_client.rs`：总超时 **600s** / 连接超时 30s），且**没有请求级超时**
- 而同类探测 `fetch_github_latest_version`（misc.rs:983）与 `fetch_hermes_latest_version`（misc.rs:1051）都已加 `.timeout(LATEST_PROBE_TIMEOUT)`（15s）；misc.rs:971-973 的注释也明确描述了这个"握手后挂起导致卡片一直等"的问题 —— npm 这条路径漏掉了

当 registry.npmjs.org 的连接停滞（典型场景：系统代理出现僵尸/半死连接，TCP 能建立但上游无响应）时，请求要等满全局 600s 总超时才放弃，期间卡片一直"加载中"。

## 修复

给 `fetch_npm_dist_tags` 补上与 GitHub / Hermes 路径一致的请求级超时（一行）：

```rust
let resp = client.get(&url).timeout(LATEST_PROBE_TIMEOUT).send().await.ok()?;
```

reqwest 的请求级 timeout 覆盖从建连到响应体读完的全程，与现有两处用法语义一致。超时后返回 `None`，卡片按"未知"处理并走既有降级逻辑，不再长时间转圈。

## 验证

- 本地探测 `zsh -lic "codex --version"` 实测 ~0.6s，排除本地探测挂起
- 本机无 Rust 工具链，未跑 `cargo check`；改动为同文件既有模式（`fetch_github_latest_version` / `fetch_hermes_latest_version`）的同款写法，交由 CI 验证
