### PR TITLE
[Codex] Sanitize incompatible reasoning replay for official Responses

### DIFF
--- a/src-tauri/src/proxy/forwarder.rs
+++ b/src-tauri/src/proxy/forwarder.rs
@@ -1684,6 +1684,25 @@ impl RequestForwarder {
             self.apply_media_prevention(&mut request_body, provider);
         }
 
+        // Official Codex Responses rejects array-valued reasoning content that was
+        // persisted by a third-party Responses provider.  When the same malformed
+        // item also carries encrypted_content, the foreign value fails validation
+        // immediately after content is fixed.  Normalize only the official native
+        // Responses path and only the in-memory outbound copy; never rewrite history.
+        if should_sanitize_official_codex_reasoning_replay(
+            endpoint,
+            codex_official_auth_passthrough,
+            codex_responses_to_chat,
+            codex_responses_to_anthropic,
+        ) {
+            let sanitized = sanitize_official_codex_reasoning_replay(&mut request_body);
+            if sanitized > 0 {
+                log::debug!(
+                    "[Codex] Normalized {sanitized} incompatible reasoning replay item(s) for official Responses upstream"
+                );
+            }
+        }
+
         // 过滤私有参数（以 `_` 开头的字段），防止内部信息泄露到上游
         // 默认使用空白名单，过滤所有 _ 前缀字段
         let mut filtered_body = prepare_upstream_request_body(request_body);
@@ -2953,6 +2972,23 @@ fn split_endpoint_and_query(endpoint: &str) -> (&str, Option<&str>) {
         .map_or((endpoint, None), |(path, query)| (path, Some(query)))
 }
 
