### PR TITLE
fix(models): support Zhipu OpenAI Responses model lists

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1478,7 +1478,8 @@ pub fn run() {
             commands::delete_profile,
             commands::clear_current_profile,
             commands::apply_profile,
-            // model list fetch (OpenAI-compatible /v1/models)
+            // Fetch OpenAI-compatible and Anthropic model lists. Response data structure:
+            // data[].id, data[]?.owned_by. Special: supports Zhipu OpenAI Responses models[].slug.
             commands::fetch_models_for_config,
             commands::get_opencode_models,
             // ours: endpoint speed test + custom endpoint management

--- a/src-tauri/src/services/model_fetch.rs
+++ b/src-tauri/src/services/model_fetch.rs
@@ -18,16 +18,25 @@ pub struct FetchedModel {
     pub owned_by: Option<String>,
 }
 
-/// OpenAI 兼容的 /v1/models 响应格式
+/// 模型列表响应的兼容格式。
+///
+/// OpenAI 兼容接口和 Anthropic 接口使用 `data` 字段，智谱 OpenAI Responses
+/// 接口使用 `models` 字段，此结构同时兼容这两种格式。
 #[derive(Debug, Deserialize)]
 struct ModelsResponse {
     data: Option<Vec<ModelEntry>>,
+    models: Option<Vec<ZhipuModelEntry>>,
 }
 
 #[derive(Debug, Deserialize)]
 struct ModelEntry {
     id: String,
     owned_by: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ZhipuModelEntry {
+    slug: String,
 }
 
 const FETCH_TIMEOUT_SECS: u64 = 15;
@@ -98,15 +107,23 @@ pub async fn fetch_models(
                 .await
                 .map_err(|e| format!("Failed to parse response: {e}"))?;
 
-            let mut models: Vec<FetchedModel> = resp
-                .data
-                .unwrap_or_default()
-                .into_iter()
-                .map(|m| FetchedModel {
-                    id: m.id,
-                    owned_by: m.owned_by,
-                })
-                .collect();
+            let mut models: Vec<FetchedModel> = if let Some(data) = resp.data {
+                data.into_iter()
+                    .map(|m| FetchedModel {
+                        id: m.id,
+                        owned_by: m.owned_by,
+                    })
+                    .collect()
+            } else {
+                resp.models
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|m| FetchedModel {
+                        id: m.slug,
+                        owned_by: None,
+                    })
+                    .collect()
+            };
 
             models.sort_by(|a, b| a.id.cmp(&b.id));
             return Ok(models);

--- a/src/lib/api/model-fetch.ts
+++ b/src/lib/api/model-fetch.ts
@@ -17,6 +17,13 @@ export interface ModelFetchOptions {
  *
  * 使用 OpenAI 兼容的 GET /v1/models 端点。优先用 `modelsUrl` 精确覆写；
  * 否则后端会对 baseURL 生成候选列表并按序尝试（含"剥离 /anthropic 等兼容子路径"兜底）。
+ *
+ * 该接口可以获取数据格式为
+ * OpenAI Chat Completion {"data": [{"id": "xxx","owned_by": "xxx"}]} 文档：https://developers.openai.com/api/reference/resources/models/methods/list
+ * 和
+ * Anthropic兼容 {"data":[{"id":"xxx"}]} 文档：https://platform.claude.com/docs/en/api/models/list
+ * 这两种端点的模型列表
+ * 特别支持智谱 OpenAI Responses {"models":[{"slug":"xxx"}]} 端点：https://open.bigmodel.cn/api/v1/models
  */
 export async function fetchModelsForConfig(
   baseUrl: string,


### PR DESCRIPTION
## Summary

This PR adds model-list response compatibility for the Zhipu OpenAI Responses endpoint.  
本 PR 为智谱 OpenAI Responses 端点增加模型列表响应格式兼容。

Zhipu provides three model-list endpoints for three different API styles.  
智谱为三种不同的 API 风格提供了三个模型列表端点。

| API style | Endpoint | Model list structure |
| --- | --- | --- |
| OpenAI Responses | `https://open.bigmodel.cn/api/v1/models` | `models[].slug` |
| Anthropic | `https://open.bigmodel.cn/api/anthropic/v1/models` | `data[].id` |
| OpenAI-compatible | `https://open.bigmodel.cn/api/coding/paas/v4/models` | `data[].id` and optional `data[].owned_by` |

The corresponding requests are shown below.  
对应的请求如下所示。

```http
GET https://open.bigmodel.cn/api/v1/models HTTP/1.1
Content-Type: application/json
Authorization: Bearer <ZHIPU_API_KEY>
```

```http
GET https://open.bigmodel.cn/api/anthropic/v1/models HTTP/1.1
Content-Type: application/json
Authorization: Bearer <ZHIPU_API_KEY>
```

```http
GET https://open.bigmodel.cn/api/coding/paas/v4/models HTTP/1.1
Content-Type: application/json
Authorization: Bearer <ZHIPU_API_KEY>
```

The second endpoint follows the [Anthropic model list format](https://platform.claude.com/docs/en/api/models/list), and the third endpoint follows the [OpenAI-compatible model list format](https://developers.openai.com/api/reference/resources/models/methods/list).  
第二个端点遵循 [Anthropic 模型列表格式](https://platform.claude.com/docs/en/api/models/list)，第三个端点遵循 [OpenAI 兼容模型列表格式](https://developers.openai.com/api/reference/resources/models/methods/list)。

Both formats return model entries through the `data` field.  
这两种格式都通过 `data` 字段返回模型条目。

When Codex uses Zhipu's OpenAI Responses base URL (`https://open.bigmodel.cn/api/v1`), the derived model-list request targets the first endpoint.  
当 Codex 使用智谱 OpenAI Responses 基础地址（`https://open.bigmodel.cn/api/v1`）时，派生出的模型列表请求会访问第一个端点。

```text
https://open.bigmodel.cn/api/v1/models
```

Unlike the other two endpoints, this endpoint returns model entries through `models` and uses `slug` as the model identifier.  
与另外两个端点不同，该端点通过 `models` 返回模型条目，并使用 `slug` 作为模型标识。

The following JSON is a shortened example containing the fields relevant to this change.  
以下 JSON 是仅保留与本次修改相关字段的简化示例。

```json
{
  "models": [
    {
      "slug": "glm-5.3",
      "display_name": "glm-5.3",
      "description": "Z.ai's latest flagship model",
      "context_window": 1048576,
      "input_modalities": ["text"]
    },
    {
      "slug": "glm-5.3-flash",
      "display_name": "glm-5.3-flash",
      "description": "Fast multimodal coding model",
      "context_window": 1048576,
      "input_modalities": ["text", "image"]
    },
    {
      "slug": "glm-5-turbo",
      "display_name": "glm-5-turbo",
      "description": "Agent-optimized model",
      "context_window": 204800,
      "input_modalities": ["text"]
    }
  ]
}
```

Previously, `fetch_models` only understood responses containing `data[].id`, so this valid Zhipu response produced an empty model list.  
此前，`fetch_models` 只能识别包含 `data[].id` 的响应，因此这个有效的智谱响应会产生空模型列表。

The response parser now supports both structures.

- If `data` is present, the existing OpenAI-compatible and Anthropic behavior is preserved.
  - `data[].id` is mapped to `FetchedModel.id`.
  - `data[].owned_by` is mapped to `FetchedModel.owned_by`.
- Otherwise, if `models` is present, the Zhipu OpenAI Responses format is used.
  - `models[].slug` is mapped to `FetchedModel.id`.
  - `FetchedModel.owned_by` is set to `None`.

响应解析器现在同时兼容两种结构。

- 如果存在 `data`，则保留现有的 OpenAI 兼容和 Anthropic 处理逻辑。
  - 将 `data[].id` 映射为 `FetchedModel.id`。
  - 将 `data[].owned_by` 映射为 `FetchedModel.owned_by`。
- 否则，如果存在 `models`，则使用智谱 OpenAI Responses 格式。
  - 将 `models[].slug` 映射为 `FetchedModel.id`。
  - 将 `FetchedModel.owned_by` 设为 `None`。

The existing sorting, authentication headers, endpoint derivation, timeout handling, redaction, and error handling remain unchanged.  
现有的排序、认证请求头、端点派生、超时处理、敏感信息遮盖和错误处理逻辑均保持不变。

A separate Rust function and Tauri command were initially considered.  
最初曾考虑新增独立的 Rust 函数和 Tauri 命令。

However, selecting that function from `CodexFormFields` would require the form to know which preset produced the current configuration.  
但是，从 `CodexFormFields` 选择该函数需要表单知道当前配置来自哪个预设。

The form was not designed to receive preset identity, and adding that dependency would unnecessarily couple generic form behavior to a specific provider.  
该表单在设计上并不接收预设身份，增加这一依赖会让通用表单行为与特定供应商产生不必要的耦合。

Therefore, compatibility is implemented directly in the existing Rust `model_fetch::fetch_models` response parser.  
因此，本次兼容直接实现在现有 Rust `model_fetch::fetch_models` 的响应解析逻辑中。

This keeps `CodexFormFields` provider-agnostic and allows all callers to use the same model-fetching path.  
这样可以让 `CodexFormFields` 保持与供应商无关，并让所有调用方继续使用同一条模型获取路径。

## Related Issue

<!--
Link the related issue and use "Fixes #123" to close it automatically when merged.
关联相关 Issue，并使用 "Fixes #123" 在合并时自动关闭。
-->


## Screenshots

<!--
Screenshots will be added manually.
截图将由提交者手动添加。
-->

| Before | After |
|--------|-------|
|  <img width="1063" height="792" alt="Snapzy_2026-09-12_12-06-01_413" src="https://github.com/user-attachments/assets/c35a54d8-b92b-4042-a24c-978b45c461c9" />  |  <img width="1012" height="667" alt="Snapzy_2026-09-12_12-06-20_578" src="https://github.com/user-attachments/assets/129c0097-26a1-4dfd-a742-4b30488aaf57" /> |

## Checklist

- [x] `pnpm typecheck` passes.  
  `pnpm typecheck` 类型检查通过。
- [x] `pnpm format:check` passes.  
  `pnpm format:check` 代码格式检查通过。
- [x] `cargo clippy` passes if Rust code changed.  
  如修改了 Rust 代码，`cargo clippy` 检查通过。
- [x] Updated i18n files if user-facing text changed (N/A: no user-facing text changed).  
  如修改了用户可见文本，已更新国际化文件（不适用：本次没有用户可见文本变更）。
