### PR TITLE
fix(misc): ignore shell startup output when probing tool versions in WSL

### DIFF
--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1067,6 +1067,32 @@ async fn fetch_pypi_latest_version(client: &reqwest::Client, package: &str) -> O
 static VERSION_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"\d+\.\d+\.\d+(-[\w.]+)?").expect("Invalid version regex"));
 
+/// WSL 版本探测载荷先打印的哨兵。用户 shell 的启动文件（Ubuntu 的 update-motd、
+/// `/etc/bash.bashrc` 的 sudo 提示、nvm 的 `Using Node vX.Y.Z` 等）输出都在它前面，
+/// 解析时只看它之后的内容（#7347）。
+#[cfg_attr(not(windows), allow(dead_code))]
+const VERSION_PROBE_SENTINEL: &str = "__CCSWITCH_VERSION__";
+
+/// 版本探测交给用户 shell 执行的命令：先打哨兵，再跑 `--version`。
+/// 不含单引号，可以直接嵌进外层 `'...'`。
+#[cfg_attr(not(windows), allow(dead_code))]
+fn version_probe_payload(tool: &str) -> String {
+    format!("echo {VERSION_PROBE_SENTINEL}; {tool} --version")
+}
+
+/// 取哨兵**最后一次**出现之后的输出。
+///
+/// 取最后一次：兜底链 `-lic || -lc || -c` 失败重试时会多次打印哨兵。
+/// 按子串而非整行查找：OSC 序列可能没有换行、直接粘在哨兵前面。
+/// 找不到哨兵（shell 在执行载荷之前就失败）时原样返回，保持原有行为。
+#[cfg_attr(not(windows), allow(dead_code))]
+fn after_version_sentinel(output: &str) -> &str {
+    match output.rfind(VERSION_PROBE_SENTINEL) {
+        Some(i) => output[i + VERSION_PROBE_SENTINEL.len()..].trim(),
+        None => output,
+    }
+}
+
 /// 从版本输出中提取纯版本号
 fn extract_version(raw: &str) -> String {
     VERSION_RE
@@ -1322,17 +1348,18 @@ fn try_get_version_wsl(
             default_flag_for_shell(shell)
         };
 
-        (shell.to_string(), flag, format!("{tool} --version"))
+        (shell.to_string(), flag, version_probe_payload(tool))
     } else {
+        let payload = version_probe_payload(tool);
         let cmd = if let Some(flag) = force_shell_flag {
             if !is_valid_shell_flag(flag) {
                 return ShellProbe::NotFound(format!("[WSL:{distro}] invalid shell flag: {flag}"));
             }
-            format!("\"${{SHELL:-sh}}\" {flag} '{tool} --version'")
+            format!("\"${{SHELL:-sh}}\" {flag} '{payload}'")
         } else {
             // 兜底：自动尝试 -lic, -lc, -c
             format!(
-                "\"${{SHELL:-sh}}\" -lic '{tool} --version' 2>/dev/null || \"${{SHELL:-sh}}\" -lc '{tool} --version' 2>/dev/null || \"${{SHELL:-sh}}\" -c '{tool} --version'"
+                "\"${{SHELL:-sh}}\" -lic '{payload}' 2>/dev/null || \"${{SHELL:-sh}}\" -lc '{payload}' 2>/dev/null || \"${{SHELL:-sh}}\" -c '{payload}'"
             )
         };
 
@@ -1348,15 +1375,25 @@ fn try_get_version_wsl(
         Ok(out) => {
             let stdout = decode_command_output(&out.stdout).trim().to_string();
             let stderr = decode_command_output(&out.stderr).trim().to_string();
+            // 启动文件的输出都在哨兵之前，只看它之后（#7347）
+            let payload_out = after_version_sentinel(&stdout).to_string();
             if out.status.success() {
-                let raw = if stdout.is_empty() { &stderr } else { &stdout };
+                let raw = if payload_out.is_empty() {
+                    &stderr
+                } else {
+                    &payload_out
+                };
                 if raw.is_empty() {
                     ShellProbe::NotFound(format!("[WSL:{distro}] {NOT_INSTALLED}"))
                 } else {
                     ShellProbe::Found(extract_version(raw))
                 }
             } else {
-                let err = if stderr.is_empty() { stdout } else { stderr };
+                let err = if stderr.is_empty() {
+                    payload_out
+                } else {
+                    stderr
+                };
                 // wsl.exe 透传的退出码不总可靠，故同时用 exit 127 与 "command not found"
                 // 文本兜底判别"没装"；其余非零退出视作"装了但 --version 报错"。
                 let not_found = err.is_empty()
@@ -4936,6 +4973,36 @@ mod tests {
             executable_zsh.to_string_lossy()
         )));
         assert!(!valid_user_shell_path("/usr/bin/powershell"));
+    }
+
+    #[test]
+    fn version_probe_sentinel_drops_shell_startup_output() {
+        assert_eq!(
+            version_probe_payload("claude"),
+            "echo __CCSWITCH_VERSION__; claude --version"
+        );
+
+        // Ubuntu 的 update-motd 在当天第一个交互式 login shell 里打印 MOTD，
+        // 整段取第一个版本号会拿到 24.04.4（#7347）
+        let motd = "Welcome to Ubuntu 24.04.4 LTS (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)\n\n * Documentation:  https://help.ubuntu.com\n__CCSWITCH_VERSION__\n2.1.270 (Claude Code)";
+        assert_eq!(after_version_sentinel(motd), "2.1.270 (Claude Code)");
+
+        // 兜底链 `-lic || -lc || -c` 会多次打印哨兵：取最后一次之后
+        let chained = "__CCSWITCH_VERSION__\nbash: warning\n__CCSWITCH_VERSION__\n1.2.3";
+        assert_eq!(after_version_sentinel(chained), "1.2.3");
+
+        // OSC 序列没有换行、直接粘在哨兵前面（地址取自 RFC 5737 文档保留段）
+        let glued = "\x1b]1337;RemoteHost=user@198.51.100.23\x07__CCSWITCH_VERSION__\n0.154.0";
+        assert_eq!(after_version_sentinel(glued), "0.154.0");
+
+        // 版本打在 stderr 的工具：哨兵之后为空，调用方回退到 stderr
+        assert_eq!(after_version_sentinel("__CCSWITCH_VERSION__\n"), "");
+
+        // 没有哨兵（shell 在执行载荷前就失败）：原样返回，行为不变
+        assert_eq!(
+            after_version_sentinel("sh: 1: bad: not found"),
+            "sh: 1: bad: not found"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary / 概述

On Windows, the local environment check for a tool installed in WSL can show the **distro's release number** as the tool's current version — e.g. `24.04.4` for Claude Code 2.1.270 on Ubuntu 24.04.

`try_get_version_wsl` runs `"${SHELL:-sh}" -lic '<tool> --version'` through `wsl.exe` and passes the whole stdout to `extract_version`, which returns the first `x.y.z` it finds. A login + interactive shell runs the distro's startup files first, and their output lands on the same stdout. On Ubuntu, `/etc/profile.d/update-motd.sh` prints the MOTD in interactive shells once a day:

```
Welcome to Ubuntu 24.04.4 LTS (GNU/Linux 6.6.87.2-microsoft-standard-WSL2 x86_64)
...
2.1.270 (Claude Code)
```

The once-a-day stamp (`$HOME/.motd_shown`) is why this looks unreproducible: the wrong version appears after the first probe of the day and disappears on the next refresh.

WSL 下工具版本探测走 login+交互 shell，发行版启动文件（Ubuntu 的 update-motd 每天打印一次欢迎语）和 `--version` 输出共用 stdout，`extract_version` 取到的第一个版本号是 `24.04.4`。

**Fix.** The payload now prints a sentinel before running the tool — `echo __CCSWITCH_VERSION__; <tool> --version` — and parsing looks only at what follows its **last** occurrence. Whatever the startup files print (MOTD, the sudo hint from `/etc/bash.bashrc`, `Using Node vX.Y.Z`, OSC sequences) lands before it.

- **Last occurrence**: the `-lic || -lc || -c` fallback chain can print the sentinel several times.
- **Substring, not whole line**: an OSC sequence without a trailing newline can be glued in front of it.
- **Sentinel absent** (the shell failed before running the payload): the output is used as before, so behaviour is unchanged in that case.
- The existing stderr fallback for tools that print their version there is kept; with the sentinel, "empty" now means empty after it.
- The failure branch also uses the post-sentinel stdout, so startup-file text can't be mistaken for a "not found" diagnostic.

The helpers are plain functions next to `extract_version`, not `cfg(windows)`, so they are unit-tested on every platform; they carry `cfg_attr(not(windows), allow(dead_code))` because only the Windows probe calls them.

## Related Issue / 关联 Issue

Fixes #7347

**Relation to #5817.** #5817 isolates tool output from rc files for `try_get_version`, but keeps `try_get_version_wsl` sharing stdout with the shell and only strips OSC payloads there — which doesn't cover plain-text MOTD lines. Both PRs touch the output-handling lines in `try_get_version_wsl`, so whichever lands second needs a small rebase. To keep that overlap small, this PR does **not** change `extract_version` or its return type (#5817 turns it into `Option`), and the new test doesn't depend on it.

## Verification / 验证

**End to end through the real `wsl.exe`** (Windows 11 → WSL2 Ubuntu 24.04, invoked the same way as `Command::new("wsl.exe").args(["-d", distro, "--", "sh", "-c", cmd])`):

| Case | Old parsing (first match in whole stdout) | New parsing (after last sentinel) |
|---|---|---|
| Normal HOME, MOTD already shown today | `2.1.270` | `2.1.270` |
| Throwaway HOME, so the MOTD fires | **`24.04.4`** | `2.1.270` |

The first row confirms the sentinel survives the `wsl.exe → sh -c → $SHELL -lic` quoting chain and the normal case is unaffected. The second reproduces the reported card exactly and shows the fix. (The throwaway HOME is test scaffolding to trigger the MOTD without touching the real stamp.)

**Unit test** `version_probe_sentinel_drops_shell_startup_output`: MOTD before the sentinel, repeated sentinels from the fallback chain, an OSC sequence glued to the sentinel, an empty payload (stderr fallback), and no sentinel at all.

**What I could not do:** compile the `cfg(windows)` body of `try_get_version_wsl` locally. The crate needs a C toolchain for the Windows target (`ring`, `aws-lc-sys`, bundled `libsqlite3-sys`) and I don't have one here. The change inside that function is limited to building the payload and slicing stdout with the tested helper. The `windows-latest` backend job will compile and lint it — note that workflows on this PR need maintainer approval to run.

## Screenshots / 截图

| Before / 修改前 | After / 修改后 |
|-----------------|---------------|
| WSL Claude Code card: 当前版本 `24.04.4`, 最新版本 `2.1.270` (after the first probe of the day) | 当前版本 `2.1.270` — verified via the end-to-end table above; no Windows build available here for a UI screenshot |

## Checklist / 检查清单

- [ ] `pnpm typecheck` passes — not run: no TypeScript changes
- [ ] `pnpm format:check` passes — not run: no frontend changes
- [x] `cargo clippy` passes (if Rust code changed) — `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings` on Linux
- [x] Updated i18n files if user-facing text changed — N/A, no user-facing text changed

Also run: `cargo fmt --check`; `cargo test --lib -- version_probe_sentinel test_extract_version` (2 passed).