+fn is_regular_codex_responses_endpoint(endpoint: &str) -> bool {
+    let (path, _) = split_endpoint_and_query(endpoint);
+    matches!(path.trim_end_matches('/'), "/responses" | "/v1/responses")
+}
+
+fn should_sanitize_official_codex_reasoning_replay(
+    endpoint: &str,
+    codex_official_auth_passthrough: bool,
+    codex_responses_to_chat: bool,
+    codex_responses_to_anthropic: bool,
+) -> bool {
+    codex_official_auth_passthrough
+        && !codex_responses_to_chat
+        && !codex_responses_to_anthropic
+        && is_regular_codex_responses_endpoint(endpoint)
+}
+
 fn strip_beta_query(query: Option<&str>) -> Option<String> {
     let filtered = query.map(|query| {
         query
@@ -3738,6 +3774,44 @@ fn prepare_upstream_request_body(request_body: Value) -> Value {
     canonicalize_value(filter_private_params_with_whitelist(request_body, &[]))
 }
 
+/// Normalize third-party reasoning items for the official Codex Responses input
+/// contract.  The caller must gate this to the official native Responses path and
+/// pass an outbound request copy; this function does not inspect or mutate history.
+///
+/// A reasoning item with array-valued `content` is incompatible with the official
+/// request schema.  If that same item carries a non-null `encrypted_content`, it is
+/// treated as the paired foreign state exposed by the same malformed item and is
+/// cleared as well.  Standalone encrypted reasoning items remain untouched.
+fn sanitize_official_codex_reasoning_replay(body: &mut Value) -> usize {
+    let Some(input) = body.get_mut("input").and_then(Value::as_array_mut) else {
+        return 0;
+    };
+
+    let mut sanitized = 0;
+    for item in input.iter_mut() {
+        if item.get("type").and_then(Value::as_str) != Some("reasoning")
+            || !matches!(item.get("content"), Some(Value::Array(_)))
+        {
+            continue;
+        }
+
+        let Some(object) = item.as_object_mut() else {
+            continue;
+        };
+
+        object.insert("content".to_string(), Value::Null);
+        if object
+            .get("encrypted_content")
+            .is_some_and(|value| !value.is_null())
+        {
+            object.insert("encrypted_content".to_string(), Value::Null);
+        }
+        sanitized += 1;
+    }
+
+    sanitized
+}
+
 fn log_prompt_cache_trace(
     app_type: &AppType,
     provider: &Provider,
@@ -4025,6 +4099,152 @@ mod tests {
             serde_json::to_string(&prepared).unwrap(),
             r#"{"a":2,"tools":[{"name":"lookup","parameters":{"properties":{"_id":{"type":"string"},"a":{"type":"string"},"b":{"type":"number"}},"type":"object"}}],"z":1}"#
         );
+    }
+
+    #[test]
+    fn official_reasoning_replay_sanitizes_paired_fields_only() {
+        let mut body = json!({
+            "input": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_foreign",
+                    "content": [{"type": "reasoning_text", "text": "third-party"}],
+                    "encrypted_content": "foreign-ciphertext",
+                    "summary": [{"type": "summary_text", "text": "keep"}],
+                    "status": "completed"
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_official",
+                    "content": null,
+                    "encrypted_content": "official-ciphertext"
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_standalone",
+                    "encrypted_content": "standalone-ciphertext"
+                },
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "keep message"}]
+                }
+            ]
+        });
+
+        assert_eq!(sanitize_official_codex_reasoning_replay(&mut body), 1);
+        assert_eq!(body["input"][0]["content"], Value::Null);
+        assert_eq!(body["input"][0]["encrypted_content"], Value::Null);
+        assert_eq!(
+            body["input"][0]["summary"],
+            json!([{"type": "summary_text", "text": "keep"}])
+        );
+        assert_eq!(body["input"][0]["id"], "rs_foreign");
+        assert_eq!(body["input"][1]["encrypted_content"], "official-ciphertext");
+        assert_eq!(
+            body["input"][2]["encrypted_content"],
+            "standalone-ciphertext"
+        );
+        assert_eq!(body["input"][3]["content"][0]["text"], "keep message");
+    }
+
+    #[test]
+    fn official_reasoning_replay_sanitizes_content_without_adding_encrypted_content() {
+        let mut body = json!({
+            "input": [{
+                "type": "reasoning",
+                "content": []
+            }]
+        });
+
+        assert_eq!(sanitize_official_codex_reasoning_replay(&mut body), 1);
+        assert_eq!(body["input"][0]["content"], Value::Null);
+        assert!(body["input"][0].get("encrypted_content").is_none());
+    }
+
+    #[test]
+    fn official_reasoning_replay_ignores_non_array_and_non_reasoning_content() {
+        let mut body = json!({
+            "input": [
+                {
+                    "type": "reasoning",
+                    "content": null,
+                    "encrypted_content": "official-ciphertext"
+                },
+                {
+                    "type": "reasoning",
+                    "content": "plain reasoning",
+                    "encrypted_content": "official-ciphertext-2"
+                },
+                {
+                    "type": "message",
+                    "content": [{"type": "input_text", "text": "keep"}],
+                    "encrypted_content": "not-a-reasoning-field"
+                }
+            ]
+        });
+        let original = body.clone();
+
+        assert_eq!(sanitize_official_codex_reasoning_replay(&mut body), 0);
+        assert_eq!(body, original);
+
+        for malformed in [json!({}), json!({"input": "not-an-array"}), Value::Null] {
+            let mut malformed = malformed;
+            assert_eq!(sanitize_official_codex_reasoning_replay(&mut malformed), 0);
+        }
+    }
+
+    #[test]
+    fn official_reasoning_replay_is_idempotent_and_gate_excludes_other_paths() {
+        let mut body = json!({
+            "input": [{
+                "type": "reasoning",
+                "content": [{"type": "reasoning_text", "text": "third-party"}],
+                "encrypted_content": "foreign-ciphertext"
+            }]
+        });
+
+        assert_eq!(sanitize_official_codex_reasoning_replay(&mut body), 1);
+        let once = body.clone();
+        assert_eq!(sanitize_official_codex_reasoning_replay(&mut body), 0);
+        assert_eq!(body, once);
+
+        assert!(should_sanitize_official_codex_reasoning_replay(
+            "/responses?beta=true",
+            true,
+            false,
+            false,
+        ));
+        assert!(should_sanitize_official_codex_reasoning_replay(
+            "/v1/responses/",
+            true,
+            false,
+            false,
+        ));
+        assert!(!should_sanitize_official_codex_reasoning_replay(
+            "/responses/compact",
+            true,
+            false,
+            false,
+        ));
+        assert!(!should_sanitize_official_codex_reasoning_replay(
+            "/responses",
+            false,
+            false,
+            false,
+        ));
+        assert!(!should_sanitize_official_codex_reasoning_replay(
+            "/responses",
+            true,
+            true,
+            false,
+        ));
+        assert!(!should_sanitize_official_codex_reasoning_replay(
+            "/responses",
+            true,
+            false,
+            true,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## English

### Summary

Fixes a Codex conversation replay failure that can occur after a conversation has previously been used through a third-party Responses-compatible Provider, such as a DeepSeek-compatible relay, and is later continued through the official OpenAI/Codex Provider.

A third-party Provider may persist reasoning items containing array-valued `reasoning.content` together with foreign `encrypted_content`. The official Codex Responses backend rejects the array-valued content first, and then rejects the foreign encrypted content if only `content` is cleared.

This PR clears both fields together on the outbound request copy sent to the official Codex Responses Provider.

### Scope

- Processes only direct `type == "reasoning"` items in the top-level `input` array;
- Triggers only when `content` is an array;
- Does not delete items, reorder input, or recursively scan nested objects;
- Does not modify `summary`, `id`, `status`, tool calls, or other fields;
- Preserves standalone `encrypted_content` when the item has no array-valued `content`;
- Applies only to the official native Codex `/responses` and `/v1/responses` paths;
- Does not apply to DeepSeek/custom Providers, Responses-to-Chat, Responses-to-Anthropic, or `/responses/compact`;
- Does not modify local JSONL history, the database, Provider configuration, or public APIs.

### Validation

Local diagnostics:

- `cargo test --manifest-path src-tauri/Cargo.toml reasoning_replay --lib` — 4 passed;
- `cargo test --manifest-path src-tauri/Cargo.toml explicit_codex_official_cards_use_chatgpt_backend --lib` — 1 passed;
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — passed;
- `git diff --check` — passed.

Real Provider validation:

- Native DeepSeek plaintext reasoning request — HTTP 200;
- Raw GPT OAuth replay with array-valued content — reproduced `array_above_max_length`;
- `content` cleared while foreign encrypted content is preserved — reproduced `invalid_encrypted_content`;
- Both fields cleared — HTTP 200 with `response.completed`.

A real CC Switch `ProxyServer` was also started with an isolated in-memory database and temporary loopback port. The patched forwarder sent a synthetic contaminated request to the real GPT OAuth endpoint: 1 passed. The temporary live harness was removed and is not included in this PR.

### Not run

- Full test suite;
- Continuation of an existing real Codex conversation;
- Live takeover of the user's current desktop CC Switch instance;
- A real `/responses/compact` request;
- Chat/Anthropic conversion paths;
- Long-running production validation.

### Linked issues

- Fixes #7333
- Fixes #7316

## 中文

### 概要

修复 Codex 对话曾经通过第三方 Responses-compatible Provider（例如 DeepSeek-compatible relay 或其他第三方中转站）推进后，再切换回官方 OpenAI/Codex Provider 时无法继续的问题。

第三方 Provider 可能会将 `reasoning.content` 数组和外部 `encrypted_content` 一起持久化。官方 Codex Responses 后端会先拒绝数组形式的 `content`，在只清理 `content` 后又拒绝无法验证的外部密文。

本 PR 仅在发往官方 Codex Responses Provider 的出站请求副本中，同时将同一 reasoning item 的数组 `content` 和非空 `encrypted_content` 置为 `null`。

### 修改范围

- 只处理顶层 `input` 数组中的直接 `type == "reasoning"` item；
- 仅当 `content` 为数组时触发；
- 不删除 item，不改变顺序，不递归扫描；
- 不修改 `summary`、`id`、`status`、工具调用或其他字段；
- 没有数组 `content` 的独立 `encrypted_content` 保持不变；
- 只作用于官方 Codex 原生 `/responses` 和 `/v1/responses`；
- 不作用于 DeepSeek/custom Provider、Responses→Chat、Responses→Anthropic 或 `/responses/compact`；
- 不修改本地 JSONL、数据库、Provider 配置或公共 API。

### 验证

本地诊断：

- `cargo test --manifest-path src-tauri/Cargo.toml reasoning_replay --lib` — 4 passed；
- `cargo test --manifest-path src-tauri/Cargo.toml explicit_codex_official_cards_use_chatgpt_backend --lib` — 1 passed；
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check` — passed；
- `git diff --check` — passed。

真实 Provider 验证：

- DeepSeek 原生明文 reasoning 请求 — HTTP 200；
- GPT OAuth 原始数组污染请求 — 复现 `array_above_max_length`；
- 只清理 `content`、保留外部密文 — 复现 `invalid_encrypted_content`；
- 两个字段同时清理 — HTTP 200，并收到 `response.completed`。

另外在临时内存数据库和临时 loopback 端口上启动真实 CC Switch `ProxyServer`，通过 patched forwarder 发送合成污染请求到真实 GPT OAuth endpoint：1 passed。临时 live harness 已删除，没有进入本 PR。

### 未运行

- 完整测试套件；
- 真实已有 Codex 历史会话继续对话；
- 用户当前桌面版 CC Switch 的 Live takeover；
- `/responses/compact` 真实请求；
- Chat/Anthropic 转换路径；
- 长期生产环境验收。

### 关联 Issue

- 修复 #7333
- 修复 #7316

