### PR TITLE
feat(usage): show Codex Desktop background generations on macOS

### DIFF
--- a/docs/usage/codex-desktop-background.md
+++ b/docs/usage/codex-desktop-background.md
@@ -16,7 +16,8 @@ locations are not implemented.
 The usage dashboard shows a separate **Codex Desktop background usage** table
 when the application filter is All or Codex and no provider is selected. It
 respects the date range and model filter, groups by model, feature and status,
-and hides when no matching records are present. Events with reported usage are
+and hides when no matching records are present. The model picker includes models
+found only in background events, even when no request/session records use them. Events with reported usage are
 included even when the generation status is not `success`.
 
 ## Accounting boundaries
@@ -41,6 +42,9 @@ included even when the generation status is not `success`.
 - Coverage is local to this machine and retained logs, not account-wide.
   Imported observations survive source log deletion. This first version does
   not provide a background-ledger purge/rebuild control.
+- WebDAV/S3 exports exclude background rows and file metadata. Sync imports
+  preserve the local ledger, including when an older snapshot has no background
+  tables. Full manual backups still include and restore these records.
 - Only structured usage fields and hashes are stored, plus local file metadata
   for scan caching. Prompts and unrelated log text are not stored.
 

--- a/docs/usage/codex-desktop-background.md
+++ b/docs/usage/codex-desktop-background.md
@@ -1,0 +1,65 @@
+# Codex Desktop background usage (macOS)
+
+Codex Desktop can report `ephemeral_generation_token_usage` events for background
+features such as `thread_title`, `ambient_suggestions`, and
+`ambient_suggestion_safety`. These generations can be absent from the session
+JSONL files used by the existing Codex importer.
+
+With session auto-sync enabled, CC Switch reads retained `.log` files beneath
+`~/Library/Logs/com.openai.codex/YYYY/MM/DD/`. Manual session sync uses the same
+importer. Files with unchanged size and modification time are skipped; changed
+files are scanned again, and duplicate event fingerprints are ignored. Complete
+newline-terminated records are required. Truncated or invalid records are not
+estimated. An absent log directory imports nothing. Windows and Linux log
+locations are not implemented.
+
+The usage dashboard shows a separate **Codex Desktop background usage** table
+when the application filter is All or Codex and no provider is selected. It
+respects the date range and model filter, groups by model, feature and status,
+and hides when no matching records are present. Events with reported usage are
+included even when the generation status is not `success`.
+
+## Accounting boundaries
+
+- These are generation observations, not HTTP request counts. One event may
+  aggregate several model calls.
+- They are stored separately and **excluded from existing request totals,
+  charts, model/provider statistics and request logs**. Desktop events lack a
+  stable upstream request ID, so overlap with proxy traffic cannot be resolved
+  safely. Do not add both sources together as a reconciled total.
+- Fingerprints use the normalized timestamp and sorted event fields, not file
+  paths. Copies and rotated copies of identical records therefore collapse.
+  Two actual generations with completely identical timestamps and fields
+  cannot be distinguished and would also collapse. This is record-level
+  deduplication, not proof of request identity.
+- Input tokens already include cached input. Reasoning output is already part
+  of output. Neither is added a second time.
+- Costs use the current configured model prices and the existing Codex cache
+  semantics, with a multiplier of one. Unknown prices remain unknown. These
+  are standard-rate estimates, not actual ChatGPT subscription charges or
+  service-tier/long-context adjustments.
+- Coverage is local to this machine and retained logs, not account-wide.
+  Imported observations survive source log deletion. This first version does
+  not provide a background-ledger purge/rebuild control.
+- Only structured usage fields and hashes are stored, plus local file metadata
+  for scan caching. Prompts and unrelated log text are not stored.
+
+## Validation
+
+Synthetic Rust tests cover count validation, overflow, repeated sync, copied
+logs, appends, partial lines, truncation, invalid UTF-8, oversized lines, unknown
+prices, status grouping, date/model filtering, and isolation from request totals.
+A schema test exercises the v18-to-v19 migration. Component tests check filtering,
+unknown prices, and query failures.
+
+For an explicitly supplied local fixture directory (never the installed CC Switch
+DB), an optional test imports into an in-memory database, repeats the import,
+and prints only grouped usage:
+
+```sh
+CC_SWITCH_BACKGROUND_LOG_FIXTURE=/absolute/path/to/fixture \
+  cargo test --manifest-path src-tauri/Cargo.toml --lib \
+  codex_background_usage::tests::import_local_log_fixture -- --ignored --nocapture
+```
+
+Do not commit personal logs, credentials, or configuration files with a report.

--- a/src-tauri/src/commands/usage.rs
+++ b/src-tauri/src/commands/usage.rs
@@ -328,3 +328,19 @@ mod tests {
         assert_eq!(crate::usage_events::take_test_notify_count(), 1);
     }
 }
+
+/// Background generations are independent observations, excluded from request totals.
+#[tauri::command]
+pub fn get_codex_background_usage(
+    state: State<'_, AppState>,
+    start_date: i64,
+    end_date: i64,
+    model: Option<String>,
+) -> Result<Vec<crate::services::codex_background_usage::BackgroundUsage>, AppError> {
+    crate::services::codex_background_usage::summary(
+        &state.db,
+        start_date,
+        end_date,
+        model.as_deref(),
+    )
+}

--- a/src-tauri/src/database/backup.rs
+++ b/src-tauri/src/database/backup.rs
@@ -91,6 +91,8 @@ const SYNC_SKIP_TABLES: &[&str] = &[
     "usage_daily_rollups",
     "session_log_sync",
     "session_usage_dedup",
+    "codex_background_usage",
+    "codex_background_files",
 ];
 
 /// Tables whose local data is preserved from the live database during WebDAV import.
@@ -102,6 +104,8 @@ const SYNC_PRESERVE_TABLES: &[&str] = &[
     "usage_daily_rollups",
     "session_log_sync",
     "session_usage_dedup",
+    "codex_background_usage",
+    "codex_background_files",
 ];
 
 /// A database backup entry for the UI
@@ -2147,6 +2151,70 @@ mod tests {
             cursor,
             ("/local/sessions/manual-backup.jsonl".into(), 11, 22, 33,)
         );
