### PR TITLE
feat(sessions): select and copy multiple messages

### DIFF
--- a/src/components/sessions/SessionManagerPage.tsx
+++ b/src/components/sessions/SessionManagerPage.tsx
@@ -69,6 +69,7 @@ import {
   getBaseName,
   getProviderIconName,
   getProviderLabel,
+  getRoleLabel,
   getSessionDirectoryGroupKey,
   getSessionKey,
   groupSessionsByProviderAndDirectory,
@@ -222,6 +223,10 @@ export function SessionManagerPage({ appId }: { appId: string }) {
     appId as ProviderFilter,
   );
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [messageSelectionMode, setMessageSelectionMode] = useState(false);
+  const [selectedMessages, setSelectedMessages] = useState<Set<number>>(
+    new Set(),
+  );
   const [listViewMode, setListViewMode] = useState<SessionListViewMode>(
     readInitialSessionListViewMode,
   );
@@ -350,6 +355,8 @@ export function SessionManagerPage({ appId }: { appId: string }) {
   });
 
   useEffect(() => {
+    setSelectedMessages(new Set());
+    setMessageSelectionMode(false);
     if (scrollContainerRef.current) {
       scrollContainerRef.current.scrollTop = 0;
     }
@@ -427,6 +434,25 @@ export function SessionManagerPage({ appId }: { appId: string }) {
     },
     [handleCopy, t],
   );
+
+  const selectMessageRange = (start: number, end: number, checked: boolean) => {
+    setSelectedMessages((previous) => {
+      const next = new Set(previous);
+      for (let index = start; index < end; index++) {
+        if (checked) next.add(index);
+        else next.delete(index);
+      }
+      return next;
+    });
+  };
+
+  const copySelectedMessages = () => {
+    const text = messages
+      .filter((_, index) => selectedMessages.has(index))
+      .map((message) => `${getRoleLabel(message.role, t)}\n${message.content}`)
+      .join("\n\n");
+    void handleCopy(text, t("sessionManager.messageCopied"));
+  };
 
   const handleResume = async () => {
     if (!selectedSession?.resumeCommand) return;
@@ -1668,7 +1694,7 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                       {/* 消息列表 */}
                       <div className="flex-1 min-w-0 flex flex-col">
                         <div className="px-4 pt-4 pb-2 min-w-0">
-                          <div className="flex items-center gap-2">
+                          <div className="flex items-center gap-2 flex-wrap">
                             <MessageSquare className="size-4 text-muted-foreground" />
                             <span className="text-sm font-medium">
                               {t("sessionManager.conversationHistory", {
@@ -1678,6 +1704,54 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                             <Badge variant="secondary" className="text-xs">
                               {messages.length}
                             </Badge>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="ml-auto h-7"
+                              onClick={() => {
+                                setMessageSelectionMode(!messageSelectionMode);
+                                setSelectedMessages(new Set());
+                              }}
+                            >
+                              {t(
+                                messageSelectionMode
+                                  ? "common.cancel"
+                                  : "sessionManager.selectMessages",
+                              )}
+                            </Button>
+                            {messageSelectionMode && (
+                              <>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-7"
+                                  onClick={() =>
+                                    selectMessageRange(
+                                      0,
+                                      messages.length,
+                                      selectedMessages.size !== messages.length,
+                                    )
+                                  }
+                                >
+                                  {t(
+                                    selectedMessages.size === messages.length
+                                      ? "sessionManager.clearMessageSelection"
+                                      : "sessionManager.selectAllMessages",
+                                  )}
+                                </Button>
+                                <Button
+                                  size="sm"
+                                  className="h-7"
+                                  disabled={selectedMessages.size === 0}
+                                  onClick={copySelectedMessages}
+                                >
+                                  <Copy className="size-3.5 mr-1" />
+                                  {t("sessionManager.copySelectedMessages", {
+                                    count: selectedMessages.size,
+                                  })}
+                                </Button>
+                              </>
+                            )}
                           </div>
                         </div>
                         <div
@@ -1724,6 +1798,27 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                                       }
                                       searchQuery={search}
                                       onCopy={handleMessageCopy}
+                                      selection={
+                                        messageSelectionMode
+                                          ? {
+                                              checked: selectedMessages.has(
+                                                virtualRow.index,
+                                              ),
+                                              label: t(
+                                                "sessionManager.selectMessage",
+                                                {
+                                                  number: virtualRow.index + 1,
+                                                },
+                                              ),
+                                              onChange: (checked) =>
+                                                selectMessageRange(
+                                                  virtualRow.index,
+                                                  virtualRow.index + 1,
+                                                  checked,
+                                                ),
+                                            }
+                                          : undefined
+                                      }
                                     />
                                   </div>
                                 ))}
@@ -1735,6 +1830,15 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                       {/* 右侧目录 - 类似少数派 (大屏幕) */}
                       <SessionTocSidebar
                         items={userMessagesToc}
+                        selection={
+                          messageSelectionMode
+                            ? {
+                                selected: selectedMessages,
+                                messageCount: messages.length,
+                                onChange: selectMessageRange,
+                              }
+                            : undefined
+                        }
                         onItemClick={scrollToMessage}
                       />
                     </div>
@@ -1742,6 +1846,15 @@ export function SessionManagerPage({ appId }: { appId: string }) {
                     {/* 浮动目录按钮 (小屏幕) */}
                     <SessionTocDialog
                       items={userMessagesToc}
+                      selection={
+                        messageSelectionMode
+                          ? {
+                              selected: selectedMessages,
+                              messageCount: messages.length,
+                              onChange: selectMessageRange,
+                            }
+                          : undefined
+                      }
                       onItemClick={scrollToMessage}
                       open={tocDialogOpen}
                       onOpenChange={setTocDialogOpen}

--- a/src/components/sessions/SessionMessageItem.tsx
+++ b/src/components/sessions/SessionMessageItem.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronUp, Copy } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Tooltip,
   TooltipContent,
@@ -25,6 +26,11 @@ interface SessionMessageItemProps {
   isActive: boolean;
   searchQuery?: string;
   onCopy: (content: string) => void;
+  selection?: {
+    checked: boolean;
+    label: string;
+    onChange: (checked: boolean) => void;
+  };
 }
 
 export const SessionMessageItem = memo(function SessionMessageItem({
@@ -32,6 +38,7 @@ export const SessionMessageItem = memo(function SessionMessageItem({
   isActive,
   searchQuery,
   onCopy,
+  selection,
 }: SessionMessageItemProps) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
@@ -76,12 +83,19 @@ export const SessionMessageItem = memo(function SessionMessageItem({
           })}
         </TooltipContent>
       </Tooltip>
-      <div className="flex items-center justify-between text-xs mb-1.5 pr-6">
+      <div className="flex items-center gap-2 text-xs mb-1.5 pr-6">
+        {selection && (
+          <Checkbox
+            checked={selection.checked}
+            aria-label={selection.label}
+            onCheckedChange={selection.onChange}
+          />
+        )}
         <span className={cn("font-semibold", getRoleTone(message.role))}>
           {getRoleLabel(message.role, t)}
         </span>
         {message.ts && (
-          <span className="text-muted-foreground">
+          <span className="text-muted-foreground ml-auto">
             {formatTimestamp(message.ts)}
           </span>
         )}

--- a/src/components/sessions/SessionToc.tsx
+++ b/src/components/sessions/SessionToc.tsx
@@ -2,6 +2,7 @@ import { List, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Dialog,
@@ -21,14 +22,52 @@ interface TocItem {
 interface SessionTocSidebarProps {
   items: TocItem[];
   onItemClick: (index: number) => void;
+  selection?: {
+    selected: Set<number>;
+    messageCount: number;
+    onChange: (start: number, end: number, checked: boolean) => void;
+  };
+}
+
+function TurnCheckbox({
+  start,
+  end,
+  number,
+  selection,
+}: {
+  start: number;
+  end: number;
+  number: number;
+  selection: NonNullable<SessionTocSidebarProps["selection"]>;
+}) {
+  const { t } = useTranslation();
+  let selectedCount = 0;
+  for (let index = start; index < end; index++) {
+    if (selection.selected.has(index)) selectedCount++;
+  }
+  return (
+    <Checkbox
+      className="shrink-0 mt-2"
+      aria-label={t("sessionManager.selectTurn", { number })}
+      checked={
+        selectedCount === end - start
+          ? true
+          : selectedCount > 0
+            ? "indeterminate"
+            : false
+      }
+      onCheckedChange={(checked) => selection.onChange(start, end, checked)}
+    />
+  );
 }
 
 export function SessionTocSidebar({
   items,
   onItemClick,
+  selection,
 }: SessionTocSidebarProps) {
   const { t } = useTranslation();
-  if (items.length <= 2) return null;
+  if (items.length === 0 || (!selection && items.length <= 2)) return null;
 
   return (
     <div className="w-64 border-l shrink-0 hidden xl:block">
@@ -41,21 +80,32 @@ export function SessionTocSidebar({
       <ScrollArea className="h-[calc(100%-40px)]">
         <div className="p-2 space-y-0.5">
           {items.map((item, tocIndex) => (
-            <button
-              key={item.index}
-              type="button"
-              onClick={() => onItemClick(item.index)}
-              className={cn(
-                "w-full text-left px-2 py-1.5 rounded text-xs transition-colors",
-                "hover:bg-muted/80 text-muted-foreground hover:text-foreground",
-                "flex items-start gap-2",
+            <div key={item.index} className="flex items-start gap-1">
+              {selection && (
+                <TurnCheckbox
+                  start={item.index}
+                  end={items[tocIndex + 1]?.index ?? selection.messageCount}
+                  number={tocIndex + 1}
+                  selection={selection}
+                />
               )}
-            >
-              <span className="shrink-0 w-4 h-4 rounded-full bg-primary/10 text-primary text-[10px] flex items-center justify-center font-medium">
-                {tocIndex + 1}
-              </span>
-              <span className="line-clamp-2 leading-snug">{item.preview}</span>
-            </button>
+              <button
+                type="button"
+                onClick={() => onItemClick(item.index)}
+                className={cn(
+                  "w-full text-left px-2 py-1.5 rounded text-xs transition-colors",
+                  "hover:bg-muted/80 text-muted-foreground hover:text-foreground",
+                  "flex items-start gap-2",
+                )}
+              >
+                <span className="shrink-0 w-4 h-4 rounded-full bg-primary/10 text-primary text-[10px] flex items-center justify-center font-medium">
+                  {tocIndex + 1}
+                </span>
+                <span className="line-clamp-2 leading-snug">
+                  {item.preview}
+                </span>
+              </button>
+            </div>
           ))}
         </div>
       </ScrollArea>
@@ -63,9 +113,7 @@ export function SessionTocSidebar({
   );
 }
 
-interface SessionTocDialogProps {
-  items: TocItem[];
-  onItemClick: (index: number) => void;
+interface SessionTocDialogProps extends SessionTocSidebarProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
@@ -75,9 +123,10 @@ export function SessionTocDialog({
   onItemClick,
   open,
   onOpenChange,
+  selection,
 }: SessionTocDialogProps) {
   const { t } = useTranslation();
-  if (items.length <= 2) return null;
+  if (items.length === 0 || (!selection && items.length <= 2)) return null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -85,6 +134,7 @@ export function SessionTocDialog({
         <Button
           size="icon"
           className="fixed bottom-20 right-4 xl:hidden size-10 rounded-full shadow-lg z-30"
+          aria-label={t("sessionManager.tocTitle")}
         >
           <List className="size-4" />
         </Button>
@@ -110,24 +160,33 @@ export function SessionTocDialog({
         <div className="overflow-y-auto max-h-[calc(70vh-80px)]">
           <div className="p-3 pb-4 space-y-1">
             {items.map((item, tocIndex) => (
-              <button
-                key={item.index}
-                type="button"
-                onClick={() => onItemClick(item.index)}
-                className={cn(
-                  "w-full text-left px-3 py-2.5 rounded-lg text-sm transition-all",
-                  "hover:bg-primary/10 text-foreground",
-                  "flex items-start gap-3",
-                  "focus:outline-none focus:ring-2 focus:ring-primary focus:ring-inset",
+              <div key={item.index} className="flex items-start gap-1">
+                {selection && (
+                  <TurnCheckbox
+                    start={item.index}
+                    end={items[tocIndex + 1]?.index ?? selection.messageCount}
+                    number={tocIndex + 1}
+                    selection={selection}
+                  />
                 )}
-              >
-                <span className="shrink-0 w-6 h-6 rounded-full bg-primary text-primary-foreground text-xs flex items-center justify-center font-semibold">
-                  {tocIndex + 1}
-                </span>
-                <span className="line-clamp-2 leading-relaxed pt-0.5">
-                  {item.preview}
-                </span>
-              </button>
+                <button
+                  type="button"
+                  onClick={() => onItemClick(item.index)}
+                  className={cn(
+                    "w-full text-left px-3 py-2.5 rounded-lg text-sm transition-all",
+                    "hover:bg-primary/10 text-foreground",
+                    "flex items-start gap-3",
+                    "focus:outline-none focus:ring-2 focus:ring-primary focus:ring-inset",
+                  )}
+                >
+                  <span className="shrink-0 w-6 h-6 rounded-full bg-primary text-primary-foreground text-xs flex items-center justify-center font-semibold">
+                    {tocIndex + 1}
+                  </span>
+                  <span className="line-clamp-2 leading-relaxed pt-0.5">
+                    {item.preview}
+                  </span>
+                </button>
+              </div>
             ))}
           </div>
         </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1074,6 +1074,12 @@
     "maxOutputTokensHint": "The default 8192 ceiling can truncate long or thinking-heavy responses (stop_reason=max_tokens). This value overrides the request's max_tokens on the Anthropic path. Do not exceed the real output ceiling of the model/gateway or it may 400. Leave empty to use the default 8192."
   },
   "sessionManager": {
+    "selectMessages": "Select messages",
+    "selectAllMessages": "Select all",
+    "clearMessageSelection": "Clear selection",
+    "copySelectedMessages": "Copy ({{count}})",
+    "selectMessage": "Select message {{number}}",
+    "selectTurn": "Select turn {{number}}",
     "title": "Session Manager",
     "subtitle": "Manage Claude Code, Codex, Gemini CLI, Grok Build, OpenCode, OpenClaw, Hermes, and Pi sessions",
     "searchPlaceholder": "Search by content, directory, or ID",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1074,6 +1074,12 @@
     "maxOutputTokensHint": "デフォルト上限 8192 では長い回答や深い思考時に切り詰められることがあります（stop_reason=max_tokens）。この値は Anthropic 経路で max_tokens を上書きします。モデル／ゲートウェイの実際の出力上限を超えると 400 になる場合があります。空欄でデフォルトの 8192 を使用します。"
   },
   "sessionManager": {
+    "selectMessages": "メッセージを選択",
+    "selectAllMessages": "すべて選択",
+    "clearMessageSelection": "選択を解除",
+    "copySelectedMessages": "コピー（{{count}}）",
+    "selectMessage": "メッセージ {{number}} を選択",
+    "selectTurn": "会話 {{number}} を選択",
     "title": "セッション管理",
     "subtitle": "Claude Code / Codex / Gemini CLI / Grok Build / OpenCode / OpenClaw / Hermes / Pi のセッションを管理",
     "searchPlaceholder": "内容・ディレクトリ・ID で検索",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1075,6 +1075,12 @@
     "maxOutputTokensHint": "預設上限 8192 容易在長回答或深度思考時被截斷（stop_reason=max_tokens）。此處設定會作為 Anthropic 的 max_tokens 覆蓋請求值。請勿超過該模型／閘道的真實輸出上限，否則可能 400。留空使用預設 8192。"
   },
   "sessionManager": {
+    "selectMessages": "選擇訊息",
+    "selectAllMessages": "全選",
+    "clearMessageSelection": "清空選擇",
+    "copySelectedMessages": "複製（{{count}}）",
+    "selectMessage": "選擇第 {{number}} 則訊息",
+    "selectTurn": "選擇第 {{number}} 輪對話",
     "title": "工作階段管理",
     "subtitle": "管理 Claude Code、Codex、Gemini CLI、Grok Build、OpenCode、OpenClaw、Hermes 與 Pi 工作階段紀錄",
     "searchPlaceholder": "搜尋對話內容、目錄或 ID",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1074,6 +1074,12 @@
     "maxOutputTokensHint": "默认上限 8192 容易在长回答或深度思考时被截断（stop_reason=max_tokens）。此处设置会作为 Anthropic 的 max_tokens 覆盖请求值。请勿超过该模型/网关的真实输出上限，否则可能 400。留空使用默认 8192。"
   },
   "sessionManager": {
+    "selectMessages": "选择消息",
+    "selectAllMessages": "全选",
+    "clearMessageSelection": "清空选择",
+    "copySelectedMessages": "复制（{{count}}）",
+    "selectMessage": "选择第 {{number}} 条消息",
+    "selectTurn": "选择第 {{number}} 轮对话",
     "title": "会话管理",
     "subtitle": "管理 Claude Code、Codex、Gemini CLI、Grok Build、OpenCode、OpenClaw、Hermes 与 Pi 会话记录",
     "searchPlaceholder": "搜索会话内容、目录或 ID",

--- a/tests/components/SessionManagerPage.test.tsx
+++ b/tests/components/SessionManagerPage.test.tsx
@@ -222,6 +222,52 @@ describe("SessionManagerPage", () => {
     setSessionFixtures(sessions, messages);
   });
 
+  it("copies complete messages in order and clears selection when switching sessions", async () => {
+    const longContent = "full response ".repeat(400);
+    const getMessages = vi.spyOn(sessionsApi, "getMessages").mockResolvedValue([
+      { role: "user", content: "question" },
+      { role: "assistant", content: longContent },
+    ]);
+    const user = userEvent.setup();
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue();
+    renderPage();
+    await screen.findByRole("heading", { name: "Alpha Session" });
+    await waitFor(() => expect(getMessages).toHaveBeenCalled());
+    await user.click(
+      screen.getByRole("button", { name: "sessionManager.selectMessages" }),
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "sessionManager.copySelectedMessages",
+      }),
+    ).toBeDisabled();
+    await user.click(
+      screen.getByRole("button", { name: "sessionManager.selectAllMessages" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "sessionManager.copySelectedMessages",
+      }),
+    );
+    expect(writeText).toHaveBeenCalledWith(
+      `sessionManager.roleUser\nquestion\n\nAI\n${longContent}`,
+    );
+    await user.click(screen.getByRole("button", { name: /Beta Session/ }));
+    await screen.findByRole("heading", { name: "Beta Session" });
+    await user.click(
+      screen.getByRole("button", { name: "sessionManager.selectMessages" }),
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "sessionManager.copySelectedMessages",
+      }),
+    ).toBeDisabled();
+    getMessages.mockRestore();
+    writeText.mockRestore();
+  });
+
   it("surfaces a relative Pi sessionDir instead of presenting an empty scan as authoritative", async () => {
     const discovery = vi.spyOn(piApi, "getSessionDiscovery").mockResolvedValue({
       status: "requires_project_context",

--- a/tests/components/SessionToc.test.tsx
+++ b/tests/components/SessionToc.test.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import { SessionTocSidebar } from "@/components/sessions/SessionToc";
+
+it("selects complete turns, represents partial turns, and keeps navigation separate", () => {
+  const navigate = vi.fn();
+  const selections: number[][] = [];
+  function Harness() {
+    const [selected, setSelected] = useState(new Set([1]));
+    return (
+      <SessionTocSidebar
+        items={[
+          { index: 0, preview: "First question" },
+          { index: 3, preview: "Last question" },
+        ]}
+        onItemClick={navigate}
+        selection={{
+          selected,
+          messageCount: 5,
+          onChange: (start, end, checked) => {
+            const next = new Set(selected);
+            for (let i = start; i < end; i++)
+              checked ? next.add(i) : next.delete(i);
+            selections.push([...next].sort());
+            setSelected(next);
+          },
+        }}
+      />
+    );
+  }
+  render(<Harness />);
+  const [first, last] = screen.getAllByRole("checkbox");
+  expect(first).toBePartiallyChecked();
+  fireEvent.click(first);
+  expect(first).toBeChecked();
+  expect(selections.at(-1)).toEqual([0, 1, 2]);
+  fireEvent.click(last);
+  expect(selections.at(-1)).toEqual([0, 1, 2, 3, 4]);
+  fireEvent.click(first);
+  expect(selections.at(-1)).toEqual([3, 4]);
+  expect(navigate).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByRole("button", { name: /Last question/ }));
+  expect(navigate).toHaveBeenCalledWith(3);
+  expect(last).toBeChecked();
+});


### PR DESCRIPTION
## Summary / 概述

Copying several messages from a session currently requires copying each message separately or dragging a text selection across the conversation.

This adds message selection to the detail pane and turn selection to the existing table of contents. A turn includes a user question and the messages before the next question. Selected messages are copied in their original order with role labels and complete content, including collapsed long replies.

会话详情支持逐条选择消息，也可以在现有目录中选择整轮提问和回复，一次复制所选消息。复制保留原始顺序和完整正文，支持全选和清空选择。

Closes #7326

## Tests

- `pnpm typecheck`
- 17 focused tests passed, including complete long-message copying, selection reset on session change, partial turn selection and navigation.
- Chromium verification of multi-turn copying, select all/clear, individual selection and the narrow-window table of contents.
- Updated en, ja, zh and zh-TW translations.
