### PR TITLE
fix(codex): allow switching away from stale managed OAuth bindings

### DIFF
--- a/src-tauri/src/proxy/providers/codex_oauth_auth.rs
+++ b/src-tauri/src/proxy/providers/codex_oauth_auth.rs
@@ -1155,14 +1155,18 @@ impl CodexOAuthManager {
         account_id: &str,
     ) -> Result<Option<String>, CodexOAuthError> {
         let _lifecycle = self.lifecycle_lock.read().await;
-        let refresh_lock = self.get_refresh_lock(account_id).await;
-        let _guard = refresh_lock.lock().await;
         {
             let accounts = self.accounts.read().await;
-            accounts
-                .get(account_id)
-                .ok_or_else(|| CodexOAuthError::AccountNotFound(account_id.to_string()))?;
+            if !accounts.contains_key(account_id) {
+                // Auth Center removal already cleared this account's live
+                // credentials. Provider bindings are intentionally retained so
+                // the same local account ID can recover after re-login, so a
+                // switch away from that stale binding is already complete.
+                return Ok(None);
+            }
         }
+        let refresh_lock = self.get_refresh_lock(account_id).await;
+        let _guard = refresh_lock.lock().await;
         let Some((live_refresh, live_id_token, live_last_refresh_ms)) = self
             .read_managed_live_auth_refresh_for_account(account_id)
             .await?

--- a/src-tauri/src/services/provider/mod.rs
+++ b/src-tauri/src/services/provider/mod.rs
@@ -3037,6 +3037,74 @@ wire_api = "responses"
 
     #[test]
     #[serial]
+    fn switch_away_from_removed_managed_codex_account_succeeds() {
+        with_test_home(|state, _| {
+            crate::settings::reload_settings().expect("reload settings");
+            tauri::async_runtime::block_on(async {
+                state
+                    .codex_oauth_manager
+                    .add_test_account_with_user_identity(
+                        "acct-managed",
+                        "managed-access",
+                        "managed-user",
+                    )
+                    .await
+                    .expect("seed managed account");
+            });
+
+            let managed = managed_codex_provider("managed-auth-center", "acct-managed");
+            let mut baseline = Provider::with_id(
+                "baseline".to_string(),
+                "Baseline".to_string(),
+                json!({
+                    "auth": { "OPENAI_API_KEY": "sk-baseline" },
+                    "config": "model_provider = \"baseline\"\n[model_providers.baseline]\nbase_url = \"https://baseline.example/v1\"\n"
+                }),
+                None,
+            );
+            baseline.category = Some("custom".to_string());
+
+            state
+                .db
+                .save_provider(AppType::Codex.as_str(), &managed)
+                .expect("save managed provider");
+            state
+                .db
+                .save_provider(AppType::Codex.as_str(), &baseline)
+                .expect("save baseline provider");
+
+            ProviderService::switch(state, AppType::Codex, &managed.id)
+                .expect("activate managed provider");
+            tauri::async_runtime::block_on(
+                crate::commands::remove_codex_oauth_account_with_switch_lock(state, "acct-managed"),
+            )
+            .expect("remove managed account");
+
+            assert_eq!(
+                state
+                    .db
+                    .get_provider_by_id(&managed.id, AppType::Codex.as_str())
+                    .expect("read managed provider")
+                    .and_then(|provider| provider.meta)
+                    .and_then(|meta| meta.managed_account_id_for("codex_oauth"))
+                    .as_deref(),
+                Some("acct-managed"),
+                "the binding remains available for same-account recovery"
+            );
+
+            ProviderService::switch(state, AppType::Codex, &baseline.id)
+                .expect("switch away from removed managed account");
+            assert_eq!(
+                crate::settings::get_effective_current_provider(&state.db, &AppType::Codex)
+                    .expect("read current")
+                    .as_deref(),
+                Some(baseline.id.as_str())
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
     fn codex_auth_center_removal_waits_for_provider_switch_lock() {
         with_test_home(|state, _| {
             crate::settings::reload_settings().expect("reload settings");

--- a/src/components/providers/ProviderActions.tsx
+++ b/src/components/providers/ProviderActions.tsx
@@ -34,6 +34,7 @@ interface OpenClawDefaultModelOption {
 interface ProviderActionsProps {
   appId?: AppId;
   isCurrent: boolean;
+  isManagedCodexAccountUnavailable?: boolean;
   isInConfig?: boolean;
   isTesting?: boolean;
   isProxyTakeover?: boolean;
@@ -76,6 +77,7 @@ interface MainButtonState {
 export function ProviderActions({
   appId,
   isCurrent,
+  isManagedCodexAccountUnavailable = false,
   isInConfig = false,
   isTesting,
   isProxyTakeover = false,
@@ -233,6 +235,19 @@ export function ProviderActions({
           "bg-gray-200 text-muted-foreground hover:bg-gray-200 hover:text-muted-foreground dark:bg-gray-700 dark:hover:bg-gray-700",
         icon: <Check className="h-4 w-4" />,
         text: t("provider.inUse"),
+      };
+    }
+
+    if (isManagedCodexAccountUnavailable) {
+      return {
+        disabled: true,
+        variant: "default" as const,
+        className: "",
+        icon: <Play className="h-4 w-4" />,
+        text: t("provider.enable"),
+        title: t("codex.boundAccountUnavailable", {
+          defaultValue: "绑定的账号不可用",
+        }),
       };
     }
 

--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -219,6 +219,10 @@ export function ProviderCard({
   const managedCodexAccount = codexAuthStatus?.accounts.find(
     (account) => account.id === managedCodexAccountId,
   );
+  const isManagedCodexAccountUnavailable =
+    codexOfficialIdentity === "managed_account" &&
+    isCodexAuthStatusSuccess &&
+    !managedCodexAccount;
   const manualNote = provider.notes?.trim() || undefined;
   const providerNameIncludesAccountLogin = Boolean(
     managedCodexAccount?.login &&
@@ -684,6 +688,9 @@ export function ProviderCard({
             <ProviderActions
               appId={appId}
               isCurrent={isCurrent}
+              isManagedCodexAccountUnavailable={
+                isManagedCodexAccountUnavailable
+              }
               isInConfig={isInConfig}
               isTesting={isTesting}
               isProxyTakeover={isProxyTakeover}

--- a/tests/components/ProviderActions.test.tsx
+++ b/tests/components/ProviderActions.test.tsx
@@ -148,3 +148,33 @@ describe("ProviderActions Pi provider switching", () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe("ProviderActions managed Codex account switching", () => {
+  it("blocks enabling a provider whose bound account is unavailable", async () => {
+    const user = userEvent.setup();
+    const onSwitch = vi.fn();
+
+    render(
+      <ProviderActions
+        appId="codex"
+        isCurrent={false}
+        isManagedCodexAccountUnavailable
+        onSwitch={onSwitch}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const enableButton = screen.getByRole("button", {
+      name: "provider.enable",
+    });
+    expect(enableButton).toBeDisabled();
+    expect(enableButton.parentElement).toHaveAttribute(
+      "title",
+      "绑定的账号不可用",
+    );
+
+    await user.click(enableButton);
+    expect(onSwitch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/ProviderCard.codexAccount.test.tsx
+++ b/tests/components/ProviderCard.codexAccount.test.tsx
@@ -11,10 +11,14 @@ const codexQuotaFooterProps = vi.hoisted(() => vi.fn());
 
 vi.mock("@/components/providers/ProviderActions", () => ({
   ProviderActions: (props: {
+    isManagedCodexAccountUnavailable?: boolean;
     onDuplicate?: () => void;
     onConfigureUsage?: () => void;
   }) => (
     <>
+      {props.isManagedCodexAccountUnavailable ? (
+        <span data-testid="managed-account-unavailable" />
+      ) : null}
       {props.onDuplicate ? (
         <button onClick={props.onDuplicate}>duplicate-provider</button>
       ) : null}
@@ -262,6 +266,22 @@ describe("ProviderCard Codex Official account identity", () => {
     expect(screen.getByText("codex-oauth-quota")).toBeInTheDocument();
   });
 
+  it("passes unavailable state for a missing bound account", () => {
+    const provider = managedProvider("Work account");
+    renderCard(provider, {
+      status: {
+        ...authStatus("other@example.com"),
+        accounts: [],
+      },
+    });
+
+    expect(screen.getByText("绑定的账号不可用")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("managed-account-unavailable"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "选择账号" })).toBeEnabled();
+  });
+
   it("shows a manual note instead of generated account guidance", () => {
     renderCard({
       id: "codex-official",
@@ -287,7 +307,7 @@ describe("ProviderCard Codex Official account identity", () => {
     };
     renderCard(provider, { isCurrent: true });
 
-expect(
+    expect(
       screen.getByText("账号会随 Codex CLI 当前登录变化"),
     ).toBeInTheDocument();
     expect(


### PR DESCRIPTION
# English

## Summary

When a managed Codex OAuth account is removed from the Auth Center, its provider binding is intentionally retained so the same local account ID can be restored after re-login.

Previously, switching away from a provider whose binding pointed to the removed account failed with `AccountNotFound` before the target provider could be preflighted.

This PR treats a missing outgoing managed account as an idempotent switch-away state while preserving target-account validation and the existing same-account recovery behavior.

It also disables the `Enable` action for a non-current managed Codex provider only when a successful Auth Center status response confirms that its bound account no longer exists.

## Changes

### Backend

- Treat a missing outgoing managed Codex account as already cleared.
- Preserve all other live-auth, refresh-token, and consistency errors.
- Keep target provider preflight behavior unchanged.
- Keep existing marker and managed-auth ownership checks unchanged.
- Preserve provider bindings after Auth Center account removal.

### UI

- Detect a confirmed missing managed Codex account from a successful Auth Center status response.
- Disable `Enable` for non-current providers with a confirmed unavailable binding.
- Preserve the existing unavailable-account warning and account selection/editing entry points.
- Do not classify loading, status-query errors, or an existing `reauth_required` account as missing.
- Reuse the existing `codex.boundAccountUnavailable` translation key.

### Tests

- Add a backend regression test for switching away after removing the active managed account.
- Add frontend coverage for the disabled action and ProviderCard-to-ProviderActions state propagation.
- Reuse existing test files; no new test files are introduced.

## Related Issue

Fixes #7309

## Screenshots

The original reproduction screenshot is included in #7309. The fix was also checked in the native Windows application with an isolated mock home; no real OAuth account or production database was used.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml services::provider::tests::switch -- --nocapture`
  - 4 passed, 0 failed
- `pnpm exec vitest run tests/components/ProviderActions.test.tsx tests/components/ProviderCard.codexAccount.test.tsx`
  - 18 passed, 0 failed
- `pnpm typecheck`
  - Passed
- `pnpm format:check`
  - Passed
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
  - Passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
  - Passed
- `git diff --check`
  - Passed
- Native Windows mock acceptance:
  - switching away from a stale current binding to a valid mock provider succeeded;
  - stale non-current providers displayed a disabled `Enable` action;
  - SQLite `PRAGMA quick_check` returned `ok`.

The full repository test suites and GitHub Actions CI are left for CI validation.

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm format:check` passes
- [x] `cargo clippy` passes
- [x] i18n requirement reviewed: no new user-facing text was added; the existing key is reused.

---

# 中文

## 概述

从认证中心删除托管 Codex OAuth 账号后，程序会有意保留 provider 的账号绑定，以便使用相同本地账号 ID 重新登录时恢复该绑定。

此前，当 provider 绑定的账号已经被删除时，从该 provider 切换离开会在目标 provider 预检之前返回 `AccountNotFound`，导致即使目标 provider 有效也无法完成切换。

本 PR 将“切换离开时旧托管账号已不存在”视为幂等状态，同时保留目标账号校验和同账号恢复行为。

此外，只有在认证中心状态查询成功，并明确确认绑定账号不存在时，才会禁用非当前托管 Codex provider 的“启用”操作。

## 修改内容

### 后端

- 将切换离开时不存在的旧托管 Codex 账号视为已经完成清理。
- 保留其他 live auth、refresh token 和一致性错误。
- 保持目标 provider 的预检逻辑不变。
- 保持现有 marker 和托管凭据所有权检查不变。
- 保留认证中心删除账号后的 provider binding。

### 界面

- 仅根据成功的认证中心状态查询识别明确不存在的托管 Codex 账号。
- 禁用绑定账号已确认失效的非当前 provider 的“启用”按钮。
- 保留现有“绑定的账号不可用”提示以及账号选择/编辑入口。
- 不会把加载中、状态查询失败或仍存在但需要重新验证的账号误判为不存在。
- 复用现有 `codex.boundAccountUnavailable` 翻译 key。

### 测试

- 增加删除当前托管账号后仍可切换离开的后端回归测试。
- 增加前端按钮禁用和 ProviderCard 到 ProviderActions 状态传递测试。
- 复用现有测试文件，不新增测试文件。

## 关联 Issue

Fixes #7309

## 截图

原始复现截图已保存在 #7309 中。本次修复也已通过隔离 mock home 在 Windows 原生应用中完成验证，未使用真实 OAuth 账号或生产数据库。

## 验证

- Rust 聚焦测试：4 项通过，0 项失败
- React 聚焦测试：18 项通过，0 项失败
- `pnpm typecheck`：通过
- `pnpm format:check`：通过
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`：通过
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`：通过
- `git diff --check`：通过
- Windows 原生 mock 验收：
  - 可以从绑定已失效的当前 provider 切换到有效 mock provider；
  - 失效的非当前 provider 显示 disabled 的“启用”按钮；
  - SQLite `PRAGMA quick_check` 返回 `ok`。

完整仓库测试套件和 GitHub Actions CI 将由 CI 继续验证。

## 检查清单

- [x] `pnpm typecheck` 通过
- [x] `pnpm format:check` 通过
- [x] `cargo clippy` 通过
- [x] 已核对国际化要求：没有新增用户可见文案，复用了现有翻译 key。