+        Ok(())
+    }
+
+    fn seed_background_fixture(db: &Database, key: &str) -> Result<(), AppError> {
+        let conn = crate::database::lock_conn!(db.conn);
+        conn.execute("INSERT INTO codex_background_usage VALUES (?1, 100, 'test-model', 'thread_title', 'success', 100, 80, 10)", [key])?;
+        conn.execute(
+            "INSERT INTO codex_background_files VALUES (?1, 200, 'modified')",
+            [key],
+        )?;
+        Ok(())
+    }
+
+    fn assert_background_fixture(db: &Database, key: &str) -> Result<(), AppError> {
+        let conn = crate::database::lock_conn!(db.conn);
+        let rows: (i64, String, i64, i64, i64) = conn.query_row(
+            "SELECT COUNT(*), event_key, input_tokens, cached_input_tokens, output_tokens FROM codex_background_usage",
+            [], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
+        )?;
+        assert_eq!(rows, (1, key.into(), 100, 80, 10));
+        let files: (i64, String, i64, String) = conn.query_row(
+            "SELECT COUNT(*), path, size, modified FROM codex_background_files",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+        )?;
+        assert_eq!(files, (1, key.into(), 200, "modified".into()));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn background_ledger_stays_local_during_sync_and_survives_older_snapshots(
+    ) -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let local = Database::memory()?;
+        let remote = Database::memory()?;
+        seed_background_fixture(&local, "/local/private-background.log")?;
+        seed_background_fixture(&remote, "/remote/private-background.log")?;
+        let sync_sql = remote.export_sql_string_for_sync()?;
+        assert!(!sync_sql.contains("/remote/private-background.log"));
+        local.import_sql_string_for_sync(&sync_sql)?;
+        assert_background_fixture(&local, "/local/private-background.log")?;
+        // Even a payload produced by the first draft (containing remote rows)
+        // must not replace this device's ledger or scan metadata.
+        local.import_sql_string_for_sync(&remote.export_sql_string()?)?;
+        assert_background_fixture(&local, "/local/private-background.log")?;
+        {
+            let conn = crate::database::lock_conn!(remote.conn);
+            conn.execute_batch("DROP TABLE codex_background_usage; DROP TABLE codex_background_files; PRAGMA user_version=18;")?;
+        }
+        local.import_sql_string_for_sync(&remote.export_sql_string_for_sync()?)?;
+        assert_background_fixture(&local, "/local/private-background.log")?;
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn full_backup_still_restores_background_ledger() -> Result<(), AppError> {
+        let _test_home = TestHomeGuard::new();
+        let source = Database::memory()?;
+        seed_background_fixture(&source, "/local/full-backup.log")?;
+        let target = Database::memory()?;
+        target.import_sql_string(&source.export_sql_string()?)?;
+        assert_background_fixture(&target, "/local/full-backup.log")?;
         Ok(())
     }
 

--- a/src-tauri/src/database/mod.rs
+++ b/src-tauri/src/database/mod.rs
@@ -53,7 +53,7 @@ use std::sync::Mutex;
 
 /// 当前 Schema 版本号
 /// 每次修改表结构时递增，并在 schema.rs 中添加相应的迁移逻辑
-pub(crate) const SCHEMA_VERSION: i32 = 18;
+pub(crate) const SCHEMA_VERSION: i32 = 19;
 
 /// 安全地序列化 JSON，避免 unwrap panic
 pub(crate) fn to_json_string<T: Serialize>(value: &T) -> Result<String, AppError> {

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -22,6 +22,7 @@ impl Database {
 
     /// 在指定连接上创建表（供迁移和测试使用）
     pub(crate) fn create_tables_on_conn(conn: &Connection) -> Result<(), AppError> {
+        crate::services::codex_background_usage::create_tables(conn)?;
         // 1. Providers 表
         conn.execute(
             "CREATE TABLE IF NOT EXISTS providers (
@@ -548,6 +549,10 @@ impl Database {
                         log::info!("迁移数据库从 v17 到 v18（会话日志字节游标列）");
                         Self::migrate_v17_to_v18(conn)?;
                         Self::set_user_version(conn, 18)?;
+                    }
+                    18 => {
+                        crate::services::codex_background_usage::create_tables(conn)?;
+                        Self::set_user_version(conn, 19)?;
                     }
                     _ => {
                         return Err(AppError::Database(format!(
@@ -3753,6 +3758,23 @@ mod tests {
              VALUES ('pi_session', 'request', 'semantic', 1)",
             [],
         )?;
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_v18_to_v19_adds_separate_background_ledger() -> Result<(), AppError> {
+        let conn = Connection::open_in_memory()?;
+        conn.execute_batch(
+            "CREATE TABLE existing_data (value TEXT); INSERT INTO existing_data VALUES ('keep');",
+        )?;
+        Database::set_user_version(&conn, 18)?;
+        Database::apply_schema_migrations_on_conn(&conn)?;
+        assert_eq!(Database::get_user_version(&conn)?, SCHEMA_VERSION);
+        assert!(Database::table_exists(&conn, "codex_background_usage")?);
+        assert!(Database::table_exists(&conn, "codex_background_files")?);
+        let value: String =
+            conn.query_row("SELECT value FROM existing_data", [], |row| row.get(0))?;
+        assert_eq!(value, "keep");
         Ok(())
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1589,6 +1589,7 @@ pub fn run() {
             commands::set_auto_failover_enabled,
             // Usage statistics
             commands::get_usage_summary,
+            commands::get_codex_background_usage,
             commands::get_usage_summary_by_app,
             commands::get_usage_trends,
             commands::get_provider_stats,

--- a/src-tauri/src/services/codex_background_usage.rs
+++ b/src-tauri/src/services/codex_background_usage.rs
@@ -1,0 +1,449 @@
+//! Local Codex Desktop generation accounting, deliberately separate from request totals.
+//! Desktop events have no request ID and may aggregate several model calls. Never
+//! infer cross-source identity from timestamps, model names, or matching token counts.
+use crate::database::{lock_conn, Database};
+use crate::error::AppError;
+use crate::proxy::usage::{calculator::CostCalculator, parser::TokenUsage};
+use crate::services::session_usage::SessionSyncResult;
+use crate::services::usage_stats::find_model_pricing;
+use chrono::DateTime;
+use rusqlite::{params, Connection};
+use rust_decimal::Decimal;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufRead, BufReader, Read};
+use std::path::Path;
+
+pub(crate) fn create_tables(conn: &Connection) -> Result<(), AppError> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS codex_background_usage (
+            event_key TEXT PRIMARY KEY, created_at INTEGER NOT NULL,
+            model TEXT NOT NULL, feature TEXT NOT NULL, status TEXT NOT NULL,
+            input_tokens INTEGER NOT NULL, cached_input_tokens INTEGER NOT NULL,
+            output_tokens INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_codex_background_time ON codex_background_usage(created_at);
+        CREATE TABLE IF NOT EXISTS codex_background_files (
+            path TEXT PRIMARY KEY, size INTEGER NOT NULL, modified TEXT NOT NULL
+        );",
+    )
+    .map_err(db_error)
+}
+
+fn db_error(error: rusqlite::Error) -> AppError {
+    AppError::Database(format!("Codex background usage: {error}"))
+}
+
+#[derive(Debug, PartialEq)]
+struct Event {
+    key: String,
+    timestamp: i64,
+    model: String,
+    feature: String,
+    status: String,
+    input: u32,
+    cached: u32,
+    output: u32,
+}
+
+fn parse(line: &str) -> Option<Event> {
+    let (timestamp, rest) = line.split_once(' ')?;
+    let rest =
+        rest.strip_prefix("info [ephemeral-generation] ephemeral_generation_token_usage ")?;
+    let mut fields = HashMap::new();
+    for field in rest.split_whitespace() {
+        let (key, value) = field.split_once('=')?;
+        if fields.insert(key, value).is_some() {
+            return None;
+        }
+    }
+    if fields.get("event")? != &"ephemeral_generation_token_usage" {
+        return None;
+    }
+    let input: u32 = fields.get("inputTokens")?.parse().ok()?;
+    let cached: u32 = fields.get("cachedInputTokens")?.parse().ok()?;
+    let output: u32 = fields.get("outputTokens")?.parse().ok()?;
+    let total: u64 = fields.get("totalTokens")?.parse().ok()?;
+    if cached > input || total != u64::from(input) + u64::from(output) {
+        return None;
+    }
+    if let Some(reasoning) = fields.get("reasoningOutputTokens") {
+        if reasoning.parse::<u32>().ok()? > output {
+            return None;
+        }
+    }
+    let date = DateTime::parse_from_rfc3339(timestamp).ok()?;
+    // Keep all reported statuses: a failed generation can still consume tokens.
+    let model = fields.get("model")?.to_string();
+    let feature = fields.get("feature")?.to_string();
+    let status = fields.get("status")?.to_string();
+    if [&model, &feature, &status]
+        .iter()
+        .any(|v| v.is_empty() || v.len() > 128)
+    {
+        return None;
+    }
+    // A source-record fingerprint, NOT an upstream request ID. Canonical ordering
+    // also tolerates reordered fields. Exact copies of records collapse.
+    let mut sorted_fields: Vec<_> = fields.into_iter().collect();
+    sorted_fields.sort_unstable();
+    let canonical = format!("{}|{sorted_fields:?}", date.to_rfc3339());
+    Some(Event {
+        key: format!("{:x}", Sha256::digest(canonical.as_bytes())),
+        timestamp: date.timestamp(),
+        model,
+        feature,
+        status,
+        input,
+        cached,
+        output,
+    })
+}
+
+pub fn sync(db: &Database) -> Result<SessionSyncResult, AppError> {
+    #[cfg(target_os = "macos")]
+    {
+        sync_root(
+            db,
+            &crate::config::get_home_dir().join("Library/Logs/com.openai.codex"),
+        )
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = db;
+        Ok(SessionSyncResult::default())
+    }
+}
+
+// Changed-file incremental scan. No raw log text, prompts, or conversation IDs
+// are persisted. Re-scan changed files so truncation/rotation need no byte repair.
+fn sync_root(db: &Database, root: &Path) -> Result<SessionSyncResult, AppError> {
+    let mut result = SessionSyncResult::default();
+    if !root.exists() {
+        return Ok(result);
+    }
+    visit(db, root, 0, &mut result)?;
+    Ok(result)
+}
+
+fn visit(
+    db: &Database,
+    dir: &Path,
+    depth: usize,
+    result: &mut SessionSyncResult,
+) -> Result<(), AppError> {
+    for entry in fs::read_dir(dir).map_err(|e| AppError::io(dir, e))? {
+        let entry = entry.map_err(|e| AppError::io(dir, e))?;
+        let path = entry.path();
+        let kind = entry.file_type().map_err(|e| AppError::io(&path, e))?;
+        if kind.is_dir() && depth < 3 {
+            visit(db, &path, depth + 1, result)?;
+        } else if kind.is_file() && path.extension().is_some_and(|v| v == "log") {
+            match sync_file(db, &path) {
+                Ok(Some(imported)) => {
+                    result.files_scanned += 1;
+                    result.imported += imported;
+                }
+                Ok(None) => {}
+                Err(error) => result.errors.push(error.to_string()),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn sync_file(db: &Database, path: &Path) -> Result<Option<u32>, AppError> {
+    let metadata = fs::metadata(path).map_err(|e| AppError::io(path, e))?;
+    let modified = format!(
+        "{:?}",
+        metadata.modified().map_err(|e| AppError::io(path, e))?
+    );
+    let size = i64::try_from(metadata.len())
+        .map_err(|_| AppError::Message("Codex desktop log too large".into()))?;
+    let path_key = path.to_string_lossy();
+    {
+        let conn = lock_conn!(db.conn);
+        let unchanged: bool = conn.query_row("SELECT EXISTS(SELECT 1 FROM codex_background_files WHERE path=?1 AND size=?2 AND modified=?3)", params![path_key, size, modified], |row| row.get(0)).map_err(db_error)?;
+        if unchanged {
+            return Ok(None);
+        }
+    }
+    let file = fs::File::open(path).map_err(|e| AppError::io(path, e))?;
+    let mut reader = BufReader::new(file.take(metadata.len()));
+    let mut events = Vec::new();
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        // Bound memory even when unrelated application log lines are huge.
+        let n = reader
+            .by_ref()
+            .take(65537)
+            .read_until(b'\n', &mut line)
+            .map_err(|e| AppError::io(path, e))?;
+        if n == 0 {
+            break;
+        }
+        if line.last() != Some(&b'\n') {
+            if n <= 65536 {
+                break;
+            } // Incomplete last line: reconsider on the next append.
+            loop {
+                line.clear();
+                let n = reader
+                    .by_ref()
+                    .take(65537)
+                    .read_until(b'\n', &mut line)
+                    .map_err(|e| AppError::io(path, e))?;
+                if n == 0 || line.last() == Some(&b'\n') {
+                    break;
+                }
+            }
+            continue;
+        }
+        if let Ok(line) = std::str::from_utf8(&line) {
+            if let Some(event) = parse(line.trim_end()) {
+                events.push(event);
+            }
+        }
+    }
+    let mut conn = lock_conn!(db.conn);
+    let tx = conn.transaction().map_err(db_error)?;
+    let mut imported = 0;
+    for event in events {
+        imported += tx
+            .execute(
+                "INSERT OR IGNORE INTO codex_background_usage VALUES (?1,?2,?3,?4,?5,?6,?7,?8)",
+                params![
+                    event.key,
+                    event.timestamp,
+                    event.model,
+                    event.feature,
+                    event.status,
+                    event.input,
+                    event.cached,
+                    event.output
+                ],
+            )
+            .map_err(db_error)? as u32;
+    }
+    tx.execute("INSERT INTO codex_background_files VALUES (?1,?2,?3) ON CONFLICT(path) DO UPDATE SET size=excluded.size,modified=excluded.modified", params![path_key,size,modified]).map_err(db_error)?;
+    tx.commit().map_err(db_error)?;
+    Ok(Some(imported))
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackgroundUsage {
+    pub model: String,
+    pub feature: String,
+    pub status: String,
+    pub generations: u64,
+    pub input_tokens: u64,
+    pub cached_input_tokens: u64,
+    pub output_tokens: u64,
+    /// Current configured standard-rate estimate, never subscription billing.
+    pub estimated_cost_usd: Option<String>,
+}
+
+pub fn summary(
+    db: &Database,
+    start: i64,
+    end: i64,
+    model: Option<&str>,
+) -> Result<Vec<BackgroundUsage>, AppError> {
+    let conn = lock_conn!(db.conn);
+    let mut stmt = conn.prepare("SELECT model,feature,status,input_tokens,cached_input_tokens,output_tokens FROM codex_background_usage WHERE created_at >= ?1 AND created_at <= ?2 AND (?3 IS NULL OR model=?3)").map_err(db_error)?;
+    let rows = stmt
+        .query_map(params![start, end, model], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, String>(2)?,
+                r.get::<_, u32>(3)?,
+                r.get::<_, u32>(4)?,
+                r.get::<_, u32>(5)?,
+            ))
+        })
+        .map_err(db_error)?;
+    let mut groups: std::collections::BTreeMap<
+        (String, String, String),
+        (BackgroundUsage, Option<Decimal>),
+    > = std::collections::BTreeMap::new();
+    for row in rows {
+        let (model, feature, status, input, cached, output) = row.map_err(db_error)?;
+        let pricing = find_model_pricing(&conn, &model);
+        let cost = pricing.map(|pricing| {
+            CostCalculator::calculate_for_app(
+                "codex",
+                &TokenUsage {
+                    input_tokens: input,
+                    cache_read_tokens: cached,
+                    output_tokens: output,
+                    ..Default::default()
+                },
+                &pricing,
+                Decimal::ONE,
+            )
+            .total_cost
+        });
+        let (group, sum) = groups
+            .entry((model.clone(), feature.clone(), status.clone()))
+            .or_insert_with(|| {
+                (
+                    BackgroundUsage {
+                        model,
+                        feature,
+                        status,
+                        generations: 0,
+                        input_tokens: 0,
+                        cached_input_tokens: 0,
+                        output_tokens: 0,
+                        estimated_cost_usd: None,
+                    },
+                    Some(Decimal::ZERO),
+                )
+            });
+        group.generations += 1;
+        group.input_tokens += u64::from(input);
+        group.cached_input_tokens += u64::from(cached);
+        group.output_tokens += u64::from(output);
+        *sum = sum.and_then(|sum| cost.map(|cost| sum + cost));
+    }
+    Ok(groups
+        .into_values()
+        .map(|(mut group, cost)| {
+            group.estimated_cost_usd = cost.map(|c| c.to_string());
+            group
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    const LINE: &str = "2026-09-12T05:40:08.305Z info [ephemeral-generation] ephemeral_generation_token_usage cachedInputTokens=80 event=ephemeral_generation_token_usage feature=ambient_suggestions inputTokens=100 model=gpt-5.6-terra outputTokens=10 reasoningEffort=medium reasoningOutputTokens=5 serviceTier=null status=success totalTokens=110";
+
+    #[test]
+    fn validates_inclusive_counts_without_adding_reasoning_twice() {
+        let event = parse(LINE).unwrap();
+        assert_eq!((event.input, event.cached, event.output), (100, 80, 10));
+        for (from, to) in [
+            ("cachedInputTokens=80", "cachedInputTokens=101"),
+            ("totalTokens=110", "totalTokens=111"),
+            ("inputTokens=100", "inputTokens=4294967296"),
+            ("reasoningOutputTokens=5", "reasoningOutputTokens=11"),
+            ("outputTokens=10", "outputTokens=-1"),
+            ("2026-09-12", "invalid"),
+        ] {
+            assert!(parse(&LINE.replace(from, to)).is_none());
+        }
+        assert!(parse(&format!("{LINE} inputTokens=100")).is_none());
+        assert!(parse("unrelated log message").is_none());
+        assert!(parse(&LINE.replace("status=success", "status=failed")).is_some());
+    }
+
+    #[test]
+    fn repeated_scans_copies_append_and_truncation_do_not_inflate_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::memory().unwrap();
+        let path = dir.path().join("desktop.log");
+        fs::write(&path, format!("{LINE}\n")).unwrap();
+        assert_eq!(sync_root(&db, dir.path()).unwrap().imported, 1);
+        assert_eq!(sync_root(&db, dir.path()).unwrap().files_scanned, 0);
+        fs::copy(&path, dir.path().join("rotated.log")).unwrap();
+        assert_eq!(sync_root(&db, dir.path()).unwrap().imported, 0);
+        let second = LINE.replace("08.305Z", "09.305Z");
+        let mut file = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        write!(file, "{second}").unwrap();
+        assert_eq!(sync_root(&db, dir.path()).unwrap().imported, 0);
+        writeln!(file).unwrap();
+        assert_eq!(sync_root(&db, dir.path()).unwrap().imported, 1);
+        fs::write(&path, format!("{}\n", LINE.replace("08.305Z", "10.305Z"))).unwrap();
+        assert_eq!(sync_root(&db, dir.path()).unwrap().imported, 1);
+        let rows = summary(&db, 0, i64::MAX, None).unwrap();
+        assert_eq!(rows[0].generations, 3);
+        assert_eq!(rows[0].input_tokens, 300);
+        assert_eq!(rows[0].cached_input_tokens, 240);
+        assert_eq!(rows[0].output_tokens, 30);
+        let cost: Decimal = rows[0]
+            .estimated_cost_usd
+            .as_ref()
+            .unwrap()
+            .parse()
+            .unwrap();
+        // Terra: 20 fresh * $2/M + 80 cached * $0.2/M + 10 output * $12/M.
+        assert_eq!(cost, Decimal::new(528, 6));
+        let conn = db.conn.lock().unwrap();
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM proxy_request_logs", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn filters_unknown_prices_and_failed_generations_are_explicit() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::memory().unwrap();
+        let unknown = LINE
+            .replace("gpt-5.6-terra", "unpriced-future-model")
+            .replace("status=success", "status=failed");
+        fs::write(dir.path().join("app.log"), format!("{LINE}\n{unknown}\n")).unwrap();
+        sync_root(&db, dir.path()).unwrap();
+        let rows = summary(&db, 0, i64::MAX, Some("unpriced-future-model")).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].status, "failed");
+        assert!(rows[0].estimated_cost_usd.is_none());
+        let timestamp = parse(LINE).unwrap().timestamp;
+        assert!(summary(&db, 0, timestamp - 1, None).unwrap().is_empty());
+        assert_eq!(summary(&db, timestamp, timestamp, None).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn oversized_and_invalid_utf8_lines_do_not_hide_following_usage() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = Database::memory().unwrap();
+        let mut bytes = vec![b'x'; 150_000];
+        bytes.extend_from_slice(b"\n\xff\n");
+        bytes.extend_from_slice(format!("{LINE}\n").as_bytes());
+        fs::write(dir.path().join("app.log"), bytes).unwrap();
+        assert_eq!(sync_root(&db, dir.path()).unwrap().imported, 1);
+    }
+
+    #[test]
+    fn schema_creation_is_idempotent_and_preserves_existing_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        create_tables(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO codex_background_files VALUES ('fixture',1,'1')",
+            [],
+        )
+        .unwrap();
+        create_tables(&conn).unwrap();
+        assert_eq!(
+            conn.query_row("SELECT COUNT(*) FROM codex_background_files", [], |r| r
+                .get::<_, i64>(0))
+                .unwrap(),
+            1
+        );
+    }
+    /// Opt-in local verification. Reads only the supplied directory; all writes
+    /// go to a new in-memory database. Never accesses the installed CC Switch DB.
+    #[test]
+    #[ignore = "requires CC_SWITCH_BACKGROUND_LOG_FIXTURE directory"]
+    fn import_local_log_fixture() {
+        let root = std::env::var_os("CC_SWITCH_BACKGROUND_LOG_FIXTURE")
+            .expect("explicit fixture directory required");
+        let db = Database::memory().unwrap();
+        let first = sync_root(&db, Path::new(&root)).unwrap();
+        assert!(first.errors.is_empty(), "{:?}", first.errors);
+        assert!(first.imported > 0);
+        assert_eq!(sync_root(&db, Path::new(&root)).unwrap().imported, 0);
+        println!(
+            "{}",
+            serde_json::to_string(&summary(&db, 0, i64::MAX, None).unwrap()).unwrap()
+        );
+    }
+}

--- a/src-tauri/src/services/codex_background_usage.rs
+++ b/src-tauri/src/services/codex_background_usage.rs
@@ -6,14 +6,20 @@ use crate::error::AppError;
 use crate::proxy::usage::{calculator::CostCalculator, parser::TokenUsage};
 use crate::services::session_usage::SessionSyncResult;
 use crate::services::usage_stats::find_model_pricing;
+#[cfg(any(target_os = "macos", test))]
 use chrono::DateTime;
 use rusqlite::{params, Connection};
 use rust_decimal::Decimal;
 use serde::Serialize;
+#[cfg(any(target_os = "macos", test))]
 use sha2::{Digest, Sha256};
+#[cfg(any(target_os = "macos", test))]
 use std::collections::HashMap;
+#[cfg(any(target_os = "macos", test))]
 use std::fs;
+#[cfg(any(target_os = "macos", test))]
 use std::io::{BufRead, BufReader, Read};
+#[cfg(any(target_os = "macos", test))]
 use std::path::Path;
 
 pub(crate) fn create_tables(conn: &Connection) -> Result<(), AppError> {
@@ -36,6 +42,7 @@ fn db_error(error: rusqlite::Error) -> AppError {
     AppError::Database(format!("Codex background usage: {error}"))
 }
 
+#[cfg(any(target_os = "macos", test))]
 #[derive(Debug, PartialEq)]
 struct Event {
     key: String,
@@ -48,6 +55,7 @@ struct Event {
     output: u32,
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn parse(line: &str) -> Option<Event> {
     let (timestamp, rest) = line.split_once(' ')?;
     let rest =
@@ -119,6 +127,7 @@ pub fn sync(db: &Database) -> Result<SessionSyncResult, AppError> {
 
 // Changed-file incremental scan. No raw log text, prompts, or conversation IDs
 // are persisted. Re-scan changed files so truncation/rotation need no byte repair.
+#[cfg(any(target_os = "macos", test))]
 fn sync_root(db: &Database, root: &Path) -> Result<SessionSyncResult, AppError> {
     let mut result = SessionSyncResult::default();
     if !root.exists() {
@@ -128,6 +137,7 @@ fn sync_root(db: &Database, root: &Path) -> Result<SessionSyncResult, AppError> 
     Ok(result)
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn visit(
     db: &Database,
     dir: &Path,
@@ -154,6 +164,7 @@ fn visit(
     Ok(())
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn sync_file(db: &Database, path: &Path) -> Result<Option<u32>, AppError> {
     let metadata = fs::metadata(path).map_err(|e| AppError::io(path, e))?;
     let modified = format!(

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -51,3 +51,5 @@ pub use usage_stats::{
     DailyStats, LogFilters, ModelStats, PaginatedLogs, ProviderLimitStatus, ProviderStats,
     RequestLogDetail, UsageSummary, UsageSummaryByApp,
 };
+
+pub mod codex_background_usage;

--- a/src-tauri/src/services/session_usage.rs
+++ b/src-tauri/src/services/session_usage.rs
@@ -145,6 +145,11 @@ pub fn sync_all_unlocked(db: &Database) -> SessionSyncResult {
         "Pi",
         crate::services::session_usage_pi::sync_pi_usage(db),
     );
+    merge_sync_step(
+        &mut result,
+        "Codex Desktop background",
+        crate::services::codex_background_usage::sync(db),
+    );
     notify_sync_result(&result);
     result
 }

--- a/src/components/usage/CodexBackgroundUsage.tsx
+++ b/src/components/usage/CodexBackgroundUsage.tsx
@@ -1,0 +1,85 @@
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { usageApi } from "@/lib/api/usage";
+import { usageKeys } from "@/lib/query/usage";
+import { resolveUsageRange } from "@/lib/usageRange";
+import type { UsageRangeSelection } from "@/types/usage";
+
+export function CodexBackgroundUsage({
+  range,
+  model,
+  refreshIntervalMs,
+}: {
+  range: UsageRangeSelection;
+  model?: string;
+  refreshIntervalMs: number;
+}) {
+  const { t } = useTranslation();
+  const query = useQuery({
+    queryKey: [...usageKeys.all, "codex-background", range, model],
+    queryFn: () => {
+      const { startDate, endDate } = resolveUsageRange(range);
+      return usageApi.getCodexBackgroundUsage(startDate, endDate, model);
+    },
+    refetchInterval: refreshIntervalMs || false,
+  });
+  if (query.isPending) return null;
+  if (query.isError) return <p role="alert">{t("usage.background.error")}</p>;
+  if (!query.data.length) return null;
+  return (
+    <section
+      className="rounded-xl border bg-card p-4 space-y-3"
+      aria-label={t("usage.background.title")}
+    >
+      <h3 className="font-medium">{t("usage.background.title")}</h3>
+      <p className="text-sm text-muted-foreground">
+        {t("usage.background.description")}
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left">
+          <thead>
+            <tr>
+              {[
+                "model",
+                "feature",
+                "status",
+                "generations",
+                "input",
+                "cached",
+                "output",
+                "cost",
+              ].map((key) => (
+                <th className="p-2" key={key}>
+                  {t(`usage.background.${key}`)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {query.data.map((row) => (
+              <tr
+                key={`${row.model}:${row.feature}:${row.status}`}
+                className="border-t"
+              >
+                <td className="p-2">{row.model}</td>
+                <td className="p-2">{row.feature}</td>
+                <td className="p-2">{row.status}</td>
+                <td className="p-2">{row.generations.toLocaleString()}</td>
+                <td className="p-2">{row.inputTokens.toLocaleString()}</td>
+                <td className="p-2">
+                  {row.cachedInputTokens.toLocaleString()}
+                </td>
+                <td className="p-2">{row.outputTokens.toLocaleString()}</td>
+                <td className="p-2">
+                  {row.estimatedCostUsd === null
+                    ? t("usage.background.unknown")
+                    : `$${Number(row.estimatedCostUsd).toFixed(6)}`}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/usage/CodexBackgroundUsage.tsx
+++ b/src/components/usage/CodexBackgroundUsage.tsx
@@ -1,8 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
 import { useTranslation } from "react-i18next";
-import { usageApi } from "@/lib/api/usage";
-import { usageKeys } from "@/lib/query/usage";
-import { resolveUsageRange } from "@/lib/usageRange";
+import { useCodexBackgroundUsage } from "@/lib/query/usage";
 import type { UsageRangeSelection } from "@/types/usage";
 
 export function CodexBackgroundUsage({
@@ -15,14 +12,7 @@ export function CodexBackgroundUsage({
   refreshIntervalMs: number;
 }) {
   const { t } = useTranslation();
-  const query = useQuery({
-    queryKey: [...usageKeys.all, "codex-background", range, model],
-    queryFn: () => {
-      const { startDate, endDate } = resolveUsageRange(range);
-      return usageApi.getCodexBackgroundUsage(startDate, endDate, model);
-    },
-    refetchInterval: refreshIntervalMs || false,
-  });
+  const query = useCodexBackgroundUsage(range, model, refreshIntervalMs);
   if (query.isPending) return null;
   if (query.isError) return <p role="alert">{t("usage.background.error")}</p>;
   if (!query.data.length) return null;

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { CodexBackgroundUsage } from "./CodexBackgroundUsage";
 import { UsageHero } from "./UsageHero";
 import { UsageTrendChart } from "./UsageTrendChart";
 import { RequestLogTable } from "./RequestLogTable";
@@ -412,6 +413,14 @@ export function UsageDashboard({
         model={model}
         refreshIntervalMs={refreshIntervalMs}
       />
+
+      {(appType === "all" || appType === "codex") && !providerName && (
+        <CodexBackgroundUsage
+          range={range}
+          model={model}
+          refreshIntervalMs={refreshIntervalMs}
+        />
+      )}
 
       <UsageTrendChart
         range={range}

--- a/src/components/usage/UsageDashboard.tsx
+++ b/src/components/usage/UsageDashboard.tsx
@@ -33,7 +33,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useQueryClient } from "@tanstack/react-query";
-import { usageKeys, useModelStats, useProviderStats } from "@/lib/query/usage";
+import {
+  useCodexBackgroundUsage,
+  usageKeys,
+  useModelStats,
+  useProviderStats,
+} from "@/lib/query/usage";
 import { useUsageEventBridge } from "@/hooks/useUsageEventBridge";
 import {
   Accordion,
@@ -254,6 +259,15 @@ export function UsageDashboard({
     optionsRefetch,
   );
 
+  const backgroundVisible =
+    (appType === "all" || appType === "codex") && !providerName;
+  const { data: backgroundOptionsData } = useCodexBackgroundUsage(
+    range,
+    undefined,
+    refreshIntervalMs,
+    backgroundVisible,
+  );
+
   const providerOptions = useMemo(() => {
     const names = new Set<string>();
     for (const stat of providerOptionsData ?? []) {
@@ -270,9 +284,12 @@ export function UsageDashboard({
     for (const stat of modelOptionsData ?? []) {
       names.add(stat.model);
     }
+    if (backgroundVisible) {
+      for (const stat of backgroundOptionsData ?? []) names.add(stat.model);
+    }
     if (model) names.add(model);
     return Array.from(names);
-  }, [modelOptionsData, model]);
+  }, [modelOptionsData, backgroundOptionsData, backgroundVisible, model]);
 
   return (
     <motion.div
@@ -414,7 +431,7 @@ export function UsageDashboard({
         refreshIntervalMs={refreshIntervalMs}
       />
 
-      {(appType === "all" || appType === "codex") && !providerName && (
+      {backgroundVisible && (
         <CodexBackgroundUsage
           range={range}
           model={model}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1876,7 +1876,21 @@
       "syncNow": "Sync now"
     },
     "cacheReadCostPerMillion": "Cache Read Cost (per million tokens, USD)",
-    "cacheCreationCostPerMillion": "Cache Write Cost (per million tokens, USD)"
+    "cacheCreationCostPerMillion": "Cache Write Cost (per million tokens, USD)",
+    "background": {
+      "title": "Codex Desktop background usage",
+      "description": "Local macOS generation events, excluded from the totals above: overlap with proxy requests cannot be determined. Cached tokens are included in input. Costs estimate current configured standard rates, not subscription charges. Log retention and other devices limit coverage.",
+      "model": "Model",
+      "feature": "Feature",
+      "status": "Status",
+      "generations": "Generations",
+      "input": "Input",
+      "cached": "Cached input",
+      "output": "Output",
+      "cost": "Estimated USD",
+      "unknown": "Unknown price",
+      "error": "Could not load Codex background usage."
+    }
   },
   "usageScript": {
     "title": "Configure Usage Query",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1876,7 +1876,21 @@
       "syncNow": "今すぐ同期"
     },
     "cacheReadCostPerMillion": "キャッシュ読み取りコスト（100万トークンあたり、USD）",
-    "cacheCreationCostPerMillion": "キャッシュ書き込みコスト（100万トークンあたり、USD）"
+    "cacheCreationCostPerMillion": "キャッシュ書き込みコスト（100万トークンあたり、USD）",
+    "background": {
+      "title": "Codex Desktop バックグラウンド使用量",
+      "description": "この Mac の生成イベントです。プロキシ要求との重複を判定できないため、上の合計には含みません。入力にはキャッシュが含まれます。費用は現在設定されている標準単価での概算で、サブスクリプションの請求額ではありません。ログの保存期間や別の端末の利用により、記録は不完全です。",
+      "model": "モデル",
+      "feature": "機能",
+      "status": "状態",
+      "generations": "生成回数",
+      "input": "入力",
+      "cached": "キャッシュ入力",
+      "output": "出力",
+      "cost": "概算 USD",
+      "unknown": "単価不明",
+      "error": "Codex バックグラウンド使用量を読み込めませんでした。"
+    }
   },
   "usageScript": {
     "title": "利用状況を設定",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1877,7 +1877,21 @@
       "syncNow": "立即同步"
     },
     "cacheReadCostPerMillion": "快取讀取成本 (每百萬 tokens, USD)",
-    "cacheCreationCostPerMillion": "快取寫入成本 (每百萬 tokens, USD)"
+    "cacheCreationCostPerMillion": "快取寫入成本 (每百萬 tokens, USD)",
+    "background": {
+      "title": "Codex Desktop 背景用量",
+      "description": "本機 macOS 背景生成事件，未計入上方總計：無法判定與代理請求的重疊。輸入已包含快取 token。費用按目前設定的標準價格估算，不代表訂閱扣費。日誌保留期限及其他裝置會限制涵蓋範圍。",
+      "model": "模型",
+      "feature": "功能",
+      "status": "狀態",
+      "generations": "生成次數",
+      "input": "輸入",
+      "cached": "快取輸入",
+      "output": "輸出",
+      "cost": "估算美元",
+      "unknown": "未知價格",
+      "error": "無法載入 Codex 背景用量。"
+    }
   },
   "usageScript": {
     "title": "設定用量查詢",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1876,7 +1876,21 @@
       "syncNow": "立即同步"
     },
     "cacheReadCostPerMillion": "缓存读取成本 (每百万 tokens, USD)",
-    "cacheCreationCostPerMillion": "缓存写入成本 (每百万 tokens, USD)"
+    "cacheCreationCostPerMillion": "缓存写入成本 (每百万 tokens, USD)",
+    "background": {
+      "title": "Codex Desktop 后台用量",
+      "description": "本机 macOS 后台生成事件，未计入上方总计：无法判定与代理请求的重叠。输入已包含缓存 token。费用按当前配置的标准价格估算，不代表订阅扣费。日志保留期限及其他设备会限制覆盖范围。",
+      "model": "模型",
+      "feature": "功能",
+      "status": "状态",
+      "generations": "生成次数",
+      "input": "输入",
+      "cached": "缓存输入",
+      "output": "输出",
+      "cost": "估算美元",
+      "unknown": "未知价格",
+      "error": "无法加载 Codex 后台用量。"
+    }
   },
   "usageScript": {
     "title": "配置用量查询",

--- a/src/lib/api/usage.ts
+++ b/src/lib/api/usage.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type {
+  CodexBackgroundUsage,
   UsageSummary,
   UsageSummaryByApp,
   DailyStats,
@@ -20,6 +21,12 @@ import type { AppId } from "./types";
 import type { TemplateType } from "@/config/constants";
 
 export const usageApi = {
+  getCodexBackgroundUsage: (
+    startDate: number,
+    endDate: number,
+    model?: string,
+  ): Promise<CodexBackgroundUsage[]> =>
+    invoke("get_codex_background_usage", { startDate, endDate, model }),
   // Provider usage script methods
   query: async (providerId: string, appId: AppId): Promise<UsageResult> => {
     return invoke("queryProviderUsage", { providerId, app: appId });

--- a/src/lib/query/usage.ts
+++ b/src/lib/query/usage.ts
@@ -390,3 +390,21 @@ export function useDeleteModelPricing() {
     },
   });
 }
+
+// Unfiltered background observations also supply models absent from request logs.
+export function useCodexBackgroundUsage(
+  range: UsageRangeSelection,
+  model: string | undefined,
+  refreshIntervalMs: number,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: [...usageKeys.all, "codex-background", range, model],
+    queryFn: () => {
+      const { startDate, endDate } = resolveUsageRange(range);
+      return usageApi.getCodexBackgroundUsage(startDate, endDate, model);
+    },
+    refetchInterval: refreshIntervalMs || false,
+    enabled,
+  });
+}

--- a/src/types/usage.ts
+++ b/src/types/usage.ts
@@ -318,3 +318,14 @@ export interface StatsFilters {
   providerId?: string;
   appType?: string;
 }
+
+export interface CodexBackgroundUsage {
+  model: string;
+  feature: string;
+  status: string;
+  generations: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: string | null;
+}

--- a/tests/components/CodexBackgroundUsage.test.tsx
+++ b/tests/components/CodexBackgroundUsage.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CodexBackgroundUsage } from "@/components/usage/CodexBackgroundUsage";
+import { usageApi } from "@/lib/api/usage";
+import i18n from "i18next";
+import en from "@/i18n/locales/en.json";
+
+vi.mock("@/lib/api/usage", () => ({
+  usageApi: { getCodexBackgroundUsage: vi.fn() },
+}));
+
+function mount() {
+  return render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <CodexBackgroundUsage
+        range={{ preset: "custom", customStartDate: 100, customEndDate: 200 }}
+        model="test-model"
+        refreshIntervalMs={0}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("Codex background usage", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    i18n.addResourceBundle("en", "translation", en, true, true);
+    await i18n.changeLanguage("en");
+  });
+  it("keeps unknown prices explicit and forwards date/model filters", async () => {
+    vi.mocked(usageApi.getCodexBackgroundUsage).mockResolvedValue([
+      {
+        model: "test-model",
+        feature: "thread_title",
+        status: "success",
+        generations: 2,
+        inputTokens: 100,
+        cachedInputTokens: 80,
+        outputTokens: 10,
+        estimatedCostUsd: null,
+      },
+    ]);
+    mount();
+    expect(await screen.findByText("Unknown price")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Local macOS generation events, excluded from the totals above/,
+      ),
+    ).toBeInTheDocument();
+    expect(usageApi.getCodexBackgroundUsage).toHaveBeenCalledWith(
+      100,
+      200,
+      "test-model",
+    );
+    expect(screen.getByText("thread_title")).toBeInTheDocument();
+  });
+  it("does not show failed reads as zero usage", async () => {
+    vi.mocked(usageApi.getCodexBackgroundUsage).mockRejectedValue(
+      new Error("database unavailable"),
+    );
+    mount();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Could not load Codex background usage.",
+    );
+  });
+});

--- a/tests/components/UsageDashboard.test.tsx
+++ b/tests/components/UsageDashboard.test.tsx
@@ -12,6 +12,8 @@ import { UsageDashboard } from "@/components/usage/UsageDashboard";
 
 const useProviderStatsMock = vi.hoisted(() => vi.fn());
 const useModelStatsMock = vi.hoisted(() => vi.fn());
+const useBackgroundMock = vi.hoisted(() => vi.fn());
+const backgroundCardMock = vi.hoisted(() => vi.fn());
 const usageHeroMock = vi.hoisted(() => vi.fn());
 
 vi.mock("react-i18next", () => ({
@@ -41,13 +43,17 @@ vi.mock("@/lib/query/usage", async () => {
     );
   return {
     ...actual,
+    useCodexBackgroundUsage: (...args: unknown[]) => useBackgroundMock(...args),
     useProviderStats: (...args: unknown[]) => useProviderStatsMock(...args),
     useModelStats: (...args: unknown[]) => useModelStatsMock(...args),
   };
 });
 
 vi.mock("@/components/usage/CodexBackgroundUsage", () => ({
-  CodexBackgroundUsage: () => <div data-testid="codex-background-usage" />,
+  CodexBackgroundUsage: (props: unknown) => {
+    backgroundCardMock(props);
+    return <div data-testid="codex-background-usage" />;
+  },
 }));
 
 vi.mock("@/components/usage/UsageHero", () => ({
@@ -84,7 +90,16 @@ vi.mock("@/components/usage/UsageDateRangePicker", () => ({
 vi.mock("@/components/ui/select", () => ({
   Select: ({ value, onValueChange, children }: any) => (
     <div data-testid={`select-${value}`}>
-      {children}
+      <div
+        onClick={(event) => {
+          const value = (event.target as HTMLElement)
+            .closest("[data-option-value]")
+            ?.getAttribute("data-option-value");
+          if (value) onValueChange?.(value);
+        }}
+      >
+        {children}
+      </div>
       <button type="button" onClick={() => onValueChange?.("5000")}>
         choose-5000
       </button>
@@ -97,7 +112,11 @@ vi.mock("@/components/ui/select", () => ({
   ),
   SelectValue: () => null,
   SelectContent: ({ children }: any) => <div>{children}</div>,
-  SelectItem: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  SelectItem: ({ children, value, ...props }: any) => (
+    <div data-option-value={value} {...props}>
+      {children}
+    </div>
+  ),
 }));
 
 const renderDashboard = (props: ComponentProps<typeof UsageDashboard> = {}) => {
@@ -118,6 +137,9 @@ describe("UsageDashboard", () => {
     useProviderStatsMock.mockReset();
     useModelStatsMock.mockReset();
     usageHeroMock.mockReset();
+    useBackgroundMock.mockReset();
+    backgroundCardMock.mockReset();
+    useBackgroundMock.mockReturnValue({ data: [] });
     useProviderStatsMock.mockReturnValue({ data: [] });
     useModelStatsMock.mockReturnValue({ data: [] });
   });
@@ -182,5 +204,44 @@ describe("UsageDashboard", () => {
     await waitFor(() =>
       expect(screen.getByTestId("select-30000")).toBeInTheDocument(),
     );
+  });
+  it("selects background-only models and keeps the option pool unfiltered", () => {
+    useBackgroundMock.mockReturnValue({
+      data: [{ model: "background-only" }, { model: "shared" }],
+    });
+    useModelStatsMock.mockReturnValue({ data: [{ model: "shared" }] });
+    renderDashboard({ refreshIntervalMs: 5000 });
+    expect(screen.getAllByText("shared")).toHaveLength(1);
+    fireEvent.click(screen.getByText("background-only"));
+    expect(backgroundCardMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ model: "background-only" }),
+    );
+    expect(useBackgroundMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      undefined,
+      5000,
+      true,
+    );
+  });
+
+  it("excludes cached background options for other apps and provider filters", () => {
+    useBackgroundMock.mockReturnValue({ data: [{ model: "background-only" }] });
+    useProviderStatsMock.mockReturnValue({
+      data: [{ providerName: "test-provider" }],
+    });
+    renderDashboard();
+    fireEvent.click(screen.getByText("test-provider"));
+    expect(screen.queryByText("background-only")).not.toBeInTheDocument();
+    expect(useBackgroundMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      undefined,
+      30000,
+      false,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "usage.appFilter.pi" }));
+    expect(screen.queryByText("background-only")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("codex-background-usage"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/tests/components/UsageDashboard.test.tsx
+++ b/tests/components/UsageDashboard.test.tsx
@@ -46,6 +46,10 @@ vi.mock("@/lib/query/usage", async () => {
   };
 });
 
+vi.mock("@/components/usage/CodexBackgroundUsage", () => ({
+  CodexBackgroundUsage: () => <div data-testid="codex-background-usage" />,
+}));
+
 vi.mock("@/components/usage/UsageHero", () => ({
   UsageHero: (props: unknown) => {
     usageHeroMock(props);


### PR DESCRIPTION
## Summary / 概述

Codex Desktop 的 `ephemeral_generation_token_usage` 记录可以包含后台生成的实际 token 用量，但这些生成不一定产生现有导入器读取的会话 JSONL。例如 `thread_title`、`ambient_suggestions` 和 `ambient_suggestion_safety` 因此可能不可见。

本 Draft PR 在 macOS 增加独立的后台用量展示：

- 随现有自动/手动会话同步读取 `~/Library/Logs/com.openai.codex/YYYY/MM/DD/*.log`，按文件元数据跳过未变化文件；变化文件重新扫描，记录指纹防止重复导入。
- v18 → v19 新增独立事件表与文件扫描状态表，不写入 `proxy_request_logs`。
- Dashboard 在 All/Codex 且未筛选供应商时展示后台生成，支持日期和模型筛选，按模型、功能、状态分组。
- 复用现有 Codex 成本计算和当前模型定价；输入已包含缓存，输出已包含 reasoning，不重复相加。未知价格保持未知。
- 更新 en / zh / zh-TW / ja 文案，附带测试与统计边界说明。

### Why Draft / 待确认的统计边界

后台记录没有稳定的上游 request ID，而且一个生成可能聚合多次模型调用。因此本实现**不把后台记录并入原有总计、图表、模型/供应商统计或请求列表**，也不根据时间和 token 相似度猜测跨来源去重。希望先确认独立展示是否符合项目方向，再讨论可证明的跨来源合并方案。

记录指纹仅用于同源记录去重：完全相同的时间戳和字段会合并，包括无法区分的两次真实生成。覆盖范围也受本机日志保留期限限制，不代表跨设备账号总量。费用是标准价估算，不是订阅实际扣费；特殊 service tier / 长上下文价格未单独推算。本版没有后台账本清空/重建入口，未实现 Windows/Linux 日志位置。

## Related Issue / 关联 Issue

Refs #7340

## Validation / 验证

在 macOS 本地验证，未修改正在使用的 CC Switch 数据库或 Codex 配置：

- Rust 全量：2,987 passed，6 ignored（其中可选日志样本测试另行执行）。
- 新导入器测试及显式样本测试：6 passed。覆盖重复同步、轮转副本、追加、未完成行、截断、非法/超长行、token 校验、未知价格、筛选和与原请求总账隔离。
- 对本机指定时间窗的 82 条记录，仅在内存数据库中导入，得到 5,025,338 tokens、标准价估算 $3.14071904，与独立审计一致；重复导入为 0。私人日志没有提交。
- 新组件与 Dashboard 定向测试：8 passed；组件测试使用实际翻译资源。使用合成数据在浏览器中挂载验证文本与数据展示。
- 前端全量：`pnpm exec vitest run --maxWorkers=2 --minWorkers=1`，138 个文件 / 1,110 tests passed。默认并发与 Rust 编译同时运行时，PiProviderForm 出现 3–5 项 5 秒超时；该文件单独复跑 46/46 通过，限制并发后的全量复跑全部通过。
- `pnpm typecheck`、`pnpm format:check`、`pnpm build:renderer`、`cargo fmt --check`、`cargo clippy -- -D warnings` 均通过。

## Screenshots / 截图

未附截图。浏览器验证使用临时合成数据入口，该入口没有提交；未安装或启动修改后的原生打包应用。

## Checklist / 检查清单

- [x] `pnpm typecheck` passes / 通过 TypeScript 类型检查
- [x] `pnpm format:check` passes / 通过代码格式检查
- [x] `cargo clippy` passes / 通过 Clippy 检查
- [x] Updated i18n files / 已更新四种语言文案

AI-assisted implementation; the diff and local test results were reviewed before submission.



## Review follow-up / 审查修复（`c7397c0`）

- **P1**：将 `codex_background_usage` 和 `codex_background_files` 同时加入同步导出排除名单和导入保留名单。新增测试验证远端 payload 不包含本机记录、带有远端记录的旧 Draft payload 不会覆盖本机账本、v18 快照导入后仍保留本机记录，以及完整手动备份可以恢复账本。备份模块定向测试 35 passed、2 ignored。
- **P2**：模型选择器合并当前日期范围内后台事件中的模型；选项池不受当前模型选择影响，并在其他应用或供应商范围内排除后台选项。共享查询 hook 保持刷新和缓存一致。新增交互测试验证后台独有模型可以选中，以及跨应用/供应商范围隔离。
- **Linux / Windows Clippy**：将 macOS 日志解析、扫描函数及相关 import 限定为 `cfg(any(target_os = "macos", test))`，非 macOS 正常构建不再编译未使用的导入器，测试构建仍保留通用解析与导入测试。没有关闭 `dead_code` 或降低 CI 严格度。

本次本地验证：Rust 全量 2,987 passed / 6 ignored；前端全量 138 files / 1,110 passed；类型检查、格式检查、renderer 构建、Rust fmt 和严格 Clippy 均通过。

[当前提交的 CI](https://github.com/farion1231/cc-switch/actions/runs/34744323444) 返回 `action_required`，等待维护者批准运行；尚不能声称新的 Linux/Windows CI 已通过。PR 保持 Draft。
