### PR TITLE
fix(sessions): preserve text selection while scrolling

### DIFF
--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSessionSearch } from "@/hooks/useSessionSearch";
+import { useMessageSelectionRange } from "@/hooks/useMessageSelectionRange";
 import { useTranslation } from "react-i18next";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { toast } from "sonner";
@@ -341,11 +342,16 @@ export function SessionManagerPage({ appId }: { appId: string }) {
   const deleteSessionMutation = useDeleteSessionMutation();
   const isDeleting = deleteSessionMutation.isPending || isBatchDeleting;
 
+  const rangeExtractor = useMessageSelectionRange(
+    scrollContainerRef,
+    selectedKey,
+  );
   const virtualizer = useVirtualizer({
     count: messages.length,
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: () => 120,
     overscan: 5,
+    rangeExtractor,
     gap: 12,
   });
 

--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -352,7 +352,6 @@ export function SessionManagerPage({ appId }: { appId: string }) {
     estimateSize: () => 120,
     overscan: 5,
     rangeExtractor,
-    gap: 12,
   });
 
   useEffect(() => {
@@ -1720,6 +1719,10 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                                       top: 0,
                                       left: 0,
                                       width: "100%",
+                                      paddingBottom:
+                                        virtualRow.index === messages.length - 1
+                                          ? 0
+                                          : 12,
                                       transform: `translateY(${virtualRow.start}px)`,
                                     }}
                                   >

