### PR TITLE
fix(ui): prevent descender glyph clipping in truncated card titles

### DIFF
--- a/src/components/providers/ProviderCard.tsx
+++ b/src/components/providers/ProviderCard.tsx
@@ -426,7 +426,7 @@ export function ProviderCard({
             <div className="flex flex-wrap items-center gap-2 min-h-7">
               <h3
                 className={cn(
-                  "text-base font-semibold leading-none",
+                  "text-base font-semibold leading-tight",
                   codexOfficialIdentity && "min-w-0 flex-1 truncate",
                 )}
                 title={codexOfficialIdentity ? provider.name : undefined}

--- a/src/components/skills/SkillCard.tsx
+++ b/src/components/skills/SkillCard.tsx
@@ -70,7 +70,7 @@ export function SkillCard({
       <CardHeader className="pb-3">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
-            <CardTitle className="text-base font-semibold truncate">
+            <CardTitle className="text-base font-semibold leading-tight truncate">
               {skill.name}
             </CardTitle>
             <div className="flex items-center gap-2 mt-1.5">


### PR DESCRIPTION
## English

### Summary

This PR fixes vertical clipping of descender glyphs in truncated card titles.

The issue was first observed in Codex provider cards, but the underlying cause is a shared UI styling pattern: a compact line height combined with Tailwind's `truncate` utility, which applies `overflow: hidden`.

This change:
- Keeps single-line titles and horizontal ellipsis behavior.
- Prevents descender letters such as `y`, `g`, `q`, and `p` from being vertically clipped.
- Applies the fix to the confirmed ProviderCard and SkillCard title paths.
- Does not change provider data, account data, quota logic, authentication, or backend behavior.

### Related Issue

Fixes #7315

### Scope

The implementation is intentionally limited to the two confirmed card-title paths:
- `src/components/providers/ProviderCard.tsx`
- `src/components/skills/SkillCard.tsx`

The shared `CardTitle` component is not modified, and other `truncate` usages are not migrated in this PR because they do not currently have confirmed clipping evidence.

### Implementation Details

- Updated the `ProviderCard` title from `leading-none` to `leading-tight`.
- Added `leading-tight` to the `SkillCard` title while preserving `truncate`.
- Preserved the existing `min-w-0`, `flex-1`, title attributes, card structure, and horizontal truncation behavior.
- No public API, type, backend, database, authentication, or i18n changes were made.
- No test mock data was added or modified.

### Validation

The following checks passed:
- `pnpm.cmd exec vitest run tests/components/ProviderCard.codexAccount.test.tsx tests/components/ProviderCardLayout.test.ts` — 13 tests passed.
- `pnpm.cmd typecheck`
- `pnpm.cmd format:check`
- `pnpm.cmd build:renderer`
- Targeted Prettier checks for the changed source files
- `git diff --check`

The renderer build only reported existing warnings about outdated Browserslist data, a dynamic/static import combination, and large chunks.

Manual visual acceptance was performed with the synthetic title:

`OpenAI Official (xxyyzzggqqpp)`

The descender strokes are visibly complete after the change.

The full Rust test suite and Rust Clippy were not run because this PR only changes frontend TypeScript/TSX styling.

### Screenshots

Before and after screenshots are attached below.

The first image represents the original rendering, and the second image represents the corrected rendering.

---

## 中文

### 概述

本 PR 修复了卡片标题在使用文本截断时，部分下伸字母被垂直裁剪的问题。

最初是在 Codex 供应商卡片中发现的，但根本原因属于通用 UI 样式组合：较紧凑的行高与 Tailwind 的 `truncate` 同时使用，而 `truncate` 会设置 `overflow: hidden`。

本次修改：
- 保留单行标题和水平省略号行为。
- 避免 `y`、`g`、`q`、`p` 等下伸字母的下半部分被垂直裁剪。
- 修复已经确认存在问题的 ProviderCard 和 SkillCard 标题路径。
- 不改变供应商数据、账号数据、额度逻辑、认证流程或后端行为。

### 关联 Issue

Fixes #7315

### 修改范围

本次实现只覆盖已经确认存在问题的两个卡片标题路径：
- `src/components/providers/ProviderCard.tsx`
- `src/components/skills/SkillCard.tsx`

本 PR 不修改共享的 `CardTitle` 组件，也不批量迁移其他 `truncate` 使用点，因为目前没有证据证明它们都存在相同的字形裁剪问题。

### 实现细节

- 将 `ProviderCard` 标题的 `leading-none` 调整为 `leading-tight`。
- 在 `SkillCard` 标题上增加 `leading-tight`，同时保留 `truncate`。
- 保留原有的 `min-w-0`、`flex-1`、title 属性、卡片结构和水平截断行为。
- 没有修改公共 API、类型、后端、数据库、认证逻辑或国际化文件。
- 没有新增或修改测试 mock 数据。

### 验证结果

以下检查已通过：
- `pnpm.cmd exec vitest run tests/components/ProviderCard.codexAccount.test.tsx tests/components/ProviderCardLayout.test.ts` — 13 个测试通过。
- `pnpm.cmd typecheck`
- `pnpm.cmd format:check`
- `pnpm.cmd build:renderer`
- 修改源码文件的定向 Prettier 检查
- `git diff --check`

Renderer 构建只报告了已有警告，包括 Browserslist 数据较旧、动态/静态导入组合以及 bundle 较大的提示。

本次使用以下合成标题进行了人工视觉验收：

`OpenAI Official (xxyyzzggqqpp)`

修改后，下伸字母的下半部分已经能够完整显示。

由于本 PR 只修改前端 TypeScript/TSX 样式，因此没有运行完整 Rust 测试和 Rust Clippy。

### 截图

下面将附上修改前和修改后的截图。

第一张上传图片代表修改前的显示效果，第二张上传图片代表修改后的显示效果。
<img width="521" height="70" alt="屏幕截图 2026-09-11 230631" src="https://github.com/user-attachments/assets/672b31ec-a602-499f-b9ee-3f0613f06f07" />
<img width="549" height="68" alt="屏幕截图 2026-09-12 021124" src="https://github.com/user-attachments/assets/cb659819-d274-49ef-868d-9755515a11be" />

