### PR TITLE
fix(misc): fetch npm dist-tags from the dedicated endpoint with the probe timeout

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -945,15 +945,37 @@ fn pick_latest_version(
     Some(best)
 }
 
+/// npm 包 dist-tags 专用端点的 URL。
+///
+/// 该端点的响应体就是 dist-tags 对象本身(几十到几千字节);而 `/{package}` 返回的是
+/// 含每个历史版本元数据的完整 packument,codex / opencode / openclaw 这类高频发版的包
+/// 已有十几到二十几 MB,一次刷新要下几十 MB(#7339)。scoped 包名的 `/` 按 registry
+/// 约定转义成 `%2f`。
+fn npm_dist_tags_url(package: &str) -> String {
+    format!(
+        "https://registry.npmjs.org/-/package/{}/dist-tags",
+        package.replace('/', "%2f")
+    )
+}
+
 /// 拉取 npm 包的完整 dist-tags(单次请求即含 latest/next/beta/...)。
+///
+/// 与 GitHub / PyPI 两条来源一样套 `LATEST_PROBE_TIMEOUT`:取不到就返回 None,由调用方
+/// 显示「未知」,而不是沿用全局客户端的 600s 总超时让卡片一直「加载中」。包不存在时
+/// 端点返回 404 与一个 JSON 字符串体,解析成 Map 失败,同样落到 None。
 async fn fetch_npm_dist_tags(
     client: &reqwest::Client,
     package: &str,
 ) -> Option<serde_json::Map<String, serde_json::Value>> {
-    let url = format!("https://registry.npmjs.org/{package}");
-    let resp = client.get(&url).send().await.ok()?;
-    let json = resp.json::<serde_json::Value>().await.ok()?;
-    json.get("dist-tags")?.as_object().cloned()
+    let resp = client
+        .get(npm_dist_tags_url(package))
+        .timeout(LATEST_PROBE_TIMEOUT)
+        .send()
+        .await
+        .ok()?;
+    resp.json::<serde_json::Map<String, serde_json::Value>>()
+        .await
+        .ok()
 }
 
 /// 查询某 npm 工具要展示的"最新版本":取 `latest`,并在本地版本领先时按工具的
@@ -5163,6 +5185,20 @@ mod tests {
         assert_eq!(
             pick_latest_version(map, &["beta"], Some("0.200.0")),
             Some("0.135.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_npm_dist_tags_url() {
+        // 普通包名直接拼进路径
+        assert_eq!(
+            npm_dist_tags_url("openclaw"),
+            "https://registry.npmjs.org/-/package/openclaw/dist-tags"
+        );
+        // scoped 包名的 `/` 按 registry 约定转义成 %2f
+        assert_eq!(
+            npm_dist_tags_url("@openai/codex"),
+            "https://registry.npmjs.org/-/package/@openai%2fcodex/dist-tags"
         );
     }
 


### PR DESCRIPTION
## Summary / 概述

The tool version probe requested `https://registry.npmjs.org/{package}` — the full packument, with metadata for every historical version — only to read its `dist-tags`. For frequently released packages that is tens of MB per request, so the codex / opencode / openclaw cards stayed on "loading" for minutes. It was also the only probe in the file without `LATEST_PROBE_TIMEOUT`; the GitHub and PyPI probes already set it, so npm fell back to the proxy client's 600 s total timeout.

This switches `fetch_npm_dist_tags` to `/-/package/{package}/dist-tags`, whose response body is the dist-tags object itself, and applies the same 15 s timeout.

工具版本检测为了读 `dist-tags` 拉取了完整 packument（含全部历史版本元数据），高频发版的包单次就是几十 MB，卡片长时间「加载中」；且这是同文件里唯一没套 `LATEST_PROBE_TIMEOUT` 的探测。现改为 dist-tags 专用端点并补上 15 s 超时。

- No data is lost: the only caller, `fetch_npm_latest_for_tool`, passes the map to `pick_latest_version`, which reads `latest` and the tool's prerelease tags only.
- Scoped names escape `/` as `%2f`. I checked that unescaped, `%2f` and `%2F` all return 200 today; `%2f` follows the registry convention for a path segment.
- A missing package returns `404` with the JSON string body `"Not Found"`, which fails to parse as a map, so the result is still `None` — same as before. (Even if the body became an object, a map without `latest` makes `pick_latest_version` return `None`.)
- URL construction is extracted into `npm_dist_tags_url` so it can be unit-tested without adding an HTTP mocking dependency.

## Related Issue / 关联 Issue

Fixes #7339

## Measurements / 实测

New endpoint, all seven npm packages the probe queries, from one machine behind a local proxy:

| Package | Response | Time | `latest` |
|---|---|---|---|
| `@anthropic-ai/claude-code` | 56 B | 0.72 s | 2.1.270 |
| `@openai/codex` | 617 B | 0.86 s | 0.154.0 |
| `@google/gemini-cli` | 191 B | 0.61 s | 0.59.0 |
| `@xai-official/grok` | 36 B | 0.80 s | 1.0.30 |
| `opencode-ai` | 2,332 B | 0.71 s | 1.18.30 |
| `openclaw` | 69 B | 0.61 s | 2026.9.4 |
| `@earendil-works/pi-coding-agent` | 44 B | 0.90 s | 0.85.1 |

For the old URL, sizes for the same packages are in #7339 (14–24 MB for codex / opencode / openclaw).

## Screenshots / 截图

N/A — backend-only change.

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes — not run: no TypeScript changes
- [ ] `pnpm format:check` passes — not run: no frontend changes
- [x] `cargo clippy` passes (if Rust code changed) — `cargo clippy --lib`: 0 warnings
- [x] Updated i18n files if user-facing text changed — N/A, no user-facing text changed

Also run: `cargo fmt --check`; `cargo test --lib -- npm_dist_tags_url pick_latest_version` (3 passed, including the new `test_npm_dist_tags_url`). Tested on Linux; the changed code has no platform-specific paths.