--- a/src/hooks/useMessageSelectionRange.ts
+++ b/src/hooks/useMessageSelectionRange.ts
@@ -34,7 +34,6 @@ export function useMessageSelectionRange(
       const anchor = getMessage(selection.anchorNode);
       const focus = getMessage(selection.focusNode);
       if (!anchor || !focus) {
-        setSelectedRange(null);
         return;
       }
       const start = Math.min(

--- a/src/hooks/useMessageSelectionRange.ts
+++ b/src/hooks/useMessageSelectionRange.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState, type RefObject } from "react";
+import { defaultRangeExtractor, type Range } from "@tanstack/react-virtual";
+
+// Keep native Selection endpoints and the intervening messages mounted while scrolling.
+export function useMessageSelectionRange(
+  containerRef: RefObject<HTMLDivElement>,
+  sessionKey: string | null,
+) {
+  const [selectedRange, setSelectedRange] = useState<{
+    start: number;
+    end: number;
+  } | null>(null);
+
+  useEffect(() => {
+    setSelectedRange(null);
+    const updateSelection = () => {
+      const selection = document.getSelection();
+      const container = containerRef.current;
+      if (
+        !container ||
+        !selection ||
+        selection.isCollapsed ||
+        !container.contains(selection.anchorNode) ||
+        !container.contains(selection.focusNode)
+      ) {
+        setSelectedRange(null);
+        return;
+      }
+      const getMessage = (node: Node | null) =>
+        (node instanceof Element
+          ? node
+          : node?.parentElement
+        )?.closest<HTMLElement>("[data-index]");
+      const anchor = getMessage(selection.anchorNode);
+      const focus = getMessage(selection.focusNode);
+      if (!anchor || !focus) {
+        setSelectedRange(null);
+        return;
+      }
+      const start = Math.min(
+        Number(anchor.dataset.index),
+        Number(focus.dataset.index),
+      );
+      const end = Math.max(
+        Number(anchor.dataset.index),
+        Number(focus.dataset.index),
+      );
+      setSelectedRange((previous) =>
+        previous?.start === start && previous.end === end
+          ? previous
+          : { start, end },
+      );
+    };
+    document.addEventListener("selectionchange", updateSelection);
+    return () =>
+      document.removeEventListener("selectionchange", updateSelection);
+  }, [containerRef, sessionKey]);
+
+  return useCallback(
+    (range: Range) => {
+      const visible = defaultRangeExtractor(range);
+      if (!selectedRange || visible.length === 0) return visible;
+      const start = Math.min(visible[0], selectedRange.start);
+      const end = Math.min(
+        range.count - 1,
+        Math.max(visible[visible.length - 1], selectedRange.end),
+      );
+      return Array.from(
+        { length: end - start + 1 },
+        (_, index) => start + index,
+      );
+    },
+    [selectedRange],
+  );
+}

--- a/tests/hooks/useMessageSelectionRange.test.tsx
+++ b/tests/hooks/useMessageSelectionRange.test.tsx
@@ -36,6 +36,15 @@ it("keeps a reverse selection and the intervening rows mounted, then releases th
     Array.from({ length: 22 }, (_, i) => i + 2),
   );
   act(() => {
+    document
+      .getSelection()!
+      .setBaseAndExtent(container.lastChild!.firstChild!, 1, container, 1);
+    document.dispatchEvent(new Event("selectionchange"));
+  });
+  expect(result.current(range)).toEqual(
+    Array.from({ length: 22 }, (_, i) => i + 2),
+  );
+  act(() => {
     document.getSelection()!.removeAllRanges();
     document.dispatchEvent(new Event("selectionchange"));
   });

--- a/tests/hooks/useMessageSelectionRange.test.tsx
+++ b/tests/hooks/useMessageSelectionRange.test.tsx
@@ -1,0 +1,51 @@
+import { createRef } from "react";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+import { useMessageSelectionRange } from "@/hooks/useMessageSelectionRange";
+
+afterEach(() => {
+  document.getSelection()!.removeAllRanges();
+  document.querySelector("#messages")?.remove();
+});
+
+it("keeps a reverse selection and the intervening rows mounted, then releases them", () => {
+  const container = document.createElement("div");
+  container.id = "messages";
+  container.innerHTML =
+    '<div data-index="2">second</div><div data-index="4">fourth</div>';
+  document.body.append(container);
+  const ref = createRef<HTMLDivElement>();
+  Object.assign(ref, { current: container });
+  const { result, rerender } = renderHook(
+    ({ session }) => useMessageSelectionRange(ref, session),
+    { initialProps: { session: "first" } },
+  );
+  const range = { startIndex: 20, endIndex: 22, overscan: 1, count: 100 };
+  expect(result.current(range)).toEqual([19, 20, 21, 22, 23]);
+  act(() => {
+    const selection = document.getSelection()!;
+    selection.setBaseAndExtent(
+      container.lastChild!,
+      1,
+      container.firstChild!.firstChild!,
+      0,
+    );
+    document.dispatchEvent(new Event("selectionchange"));
+  });
+  expect(result.current(range)).toEqual(
+    Array.from({ length: 22 }, (_, i) => i + 2),
+  );
+  act(() => {
+    document.getSelection()!.removeAllRanges();
+    document.dispatchEvent(new Event("selectionchange"));
+  });
+  expect(result.current(range)).toEqual([19, 20, 21, 22, 23]);
+  act(() => {
+    document
+      .getSelection()!
+      .setBaseAndExtent(container.firstChild!, 0, container.lastChild!, 1);
+    document.dispatchEvent(new Event("selectionchange"));
+  });
+  rerender({ session: "second" });
+  expect(result.current(range)).toEqual([19, 20, 21, 22, 23]);
+});


### PR DESCRIPTION
## Summary / 概述

Selecting text across session messages and scrolling could make the selection shrink or disappear. The virtualized list unmounted the selected DOM nodes once they moved outside the rendered range.

This keeps the selected messages and the range between them and the viewport mounted while a native text selection exists. Clearing the selection restores the normal virtualized range.

修复会话正文滚动时选中文字逐渐减少或消失的问题。保留选区覆盖的消息及其与可视区域之间的消息，清除选区后恢复正常虚拟化。

Closes #7325

## Tests

- `pnpm typecheck`
- 16 focused tests passed, including reverse selection, element-node endpoints, clearing the selection and switching sessions.
- Chromium verification with 432 fixture messages: selection remained unchanged after scrolling 7,800 pixels; mounted rows returned from 52 to 15 after clearing it.

Selecting across a large range keeps more messages mounted for the lifetime of that selection.
