### PR TITLE
fix(proxy): keep reasoning effort for grok-4.6 and pass xhigh through verbatim

### DIFF
--- a/src-tauri/src/proxy/providers/transform.rs
+++ b/src-tauri/src/proxy/providers/transform.rs
@@ -66,8 +66,8 @@ pub fn is_openai_o_series(model: &str) -> bool {
 /// Supported families:
 /// - o-series: o1, o3, o4-mini, etc.
 /// - GPT-5+: gpt-5, gpt-5.1, gpt-5.4, gpt-5-codex, etc.
-/// - xAI Grok Build models. `grok-4.5` is the current documented Grok Build
-///   model; retain the previous `grok-build-*` family for saved providers.
+/// - xAI Grok Build models. `grok-4.5`/`grok-4.6` are the documented Grok
+///   Build models; retain the previous `grok-build-*` family for saved providers.
 pub fn supports_reasoning_effort(model: &str) -> bool {
     let normalized = model.to_lowercase();
     is_openai_o_series(&normalized)
@@ -77,6 +77,8 @@ pub fn supports_reasoning_effort(model: &str) -> bool {
             .is_some_and(|c| c.is_ascii_digit() && c >= '5')
         || normalized == "grok-4.5"
         || normalized.starts_with("grok-4.5-")
+        || normalized == "grok-4.6"
+        || normalized.starts_with("grok-4.6-")
         || normalized.starts_with("grok-build-")
 }
 
@@ -84,7 +86,8 @@ pub fn supports_reasoning_effort(model: &str) -> bool {
 ///
 /// Priority:
 /// 1. Explicit `output_config.effort` — preserves the user's intent directly.
-///    `low`/`medium`/`high` map 1:1; `max` maps to `xhigh`
+///    `low`/`medium`/`high`/`xhigh` map 1:1 (`xhigh` is what Claude Code's
+///    `/effort xhigh` sends); `max` maps to `xhigh`
 ///    (supported by mainstream GPT models). Unknown values are ignored.
 /// 2. Fallback: `thinking.type` + `budget_tokens`:
 ///    - `adaptive` → `xhigh` (adaptive = maximum reasoning effort)
@@ -101,6 +104,7 @@ pub fn resolve_reasoning_effort(body: &Value) -> Option<&'static str> {
             "low" => Some("low"),
             "medium" => Some("medium"),
             "high" => Some("high"),
+            "xhigh" => Some("xhigh"),
             "max" => Some("xhigh"), // OpenAI xhigh = maximum reasoning effort
             _ => None,              // unknown value — do not inject
         };
@@ -1736,9 +1740,12 @@ mod tests {
         assert!(supports_reasoning_effort("gpt-5.4"));
         assert!(supports_reasoning_effort("gpt-5-codex"));
         assert!(supports_reasoning_effort("grok-4.5"));
+        assert!(supports_reasoning_effort("grok-4.6"));
+        assert!(supports_reasoning_effort("grok-4.6-build"));
         assert!(supports_reasoning_effort("grok-build-0.1"));
         assert!(!supports_reasoning_effort("gpt-4o"));
         assert!(!supports_reasoning_effort("claude-sonnet-4-6"));
+        assert!(!supports_reasoning_effort("grok-4"));
     }
 
     // ── resolve_reasoning_effort unit tests ──
@@ -1764,6 +1771,13 @@ mod tests {
     #[test]
     fn test_output_config_max_maps_to_reasoning_effort_xhigh() {
         let body = json!({"output_config": {"effort": "max"}});
+        assert_eq!(resolve_reasoning_effort(&body), Some("xhigh"));
+    }
+
+    #[test]
+    fn test_output_config_xhigh_maps_verbatim() {
+        // Claude Code's `/effort xhigh` sends output_config.effort="xhigh"
+        let body = json!({"output_config": {"effort": "xhigh"}});
         assert_eq!(resolve_reasoning_effort(&body), Some("xhigh"));
     }
 

--- a/src-tauri/src/proxy/providers/transform_responses.rs
+++ b/src-tauri/src/proxy/providers/transform_responses.rs
@@ -4837,6 +4837,36 @@ mod tests {
     }
 
     #[test]
+    fn test_responses_output_config_xhigh_sets_reasoning_xhigh() {
+        // Claude Code's `/effort xhigh` sends output_config.effort="xhigh";
+        // previously it fell into the unknown-value branch and was dropped.
+        let input = json!({
+            "model": "gpt-5.4",
+            "max_tokens": 1024,
+            "output_config": {"effort": "xhigh"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+    }
+
+    #[test]
+    fn test_responses_grok_4_6_reasoning_effort_not_dropped() {
+        // After model mapping, the Responses gate runs on the mapped name;
+        // grok-4.6 / grok-4.6-* were missing from the whitelist (#7314).
+        let input = json!({
+            "model": "grok-4.6-build",
+            "max_tokens": 1024,
+            "output_config": {"effort": "xhigh"},
+            "messages": [{"role": "user", "content": "Hello"}]
+        });
+
+        let result = anthropic_to_responses(input, None, false, false).unwrap();
+        assert_eq!(result["reasoning"]["effort"], "xhigh");
+    }
+
+    #[test]
     fn test_responses_output_config_takes_priority_over_thinking() {
         let input = json!({
             "model": "gpt-5.4",


### PR DESCRIPTION
## Summary / 概述

Anthropic→Responses 转换会把 Claude Code `/effort xhigh` 的推理强度整段丢掉；claude 系模型映射到 grok-4.6 时同样丢——出站请求体没有 `reasoning` 字段，上游按默认档跑。两处独立原因都在 `transform.rs`：

- `supports_reasoning_effort` 白名单只认 `grok-4.5` / `grok-build-*`，映射后的 `grok-4.6` / `grok-4.6-build` 不在其中，`anthropic_to_responses` 直接跳过 reasoning 注入（发 max 也一样丢）。
- `resolve_reasoning_effort` 的显式档位只认 low/medium/high/max；`/effort xhigh` 发的是 `output_config.effort="xhigh"`，落进未知值分支返回 None（`output_config.effort` 存在时不会再走 thinking 兜底）。

修法：白名单按 grok-4.5 的既有形状补 `grok-4.6` 精确名与 `grok-4.6-*` 前缀；`xhigh` 原样映射。此前已生效的 low/medium/high/max 出站字节不变。

## Related Issue / 关联 Issue

Fixes #7314

## Verification / 验证

- 新增回归测试：`test_output_config_xhigh_maps_verbatim`、`test_responses_output_config_xhigh_sets_reasoning_xhigh`、`test_responses_grok_4_6_reasoning_effort_not_dropped`；`test_supports_reasoning_effort` 补 grok-4.6 / grok-4.6-build / grok-4（负例）断言。还原修复后新测试红、恢复后绿。
- `cargo test --lib`：2854 passed / 0 failed。
- `cargo fmt --check`、`git diff --check` 通过；`cargo clippy --lib --all-targets` 对本次改动无告警（`transform_codex_chat.rs:4328` 有一处 main 上已有的 op_ref 告警，本 PR 未触碰该文件）。

## Checklist / 检查清单

- [ ] `pnpm typecheck`（无前端改动，未运行）
- [ ] `pnpm format:check`（无前端改动，未运行）
- [x] `cargo clippy` passes
- [x] 无用户界面文案变更
